### PR TITLE
 NMS-13858: fix logging dependencies (Foundation 2020)

### DIFF
--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -107,6 +107,46 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                      <phase>prepare-package</phase>
+                      <goals>
+                          <goal>copy</goal>
+                      </goals>
+                      <configuration>
+                          <artifactItems>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-api</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-api-1.10.2.jar</destFileName>
+                              </artifactItem>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-log4j2</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-log4j2-1.10.2.jar</destFileName>
+                              </artifactItem>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-logback</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-logback/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-logback-1.10.2.jar</destFileName>
+                              </artifactItem>
+                          </artifactItems>
+                      </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>net.nicoulaj.maven.plugins</groupId>
                 <artifactId>checksum-maven-plugin</artifactId>
                 <executions>

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -108,6 +108,46 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                      <phase>prepare-package</phase>
+                      <goals>
+                          <goal>copy</goal>
+                      </goals>
+                      <configuration>
+                          <artifactItems>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-api</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-api-1.10.2.jar</destFileName>
+                              </artifactItem>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-log4j2</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-log4j2-1.10.2.jar</destFileName>
+                              </artifactItem>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-logback</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-logback/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-logback-1.10.2.jar</destFileName>
+                              </artifactItem>
+                          </artifactItems>
+                      </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <executions>
                     <execution>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
@@ -192,6 +192,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-dao-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdEdgeStatusProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdEdgeStatusProvider.java
@@ -41,6 +41,7 @@ import org.opennms.features.topology.api.topo.EdgeStatusProvider;
 import org.opennms.features.topology.api.topo.Status;
 import org.opennms.features.topology.api.topo.BackendGraph;
 import org.opennms.netmgt.dao.api.AlarmDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsSeverity;
@@ -50,7 +51,7 @@ import com.google.common.collect.Maps;
 
 public class LinkdEdgeStatusProvider implements EdgeStatusProvider {
 
-    public static class LinkdEdgeStatus implements Status{
+    public static class LinkdEdgeStatus implements Status {
 
         private final String m_status;
 
@@ -87,6 +88,7 @@ public class LinkdEdgeStatusProvider implements EdgeStatusProvider {
     }
 
     private AlarmDao m_alarmDao;
+    private SessionUtils m_sessionUtils;
 
     @Override
     public String getNamespace() {
@@ -99,20 +101,20 @@ public class LinkdEdgeStatusProvider implements EdgeStatusProvider {
 EDGES:        for (EdgeRef edgeRef : edges) {
                 LinkdEdge edge = (LinkdEdge) graph.getEdge(edgeRef);
                 for (OnmsAlarm alarm: getLinkdEdgeDownAlarms()) {
-                    if (alarm.getNode().getId() == null)
+                    if (alarm.getNode() == null)
                         continue;
                     if (alarm.getIfIndex() == null)
                         continue;
-                    int alarmnodeid = alarm.getNode().getId().intValue();
+                    int alarmnodeid = alarm.getNode().getId();
                     if ( edge.getSourcePort().getVertex().getNodeID() != null 
-                            && edge.getSourcePort().getVertex().getNodeID().intValue() == alarmnodeid
+                            && edge.getSourcePort().getVertex().getNodeID() == alarmnodeid
                             && edge.getSourcePort().getIfIndex() != null
                             && edge.getSourcePort().getIfIndex().intValue() == alarm.getIfIndex().intValue()) {
                         retVal.put(edgeRef, new LinkdEdgeStatus(alarm));
                         continue EDGES;
                     }
                     if ( edge.getTargetPort().getVertex().getNodeID() != null 
-                            && edge.getTargetPort().getVertex().getNodeID().intValue() == alarmnodeid
+                            && edge.getTargetPort().getVertex().getNodeID() == alarmnodeid
                             && edge.getTargetPort().getIfIndex() != null
                             && edge.getTargetPort().getIfIndex().intValue() == alarm.getIfIndex().intValue()) {
                         retVal.put(edgeRef, new LinkdEdgeStatus(alarm));
@@ -134,14 +136,23 @@ EDGES:        for (EdgeRef edgeRef : edges) {
     }
 
     protected List<OnmsAlarm> getLinkdEdgeDownAlarms() {
-        org.opennms.core.criteria.Criteria criteria = new org.opennms.core.criteria.Criteria(OnmsAlarm.class);
-        criteria.addRestriction(new EqRestriction("uei", EventConstants.TOPOLOGY_LINK_DOWN_EVENT_UEI));
-        criteria.addRestriction(new NeRestriction("severity", OnmsSeverity.CLEARED));
-        return getAlarmDao().findMatching(criteria);
+        return getSessionUtils().withReadOnlyTransaction(() -> {
+            org.opennms.core.criteria.Criteria criteria = new org.opennms.core.criteria.Criteria(OnmsAlarm.class);
+            criteria.addRestriction(new EqRestriction("uei", EventConstants.TOPOLOGY_LINK_DOWN_EVENT_UEI));
+            criteria.addRestriction(new NeRestriction("severity", OnmsSeverity.CLEARED));
+            return getAlarmDao().findMatching(criteria);
+        });
     }
 
     public void setAlarmDao(AlarmDao alarmDao) {
         m_alarmDao = alarmDao;
     }
 
+    public SessionUtils getSessionUtils() {
+        return m_sessionUtils;
+    }
+
+    public void setSessionUtils(SessionUtils m_sessionUtils) {
+        this.m_sessionUtils = m_sessionUtils;
+    }
 }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -59,9 +59,12 @@ xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
         </service-properties>
     </service>
 
+    <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils" />
+
     <!-- EnhancedLinkd StatusProviders Service and CheckedOperation -->
     <bean id="linkdEdgeStatusProvider" class="org.opennms.features.topology.plugins.topo.linkd.internal.LinkdEdgeStatusProvider">
         <property name="alarmDao" ref="alarmDao"/>
+        <property name="sessionUtils" ref="sessionUtils"/>
     </bean>
 
 	<bean id="linkdWrappedEdgeStatusProvider" class="org.opennms.features.topology.plugins.topo.linkd.internal.LinkdWrappedEdgeStatusProviders" init-method="init">

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdEdgeStatusProviderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdEdgeStatusProviderTest.java
@@ -28,14 +28,6 @@
 
 package org.opennms.features.topology.plugins.topo.linkd.internal;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
@@ -46,6 +38,8 @@ import org.opennms.features.topology.api.topo.EdgeRef;
 import org.opennms.features.topology.api.topo.Status;
 import org.opennms.features.topology.api.topo.BackendGraph;
 import org.opennms.netmgt.dao.api.AlarmDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
 import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
@@ -54,12 +48,21 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
 public class LinkdEdgeStatusProviderTest {
 
     public LinkdEdgeStatusProviderTest() {
     }
 
     private AlarmDao m_alarmDao;
+    private SessionUtils sessionUtils;
     private LinkdEdgeStatusProvider m_statusProvider;
     private BackendGraph m_graph;
     private OnmsNode m_node1;
@@ -161,6 +164,7 @@ public class LinkdEdgeStatusProviderTest {
         m_graph = EasyMock.createMock(BackendGraph.class);
         m_statusProvider = new LinkdEdgeStatusProvider();
         m_statusProvider.setAlarmDao(m_alarmDao);
+        m_statusProvider.setSessionUtils(new MockSessionUtils());
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1446,7 +1446,7 @@
     <liquibaseVersion>3.6.3</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.15.0</log4j2Version>
+    <log4j2Version>2.16.0</log4j2Version>
     <logbackClassicVersion>1.2.3</logbackClassicVersion>
     <mapstructVersion>1.3.0.Final</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1454,6 +1454,7 @@
     <netty4Version>4.1.48.Final</netty4Version>
     <newtsVersion>1.5.5</newtsVersion>
     <paxExamVersion>4.13.1</paxExamVersion>
+    <paxLoggingVersion>1.11.11</paxLoggingVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
     <paxWebVersion>7.2.8</paxWebVersion>
     <protobufVersion>3.11.4</protobufVersion>


### PR DESCRIPTION
This PR fixes logging dependencies both inside and outside of Karaf.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13858