### PR TITLE
NMS-13868: update logging dependencies

### DIFF
--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -78,6 +78,12 @@
                         <feature>http</feature>
                         <feature>http-whiteboard</feature>
                     </bootFeatures>
+                    <installedBundles>
+                        <!-- override for security (see etc/overrides.properties) -->
+                        <bundle>mvn:org.ops4j.pax.logging/pax-logging-api/${paxLoggingVersion}</bundle>
+                        <bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion}</bundle>
+                        <bundle>mvn:org.ops4j.pax.logging/pax-logging-logback/${paxLoggingVersion}</bundle>
+                    </installedBundles>
                     <libraries>
                         <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.11.0_1;type:=endorsed;export:=true;delegate:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxp-api-1.4/${karaf.servicemix.specs.version};type:=endorsed;export:=true</library>
@@ -108,41 +114,27 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
-                      <phase>prepare-package</phase>
-                      <goals>
-                          <goal>copy</goal>
-                      </goals>
-                      <configuration>
-                          <artifactItems>
-                              <artifactItem>
-                                  <groupId>org.ops4j.pax.logging</groupId>
-                                  <artifactId>pax-logging-api</artifactId>
-                                  <version>${paxLoggingVersion}</version>
-                                  <overWrite>true</overWrite>
-                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.10.2</outputDirectory>
-                                  <destFileName>pax-logging-api-1.10.2.jar</destFileName>
-                              </artifactItem>
-                              <artifactItem>
-                                  <groupId>org.ops4j.pax.logging</groupId>
-                                  <artifactId>pax-logging-log4j2</artifactId>
-                                  <version>${paxLoggingVersion}</version>
-                                  <overWrite>true</overWrite>
-                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.10.2</outputDirectory>
-                                  <destFileName>pax-logging-log4j2-1.10.2.jar</destFileName>
-                              </artifactItem>
-                              <artifactItem>
-                                  <groupId>org.ops4j.pax.logging</groupId>
-                                  <artifactId>pax-logging-logback</artifactId>
-                                  <version>${paxLoggingVersion}</version>
-                                  <overWrite>true</overWrite>
-                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-logback/1.10.2</outputDirectory>
-                                  <destFileName>pax-logging-logback-1.10.2.jar</destFileName>
-                              </artifactItem>
-                          </artifactItems>
-                      </configuration>
+                        <phase>prepare-package</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/bin/instance" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/bin/instance.bat" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/bin/shell" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/bin/shell.bat" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/etc/startup.properties" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/system/org/apache/karaf/features/framework/${karafVersion}/framework-${karafVersion}-features.xml" />
+                                <delete>
+                                  <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.10.2" />
+                                  <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.10.2" />
+                                  <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-logback/1.10.2" />
+                                </delete>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/container/karaf/src/main/filtered-resources/etc/overrides.properties
+++ b/container/karaf/src/main/filtered-resources/etc/overrides.properties
@@ -1,0 +1,3 @@
+mvn:org.ops4j.pax.logging/pax-logging-api/${paxLoggingVersion};range=[1.0,2.0)
+mvn:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion};range=[1.0,2.0)
+mvn:org.ops4j.pax.logging/pax-logging-logback/${paxLoggingVersion};range=[1.0,2.0)

--- a/container/karaf/src/main/filtered-resources/etc/startup.properties
+++ b/container/karaf/src/main/filtered-resources/etc/startup.properties
@@ -1,15 +1,15 @@
 # Bundles to be started on startup, with startlevel
-mvn\:org.apache.karaf.features/org.apache.karaf.features.extension/4.2.6 = 1
+mvn\:org.apache.karaf.features/org.apache.karaf.features.extension/${karafVersion} = 1
 mvn\:org.apache.felix/org.apache.felix.metatype/1.2.2 = 5
-mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/4.2.6 = 5
+mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/${karafVersion} = 5
 mvn\:org.ops4j.pax.url/pax-url-aether/2.6.1 = 5
 mvn\:org.fusesource.jansi/jansi/1.18 = 8
-mvn\:org.ops4j.pax.logging/pax-logging-api/1.10.2 = 8
-mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.10.2 = 8
+mvn\:org.ops4j.pax.logging/pax-logging-api/${paxLoggingVersion} = 8
+mvn\:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion} = 8
 mvn\:org.apache.felix/org.apache.felix.coordinator/1.0.2 = 9
 mvn\:org.apache.felix/org.apache.felix.configadmin/1.9.14 = 10
 mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.4 = 11
-mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.2.6 = 15
+mvn\:org.apache.karaf.features/org.apache.karaf.features.core/${karafVersion} = 15
 mvn\:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0 = 30
 
 # OPENNMS: Add JNA bundles to prevent jline from refreshing (KARAF-5251)

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -95,6 +95,12 @@
                         <!-- OPENNMS: Additional tools -->
                         <feature>hawtio-offline</feature>
                     </bootFeatures>
+                    <installedBundles>
+                        <!-- override for security (see etc/overrides.properties) -->
+                        <bundle>mvn:org.ops4j.pax.logging/pax-logging-api/${paxLoggingVersion}</bundle>
+                        <bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion}</bundle>
+                        <bundle>mvn:org.ops4j.pax.logging/pax-logging-logback/${paxLoggingVersion}</bundle>
+                    </installedBundles>
                     <libraries>
                         <!-- OPENNMS: Add JNA bundles to prevent jline from refreshing (KARAF-5251) -->
                         <library>mvn:net.java.dev.jna/jna/${jnaVersion};type:=boot;export:=false</library>
@@ -108,41 +114,27 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
-                      <phase>prepare-package</phase>
-                      <goals>
-                          <goal>copy</goal>
-                      </goals>
-                      <configuration>
-                          <artifactItems>
-                              <artifactItem>
-                                  <groupId>org.ops4j.pax.logging</groupId>
-                                  <artifactId>pax-logging-api</artifactId>
-                                  <version>${paxLoggingVersion}</version>
-                                  <overWrite>true</overWrite>
-                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.10.2</outputDirectory>
-                                  <destFileName>pax-logging-api-1.10.2.jar</destFileName>
-                              </artifactItem>
-                              <artifactItem>
-                                  <groupId>org.ops4j.pax.logging</groupId>
-                                  <artifactId>pax-logging-log4j2</artifactId>
-                                  <version>${paxLoggingVersion}</version>
-                                  <overWrite>true</overWrite>
-                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.10.2</outputDirectory>
-                                  <destFileName>pax-logging-log4j2-1.10.2.jar</destFileName>
-                              </artifactItem>
-                              <artifactItem>
-                                  <groupId>org.ops4j.pax.logging</groupId>
-                                  <artifactId>pax-logging-logback</artifactId>
-                                  <version>${paxLoggingVersion}</version>
-                                  <overWrite>true</overWrite>
-                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-logback/1.10.2</outputDirectory>
-                                  <destFileName>pax-logging-logback-1.10.2.jar</destFileName>
-                              </artifactItem>
-                          </artifactItems>
-                      </configuration>
+                        <phase>prepare-package</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/bin/instance" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/bin/instance.bat" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/bin/shell" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/bin/shell.bat" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/etc/startup.properties" />
+                                <replace token="1.10.2" value="${paxLoggingVersion}" file="${project.build.directory}/assembly/system/org/apache/karaf/features/framework/${karafVersion}/framework-${karafVersion}-features.xml" />
+                                <delete>
+                                  <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.10.2" />
+                                  <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.10.2" />
+                                  <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-logback/1.10.2" />
+                                </delete>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -1,0 +1,3 @@
+mvn:org.ops4j.pax.logging/pax-logging-api/${paxLoggingVersion};range=[1.0,2.0)
+mvn:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion};range=[1.0,2.0)
+mvn:org.ops4j.pax.logging/pax-logging-logback/${paxLoggingVersion};range=[1.0,2.0)

--- a/container/shared/src/main/filtered-resources/etc/startup.properties
+++ b/container/shared/src/main/filtered-resources/etc/startup.properties
@@ -1,15 +1,15 @@
 # Bundles to be started on startup, with startlevel
-mvn\:org.apache.karaf.features/org.apache.karaf.features.extension/4.2.6 = 1
+mvn\:org.apache.karaf.features/org.apache.karaf.features.extension/${karafVersion} = 1
 mvn\:org.apache.felix/org.apache.felix.metatype/1.2.2 = 5
-mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/4.2.6 = 5
+mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/${karafVersion} = 5
 mvn\:org.ops4j.pax.url/pax-url-aether/2.6.1 = 5
 mvn\:org.fusesource.jansi/jansi/1.18 = 8
-mvn\:org.ops4j.pax.logging/pax-logging-api/1.10.2 = 8
-mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.10.2 = 8
+mvn\:org.ops4j.pax.logging/pax-logging-api/${paxLoggingVersion} = 8
+mvn\:org.ops4j.pax.logging/pax-logging-log4j2/${paxLoggingVersion} = 8
 mvn\:org.apache.felix/org.apache.felix.coordinator/1.0.2 = 9
 mvn\:org.apache.felix/org.apache.felix.configadmin/1.9.14 = 10
 mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.4 = 11
-mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.2.6 = 15
+mvn\:org.apache.karaf.features/org.apache.karaf.features.core/${karafVersion} = 15
 mvn\:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0 = 30
 
 # OPENNMS: Add JNA bundles to prevent jline from refreshing (KARAF-5251)

--- a/pom.xml
+++ b/pom.xml
@@ -1442,7 +1442,7 @@
     <liquibaseVersion>3.6.3</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.16.0</log4j2Version>
+    <log4j2Version>2.17.0</log4j2Version>
     <logbackClassicVersion>1.2.3</logbackClassicVersion>
     <mapstructVersion>1.3.0.Final</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>
@@ -1450,7 +1450,7 @@
     <netty4Version>4.1.48.Final</netty4Version>
     <newtsVersion>1.5.5</newtsVersion>
     <paxExamVersion>4.13.1</paxExamVersion>
-    <paxLoggingVersion>1.11.11</paxLoggingVersion>
+    <paxLoggingVersion>1.11.12</paxLoggingVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
     <paxWebVersion>7.2.8</paxWebVersion>
     <protobufVersion>3.6.1</protobufVersion>


### PR DESCRIPTION
This PR does a number of things to deal with logging version updates:

* updates to the latest `log4j2` and `pax-logging-*` dependencies
* creates an `etc/overrides.properties` file for Karaf to make sure that it _always_ uses the newer `pax-logging-*`,
  even if an external feature is pulled in
* simplifies the code to replace the latest `pax-logging-*` jars in our Karaf bundles

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13868
