### PR TITLE
NMS-13869: make eventId a BIGINT

### DIFF
--- a/core/schema/src/main/liquibase/27.1.0/eventid-bigint.xml
+++ b/core/schema/src/main/liquibase/27.1.0/eventid-bigint.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" >
+
+  <changeSet author="rangerrick" id="27.1.0-eventid-drop-related-views" runAlways="true">
+    <preConditions onFail="MARK_RAN">
+      <viewExists viewName="node_outages" />
+    </preConditions>
+
+    <!-- these will get recreated by views/*.xml -->
+    <dropView viewName="node_alarms" />
+    <dropView viewName="node_outages" />
+    <dropView viewName="node_outage_status" />
+  </changeSet>
+
+  <changeSet author="rangerrick" id="27.1.0-eventid-to-bigint">
+    <modifyDataType tableName="events" columnName="eventid" newDataType="BIGINT" />
+
+    <modifyDataType tableName="alarms" columnName="lasteventid" newDataType="BIGINT" />
+    <modifyDataType tableName="event_parameters" columnName="eventid" newDataType="BIGINT" />
+    <modifyDataType tableName="notifications" columnName="eventid" newDataType="BIGINT" />
+    <modifyDataType tableName="outages" columnName="svclosteventid" newDataType="BIGINT" />
+    <modifyDataType tableName="outages" columnName="svcregainedeventid" newDataType="BIGINT" />
+
+    <rollback>
+      <modifyDataType tableName="events" columnName="eventid" newDataType="INTEGER" />
+
+      <modifyDataType tableName="alarms" columnName="lasteventid" newDataType="INTEGER" />
+      <modifyDataType tableName="event_parameters" columnName="eventid" newDataType="INTEGER" />
+      <modifyDataType tableName="notifications" columnName="eventid" newDataType="INTEGER" />
+      <modifyDataType tableName="outages" columnName="svclosteventid" newDataType="INTEGER" />
+      <modifyDataType tableName="outages" columnName="svcregainedeventid" newDataType="INTEGER" />
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/core/schema/src/main/liquibase/changelog.xml
+++ b/core/schema/src/main/liquibase/changelog.xml
@@ -95,6 +95,7 @@
 	<include file="27.0.1/changelog.xml"/>
 	<include file="27.0.4/changelog.xml"/>
 	<include file="27.1.0/changelog.xml"/>
+	<include file="27.1.0/eventid-bigint.xml"/>
 
 	<include file="stored-procedures/getManagePercentAvailIntfWindow.xml" />
 	<include file="stored-procedures/getManagePercentAvailNodeWindow.xml" />
@@ -106,5 +107,8 @@
 	<include file="stored-procedures/getPercentAvailabilityInWindow.xml" />
 	<include file="stored-procedures/dropTriggerIfExists.xml" />
 	<include file="stored-procedures/generate_daily_series.xml"/>
+
+	<include file="views/node_alarms.xml"/>
+	<include file="views/node_outages.xml"/>
 
 </databaseChangeLog>

--- a/core/schema/src/main/liquibase/views/node_alarms.xml
+++ b/core/schema/src/main/liquibase/views/node_alarms.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" >
+
+  <changeSet author="rangerrick" id="drop_view_node_alarms" runAlways="true">
+    <preConditions onFail="MARK_RAN">
+      <viewExists viewName="node_alarms" />
+    </preConditions>
+
+    <dropView viewName="node_alarms" />
+  </changeSet>
+
+  <changeSet author="rangerrick" id="view_node_alarms" runAlways="true">
+
+    <createView replaceIfExists="true" viewName="node_alarms">
+      SELECT
+        n.*,
+        a.alarmid,
+        a.eventuei,
+        a.ipaddr,
+        a.reductionkey,
+        a.alarmtype,
+        a.counter,
+        a.severity,
+        a.lasteventid,
+        a.firsteventtime,
+        a.lasteventtime,
+        a.firstautomationtime,
+        a.lastautomationtime,
+        a.description,
+        a.logmsg,
+        a.operinstruct,
+        a.tticketid,
+        a.tticketstate,
+        a.suppresseduntil,
+        a.suppresseduser,
+        a.suppressedtime,
+        a.alarmackuser,
+        a.alarmacktime,
+        a.managedobjectinstance,
+        a.managedobjecttype,
+        a.applicationdn,
+        a.ossprimarykey,
+        a.x733alarmtype,
+        a.qosalarmstate,
+        a.clearkey,
+        a.ifindex,
+        a.stickymemo,
+        a.systemid,
+        (a.alarmacktime NOTNULL) AS acknowledged,
+        COALESCE(s_cat.categoryname, 'no category') AS categoryname,
+        s_cat.categorydescription,
+        s.servicename,
+        nas.max_alarm_severity,
+        nas.max_alarm_severity_unack,
+        nas.alarm_count_unack,
+        nas.alarm_count
+      FROM
+        node n
+      JOIN alarms a ON n.nodeid = a.nodeid
+      JOIN node_alarm_status nas ON a.nodeid = nas.nodeid
+      LEFT JOIN service s ON a.serviceid = s.serviceid
+      LEFT JOIN category_node cat ON n.nodeid = cat.nodeid
+      LEFT JOIN categories s_cat ON cat.categoryid = s_cat.categoryid
+    </createView>
+
+  </changeSet>
+</databaseChangeLog>

--- a/core/schema/src/main/liquibase/views/node_outages.xml
+++ b/core/schema/src/main/liquibase/views/node_outages.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" >
+
+  <changeSet author="rangerrick" id="drop_view_node_outages" runAlways="true">
+    <preConditions onFail="MARK_RAN">
+      <viewExists viewName="node_outages" />
+    </preConditions>
+
+    <dropView viewName="node_outages" />
+    <dropView viewName="node_outage_status" />
+  </changeSet>
+
+  <changeSet author="rangerrick" id="view_node_outages" runAlways="true">
+
+    <createView replaceIfExists="true" viewName="node_outage_status">
+      SELECT
+        node.nodeid,
+        CASE
+          WHEN tmp.severity IS NULL OR tmp.severity &lt; 3 THEN 3
+          ELSE tmp.severity
+        END AS max_outage_severity
+      FROM (
+        SELECT
+          events.nodeid,
+          max(events.eventseverity) AS severity
+        FROM events
+        JOIN outages ON outages.svclosteventid = events.eventid
+        WHERE
+          outages.ifregainedservice IS NULL
+          AND outages.perspective IS NULL
+        GROUP BY events.nodeid
+      ) AS tmp
+      RIGHT JOIN node ON tmp.nodeid = node.nodeid
+    </createView>
+    <createView replaceIfExists="true" viewName="node_outages">
+      SELECT
+        outages.outageid,
+        outages.svclosteventid,
+        outages.svcregainedeventid,
+        outages.iflostservice,
+        outages.ifregainedservice,
+        outages.ifserviceid,
+        e.eventuei AS svclosteventuei,
+        e.eventsource,
+        e.alarmid,
+        e.eventseverity,
+        outages.ifregainedservice IS NOT NULL AS resolved,
+        s.servicename,
+        i.serviceid,
+        ipif.ipaddr,
+        COALESCE(outages.ifregainedservice - outages.iflostservice, now() - outages.iflostservice) AS duration,
+        nos.max_outage_severity,
+        nc.*
+      FROM outages
+        JOIN events e ON outages.svclosteventid = e.eventid
+        JOIN ifservices i ON outages.ifserviceid = i.id
+        JOIN service s ON i.serviceid = s.serviceid
+        JOIN ipinterface ipif ON i.ipinterfaceid = ipif.id
+        JOIN node_categories nc ON nc.nodeid = e.nodeid
+        JOIN node_outage_status nos ON nc.nodeid = nos.nodeid
+        WHERE outages.perspective IS NULL
+    </createView>
+
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
To update the `eventid`, we also have to delete and recreate the `node_alarms`, `node_outages` and `node_outage_status` views since they rely on the eventid internally.  I ended up reworking how those views get created/recreated so that we don't have to keep making new changelogs deleting and remaking them whenever something changes.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13869

