### PR TITLE
NMS-13863: Add rest endpoint to select partial node resources

### DIFF
--- a/docs/modules/development/pages/rest/resources.adoc
+++ b/docs/modules/development/pages/rest/resources.adoc
@@ -18,7 +18,8 @@ This service is especially useful in conjunction with the Measurements API.
 The `/resources/select` endpoint returns only selected parts of node resources:
 
 * If the `nodeSubresources` attribute is not set then a shallow copy of all node subresources (i.e. without nested content) is included. Otherwise the selected node subresources are included and some or all of their string properties.
-* Similarly, if the `stringProperties` attribute is not set then all string properties are included. Otherwise only selected string properties are included.
+* Similarly, if the `stringProperties` attribute is not set, then all string properties are included. 
+Otherwise, only selected string properties are included.
 
 == DELETEs (Removing Data)
 [options="header", cols="5,10"]

--- a/docs/modules/development/pages/rest/resources.adoc
+++ b/docs/modules/development/pages/rest/resources.adoc
@@ -12,7 +12,13 @@ This service is especially useful in conjunction with the Measurements API.
 | `/resources`                            | Retrieve the full tree of resources in the system (expensive, use with care).
 | `/resources/\{resourceid}`              | Retrieve the tree of resources starting with the named resource ID.
 | `/resources/fornode/\{nodecriteria}`    | Retrieve the tree of resources for a node, given its database ID or `foreign-source:foreign-ID` tuple.
+| `/resources/select`                     | Select partial node resources by specifying node ids (database ids or external ids), node filter rules, subresource names, and string property names using the attributes `nodes`, `filterRules`, `nodeSubresources`, and `stringProperties`, respectively. All attributes can have comma separated lists of values.
 |===
+
+The `/resources/select` endpoint returns only selected parts of node resources:
+
+* If the `nodeSubresources` attribute is not set then a shallow copy of all node subresources (i.e. without nested content) is included. Otherwise the selected node subresources are included and some or all of their string properties.
+* Similarly, if the `stringProperties` attribute is not set then all string properties are included. Otherwise only selected string properties are included.
 
 == DELETEs (Removing Data)
 [options="header", cols="5,10"]

--- a/docs/modules/development/pages/rest/resources.adoc
+++ b/docs/modules/development/pages/rest/resources.adoc
@@ -12,7 +12,8 @@ This service is especially useful in conjunction with the Measurements API.
 | `/resources`                            | Retrieve the full tree of resources in the system (expensive, use with care).
 | `/resources/\{resourceid}`              | Retrieve the tree of resources starting with the named resource ID.
 | `/resources/fornode/\{nodecriteria}`    | Retrieve the tree of resources for a node, given its database ID or `foreign-source:foreign-ID` tuple.
-| `/resources/select`                     | Select partial node resources by specifying node ids (database ids or external ids), node filter rules, subresource names, and string property names using the attributes `nodes`, `filterRules`, `nodeSubresources`, and `stringProperties`, respectively. All attributes can have comma separated lists of values.
+| `/resources/select`                     | Select partial node resources by specifying node IDs (database IDs or external ids), node filter rules, subresource names, and string property names using the attributes `nodes`, `filterRules`, `nodeSubresources`, and `stringProperties`, respectively. 
+All attributes can have comma-separated lists of values.
 |===
 
 The `/resources/select` endpoint returns only selected parts of node resources:

--- a/docs/modules/development/pages/rest/resources.adoc
+++ b/docs/modules/development/pages/rest/resources.adoc
@@ -17,7 +17,8 @@ This service is especially useful in conjunction with the Measurements API.
 
 The `/resources/select` endpoint returns only selected parts of node resources:
 
-* If the `nodeSubresources` attribute is not set then a shallow copy of all node subresources (i.e. without nested content) is included. Otherwise the selected node subresources are included and some or all of their string properties.
+* If the `nodeSubresources` attribute is not set, then a shallow copy of all node subresources (i.e., without nested content) is included. 
+Otherwise, the selected node subresources are included and some or all of their string properties.
 * Similarly, if the `stringProperties` attribute is not set, then all string properties are included. 
 Otherwise, only selected string properties are included.
 

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/InterfaceToNodeCacheImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/InterfaceToNodeCacheImpl.java
@@ -44,7 +44,7 @@ public class InterfaceToNodeCacheImpl implements InterfaceToNodeCache {
         this.cache = Objects.requireNonNull(cache);
     }
 
-    @Override
+//    @Override
     public Stream<Integer> getNodeIds(String location, InetAddress ipAddr) {
         return StreamSupport.stream(cache.getNodeId(location, ipAddr).spliterator(), false);
     }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/InterfaceToNodeCacheImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/InterfaceToNodeCacheImpl.java
@@ -44,7 +44,7 @@ public class InterfaceToNodeCacheImpl implements InterfaceToNodeCache {
         this.cache = Objects.requireNonNull(cache);
     }
 
-//    @Override
+    @Override
     public Stream<Integer> getNodeIds(String location, InetAddress ipAddr) {
         return StreamSupport.stream(cache.getNodeId(location, ipAddr).spliterator(), false);
     }


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13863

This PR adds the `/rest/resources/select` endpoints that allows to select parts of node resources for several nodes in one go. This endpoint is meant to be used by the performance datasource when string properties are retrieved.
