### PR TITLE
NMS-13878: bump pax-logging and log4j2 to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1442,7 +1442,7 @@
     <liquibaseVersion>3.6.3</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.17.0</log4j2Version>
+    <log4j2Version>2.17.1</log4j2Version>
     <logbackClassicVersion>1.2.3</logbackClassicVersion>
     <mapstructVersion>1.3.0.Final</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>
@@ -1450,7 +1450,7 @@
     <netty4Version>4.1.48.Final</netty4Version>
     <newtsVersion>1.5.5</newtsVersion>
     <paxExamVersion>4.13.1</paxExamVersion>
-    <paxLoggingVersion>1.11.12</paxLoggingVersion>
+    <paxLoggingVersion>1.11.13</paxLoggingVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
     <paxWebVersion>7.2.8</paxWebVersion>
     <protobufVersion>3.6.1</protobufVersion>


### PR DESCRIPTION
does what it says on the tin

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13878

