### PR TITLE
 NMS-13878: bump pax-logging and log4j2 to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1460,7 +1460,7 @@
     <netty4Version>4.1.48.Final</netty4Version>
     <newtsVersion>1.5.5</newtsVersion>
     <paxExamVersion>4.13.1</paxExamVersion>
-    <paxLoggingVersion>2.0.13</paxLoggingVersion>
+    <paxLoggingVersion>2.0.14</paxLoggingVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
     <paxWebVersion>7.3.16</paxWebVersion>
     <protobufVersion>3.12.0</protobufVersion>


### PR DESCRIPTION
This is a version of https://github.com/OpenNMS/opennms/pull/4055 that is updated for pax-logging 2.x in newer embedded Karaf.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13878
