### PR TITLE
NMS-13818: split docs and main build in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,8 @@ docker_container_config: &docker_container_config
 
 orbs:
   cloudsmith: cloudsmith/cloudsmith@1.0.3
-  path-filtering: circleci/path-filtering@0.1.1
+  continuation: circleci/continuation@0.2.0
+  # path-filtering: circleci/path-filtering@0.1.1
   sign-packages: opennms/sign-packages@2.1.3
 
 commands:
@@ -525,9 +526,8 @@ workflows:
   pre-build:
     when: << pipeline.parameters.trigger-setup >>
     jobs:
-      - path-filtering/filter:
+      - trigger-path-filtering:
           base-revision: << pipeline.git.branch >>
-          config-path: .circleci/config.yml
           mapping: |
             .*            trigger-setup false
             ((?!docs/).)* trigger-build true
@@ -906,6 +906,115 @@ workflows:
                 - /^foundation.*/
 
 jobs:
+  trigger-path-filtering:
+    docker:
+      - image: cimg/python:3.8
+    parameters:
+      base-revision:
+        default: main
+        description: The revision to compare the current one against for the purpose of determining changed files.
+        type: string
+      mapping:
+        default: ""
+        description: Mapping of path regular expressions to pipeline parameters and values. One mapping per line, whitespace-delimited.
+        type: string
+    steps:
+      - cached-checkout
+      # copied from https://circleci.com/developer/orbs/orb/circleci/path-filtering
+      # we do it ourselves because otherwise we have to do a full un-cached checkout every time
+      - run:
+          name: process mapping
+          environment:
+            BASE_REVISION: << parameters.base-revision >>
+            MAPPING: << parameters.mapping >>
+            OUTPUT_PATH: /tmp/pipeline-parameters.json
+          shell: /usr/bin/env python3
+          command: |+
+            #!/usr/bin/env python3
+
+            import json
+            import os
+            import re
+            import subprocess
+
+            def checkout(revision):
+              """
+              Helper function for checking out a branch
+
+              :param revision: The revision to checkout
+              :type revision: str
+              """
+              subprocess.run(
+                ['git', 'checkout', revision],
+                check=True
+              )
+
+            output_path = os.environ.get('OUTPUT_PATH')
+            head = os.environ.get('CIRCLE_SHA1')
+            base_revision = os.environ.get('BASE_REVISION')
+            checkout(base_revision)  # Checkout base revision to make sure it is available for comparison
+            checkout(head)  # return to head commit
+
+            base = subprocess.run(
+              ['git', 'merge-base', base_revision, head],
+              check=True,
+              capture_output=True
+            ).stdout.decode('utf-8').strip()
+
+            if head == base:
+              try:
+                # If building on the same branch as BASE_REVISION, we will get the
+                # current commit as merge base. In that case try to go back to the
+                # first parent, i.e. the last state of this branch before the
+                # merge, and use that as the base.
+                base = subprocess.run(
+                  ['git', 'rev-parse', 'HEAD~1'], # FIXME this breaks on the first commit, fallback to something
+                  check=True,
+                  capture_output=True
+                ).stdout.decode('utf-8').strip()
+              except:
+                # This can fail if this is the first commit of the repo, so that
+                # HEAD~1 actually doesn't resolve. In this case we can compare
+                # against this magic SHA below, which is the empty tree. The diff
+                # to that is just the first commit as patch.
+                base = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+
+            print('Comparing {}...{}'.format(base, head))
+            changes = subprocess.run(
+              ['git', 'diff', '--name-only', base, head],
+              check=True,
+              capture_output=True
+            ).stdout.decode('utf-8').splitlines()
+
+            mappings = [
+              m.split() for m in
+              os.environ.get('MAPPING').splitlines()
+            ]
+
+            def check_mapping(m):
+              if 3 != len(m):
+                raise Exception("Invalid mapping")
+              path, param, value = m
+              regex = re.compile(r'^' + path + r'$')
+              for change in changes:
+                if regex.match(change):
+                  return True
+              return False
+
+            def convert_mapping(m):
+              return [m[1], json.loads(m[2])]
+
+            mappings = filter(check_mapping, mappings)
+            mappings = map(convert_mapping, mappings)
+            mappings = dict(mappings)
+
+            with open(output_path, 'w') as fp:
+              fp.write(json.dumps(mappings))
+
+      - continuation/continue:
+          circleci_domain: circleci.com
+          configuration_path: .circleci/config.yml
+          parameters: /tmp/pipeline-parameters.json
   build:
     executor: centos-build-executor
     # Building currently requires the xlarge containers in order for the webpack compilation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,22 @@ parameters:
     type: string
     default: release-29.x
 
+  ### sub-tree "module" build setup ###
+  trigger-setup:
+    description: whether to use path filtering to determine which modules to trigger
+    type: boolean
+    default: true
+  trigger-docs:
+    description: whether to trigger the documentation build
+    type: boolean
+    default: false
+  trigger-build:
+    description: whether to trigger the main build
+    type: boolean
+    default: false
+
+setup: << pipeline.parameters.trigger-setup >>
+
 aliases:
   - &setup_dct_env
     name: Setup DCT environment
@@ -96,6 +112,7 @@ docker_container_config: &docker_container_config
 
 orbs:
   cloudsmith: cloudsmith/cloudsmith@1.0.3
+  path-filtering: circleci/path-filtering@0.1.1
   sign-packages: opennms/sign-packages@2.1.3
 
 commands:
@@ -505,28 +522,42 @@ commands:
             done
 
 workflows:
-  weekly-coverage:
-    when:
-      equal: [ false, << pipeline.parameters.minimal >> ]
-    triggers:
-      - schedule:
-          # Saturday at 12:00 AM
-          cron: "0 0 * * 6"
-          filters:
-            branches:
-              only:
-                - develop
+  pre-build:
+    when: << pipeline.parameters.trigger-setup >>
     jobs:
-      - build
-      - integration-test-with-coverage:
-          requires:
-            - build
-      - code-coverage:
-          requires:
-            - integration-test-with-coverage
+      - path-filtering/filter:
+          base-revision: << pipeline.git.branch >>
+          config-path: .circleci/config.yml
+          mapping: |
+            .*            trigger-setup false
+            ((?!docs/).)* trigger-build true
+            docs/.*       trigger-docs  true
+            .circleci/.*  trigger-docs  true
+#  weekly-coverage:
+#    when:
+#      equal: [ false, << pipeline.parameters.minimal >> ]
+#    triggers:
+#      - schedule:
+#          # Saturday at 12:00 AM
+#          cron: "0 0 * * 6"
+#          filters:
+#            branches:
+#              only:
+#                - develop
+#    jobs:
+#      - build
+#      - integration-test-with-coverage:
+#          requires:
+#            - build
+#      - code-coverage:
+#          requires:
+#            - integration-test-with-coverage
   build-minimal:
     when:
-      equal: [ true, << pipeline.parameters.minimal >> ]
+      and:
+        - equal: [ true, << pipeline.parameters.trigger-build >> ]
+        - equal: [ false, << pipeline.parameters.trigger-setup >> ]
+        - equal: [ true, << pipeline.parameters.minimal >> ]
     jobs:
       - build
       - create-merge-foundation-branch:
@@ -556,16 +587,26 @@ workflows:
             branches:
               only:
                 - /^foundation.*/
-  build-deploy:
+  docs:
     when:
-      equal: [ false, << pipeline.parameters.minimal >> ]
+      and:
+        - equal: [ true,  << pipeline.parameters.trigger-docs >> ]
+        - equal: [ false, << pipeline.parameters.trigger-setup >> ]
+        - equal: [ false, << pipeline.parameters.minimal >> ]
     jobs:
-      - build:
+      - build-docs:
           filters:
             branches:
               ignore:
                 - /^from-foundation.*/
-      - build-docs:
+  build-deploy:
+    when:
+      and:
+        - equal: [ true,  << pipeline.parameters.trigger-build >> ]
+        - equal: [ false, << pipeline.parameters.trigger-setup >> ]
+        - equal: [ false, << pipeline.parameters.minimal >> ]
+    jobs:
+      - build:
           filters:
             branches:
               ignore:
@@ -871,6 +912,8 @@ jobs:
     # in the core/web-assets module to complete reliably
     resource_class: xlarge
     steps:
+      - attach_workspace:
+          at: ~/
       - run-build:
           number-vcpu: 8
   build-docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,36 +22,35 @@ executors:
 
 # NOTE: the "_label" versions of these are for the case when your source or target
 # branches have slashes in them, that way the merge branch gets created properly
-defaults: &defaults
-  parameters:
-    minimal:
-      description: whether to do a minimal (build-and-merge only) build
-      type: boolean
-      default: false
-    previous_branch:
-      description: the previous branch, if any
-      type: string
-      default: foundation-2020
-    previous_branch_label:
-      description: the previous branch, if any (escaped, no slashes)
-      type: string
-      default: foundation-2020
-    main_branch:
-      description: the auto-merge main branch
-      type: string
-      default: foundation-2021
-    main_branch_label:
-      description: the auto-merge main branch (escaped, no slashes)
-      type: string
-      default: foundation-2021
-    next_branch:
-      description: the auto-merge target branch
-      type: string
-      default: release-29.x
-    next_branch_label:
-      description: the auto-merge target branch (escaped, no slashes)
-      type: string
-      default: release-29.x
+parameters:
+  minimal:
+    description: whether to do a minimal (build-and-merge only) build
+    type: boolean
+    default: false
+  previous_branch:
+    description: the previous branch, if any
+    type: string
+    default: foundation-2020
+  previous_branch_label:
+    description: the previous branch, if any (escaped, no slashes)
+    type: string
+    default: foundation-2020
+  main_branch:
+    description: the auto-merge main branch
+    type: string
+    default: foundation-2021
+  main_branch_label:
+    description: the auto-merge main branch (escaped, no slashes)
+    type: string
+    default: foundation-2021
+  next_branch:
+    description: the auto-merge target branch
+    type: string
+    default: release-29.x
+  next_branch_label:
+    description: the auto-merge target branch (escaped, no slashes)
+    type: string
+    default: release-29.x
 
 aliases:
   - &setup_dct_env
@@ -507,9 +506,8 @@ commands:
 
 workflows:
   weekly-coverage:
-    <<: *defaults
     when:
-      equal: [ false, << parameters.minimal >> ]
+      equal: [ false, << pipeline.parameters.minimal >> ]
     triggers:
       - schedule:
           # Saturday at 12:00 AM
@@ -527,9 +525,8 @@ workflows:
           requires:
             - integration-test-with-coverage
   build-minimal:
-    <<: *defaults
     when:
-      equal: [ true, << parameters.minimal >> ]
+      equal: [ true, << pipeline.parameters.minimal >> ]
     jobs:
       - build
       - create-merge-foundation-branch:
@@ -537,13 +534,13 @@ workflows:
             - build
           filters:
             branches:
-              only: << parameters.main_branch >>
+              only: << pipeline.parameters.main_branch >>
       - merge-foundation-branch:
           requires:
             - build
           filters:
             branches:
-              only: merge-foundation/<< parameters.previous_branch_label >>-to-<< parameters.main_branch_label >>
+              only: merge-foundation/<< pipeline.parameters.previous_branch_label >>-to-<< pipeline.parameters.main_branch_label >>
       - create-merge-meridian-branch:
           requires:
             - build
@@ -560,9 +557,8 @@ workflows:
               only:
                 - /^foundation.*/
   build-deploy:
-    <<: *defaults
     when:
-      equal: [ false, << parameters.minimal >> ]
+      equal: [ false, << pipeline.parameters.minimal >> ]
     jobs:
       - build:
           filters:
@@ -807,7 +803,7 @@ workflows:
             - smoke-test-sentinel
           filters:
             branches:
-              only: << parameters.main_branch >>
+              only: << pipeline.parameters.main_branch >>
       - merge-foundation-branch:
           # technically only requires the RPM/deb builds, but only publish
           # if everything passes
@@ -815,7 +811,7 @@ workflows:
             - tarball-assembly
           filters:
             branches:
-              only: merge-foundation/<< parameters.previous_branch_label >>-to-<< parameters.main_branch_label >>
+              only: merge-foundation/<< pipeline.parameters.previous_branch_label >>-to-<< pipeline.parameters.main_branch_label >>
       - create-merge-meridian-branch:
           # technically only requires the RPM/deb builds, but only publish
           # if everything passes
@@ -1426,15 +1422,14 @@ jobs:
       - run-smoke-tests:
           suite: minimal
   create-merge-foundation-branch:
-    <<: *defaults
     <<: *docker_container_config
     steps:
       - run:
           name: "Branch Merge Parameters"
           command: |
-            echo "previous: << parameters.previous_branch >>, main: << parameters.main_branch >>, next: << parameters.next_branch >>"
+            echo "previous: << pipeline.parameters.previous_branch >>, main: << pipeline.parameters.main_branch >>, next: << pipeline.parameters.next_branch >>"
       - when:
-          condition: << parameters.next_branch >>
+          condition: << pipeline.parameters.next_branch >>
           steps:
             - cached-checkout-for-pushing
             - run:
@@ -1442,27 +1437,26 @@ jobs:
                 command: |
                   export GIT_MERGE_AUTOEDIT=no
                   git fetch --all
-                  git checkout << parameters.next_branch >>
-                  git reset --hard origin/<< parameters.next_branch >>
-                  git merge origin/<< parameters.main_branch >>
+                  git checkout << pipeline.parameters.next_branch >>
+                  git reset --hard origin/<< pipeline.parameters.next_branch >>
+                  git merge origin/<< pipeline.parameters.main_branch >>
             - run:
                 name: Push to github
-                command: git push -f origin << parameters.next_branch >>:merge-foundation/<< parameters.main_branch_label >>-to-<< parameters.next_branch_label >>
+                command: git push -f origin << pipeline.parameters.next_branch >>:merge-foundation/<< pipeline.parameters.main_branch_label >>-to-<< pipeline.parameters.next_branch_label >>
 
   # note, this is always run as part of the _next_ branch
   # for example, if main_branch is `foundation-2016` and next_branch is `foundation-2017`,
   # it will include the contents of the `foundation-2017` branch, thus we need to actually
   # look _backwards_ to the previous_branch and main_branch to merge the correct bits.
   merge-foundation-branch:
-    <<: *defaults
     <<: *docker_container_config
     steps:
       - run:
           name: "Branch Merge Parameters"
           command: |
-            echo "previous: << parameters.previous_branch >>, main: << parameters.main_branch >>, next: << parameters.next_branch >>"
+            echo "previous: << pipeline.parameters.previous_branch >>, main: << pipeline.parameters.main_branch >>, next: << pipeline.parameters.next_branch >>"
       - when:
-          condition: << parameters.previous_branch >>
+          condition: << pipeline.parameters.previous_branch >>
           steps:
             - cached-checkout-for-pushing
             - run:
@@ -1470,19 +1464,18 @@ jobs:
                 command: |
                   export GIT_MERGE_AUTOEDIT=no
                   git fetch --all
-                  git checkout << parameters.main_branch >>
-                  git reset --hard origin/<< parameters.main_branch >>
-                  git merge origin/merge-foundation/<< parameters.previous_branch_label >>-to-<< parameters.main_branch_label >>
+                  git checkout << pipeline.parameters.main_branch >>
+                  git reset --hard origin/<< pipeline.parameters.main_branch >>
+                  git merge origin/merge-foundation/<< pipeline.parameters.previous_branch_label >>-to-<< pipeline.parameters.main_branch_label >>
             - run:
                 name: Push to github
-                command: git push origin << parameters.main_branch >>:<< parameters.main_branch >>
+                command: git push origin << pipeline.parameters.main_branch >>:<< pipeline.parameters.main_branch >>
 
   create-merge-meridian-branch:
-    <<: *defaults
     <<: *docker_container_config
     steps:
       - when:
-          condition: << parameters.main_branch >>
+          condition: << pipeline.parameters.main_branch >>
           steps:
             - restore_cache:
                 keys:
@@ -1509,23 +1502,22 @@ jobs:
                 name: Checkout target branch and merge from source
                 command: |
                   export GIT_MERGE_AUTOEDIT=no
-                  if git rev-parse from-<< parameters.main_branch >> >/dev/null 2>&1; then
-                    git checkout from-<< parameters.main_branch >>
+                  if git rev-parse from-<< pipeline.parameters.main_branch >> >/dev/null 2>&1; then
+                    git checkout from-<< pipeline.parameters.main_branch >>
                   else
-                    git checkout -b from-<< parameters.main_branch >> meridian/from-<< parameters.main_branch >>
+                    git checkout -b from-<< pipeline.parameters.main_branch >> meridian/from-<< pipeline.parameters.main_branch >>
                   fi
-                  git reset --hard meridian/from-<< parameters.main_branch >>
-                  git merge origin/<< parameters.main_branch >>
+                  git reset --hard meridian/from-<< pipeline.parameters.main_branch >>
+                  git merge origin/<< pipeline.parameters.main_branch >>
             - run:
                 name: Push to Meridian github
-                command: git push -f meridian from-<< parameters.main_branch >>:from-<< parameters.main_branch >>
+                command: git push -f meridian from-<< pipeline.parameters.main_branch >>:from-<< pipeline.parameters.main_branch >>
 
   merge-poweredby-branch:
-    <<: *defaults
     <<: *docker_container_config
     steps:
       - when:
-          condition: << parameters.main_branch >>
+          condition: << pipeline.parameters.main_branch >>
           steps:
             - restore_cache:
                 keys:


### PR DESCRIPTION
This PR does a few things:

1. Get rid of the alias-based `defaults:` parameters block, and just turn them into "global" parameters instead.
   This makes them easier to access from anywhere in the CircleCI config.
2. Creates some new parameters used to trigger sub-builds.
3. Creates a new "pre-build" workflow that is the only thing triggered by default.
4. Disables the weekly coverage run for now, dynamic configs + triggers is not supported.
   We should probably do this a different way anyway.

Note that I don't actually use the CircleCI-provided orb for path-filtering; it doesn't support caching the `.git` checkout, so it was taking an inordinate amount of time to run a full checkout on every new build.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13818
