### PR TITLE
PE-1: Simplify importConfig: use default value for configId

### DIFF
--- a/features/config/upgrade/src/main/java/liquibase/ext2/cm/change/ImportConfiguration.java
+++ b/features/config/upgrade/src/main/java/liquibase/ext2/cm/change/ImportConfiguration.java
@@ -72,9 +72,9 @@ public class ImportConfiguration extends AbstractCmChange {
 
     private static final Logger LOG = LoggerFactory.getLogger(RegisterSchema.class);
     private final static String SYSTEM_PROP_OPENNMS_HOME = "opennms.home";
+    private final static String CONFIG_ID = "default";
 
     private String schemaId;
-    private String configId;
     private String filePath;
     private Path archivePath;
     private Path etcFile = null; // user defined file
@@ -83,7 +83,6 @@ public class ImportConfiguration extends AbstractCmChange {
     @Override
     public ValidationErrors validate(CmDatabase db, ValidationErrors validationErrors) {
         validationErrors.checkRequiredField("schemaId", this.schemaId);
-        validationErrors.checkRequiredField("configId", this.configId);
         validationErrors.checkRequiredField("filePath", this.filePath);
 
         String opennmsHome = System.getProperty(SYSTEM_PROP_OPENNMS_HOME, "");
@@ -134,14 +133,14 @@ public class ImportConfiguration extends AbstractCmChange {
 
     @Override
     public String getConfirmationMessage() {
-        return String.format("Imported configuration from %s with id=%s for schema=%s", this.filePath, this.configId, this.schemaId);
+        return String.format("Imported configuration from %s with id=default for schema=%s", this.filePath, this.schemaId);
     }
 
     @Override
     public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[] {
                 new GenericCmStatement((ConfigurationManagerService m) -> {
-                    LOG.info("Importing configuration from {} with id={} for schema={}", this.filePath, this.configId, this.schemaId);
+                    LOG.info("Importing configuration from {} with id=default for schema={}", this.filePath, this.schemaId);
                     try {
                         Optional<ConfigDefinition> configDefinition = m.getRegisteredConfigDefinition(this.schemaId);
 
@@ -156,8 +155,8 @@ public class ImportConfiguration extends AbstractCmChange {
                         } else {
                             throw new ConfigConversionException(String.format("Unknown file type: '%s'", fileType));
                         }
-                        m.registerConfiguration(this.schemaId, this.configId, configObject);
-                        LOG.info("Configuration with id={} imported.", this.configId);
+                        m.registerConfiguration(this.schemaId, CONFIG_ID, configObject);
+                        LOG.info("Configuration with configName={} and configId=default imported.", this.schemaId);
                         if(etcFile != null) {
                             // we imported a user defined config file => move to archive
                             Path archiveFile = Path.of(this.archivePath + "/" + etcFile.getFileName());
@@ -183,14 +182,6 @@ public class ImportConfiguration extends AbstractCmChange {
 
     public void setSchemaId(String schemaId) {
         this.schemaId = schemaId;
-    }
-
-    public String getConfigId() {
-        return configId;
-    }
-
-    public void setConfigId(String configId) {
-        this.configId = configId;
     }
 
     public String getFilePath() {

--- a/features/config/upgrade/src/main/resources/changelog-cm/30.0.0/changelog-cm.xml
+++ b/features/config/upgrade/src/main/resources/changelog-cm/30.0.0/changelog-cm.xml
@@ -9,7 +9,7 @@
     <changeSet author="pschweizer" id="1.0-register-schema-provisiond">
         <cm:registerSchema id="provisiond"/>
         <cm:importSchemaFromXsd id="provisiond" xsdFileName="provisiond-configuration.xsd" xsdFileHash="8a501f54269c52b7ba5c49d89a99b5967c33acfab3d953444828fa47d76dfbab" rootElement="provisiond-configuration"/>
-        <cm:importConfig schemaId="provisiond" configId="default" filePath="provisiond-configuration.xml"/>
+        <cm:importConfig schemaId="provisiond" filePath="provisiond-configuration.xml"/>
     </changeSet>
 
     <changeSet author="pschweizer" id="register-schema-datachoices">
@@ -23,6 +23,6 @@
             <cm:put name="useSystemProxy" type="boolean" default="false"/>
             <cm:put name="systemid" type="string" />
         </cm:changeSchema>
-        <cm:importConfig schemaId="org.opennms.features.datachoices" configId="default" filePath="org.opennms.features.datachoices.cfg"/>
+        <cm:importConfig schemaId="org.opennms.features.datachoices" filePath="org.opennms.features.datachoices.cfg"/>
     </changeSet>
 </databaseChangeLog>

--- a/features/config/upgrade/src/main/resources/liquibase.parser.core.xml/dbchangelog-ext.xsd
+++ b/features/config/upgrade/src/main/resources/liquibase.parser.core.xml/dbchangelog-ext.xsd
@@ -52,7 +52,6 @@
     <xsd:element name="importConfig">
         <xsd:complexType>
             <xsd:attribute name="schemaId" type="xsd:string" use="required"/>
-            <xsd:attribute name="configId" type="xsd:string" use="required"/>
             <xsd:attribute name="filePath" type="xsd:string" use="required"/>
         </xsd:complexType>
     </xsd:element>

--- a/features/config/upgrade/src/test/resources/org/opennms/config/upgrade/LiquibaseUpgraderIT-changelog.xml
+++ b/features/config/upgrade/src/test/resources/org/opennms/config/upgrade/LiquibaseUpgraderIT-changelog.xml
@@ -11,12 +11,12 @@
         <!-- provisiond -->
         <cm:registerSchema id="provisiond"/>
         <cm:importSchemaFromXsd  id="provisiond" xsdFileName="provisiond-configuration.xsd" xsdFileHash="8a501f54269c52b7ba5c49d89a99b5967c33acfab3d953444828fa47d76dfbab" rootElement="provisiond-configuration" />
-        <cm:importConfig schemaId="provisiond" configId="default" filePath="provisiond-configuration.xml"/>
+        <cm:importConfig schemaId="provisiond" filePath="provisiond-configuration.xml"/>
 
         <!-- eventd -->
         <cm:registerSchema id="eventd"/>
         <cm:importSchemaFromXsd id="eventd" xsdFileName="eventd-configuration.xsd" xsdFileHash="dba9c50b58600a7003ed4e34735628bb656b0430864288ccbe7813a30cedf407" rootElement="EventdConfiguration"/>
-        <cm:importConfig schemaId="eventd" configId="default" filePath="eventd-configuration.xml"/>
+        <cm:importConfig schemaId="eventd" filePath="eventd-configuration.xml"/>
     </changeSet>
     <changeSet author="LiquibaseUpgraderIT" id="upgrade-schema-provisiond">
         <cm:importSchemaFromXsd id="provisiond" xsdFileName="provisiond-configuration_v2.xsd" xsdFileHash="8a501f54269c52b7ba5c49d89a99b5967c33acfab3d953444828fa47d76dfbab" rootElement="provisiond-configuration"/>
@@ -39,6 +39,6 @@
             <cm:put name="useSystemProxy" type="boolean" default="false"/>
             <cm:put name="systemid" type="string" />
         </cm:changeSchema>
-        <cm:importConfig schemaId="org.opennms.features.datachoices" configId="default" filePath="org.opennms.features.datachoices.cfg"/>
+        <cm:importConfig schemaId="org.opennms.features.datachoices" filePath="org.opennms.features.datachoices.cfg"/>
     </changeSet>
 </databaseChangeLog>

--- a/features/config/upgrade/src/test/resources/org/opennms/config/upgrade/LiquibaseUpgraderIT-changelog2.xml
+++ b/features/config/upgrade/src/test/resources/org/opennms/config/upgrade/LiquibaseUpgraderIT-changelog2.xml
@@ -10,6 +10,6 @@
     <changeSet author="LiquibaseUpgraderIT2" id="1.0-register-schema-provisiond">
         <cm:registerSchema id="provisiond" />
         <cm:importSchemaFromXsd id="provisiond" xsdFileName="provisiond-configuration.xsd" xsdFileHash="8a501f54269c52b7ba5c49d89a99b5967c33acfab3d953444828fa47d76dfbab" rootElement="provisiond-configuration"/>
-        <cm:importConfig schemaId="provisiond" configId="provisiond" filePath="file:../test/src/test/resources/provisiond-configuration.xml"/>
+        <cm:importConfig schemaId="provisiond" filePath="file:../test/src/test/resources/provisiond-configuration.xml"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This PR removes configId from the importConfig statement in liquibase since it is always "default".

* JIRA (Issue Tracker): https://issues.opennms.org/browse/PE-1

