### PR TITLE
NMS-13820: move javadoc to main build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ commands:
       steps:
         - run:
             name: Calculate cache key from pom files
-            command: find . -type f -name "pom.xml" | grep -v /target/ | sort -u | xargs cat > maven-dependency-pom-cache.key
+            command: find * -type f -name "pom.xml" | grep -v /target/ | sort -u | xargs cat > maven-dependency-pom-cache.key
         - restore_cache:
             keys:
               - maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
@@ -235,8 +235,8 @@ commands:
           when: always
           command: |
             mkdir -p ~/test-results/junit
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
-            find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find * -type f -regex ".*target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find * -type f -regex ".*target/failsafe-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
             mkdir -p ~/test-artifacts/recordings
             cp -R ~/project/smoke-test/target/*.flv ~/test-artifacts/recordings || true
             cp -R ~/project/smoke-test/target/screenshots ~/test-artifacts/ || true
@@ -348,8 +348,8 @@ commands:
           when: always
           command: |
             mkdir -p ~/test-results/junit
-            find . -type f -regex ".*/target/.*-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
-            find . -type f -regex ".*/target/.*-reports-[0-9]+/.*dump.*" -exec cp {} ~/test-results/junit/ \;
+            find * -type f -regex ".*target/.*-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find * -type f -regex ".*target/.*-reports-[0-9]+/.*dump.*" -exec cp {} ~/test-results/junit/ \;
       - run:
           name: Gather tests
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,10 +276,18 @@ commands:
       - run:
           name: Compile OpenNMS
           command: |
+            export OPENNMS_VERSION="$(.circleci/scripts/pom2version.sh pom.xml)"
             .circleci/scripts/configure-signing.sh
             mvn clean -DskipTests=true
             << parameters.node-memory >>
             export MAVEN_OPTS="$MAVEN_OPTS -Xmx8g -XX:ReservedCodeCacheSize=1g"
+            MAVEN_TARGETS="install"
+            case "${CIRCLE_BRANCH}" in
+              "master-"*|"release-"*|develop|jira/NMS-13820)
+                mkdir -p target/artifacts
+                MAVEN_TARGETS="$MAVEN_TARGETS javadoc:aggregate"
+                ;;
+            esac
             ./compile.pl -DskipTests=true -Dbuild.skip.tarball=true \
               -DupdatePolicy=never \
               -Daether.connector.resumeDownloads=false \
@@ -288,7 +296,13 @@ commands:
               -DvaadinJavaMaxMemory=<< parameters.vaadin-javamaxmem >> \
               -DmaxCpus=<< parameters.number-vcpu >> \
               -Psmoke \
-              install --batch-mode
+              --batch-mode \
+              $MAVEN_TARGETS
+            if [ -d target/site/apidocs ]; then
+              pushd target/site/apidocs
+                tar -czf "../../artifacts/opennms-${OPENNMS_VERSION}-javadoc.tar.gz" *
+              popd
+            fi
             pushd opennms-doc
               ../compile.pl \
                 -DupdatePolicy=never \
@@ -297,7 +311,8 @@ commands:
                 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
                 -DskipPdfGeneration=false \
                 -P'!jdk7+' \
-                install --batch-mode
+                --batch-mode \
+                install
             popd
       - update-maven-cache
       - run:
@@ -314,6 +329,9 @@ commands:
             # now move them back so they end up in the workspace for builds further down the workflow
             mv /tmp/maven-keep/* ~/.m2/repository/org/opennms/
       - save-nodejs-cache
+      - store_artifacts:
+          path: ~/project/target/artifacts
+          destination: artifacts
       - persist_to_workspace:
           root: ~/
           paths:
@@ -844,27 +862,6 @@ jobs:
               -Prun-expensive-tasks \
               -Dopennms.home=/opt/opennms \
               install --batch-mode
-            # javadoc
-            date
-            case "${CIRCLE_BRANCH}" in
-              "master-"*|"release-"*)
-                ./compile.pl -DskipTests=true -Dbuild.skip.tarball=false \
-                  -DupdatePolicy=never \
-                  -Daether.connector.resumeDownloads=false \
-                  -Daether.connector.basic.threads=1 \
-                  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-                  -DvaadinJavaMaxMemory=<< parameters.vaadin-javamaxmem >> \
-                  -DmaxCpus=<< parameters.number-vcpu >> \
-                  -Pbuild-bamboo \
-                  -Prun-expensive-tasks \
-                  -Dopennms.home=/opt/opennms \
-                  javadoc:aggregate --batch-mode
-                date
-                ;;
-              *)
-                echo "Skipping Javadoc compilation; it is enabled only on master/release branches."
-                ;;
-            esac
       - run:
           name: Collect Artifacts
           command: |
@@ -874,11 +871,6 @@ jobs:
             find ./opennms-assemblies/minion/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/minion-${OPENNMS_VERSION}.tar.gz" \;
             find ./opennms-assemblies/sentinel/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/sentinel-${OPENNMS_VERSION}.tar.gz" \;
             find ./opennms-assemblies/remote-poller-standalone -name "*.tar.gz" -type f -exec cp {} "./target/artifacts/remote-poller-client-${OPENNMS_VERSION}.tar.gz" \;
-            if [ -d target/site/apidocs ]; then
-              pushd target/site/apidocs
-                tar -czf "../../artifacts/opennms-${OPENNMS_VERSION}-javadoc.tar.gz" *
-              popd
-            fi
             cp ./opennms-assemblies/xsds/target/*-xsds.tar.gz "./target/artifacts/opennms-${OPENNMS_VERSION}-xsds.tar.gz"
             cp opennms-doc/guide-all/target/*.tar.gz "./target/artifacts/opennms-${OPENNMS_VERSION}-docs.tar.gz"
             cp target/*-source.tar.gz ./target/artifacts/


### PR DESCRIPTION
Since the main `build` job already does a full build, adding on the `javadoc:aggregate` costs essentially nothing. This means we don't have to go through an entire aggregate step later during the `tarball-assembly` phase.

This technically misses javadoc from anything that's in the assembly rather than compile, but we should not be publishing APIs in there anyway.  :D

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13820

