### PR TITLE
NMS-13860: fix .git-directory validation, make verifyFilesAndDirectories testable

### DIFF
--- a/opennms-bootstrap/src/main/java/org/opennms/bootstrap/FilesystemPermissionValidator.java
+++ b/opennms-bootstrap/src/main/java/org/opennms/bootstrap/FilesystemPermissionValidator.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2021 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2021-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -132,12 +132,10 @@ public class FilesystemPermissionValidator {
             }
         }
 
-        final Path git = Path.of(".git");
-
         final List<Path> failures;
         try (final Stream<Path> stream = Files.walk(dirPath, FileVisitOption.FOLLOW_LINKS)) {
             failures = stream
-                    .filter(file -> ! file.getFileName().equals(git))
+                    .filter(file -> ! file.toUri().toString().contains("/.git/"))
                     .filter(file -> {
                         try {
                             validateFile(user, file);

--- a/opennms-install/src/test/java/org/opennms/install/InstallerTest.java
+++ b/opennms-install/src/test/java/org/opennms/install/InstallerTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2021 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2021-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,7 +33,9 @@ import static org.junit.Assert.assertEquals;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.Properties;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -126,5 +128,15 @@ public class InstallerTest {
         Files.writeString(etcDir.resolve("opennms.conf"), "RUNAS=rivjaylen");
         final String runas = installer.getRunas();
         assertEquals("rivjaylen", runas);
+    }
+
+    @Test
+    public void testRunasGitDirectory() throws Exception {
+        final var lolDir = Files.createDirectories(etcDir.resolve(".git").resolve("objects"));
+        final var lol = lolDir.resolve("42042042042042042042042042042042031337");
+        Files.writeString(lol, "");
+        Files.setPosixFilePermissions(lol, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_READ, PosixFilePermission.OTHERS_READ));
+
+        installer.verifyFilesAndDirectories();
     }
 }


### PR DESCRIPTION
Fix the permissions-testing to skip files _under_ `.git`, not just the `.git` directory itself. 😅

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13860

