### PR TITLE
NMS-13910: add org.opennms.core.commands to our karaf containers

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -512,6 +512,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.core</groupId>
+      <artifactId>org.opennms.core.commands</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <!-- Required for com.eclipsesource.jaxrs/* -->

--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -68,6 +68,9 @@
         <bundle>mvn:org.opennms.features.distributed/shell/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.sentinel/core/${project.version}</bundle>
 
+        <!-- Useful Commands -->
+        <bundle>mvn:org.opennms.core/org.opennms.core.commands/${project.version}</bundle>
+
         <!-- SystemProperties -->
         <bundle>mvn:org.opennms.core/org.opennms.core.sysprops/${project.version}</bundle>
     </feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -320,6 +320,7 @@
         <bundle dependency="true">mvn:org.codehaus.jackson/jackson-mapper-asl/${jacksonVersion}</bundle>
         <bundle dependency="true">mvn:org.codehaus.jackson/jackson-xc/${jacksonVersion}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.api/${project.version}</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.commands/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.criteria/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.logging/${project.version}</bundle>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,7 @@
     <module>cache</module>
     <module>camel</module>
     <module>cli</module>
+    <module>commands</module>
     <module>config</module>
     <module>criteria</module>
     <module>daemon</module>


### PR DESCRIPTION
This PR add's @jeffgdotorg's handy core command stuff to our default containers

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13910
