### PR TITLE
NMS-13865: Set version number for docs to the major version

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: horizon
-version: '29.0.6-SNAPSHOT'
+version: '29-SNAPSHOT'
 title: Horizon
 prerelease: true
 asciidoc:
@@ -31,3 +31,4 @@ nav:
 - modules/operation/nav.adoc
 - modules/development/nav.adoc
 - modules/reference/nav.adoc
+


### PR DESCRIPTION
Publish only docs for the major version number.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13865

