### PR TITLE
NMS-13917: scrub error message to be more generic if connection fails

### DIFF
--- a/features/endpoints/grafana/rest/src/main/java/org/opennms/netmgt/endpoints/grafana/rest/internal/GrafanaEndpointRestServiceImpl.java
+++ b/features/endpoints/grafana/rest/src/main/java/org/opennms/netmgt/endpoints/grafana/rest/internal/GrafanaEndpointRestServiceImpl.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -87,8 +87,8 @@ public class GrafanaEndpointRestServiceImpl implements GrafanaEndpointRestServic
         try {
             client.getDashboards();
             return Response.ok().build();
-        } catch (IOException ex) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(createErrorObject(ex).toString()).build();
+        } catch (Exception ex) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(createErrorObject("Grafana endpoint could not be verified.", "entity").toString()).build();
         }
     }
 


### PR DESCRIPTION
This PR makes sure exceptions don't leak to the error message in the UI or ReST responses.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13917
