### PR TITLE
NMS-13645 Smoke tests should use HealthCheck Rest instead of connecting to SSH

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -29,6 +29,10 @@
 package org.opennms.smoketest.containers;
 
 import static java.nio.file.Files.createTempDirectory;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.opennms.smoketest.utils.KarafShellUtils.awaitHealthCheckSucceeded;
 import static org.opennms.smoketest.utils.OverlayUtils.jsonMapper;
 
@@ -46,6 +50,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
+import org.awaitility.core.ConditionTimeoutException;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.MinionProfile;
 import org.opennms.smoketest.stacks.NetworkProtocol;
@@ -54,6 +59,7 @@ import org.opennms.smoketest.utils.DevDebugUtils;
 import org.opennms.smoketest.utils.OverlayUtils;
 import org.opennms.smoketest.utils.SshClient;
 import org.opennms.smoketest.utils.TestContainerUtils;
+import org.opennms.smoketest.utils.RestHealthClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
@@ -241,8 +247,17 @@ public class MinionContainer extends GenericContainer implements KarafContainer,
         @Override
         protected void waitUntilReady() {
             LOG.info("Waiting for Minion health check...");
-            final InetSocketAddress sshAddr = container.getSshAddress();
-            awaitHealthCheckSucceeded(sshAddr, 5, "Minion");
+            try {
+                RestHealthClient client = new RestHealthClient(container.getWebUrl(), ALIAS);
+                await().atMost(5, MINUTES)
+                        .pollInterval(10, SECONDS)
+                        .ignoreExceptions()
+                        .until(client::getProbeHealthResponse, containsString(client.getProbeSuccessMessage()));
+            } catch(ConditionTimeoutException e) {
+                LOG.error("{} rest health check did not finish after {} minutes.", ALIAS, 5);
+                throw new RuntimeException(e);
+            }
+            LOG.info("Health check passed.");
         }
     }
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -248,7 +248,7 @@ public class MinionContainer extends GenericContainer implements KarafContainer,
         protected void waitUntilReady() {
             LOG.info("Waiting for Minion health check...");
             try {
-                RestHealthClient client = new RestHealthClient(container.getWebUrl(), ALIAS);
+                RestHealthClient client = new RestHealthClient(container.getWebUrl(), Optional.of(ALIAS));
                 await().atMost(5, MINUTES)
                         .pollInterval(10, SECONDS)
                         .ignoreExceptions()

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -264,7 +264,7 @@ public class SentinelContainer extends GenericContainer implements KarafContaine
         protected void waitUntilReady() {
             LOG.info("Waiting for Sentinel health check...");
             try {
-                RestHealthClient client = new RestHealthClient(container.getWebUrl(), ALIAS);
+                RestHealthClient client = new RestHealthClient(container.getWebUrl(), Optional.of(ALIAS));
                 await().atMost(5, MINUTES)
                         .pollInterval(10, SECONDS)
                         .ignoreExceptions()

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/RestHealthClient.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/RestHealthClient.java
@@ -1,3 +1,32 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+
 package org.opennms.smoketest.utils;
 
 import javax.ws.rs.client.Client;
@@ -6,12 +35,16 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URL;
+import java.util.Optional;
 
+/**
+ * Rest Health client used to verify HealCheck implementations statuses
+ */
 public class RestHealthClient {
 
     private URL url;
 
-    private String alias;
+    private Optional<String> alias;
 
     private Client client;
 
@@ -19,14 +52,20 @@ public class RestHealthClient {
     private final static String SUCCESS_PROBE = "Everything is awesome";
     private final static String HEALTH_KEY = "Health";
 
-    public RestHealthClient(final URL webUrl, final String alias){
+    /**
+     * HealthRestclient constructor
+     * @param webUrl: implementation url required to create the http requests
+     * @param alias: container alias
+     */
+    public RestHealthClient(final URL webUrl, final Optional<String> alias){
         this.alias = alias;
         this.url = webUrl;
         this.client = ClientBuilder.newClient();
     }
 
     private WebTarget getTargetFor(final String path){
-        return client.target(url.toString()).path(alias).path(path);
+
+        return alias.isPresent() ? client.target(url.toString()).path(alias.get()).path(path) : client.target(url.toString()).path(path);
     }
 
     public String getProbeHealthResponse(){

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/RestHealthClient.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/RestHealthClient.java
@@ -1,0 +1,40 @@
+package org.opennms.smoketest.utils;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.URL;
+
+public class RestHealthClient {
+
+    private URL url;
+
+    private String alias;
+
+    private Client client;
+
+    private final static String PROBE = "/rest/health/probe";
+    private final static String SUCCESS_PROBE = "Everything is awesome";
+    private final static String HEALTH_KEY = "Health";
+
+    public RestHealthClient(final URL webUrl, final String alias){
+        this.alias = alias;
+        this.url = webUrl;
+        this.client = ClientBuilder.newClient();
+    }
+
+    private WebTarget getTargetFor(final String path){
+        return client.target(url.toString()).path(alias).path(path);
+    }
+
+    public String getProbeHealthResponse(){
+        Response response
+                = getTargetFor(PROBE).request(MediaType.TEXT_PLAIN).get();
+        return response.getStatus() == 200 && response.getHeaders().containsKey(HEALTH_KEY) ?
+                response.getHeaders().get(HEALTH_KEY).toString() : "Health key not found";
+    }
+
+    public String getProbeSuccessMessage(){return SUCCESS_PROBE;}
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionSshIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionSshIT.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest.minion;
+
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.smoketest.junit.MinionTests;
+import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+
+import static org.opennms.smoketest.utils.KarafShellUtils.awaitHealthCheckSucceeded;
+
+
+@Category(MinionTests.class)
+public class MinionSshIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MinionSshIT.class);
+
+    @ClassRule
+    public static final OpenNMSStack stack = OpenNMSStack.MINION;
+
+    @Test
+    public void testSshHealthOnMinion(){
+        //Test for no exception to occur
+        LOG.info("Waiting for Minion ssh health check...");
+        final InetSocketAddress karafSsh = stack.minion().getSshAddress();
+        awaitHealthCheckSucceeded(karafSsh, 3, "Minion");
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SentinelSshIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SentinelSshIT.java
@@ -51,7 +51,7 @@ public class SentinelSshIT {
     public static final OpenNMSStack stack = OpenNMSStack.SENTINEL;
 
     @Test
-    public void testSshHealthOnMinion(){
+    public void testSshHealthOnSentinel(){
         //Test for no exception to occur
         LOG.info("Waiting for Sentinel ssh health check...");
         final InetSocketAddress karafSsh = stack.sentinel().getSshAddress();

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SentinelSshIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SentinelSshIT.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest.sentinel;
+
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.smoketest.junit.SentinelTests;
+import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+
+import static org.opennms.smoketest.utils.KarafShellUtils.awaitHealthCheckSucceeded;
+
+
+@Category(SentinelTests.class)
+public class SentinelSshIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SentinelSshIT.class);
+
+    @ClassRule
+    public static final OpenNMSStack stack = OpenNMSStack.SENTINEL;
+
+    @Test
+    public void testSshHealthOnMinion(){
+        //Test for no exception to occur
+        LOG.info("Waiting for Sentinel ssh health check...");
+        final InetSocketAddress karafSsh = stack.sentinel().getSshAddress();
+        awaitHealthCheckSucceeded(karafSsh, 3, "Sentinel");
+    }
+}


### PR DESCRIPTION
Updated ssh Health Check with Rest Health check for Minion and Sentinel.

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-13645

