### PR TITLE
NMS-13386 Add docs to Health-Check Rest API

### DIFF
--- a/docs/modules/development/nav.adoc
+++ b/docs/modules/development/nav.adoc
@@ -31,6 +31,7 @@
 *** xref:rest/graph.adoc[]
 *** xref:rest/groups.adoc[]
 *** xref:rest/heatmap.adoc[]
+*** xref:rest/health_rest.adoc[]
 *** xref:rest/ifservices.adoc[]
 *** xref:rest/ipinterfaces.adoc[]
 *** xref:rest/ksc_reports.adoc[]


### PR DESCRIPTION
Added missing new health_rest doc to navigation
* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13386 

