### PR TITLE
NMS-13927: fix org.opennms.netmgt.model.PrimaryTypeAdapter not found when marshalling

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -675,6 +675,7 @@
         <bundle>mvn:org.opennms/opennms-provision-persistence/${project.version}</bundle>
     </feature>
     <feature name="opennms-provisioning-api" version="${project.version}" description="OpenNMS :: Provisioning :: API">
+        <feature>opennms-model</feature>
         <bundle dependency="true">mvn:org.apache.mina/mina-core/${minaVersion}</bundle>
         <bundle dependency="true">mvn:io.netty/netty/3.9.4.Final</bundle>
         <bundle>mvn:org.opennms/opennms-provision-api/${project.version}</bundle>

--- a/opennms-provision/opennms-requisition-service/pom.xml
+++ b/opennms-provision/opennms-requisition-service/pom.xml
@@ -20,6 +20,10 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>
+              org.opennms.netmgt.model;resolution:=optional,
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
This PR fixes an issue with model objects being inaccessible on the Minion when provisioning.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13927
