### PR TITLE
NMS-13707: Added docs for Flow Thresholding

### DIFF
--- a/docs/modules/operation/nav.adoc
+++ b/docs/modules/operation/nav.adoc
@@ -132,6 +132,8 @@
 ** xref:flows/setup.adoc[]
 ** xref:flows/classification-engine.adoc[]
 ** xref:flows/aggregation.adoc[]
+** xref:flows/data-collection.adoc[]
+** xref:flows/thresholding.adoc[]
 
 * xref:kafka-producer/kafka-producer.adoc[]
 ** xref:kafka-producer/enable-kafka.adoc[]

--- a/docs/modules/operation/pages/flows/data-collection.adoc
+++ b/docs/modules/operation/pages/flows/data-collection.adoc
@@ -2,7 +2,7 @@
 = Data collection of flow applications
 
 Flows are categorized in applications using the <<flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
-OpenNMS supports summing up the bytesIn/bytesOut data of flow records based on these flow applications and the collection of this data.
+{page-component-title} allows you to collect the incoming and outgoing transferred bytes as timeseries from flow records based on an applications.
 This lets a user profile network traffic and also graph this data.
 
 == Configure data collection

--- a/docs/modules/operation/pages/flows/data-collection.adoc
+++ b/docs/modules/operation/pages/flows/data-collection.adoc
@@ -1,0 +1,34 @@
+[[ga-flow-support-data-collection]]
+= Data-collection of Flow applications
+
+Flows are categorized in applications using the <<flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
+OpenNMS supports to sum up bytesIn/bytesOut data of flow records based on these Flow applications.
+OpenNMS supports the data-collection of this data.
+This enables a user to profile traffic in a network and to also graph this data.
+
+== Configure data-collection
+
+In order to enable data-collection for Flows you need to enable the flag `applicationDataCollection` in the adapter's definition.
+Furthermore you have to assure that a valid package definition exists inside the adapter's definition.
+
+.Example of enabling data-collection for the NetFlow v9 adapter in telemetryd-configuration.xml
+[source, xml]
+----
+...
+    <queue name="Netflow-9">
+        <adapter name="Netflow-9-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter" enabled="true">
+            <parameter key="applicationDataCollection" value="true"/>
+            <parameter key="applicationThresholding" value="false"/>
+            <package name="Netflow-9-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+...
+----

--- a/docs/modules/operation/pages/flows/data-collection.adoc
+++ b/docs/modules/operation/pages/flows/data-collection.adoc
@@ -14,7 +14,7 @@ In the *Settings* tab, disable predefined rules.
 To enable data collection for flows you need to enable the `applicationDataCollection` flag in the adapter's definition.
 Furthermore, you have to ensure that a valid package definition exists inside the adapter's definition.
 This may not be necessary when using Newts- or Cortex-based storage.
-Please note, that data collection on flow applications also works without enabling thresholding on flow applications.
+Note that data collection on flow applications also works without enabling thresholding on flow applications.
 
 .Example of enabling data collection for the NetFlow v9 adapter in telemetryd-configuration.xml
 [source, xml]

--- a/docs/modules/operation/pages/flows/data-collection.adoc
+++ b/docs/modules/operation/pages/flows/data-collection.adoc
@@ -5,7 +5,9 @@ Flows are categorized in applications using the <<flows/classification-engine.ad
 OpenNMS supports summing up the bytesIn/bytesOut data of flow records based on these flow applications and the collection of this data.
 It gives you the possibility of profiling the network throughput by an application.
 
-NOTE: The flow classification engine include a so-called `pre-defined group`, which defines over 6200 applications for basic communication protocols. If you don't want to collect this kind of data you can disable this predefined set of rules in the `Settings` tab on the `Flow Classification` configuration page.
+NOTE: The flow classification engine includes a predefined set of rules, which defines over 6200 applications for basic communication protocols. 
+If you don't want to collect this kind of data, in the UI, click the gears icon in the top right and under *Flow Management* click *Manage Flow Classification*.
+In the *Settings* tab, disable predefined rules.
 
 == Configure data collection
 

--- a/docs/modules/operation/pages/flows/data-collection.adoc
+++ b/docs/modules/operation/pages/flows/data-collection.adoc
@@ -1,5 +1,5 @@
 [[ga-flow-support-data-collection]]
-= Data-collection of Flow applications
+= Data collection of flow applications
 
 Flows are categorized in applications using the <<flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
 OpenNMS supports to sum up bytesIn/bytesOut data of flow records based on these Flow applications.

--- a/docs/modules/operation/pages/flows/data-collection.adoc
+++ b/docs/modules/operation/pages/flows/data-collection.adoc
@@ -2,16 +2,15 @@
 = Data collection of flow applications
 
 Flows are categorized in applications using the <<flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
-OpenNMS supports to sum up bytesIn/bytesOut data of flow records based on these Flow applications.
-OpenNMS supports the data-collection of this data.
-This enables a user to profile traffic in a network and to also graph this data.
+OpenNMS supports summing up the bytesIn/bytesOut data of flow records based on these flow applications and the collection of this data.
+This lets a user profile network traffic and also graph this data.
 
-== Configure data-collection
+== Configure data collection
 
-In order to enable data-collection for Flows you need to enable the flag `applicationDataCollection` in the adapter's definition.
-Furthermore you have to assure that a valid package definition exists inside the adapter's definition.
+To enable data collection for flows you need to enable the `applicationDataCollection` flag in the adapter's definition.
+Furthermore, you have to ensure that a valid package definition exists inside the adapter's definition.
 
-.Example of enabling data-collection for the NetFlow v9 adapter in telemetryd-configuration.xml
+.Example of enabling data collection for the NetFlow v9 adapter in telemetryd-configuration.xml
 [source, xml]
 ----
 ...

--- a/docs/modules/operation/pages/flows/data-collection.adoc
+++ b/docs/modules/operation/pages/flows/data-collection.adoc
@@ -2,13 +2,17 @@
 = Data collection of flow applications
 
 Flows are categorized in applications using the <<flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
-{page-component-title} allows you to collect the incoming and outgoing transferred bytes as timeseries from flow records based on an applications.
-This lets a user profile network traffic and also graph this data.
+OpenNMS supports summing up the bytesIn/bytesOut data of flow records based on these flow applications and the collection of this data.
+It gives you the possibility of profiling the network throughput by an application.
+
+NOTE: The flow classification engine include a so-called `pre-defined group`, which defines over 6200 applications for basic communication protocols. If you don't want to collect this kind of data you can disable this predefined set of rules in the `Settings` tab on the `Flow Classification` configuration page.
 
 == Configure data collection
 
 To enable data collection for flows you need to enable the `applicationDataCollection` flag in the adapter's definition.
 Furthermore, you have to ensure that a valid package definition exists inside the adapter's definition.
+This may not be necessary when using Newts- or Cortex-based storage.
+Please note, that data collection on flow applications also works without enabling thresholding on flow applications.
 
 .Example of enabling data collection for the NetFlow v9 adapter in telemetryd-configuration.xml
 [source, xml]

--- a/docs/modules/operation/pages/flows/setup.adoc
+++ b/docs/modules/operation/pages/flows/setup.adoc
@@ -40,6 +40,17 @@ NOTE: In this example we enable the NetFlow v5 protocol, but you can repeat the 
 
 <queue name="Netflow-5">
     <adapter name="Netflow-5-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5Adapter" enabled="true">
+        <parameter key="applicationDataCollection" value="false"/>
+        <parameter key="applicationThresholding" value="false"/>
+        <package name="Netflow-5-Default">
+            <rrd step="300">
+                <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                <rra>RRA:AVERAGE:0.5:288:366</rra>
+                <rra>RRA:MAX:0.5:288:366</rra>
+                <rra>RRA:MIN:0.5:288:366</rra>
+            </rrd>
+        </package>
     </adapter>
 </queue>
 ----

--- a/docs/modules/operation/pages/flows/thresholding.adoc
+++ b/docs/modules/operation/pages/flows/thresholding.adoc
@@ -1,13 +1,13 @@
 [[ga-flow-support-data-collection]]
-= Thresholding Flow applications
+= Thresholding flow applications
 
 Flows are categorized in applications using the <<flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
 OpenNMS supports to sum up bytesIn/bytesOut data of flow records based on these Flow applications.
-Users can define thresholds on this data to generate alarms in the case the amount of traffic violates these thresholds.
+Users can define thresholds on this data to generate alarms when the amount of traffic violates these thresholds.
 
-== Configure thresholding for Flow applications
+== Configure thresholding for flow applications
 
-In order to enable thresholding for Flows you need to enable the flag `applicationThresholding` in the adapter's definition.
+To enable thresholding for flows you need to enable the `applicationThresholding` flag in the adapter's definition.
 
 .Example of enabling thresholding for the NetFlow v9 adapter in telemetryd-configuration.xml
 [source, xml]
@@ -51,8 +51,8 @@ Next, you need an additional package definition in your `threshd-configuration.x
 </threshd-configuration>
 ----
 
-Finally, you define the thresholds in the `thresholds.xml`.
-Use need to use `flowApp` for the `ds-type`.
+Finally, define the thresholds in the `thresholds.xml` file.
+Use `flowApp` for the `ds-type`.
 The following example defines thresholds for HTTPS traffic exceeding 4096000 bytes/second.
 
 .Example of thresholds for https traffic in thresholds.xml

--- a/docs/modules/operation/pages/flows/thresholding.adoc
+++ b/docs/modules/operation/pages/flows/thresholding.adoc
@@ -1,0 +1,74 @@
+[[ga-flow-support-data-collection]]
+= Thresholding Flow applications
+
+Flows are categorized in applications using the <<flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
+OpenNMS supports to sum up bytesIn/bytesOut data of flow records based on these Flow applications.
+Users can define thresholds on this data to generate alarms in the case the amount of traffic violates these thresholds.
+
+== Configure thresholding for Flow applications
+
+In order to enable thresholding for Flows you need to enable the flag `applicationThresholding` in the adapter's definition.
+
+.Example of enabling thresholding for the NetFlow v9 adapter in telemetryd-configuration.xml
+[source, xml]
+----
+...
+    <queue name="Netflow-9">
+        <adapter name="Netflow-9-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter" enabled="true">
+            <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="true"/>
+            <package name="Netflow-9-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+...
+----
+
+Next, you need an additional package definition in your `threshd-configuration.xml` file.
+
+.Example of a package definition in the threshd-configuration.xml
+[source, xml]
+----
+<?xml version="1.0"?>
+<threshd-configuration threads="5">
+...
+    <package name="flow-thresholding">
+        <filter>IPADDR != '0.0.0.0'</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="Flow-Threshold" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="flow-thresholding-group"/>
+        </service>
+    </package>
+...
+</threshd-configuration>
+----
+
+Finally, you define the thresholds in the `thresholds.xml`.
+Use need to use `flowApp` for the `ds-type`.
+The following example defines thresholds for HTTPS traffic exceeding 4096000 bytes/second.
+
+.Example of thresholds for https traffic in thresholds.xml
+[source, xml]
+----
+<?xml version="1.0"?>
+<thresholding-config>
+...
+    <group name="flow-thresholding-group" rrdRepository = "/opt/opennms/share/rrd/snmp/">
+        <threshold type="high" description="Flow-Threshold" ds-type="flowApp" ds-name="bytesIn" value="4096000" rearm="2048000" trigger="1" filterOperator="OR" ds-label="application">
+            <resource-filter field="application">https</resource-filter>
+        </threshold>
+        <threshold type="high" description="Flow-Threshold" ds-type="flowApp" ds-name="bytesOut" value="4096000" rearm="2048000" trigger="1" filterOperator="OR" ds-label="application">
+            <resource-filter field="application">https</resource-filter>
+        </threshold>
+    </group>
+...
+</thresholding-config>
+----

--- a/docs/modules/operation/pages/flows/thresholding.adoc
+++ b/docs/modules/operation/pages/flows/thresholding.adoc
@@ -8,6 +8,7 @@ Users can define thresholds on this data to generate alarms when the amount of t
 == Configure thresholding for flow applications
 
 To enable thresholding for flows you need to enable the `applicationThresholding` flag in the adapter's definition.
+Please note, that thresholding on flow applications also works without enabling data collection on flow applications.
 
 .Example of enabling thresholding for the NetFlow v9 adapter in telemetryd-configuration.xml
 [source, xml]

--- a/docs/modules/operation/pages/flows/thresholding.adoc
+++ b/docs/modules/operation/pages/flows/thresholding.adoc
@@ -2,7 +2,7 @@
 = Thresholding flow applications
 
 Flows are categorized in applications using the <<flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
-OpenNMS supports to sum up bytesIn/bytesOut data of flow records based on these Flow applications.
+OpenNMS supports summing up the bytesIn/bytesOut data of flow records based on these flow applications.
 Users can define thresholds on this data to generate alarms when the amount of traffic violates these thresholds.
 
 == Configure thresholding for flow applications

--- a/docs/modules/operation/pages/flows/thresholding.adoc
+++ b/docs/modules/operation/pages/flows/thresholding.adoc
@@ -8,7 +8,7 @@ Users can define thresholds on this data to generate alarms when the amount of t
 == Configure thresholding for flow applications
 
 To enable thresholding for flows you need to enable the `applicationThresholding` flag in the adapter's definition.
-Please note, that thresholding on flow applications also works without enabling data collection on flow applications.
+Note that thresholding on flow applications also works without enabling data collection on flow applications.
 
 .Example of enabling thresholding for the NetFlow v9 adapter in telemetryd-configuration.xml
 [source, xml]

--- a/docs/modules/reference/pages/telemetryd/protocols/ipfix.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/ipfix.adoc
@@ -64,7 +64,7 @@ NOTE: The parameter `maxClockSkew` in your parser definition enables clock skew 
 It specifies the maximum delta in seconds between exporter and Minion timestamps.
 If exceeded, an alarm will be generated for the exporting device.
 The default value is 0, so clock skew detection is disabled.
-Furthermore, you can use a parameter `clockSkewEventRate` to rate limit clock skew events.
+Furthermore, you can use the `clockSkewEventRate` parameter to rate limit clock skew events.
 The default is `3600` seconds, so every hour an event will be sent.
 
 [[telemetryd-ipfix-parser-tcp]]
@@ -93,11 +93,11 @@ The IPFIX TCP parser accepts packets received by a <<telemetryd/listeners/tcp.ad
 | 0
 
 | clockSkewEventRate
-| Used to rate-limit clock skew events in seconds.
+| Rate limits clock skew events, in seconds.
 | 3600
 
 | dnsLookupsEnabled
-| Used to enable or disable DNS resolution for flows.
+| Enables or disables DNS resolution for flows.
 | true
 
 | sequenceNumberPatience
@@ -121,7 +121,7 @@ NOTE: The parameter `maxClockSkew` in your parser definition enables clock skew 
 It specifies the maximum delta in seconds between exporter and Minion timestamps.
 If exceeded, an alarm will be generated for the exporting device.
 The default value is 0, so clock skew detection is disabled.
-Furthermore, you can use a parameter `clockSkewEventRate` to rate limit clock skew events.
+Furthermore, you can use the `clockSkewEventRate`  parameter to rate limit clock skew events.
 The default is `3600` seconds, so every hour an event will be sent.
 
 == Configure IPFIX listener on a Minion
@@ -167,11 +167,11 @@ Received flows are decoded from the messages into the canonical flow format and 
 | Default
 
 | applicationDataCollection
-| Used to enable data-collection of bytesIn/bytesOut based on flow applications.
+| Enables data-collection of bytesIn/bytesOut based on flow applications.
 | false
 
 | applicationThresholding
-| Used to enable thresholding based on flow applications.
+| Enables thresholding based on flow applications.
 | false
 |===
-NOTE: In order the data-collection to work properly you must also define a valid package definition inside your adapter configuration.
+NOTE: For data collection to work properly you must also define a valid package definition inside your adapter configuration.

--- a/docs/modules/reference/pages/telemetryd/protocols/ipfix.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/ipfix.adoc
@@ -167,7 +167,7 @@ Received flows are decoded from the messages into the canonical flow format and 
 | Default
 
 | applicationDataCollection
-| Enables data-collection of bytesIn/bytesOut based on flow applications.
+| Enables data collection of bytesIn/bytesOut based on flow applications.
 | false
 
 | applicationThresholding

--- a/docs/modules/reference/pages/telemetryd/protocols/ipfix.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/ipfix.adoc
@@ -60,6 +60,12 @@ The value gives the size of the history buffer allowing flows to be processed ou
 | Fallback value for sampling interval, if value is not included in exported flows.
 | none
 |===
+NOTE: The parameter `maxClockSkew` in your parser definition enables clock skew detection for exporters.
+It specifies the maximum delta in seconds between exporter and Minion timestamps.
+If exceeded, an alarm will be generated for the exporting device.
+The default value is 0, so clock skew detection is disabled.
+Furthermore, you can use a parameter `clockSkewEventRate` to rate limit clock skew events.
+The default is `3600` seconds, so every hour an event will be sent.
 
 [[telemetryd-ipfix-parser-tcp]]
 == IPFIX TCP Parser
@@ -75,7 +81,48 @@ The IPFIX TCP parser accepts packets received by a <<telemetryd/listeners/tcp.ad
 
 === Configuration and use
 
-This parser does not currently have any configurable parameters.
+.Optional parameters for the IPFIX TCP Parser
+[options="header" cols="1,3,1"]
+|===
+| Parameter
+| Description
+| Default
+
+| maxClockSkew
+| The maximum delta in seconds between exporter and Minion timestamps.
+| 0
+
+| clockSkewEventRate
+| Used to rate-limit clock skew events in seconds.
+| 3600
+
+| dnsLookupsEnabled
+| Used to enable or disable DNS resolution for flows.
+| true
+
+| sequenceNumberPatience
+| A value > 1 enables checking for sequence number completeness.
+The value gives the size of the history buffer allowing flows to be processed out of order.
+| 32
+
+| flowActiveTimeoutFallback
+| Fallback value for active flow timeout, if value is not included in exported flows.
+| none
+
+| flowInactiveTimeoutFallback
+| Fallback value for inactive flow timeout, if value is not included in exported flows.
+| none
+
+| flowSamplingIntervalFallback
+| Fallback value for sampling interval, if value is not included in exported flows.
+| none
+|===
+NOTE: The parameter `maxClockSkew` in your parser definition enables clock skew detection for exporters.
+It specifies the maximum delta in seconds between exporter and Minion timestamps.
+If exceeded, an alarm will be generated for the exporting device.
+The default value is 0, so clock skew detection is disabled.
+Furthermore, you can use a parameter `clockSkewEventRate` to rate limit clock skew events.
+The default is `3600` seconds, so every hour an event will be sent.
 
 == Configure IPFIX listener on a Minion
 
@@ -112,33 +159,19 @@ Received flows are decoded from the messages into the canonical flow format and 
 
 === Configuration and use
 
-.Optional parameters for the IPFIX TCP parser
-[options="header" cols="1,3,1"]
+.Required adapter-specific parameters
+[options="header", cols="1,3,1"]
 |===
 | Parameter
 | Description
 | Default
 
-| templateTimeout
-| Templates must be redeclared in the given duration or they will be dropped.
-| 30 minutes
+| applicationDataCollection
+| Used to enable data-collection of bytesIn/bytesOut based on flow applications.
+| false
 
-| maxClockSkew
-| The maximum delta in seconds between exporter and Minion timestamps.
-| 0
-
-| clockSkewEventRate
-| Rate-limit clock skew events in seconds.
-| 3600
-
-| dnsLookupsEnabled
-| Enable or disable DNS resolution for flows.
-| true
+| applicationThresholding
+| Used to enable thresholding based on flow applications.
+| false
 |===
-
-NOTE: The parameter `maxClockSkew` in your parser definition enables clock skew detection for exporters.
-It specifies the maximum delta in seconds between exporter and Minion timestamps.
-If exceeded, an alarm will be generated for the exporting device.
-The default value is 0, so clock skew detection is disabled.
-Furthermore, you can use a parameter `clockSkewEventRate` to rate limit clock skew events.
-The default is `3600` seconds, so every hour an event will be sent.
+NOTE: In order the data-collection to work properly you must also define a valid package definition inside your adapter configuration.

--- a/docs/modules/reference/pages/telemetryd/protocols/netflow5.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/netflow5.adoc
@@ -70,11 +70,11 @@ Flows are decoded from the messages into the canonical flow format and published
 | Default
 
 | applicationDataCollection
-| Used to enable data-collection of bytesIn/bytesOut based on flow applications.
+| Enables data collection of bytesIn/bytesOut based on flow applications.
 | false
 
 | applicationThresholding
-| Used to enable thresholding based on flow applications.
+| Enables thresholding based on flow applications.
 | false
 |===
-NOTE: In order the data-collection to work properly you must also define a valid package definition inside your adapter configuration.
+NOTE: For data collection to work properly you must also define a valid package definition inside your adapter configuration.

--- a/docs/modules/reference/pages/telemetryd/protocols/netflow5.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/netflow5.adoc
@@ -62,4 +62,19 @@ Flows are decoded from the messages into the canonical flow format and published
 
 === Configuration and use
 
-This adapter does not currently have any configurable parameters.
+.Required adapter-specific parameters
+[options="header", cols="1,3,1"]
+|===
+| Parameter
+| Description
+| Default
+
+| applicationDataCollection
+| Used to enable data-collection of bytesIn/bytesOut based on flow applications.
+| false
+
+| applicationThresholding
+| Used to enable thresholding based on flow applications.
+| false
+|===
+NOTE: In order the data-collection to work properly you must also define a valid package definition inside your adapter configuration.

--- a/docs/modules/reference/pages/telemetryd/protocols/netflow9.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/netflow9.adoc
@@ -92,11 +92,11 @@ Flows are decoded from the messages into the canonical flow format and are publi
 | Default
 
 | applicationDataCollection
-| Used to enable data-collection of bytesIn/bytesOut based on flow applications.
+| Enables data collection of bytesIn/bytesOut based on flow applications.
 | false
 
 | applicationThresholding
-| Used to enable thresholding based on flow applications.
+| Enables thresholding based on flow applications.
 | false
 |===
-NOTE: In order the data-collection to work properly you must also define a valid package definition inside your adapter configuration.
+NOTE: For data collection to work properly you must also define a valid package definition inside your adapter configuration.

--- a/docs/modules/reference/pages/telemetryd/protocols/netflow9.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/netflow9.adoc
@@ -84,4 +84,19 @@ Flows are decoded from the messages into the canonical flow format and are publi
 
 === Configuration and use
 
-This adapter does not currently have any configurable parameters.
+.Required adapter-specific parameters
+[options="header", cols="1,3,1"]
+|===
+| Parameter
+| Description
+| Default
+
+| applicationDataCollection
+| Used to enable data-collection of bytesIn/bytesOut based on flow applications.
+| false
+
+| applicationThresholding
+| Used to enable thresholding based on flow applications.
+| false
+|===
+NOTE: In order the data-collection to work properly you must also define a valid package definition inside your adapter configuration.

--- a/docs/modules/reference/pages/telemetryd/protocols/sflow.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/sflow.adoc
@@ -79,7 +79,16 @@ Using the script extension, you can extract the desired metrics from the sFlow m
 | script
 | Full path to the script used to handle the sFlow messages.
 | none
+
+| applicationDataCollection
+| Used to enable data-collection of bytesIn/bytesOut based on flow applications.
+| false
+
+| applicationThresholding
+| Used to enable thresholding based on flow applications.
+| false
 |===
+NOTE: In order the data-collection to work properly you must also define a valid package definition inside your adapter configuration.
 
 === Scripting
 

--- a/docs/modules/reference/pages/telemetryd/protocols/sflow.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/sflow.adoc
@@ -81,14 +81,14 @@ Using the script extension, you can extract the desired metrics from the sFlow m
 | none
 
 | applicationDataCollection
-| Used to enable data-collection of bytesIn/bytesOut based on flow applications.
+| Enables data collection of bytesIn/bytesOut based on flow applications.
 | false
 
 | applicationThresholding
-| Used to enable thresholding based on flow applications.
+| Enables thresholding based on flow applications.
 | false
 |===
-NOTE: In order the data-collection to work properly you must also define a valid package definition inside your adapter configuration.
+NOTE: For data collection to work properly you must also define a valid package definition inside your adapter configuration.
 
 === Scripting
 

--- a/opennms-base-assembly/src/main/filtered/etc/telemetryd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/telemetryd-configuration.xml
@@ -64,6 +64,7 @@
     <queue name="Netflow-5">
         <adapter name="Netflow-5-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5Adapter" enabled="true">
             <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="false"/>
             <package name="Netflow-5-Default">
                 <rrd step="300">
                     <rra>RRA:AVERAGE:0.5:1:2016</rra>
@@ -86,6 +87,7 @@
     <queue name="Netflow-9">
         <adapter name="Netflow-9-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter" enabled="true">
             <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="false"/>
             <package name="Netflow-9-Default">
                 <rrd step="300">
                     <rra>RRA:AVERAGE:0.5:1:2016</rra>
@@ -114,6 +116,7 @@
     <queue name="IPFIX">
         <adapter name="IPFIX-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapter" enabled="true">
             <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="false"/>
             <package name="IPFIX-Default">
                 <rrd step="300">
                     <rra>RRA:AVERAGE:0.5:1:2016</rra>
@@ -135,6 +138,17 @@
 
     <queue name="SFlow">
         <adapter name="SFlow-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapter" enabled="true">
+            <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="false"/>
+            <package name="SFlow-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
         </adapter>
 
         <adapter name="SFlow-Telemetry" class-name="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowTelemetryAdapter" enabled="true">


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13707

Please note: using a resource-filter in a flowApp threshold definition is currently broken (see NMS-13945). So the example configs won't work but will work when NMS-13945 is fixed.