### PR TITLE
NMS-13945: Use current string attrs for threshold filters

### DIFF
--- a/features/collection/thresholding/api/src/main/java/org/opennms/netmgt/threshd/api/ThresholdingService.java
+++ b/features/collection/thresholding/api/src/main/java/org/opennms/netmgt/threshd/api/ThresholdingService.java
@@ -31,7 +31,6 @@ package org.opennms.netmgt.threshd.api;
 import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.ServiceParameters;
-import org.opennms.netmgt.rrd.RrdRepository;
 
 /**
  * Thresholding API Service.
@@ -49,16 +48,14 @@ public interface ThresholdingService {
      *            The Host IP Address.
      * @param serviceName
      *            The Service name.
-     * @param rrdRepository
-     *            Must not be null. Will be used to resolve Resource Filters and for genertaing Event labels.
      * @param serviceParameters
-     *            Must not be null. Required by some existing {@link CollectionResource} objects to evaluate whether to apply thresholds when accepting a {@link CollectionSet}. 
+     *            Must not be null. Required by some existing {@link CollectionResource} objects to evaluate whether to apply thresholds when accepting a {@link CollectionSet}.
      *            If your {@link CollectionResource} does not require this, pass an empty {@link ServiceParameters} object.
      * @return A {@link ThresholdingSession}
      * @throws ThresholdInitializationException
      *             if there is an error creating the {@link ThresholdingSession} because of invalid Thresholding Configuration.
      */
-    ThresholdingSession createSession(int nodeId, String hostAddress, String serviceName, RrdRepository rrdRepository, ServiceParameters serviceParameters)
+    ThresholdingSession createSession(int nodeId, String hostAddress, String serviceName, ServiceParameters serviceParameters)
             throws ThresholdInitializationException;
 
     ThresholdingSetPersister getThresholdingSetPersister();

--- a/features/collection/thresholding/api/src/main/java/org/opennms/netmgt/threshd/api/ThresholdingSessionKey.java
+++ b/features/collection/thresholding/api/src/main/java/org/opennms/netmgt/threshd/api/ThresholdingSessionKey.java
@@ -34,6 +34,4 @@ public interface ThresholdingSessionKey {
     int getNodeId();
 
     String getServiceName();
-
-    String getResource();
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
@@ -113,7 +113,7 @@ public abstract class AbstractThresholdEvaluatorState<T extends AbstractThreshol
     private String instance;
 
 
-    private static final Map<Class<? extends AbstractThresholdEvaluatorState.AbstractState>,
+    static final Map<Class<? extends AbstractThresholdEvaluatorState.AbstractState>,
             SerializingBlobStore<? extends AbstractThresholdEvaluatorState.AbstractState>> serdesMap
             = new ConcurrentHashMap<>();
 
@@ -176,9 +176,9 @@ public abstract class AbstractThresholdEvaluatorState<T extends AbstractThreshol
 
         this.thresholdingSession = thresholdingSession;
         kvStore = getKvStoreForType(stateType, thresholdingSession.getBlobStore());
-        key = String.format("%d-%s-%s-%s-%s-%s-%s", thresholdingSession.getKey().getNodeId(),
+        key = String.format("%d-%s-%s-%s-%s-%s", thresholdingSession.getKey().getNodeId(),
                 thresholdingSession.getKey().getLocation(), threshold.getDsType(),
-                threshold.getDatasourceExpression(), thresholdingSession.getKey().getResource(), threshold.getType(),
+                threshold.getDatasourceExpression(), threshold.getType(),
                 generateHashForThresholdValues(threshold));
 
         initializeState();
@@ -396,7 +396,7 @@ public abstract class AbstractThresholdEvaluatorState<T extends AbstractThreshol
      */
     protected Event createBasicEvent(String uei, Date date, double dsValue, CollectionResourceWrapper resource, Map<String,String> additionalParams) {
         if (resource == null) { // Still works, mimic old code when instance value is null.
-            resource = new CollectionResourceWrapper(date, 0, null, null, null, null, null, null, null, null);
+            resource = new CollectionResourceWrapper(date, 0, null, null, null, null, null, null);
         }
         String dsLabelValue = resource.getFieldValue(resource.getDsLabel());
         if (dsLabelValue == null) dsLabelValue = UNKNOWN;

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/CollectionResourceWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/CollectionResourceWrapper.java
@@ -505,10 +505,9 @@ public class CollectionResourceWrapper {
             }
 
             // Find values saved in string attributes
-            ResourcePath path = ResourceTypeUtils.getResourcePathWithRepository(m_repository, m_resource.getPath());
-            retval = m_resourceStorageDao.getStringAttribute(path, ds);
-            if (retval != null) {
-                return retval;
+            final var attr = m_attributes.get(ds);
+            if (attr != null && attr.getType() == AttributeType.STRING) {
+                return attr.getStringValue();
             }
         } catch (Throwable e) {
             LOG.info("getFieldValue: Can't get value for attribute {} for resource {}.", ds, m_resource, e);

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/CollectionResourceWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/CollectionResourceWrapper.java
@@ -43,11 +43,8 @@ import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.LatencyCollectionResource;
 import org.opennms.netmgt.dao.api.IfLabel;
-import org.opennms.netmgt.dao.api.ResourceStorageDao;
 import org.opennms.netmgt.model.ResourceId;
-import org.opennms.netmgt.model.ResourcePath;
 import org.opennms.netmgt.model.ResourceTypeUtils;
-import org.opennms.netmgt.rrd.RrdRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,10 +69,8 @@ public class CollectionResourceWrapper {
     private String m_dsLabel;
     private final String m_iflabel;
     private final String m_ifindex;
-    private final RrdRepository m_repository;
     private final CollectionResource m_resource;
     private final Map<String, CollectionAttribute> m_attributes;
-    private final ResourceStorageDao m_resourceStorageDao;
     private final Long m_sequenceNumber;
 
     /**
@@ -134,20 +129,9 @@ public class CollectionResourceWrapper {
      */
     private boolean m_counterReset = false;
 
-    /**
-     * <p>Constructor for CollectionResourceWrapper.</p>
-     *
-     * @param interval a long.
-     * @param nodeId a int.
-     * @param hostAddress a {@link java.lang.String} object.
-     * @param serviceName a {@link java.lang.String} object.
-     * @param repository a {@link org.opennms.netmgt.rrd.RrdRepository} object.
-     * @param resource a {@link org.opennms.netmgt.collection.api.CollectionResource} object.
-     * @param attributes a {@link java.util.Map} object.
-     */
     public CollectionResourceWrapper(Date collectionTimestamp, int nodeId, String hostAddress, String serviceName,
-            RrdRepository repository, CollectionResource resource, Map<String, CollectionAttribute> attributes,
-            ResourceStorageDao resourceStorageDao, IfLabel ifLabelDao, Long sequenceNumber) {
+            CollectionResource resource, Map<String, CollectionAttribute> attributes,
+            IfLabel ifLabelDao, Long sequenceNumber) {
 
         if (collectionTimestamp == null) {
             throw new IllegalArgumentException(String.format("%s: Null collection timestamp when thresholding service %s on node %d (%s)", this.getClass().getSimpleName(), serviceName, nodeId, hostAddress));
@@ -157,10 +141,8 @@ public class CollectionResourceWrapper {
         m_nodeId = nodeId;
         m_hostAddress = hostAddress;
         m_serviceName = serviceName;
-        m_repository = repository;
         m_resource = resource;
         m_attributes = attributes;
-        m_resourceStorageDao = resourceStorageDao;
         m_sequenceNumber = sequenceNumber;
 
         if (isAnInterfaceResource()) {

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/DefaultThresholdingSetPersister.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/DefaultThresholdingSetPersister.java
@@ -79,10 +79,9 @@ public class DefaultThresholdingSetPersister implements ThresholdingSetPersister
         ThresholdingSet tSet = thresholdingSets.get(key);
         if (tSet == null) {
             tSet = new ThresholdingSetImpl(key.getNodeId(), key.getLocation(), key.getServiceName(),
-                    ((ThresholdingSessionImpl) session).getRrdRepository(),
-                    ((ThresholdingSessionImpl) session).getServiceParameters(),
-                    ((ThresholdingSessionImpl) session).getResourceDao(), eventProxy, session, threshdDao,
-                    thresholdingDao, pollOutagesDao, ifLabelDao, entityScopeProvider);
+                                           ((ThresholdingSessionImpl) session).getServiceParameters(),
+                                           eventProxy, session, threshdDao,
+                                           thresholdingDao, pollOutagesDao, ifLabelDao, entityScopeProvider);
             thresholdingSets.put(key, tSet);
         }
         return tSet;

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSessionImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSessionImpl.java
@@ -31,8 +31,6 @@ package org.opennms.netmgt.threshd;
 import org.opennms.features.distributed.kvstore.api.BlobStore;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.ServiceParameters;
-import org.opennms.netmgt.dao.api.ResourceStorageDao;
-import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.threshd.api.ThresholdInitializationException;
 import org.opennms.netmgt.threshd.api.ThresholdStateMonitor;
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
@@ -48,10 +46,6 @@ public class ThresholdingSessionImpl implements ThresholdingSession {
 
     protected final ThresholdingSessionKey sessionKey;
 
-    protected final ResourceStorageDao resourceStorageDao;
-
-    protected final RrdRepository rrdRepository;
-
     private ServiceParameters serviceParameters;
     
     private final BlobStore blobStore;
@@ -60,13 +54,11 @@ public class ThresholdingSessionImpl implements ThresholdingSession {
     
     private final ThresholdStateMonitor thresholdStateMonitor;
 
-    public ThresholdingSessionImpl(ThresholdingServiceImpl service, ThresholdingSessionKey sessionKey, ResourceStorageDao resourceStorageDao, RrdRepository rrdRepository,
+    public ThresholdingSessionImpl(ThresholdingServiceImpl service, ThresholdingSessionKey sessionKey,
                                    ServiceParameters serviceParams, BlobStore blobStore, boolean isDistributed,
                                    ThresholdStateMonitor thresholdStateMonitor) {
         this.service = service;
         this.sessionKey = sessionKey;
-        this.resourceStorageDao = resourceStorageDao;
-        this.rrdRepository = rrdRepository;
         this.serviceParameters = serviceParams;
         this.blobStore = blobStore;
         this.isDistributed = isDistributed;
@@ -91,14 +83,6 @@ public class ThresholdingSessionImpl implements ThresholdingSession {
     @Override
     public BlobStore getBlobStore() {
         return blobStore;
-    }
-
-    public ResourceStorageDao getResourceDao() {
-        return resourceStorageDao;
-    }
-
-    public RrdRepository getRrdRepository() {
-        return rrdRepository;
     }
 
     public ServiceParameters getServiceParameters() {

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSessionKeyImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSessionKeyImpl.java
@@ -38,13 +38,10 @@ public class ThresholdingSessionKeyImpl implements ThresholdingSessionKey {
 
     private final String serviceName;
 
-    private final String resource;
-
-    public ThresholdingSessionKeyImpl(int nodeId, String ipAddress, String serviceName, String resource) {
+    public ThresholdingSessionKeyImpl(int nodeId, String ipAddress, String serviceName) {
         this.nodeId = nodeId;
         this.ipAddress = ipAddress;
         this.serviceName = serviceName;
-        this.resource = resource;
     }
 
     public String getLocation() {
@@ -59,10 +56,6 @@ public class ThresholdingSessionKeyImpl implements ThresholdingSessionKey {
         return serviceName;
     }
 
-    public String getResource() {
-        return resource;
-    }
-
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -70,7 +63,6 @@ public class ThresholdingSessionKeyImpl implements ThresholdingSessionKey {
         result = prime * result + nodeId;
         result = prime * result + ((ipAddress == null) ? 0 : ipAddress.hashCode());
         result = prime * result + ((serviceName == null) ? 0 : serviceName.hashCode());
-        result = prime * result + ((resource == null) ? 0 : resource.hashCode());
         return result;
     }
 
@@ -94,11 +86,6 @@ public class ThresholdingSessionKeyImpl implements ThresholdingSessionKey {
             if (other.serviceName != null)
                 return false;
         } else if (!serviceName.equals(other.serviceName))
-            return false;
-        if (resource == null) {
-            if (other.resource != null)
-                return false;
-        } else if (!resource.equals(other.resource))
             return false;
         return true;
     }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSetImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSetImpl.java
@@ -58,8 +58,6 @@ import org.opennms.netmgt.config.poller.outages.Outage;
 import org.opennms.netmgt.config.threshd.FilterOperator;
 import org.opennms.netmgt.config.threshd.ResourceFilter;
 import org.opennms.netmgt.dao.api.IfLabel;
-import org.opennms.netmgt.dao.api.ResourceStorageDao;
-import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.threshd.api.ThresholdInitializationException;
 import org.opennms.netmgt.threshd.api.ThresholdingEventProxy;
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
@@ -80,13 +78,10 @@ public class ThresholdingSetImpl implements ThresholdingSet {
     protected final int m_nodeId;
     protected final String m_hostAddress;
     protected final String m_serviceName;
-    protected final RrdRepository m_repository;
 
     protected ThresholdsDao m_thresholdsDao;
 
     protected ThresholdingEventProxy m_eventProxy;
-
-    protected ResourceStorageDao m_resourceStorageDao;
 
     private boolean m_initialized = false;
     private boolean m_hasThresholds = false;
@@ -103,7 +98,7 @@ public class ThresholdingSetImpl implements ThresholdingSet {
     private final IfLabel m_ifLabelDao;
     private final EntityScopeProvider m_entityScopeProvider;
 
-    public ThresholdingSetImpl(int nodeId, String hostAddress, String serviceName, RrdRepository repository, ServiceParameters svcParams, ResourceStorageDao resourceStorageDao,
+    public ThresholdingSetImpl(int nodeId, String hostAddress, String serviceName, ServiceParameters svcParams,
                                ThresholdingEventProxy eventProxy, ThresholdingSession thresholdingSession, ReadableThreshdDao threshdDao,
                                ReadableThresholdingDao thresholdingDao, ReadablePollOutagesDao pollOutagesDao,
                                IfLabel ifLabelDao, EntityScopeProvider entityScopeProvider)
@@ -111,9 +106,7 @@ public class ThresholdingSetImpl implements ThresholdingSet {
         m_nodeId = nodeId;
         m_hostAddress = (hostAddress == null ? null : hostAddress.intern());
         m_serviceName = (serviceName == null ? null : serviceName.intern());
-        m_repository = repository;
         m_svcParams = svcParams;
-        m_resourceStorageDao = resourceStorageDao;
         m_eventProxy = eventProxy;
         m_thresholdingSession = Objects.requireNonNull(thresholdingSession);
         m_threshdDao = Objects.requireNonNull(threshdDao);
@@ -540,8 +533,7 @@ public class ThresholdingSetImpl implements ThresholdingSet {
             return new LinkedList<>();
         }
         CollectionResourceWrapper resourceWrapper = new CollectionResourceWrapper(collectionTimestamp, m_nodeId,
-                m_hostAddress, m_serviceName, m_repository, resource, attributesMap, m_resourceStorageDao,
-                m_ifLabelDao, sequenceNumber);
+                m_hostAddress, m_serviceName, resource, attributesMap, m_ifLabelDao, sequenceNumber);
         resourceWrapper.setCounterReset(m_counterReset);
         return Collections.unmodifiableList(applyThresholds(resourceWrapper, attributesMap));
     }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitorImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitorImpl.java
@@ -143,14 +143,12 @@ public class ThresholdingVisitorImpl extends AbstractCollectionSetVisitor implem
      * (The way to get attribute is against {@link AttributeGroup} object contained on {@link CollectionResource}
      * implementations).
      */
-    @Override    
+    @Override
     public void visitAttribute(CollectionAttribute attribute) {
-        if (m_thresholdingSet.hasThresholds(attribute)) {
-            String name = attribute.getName();
-            m_attributesMap.put(name, attribute);
-            LOG.debug("visitAttribute: storing value {} for attribute named {}",
-                    attribute.getNumericValue() != null ? attribute.getNumericValue() : attribute.getStringValue(), name);
-        }
+        final String name = attribute.getName();
+        m_attributesMap.put(name, attribute);
+        LOG.debug("visitAttribute: storing value {} for attribute named {}",
+                attribute.getNumericValue() != null ? attribute.getNumericValue() : attribute.getStringValue(), name);
     }
 
     /**

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitorImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitorImpl.java
@@ -39,7 +39,6 @@ import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.support.AbstractCollectionSetVisitor;
-import org.opennms.netmgt.dao.api.ResourceStorageDao;
 import org.opennms.netmgt.threshd.api.ThresholdInitializationException;
 import org.opennms.netmgt.threshd.api.ThresholdingEventProxy;
 import org.opennms.netmgt.threshd.api.ThresholdingVisitor;
@@ -86,7 +85,7 @@ public class ThresholdingVisitorImpl extends AbstractCollectionSetVisitor implem
     
     private final Long m_sequenceNumber;
 
-    protected ThresholdingVisitorImpl(ThresholdingSetImpl thresholdingSet, ResourceStorageDao resourceStorageDao,
+    protected ThresholdingVisitorImpl(ThresholdingSetImpl thresholdingSet,
                                       ThresholdingEventProxy eventProxy, Long sequenceNumber) {
         m_thresholdingSet = thresholdingSet;
         m_thresholdingEventProxy = eventProxy;

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/CollectionResourceWrapperIT.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/CollectionResourceWrapperIT.java
@@ -80,7 +80,6 @@ import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.ResourcePath;
 import org.opennms.netmgt.model.ResourceTypeUtils;
-import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.snmp.SnmpInstId;
 import org.opennms.netmgt.snmp.SnmpUtils;
 import org.opennms.netmgt.snmp.SnmpValue;
@@ -149,7 +148,7 @@ public class CollectionResourceWrapperIT {
     @Test(expected=IllegalArgumentException.class)
     public void testBadConstructorCall() throws Throwable {
         try {
-            new CollectionResourceWrapper(null, 1, "127.0.0.1", "HTTP", null, null, null, null, null, null);
+            new CollectionResourceWrapper(null, 1, "127.0.0.1", "HTTP", null, null, null, null);
         } catch (Throwable e) {
             //e.printStackTrace();
             throw e;
@@ -159,7 +158,7 @@ public class CollectionResourceWrapperIT {
     @Test(expected=IllegalArgumentException.class)
     public void testBadderConstructorCall() throws Throwable {
         try {
-            new CollectionResourceWrapper(null, -1, null, null, null, null, null, null, null, null);
+            new CollectionResourceWrapper(null, -1, null, null, null, null, null, null);
         } catch (Throwable e) {
             e.printStackTrace();
             throw e;
@@ -571,7 +570,7 @@ public class CollectionResourceWrapperIT {
     // Wrapper interval value for counter rates calculation should be expressed in seconds.
     private CollectionResourceWrapper createWrapper(SnmpCollectionResource resource, Map<String, CollectionAttribute> attributes, Date timestamp) {
         CollectionResourceWrapper wrapper = new CollectionResourceWrapper(timestamp, 1, "127.0.0.1", "SNMP",
-                getRepository(), resource, attributes, getResourceStorageDao(), m_ifLabelDao, null);
+                                                                          resource, attributes, m_ifLabelDao, null);
         return wrapper;
     }
     
@@ -635,12 +634,6 @@ public class CollectionResourceWrapperIT {
         mibObject.setMaxval(null);
         mibObject.setMinval(null);
         return mibObject;
-    }
-
-    private RrdRepository getRepository() {
-        RrdRepository repo = new RrdRepository();
-        repo.setRrdBaseDir(tempFolder.getRoot());
-        return repo;
     }
 
     private ResourceStorageDao getResourceStorageDao() {

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/MockCollectionResourceWrapper.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/MockCollectionResourceWrapper.java
@@ -39,7 +39,7 @@ import org.opennms.netmgt.model.ResourcePath;
 public class MockCollectionResourceWrapper extends CollectionResourceWrapper {
 
     public MockCollectionResourceWrapper(final String instance) {
-        super(new Date(), 0, null, null, null, new CollectionResource() {
+        super(new Date(), 0, null, null, new CollectionResource() {
             @Override
             public String getInstance() {
                 return instance;
@@ -83,7 +83,7 @@ public class MockCollectionResourceWrapper extends CollectionResourceWrapper {
             public ResourcePath getPath() {
                 return null;
             }
-        }, null, null, null, null);
+        }, null, null, null);
     }
 
 }

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/MockSession.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/MockSession.java
@@ -46,7 +46,6 @@ public class MockSession {
             ThresholdingSessionKey mockKey = mock(ThresholdingSessionKey.class);
             when(mockKey.getNodeId()).thenReturn(1);
             when(mockKey.getLocation()).thenReturn("1.1.1.1");
-            when(mockKey.getResource()).thenReturn("resource");
             when(mockKey.getServiceName()).thenReturn("service");
 
             when(mockSession.getKey()).thenReturn(mockKey);

--- a/features/collection/thresholding/impl/src/test/resources/test-thresholds-bug3554.xml
+++ b/features/collection/thresholding/impl/src/test/resources/test-thresholds-bug3554.xml
@@ -9,11 +9,11 @@
             trigger="2" ds-label="ifName" expression="ifInDiscards + ifOutDiscards"/>
         <expression type="high" ds-type="if" value="90.0" rearm="75.0"
             trigger="3" ds-label="ifName" expression="ifHCInOctets * 8 / 1000000 / ifHighSpeed * 100">
-            <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
+            <resource-filter field="snmpifspeed">^[1-9]+[0-9]*$</resource-filter>
         </expression>
         <expression type="high" ds-type="if" value="90.0" rearm="75.0"
             trigger="3" ds-label="ifName" expression="ifHCOutOctets * 8 / 1000000 / ifHighSpeed * 100">
-            <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
+            <resource-filter field="snmpifspeed">^[1-9]+[0-9]*$</resource-filter>
         </expression>
     </group>
     <group name="hrstorage" rrdRepository="/opt/opennms/share/rrd/snmp/">
@@ -37,11 +37,11 @@
     <group name="extreme" rrdRepository="/opt/opennms/share/rrd/snmp/">
         <expression type="absoluteChange" ds-type="if" value="5.0"
             rearm="0.0" trigger="1" ds-label="ifName" expression="math.abs(ifHCOutOctets * 8 / ifHighSpeed /1000000 * 100)">
-            <resource-filter field="ifHighSpeed">^[1-9][0-9]+$</resource-filter>
+            <resource-filter field="snmpifspeed">^[1-9][0-9]+$</resource-filter>
         </expression>
         <expression type="absoluteChange" ds-type="if" value="5.0"
             rearm="0.0" trigger="1" ds-label="ifName" expression="math.abs(ifHCInOctets * 8 / ifHighSpeed / 1000000 * 100)">
-            <resource-filter field="ifHighSpeed">^[1-9][0-9]+$</resource-filter>
+            <resource-filter field="snmpifspeed">^[1-9][0-9]+$</resource-filter>
         </expression>
     </group>
     <group name="TestThresholds" rrdRepository="/opt/opennms/share/rrd/snmp/">
@@ -49,11 +49,11 @@
             rearm="0.0" trigger="1" ds-label="ifName" ds-name="locIfInCRC"/>
         <expression type="absoluteChange" ds-type="if" value="12.0"
             rearm="0.0" trigger="1" ds-label="ifName" expression="math.abs(ifHCInOctets * 8 / ifHighSpeed / 1000000 * 100)">
-            <resource-filter field="ifHighSpeed">^[1-9][0-9]+$</resource-filter>
+            <resource-filter field="snmpifspeed">^[1-9][0-9]+$</resource-filter>
         </expression>
         <expression type="absoluteChange" ds-type="if" value="12.0"
             rearm="0.0" trigger="1" ds-label="ifName" expression="math.abs(ifHCOutOctets * 8 / ifHighSpeed / 1000000 * 100)">
-            <resource-filter field="ifHighSpeed">^[1-9][0-9]+$</resource-filter>
+            <resource-filter field="snmpifspeed">^[1-9][0-9]+$</resource-filter>
         </expression>
     </group>
     <group name="netsnmp" rrdRepository="/opt/opennms/share/rrd/snmp/">

--- a/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/ThresholdingSessionIT.java
+++ b/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/ThresholdingSessionIT.java
@@ -41,7 +41,6 @@ import org.opennms.core.test.db.TemporaryDatabaseAware;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.netmgt.collection.api.ServiceParameters;
 import org.opennms.netmgt.dao.hibernate.IfLabelDaoImpl;
-import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.threshd.api.ThresholdInitializationException;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
@@ -98,7 +97,7 @@ public class ThresholdingSessionIT implements TemporaryDatabaseAware<MockDatabas
     @Test
     public void canLoadServiceContext() throws ThresholdInitializationException {
         ServiceParameters serviceParams = new ServiceParameters(new HashMap<>());
-        ThresholdingSession visitor = service.createSession(nodeId, ipAddress, serviceName, new RrdRepository(), serviceParams);
+        ThresholdingSession visitor = service.createSession(nodeId, ipAddress, serviceName, serviceParams);
         assertNotNull("Failed  to instantiate ThresholdingVisitor", visitor);
     }
 

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/thresholding/FlowThresholding.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/thresholding/FlowThresholding.java
@@ -55,7 +55,6 @@ import org.opennms.netmgt.collection.support.builder.NodeLevelResource;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
-import org.opennms.netmgt.flows.api.FlowSource;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.flows.api.ProcessingOptions;
 import org.opennms.netmgt.flows.elastic.Direction;
@@ -80,8 +79,6 @@ public class FlowThresholding implements Closeable {
     public static final String SERVICE_NAME = "Flow-Threshold";
     public static final String RESOURCE_TYPE_NAME = "flowApp";
     public static final String RESOURCE_GROUP = "application";
-
-    private final static RrdRepository FLOW_APP_RRD_REPO = new RrdRepository();
 
     private final ThresholdingService thresholdingService;
     private final CollectionAgentFactory collectionAgentFactory;
@@ -283,7 +280,6 @@ public class FlowThresholding implements Closeable {
                         thresholdingSession = FlowThresholding.this.thresholdingService.createSession(iface.getNodeId(),
                                                                                                       collectionAgent.getHostAddress(),
                                                                                                       SERVICE_NAME,
-                                                                                                      FLOW_APP_RRD_REPO,
                                                                                                       new ServiceParameters(Collections.emptyMap()));
                     } catch (ThresholdInitializationException e) {
                         throw new RuntimeException("Error initializing thresholding session", e);

--- a/features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerd.java
+++ b/features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerd.java
@@ -232,18 +232,16 @@ public class PerspectivePollerd implements SpringServiceDaemon, PerspectiveServi
         });
 
         // Create the thresholding session for this poller
-        final Optional<ThresholdingSession> thresholdingSession = rrdRepository.flatMap(repository -> {
-            try {
-                return Optional.of(this.thresholdingService.createSession(service.getNodeId(),
-                        InetAddressUtils.str(service.getIpAddress()),
-                        service.getServiceName(),
-                        repository,
-                        new ServiceParameters(Collections.emptyMap())));
-            } catch (final ThresholdInitializationException ex) {
-                LOG.error("Failed to create thresholding session", ex);
-                return Optional.empty();
-            }
-        });
+        final ThresholdingSession thresholdingSession;
+        try {
+            thresholdingSession = this.thresholdingService.createSession(service.getNodeId(),
+                                                                         InetAddressUtils.str(service.getIpAddress()),
+                                                                         service.getServiceName(),
+                                                                         new ServiceParameters(Collections.emptyMap()));
+        } catch (final ThresholdInitializationException ex) {
+            LOG.error("Failed to create thresholding session", ex);
+            return;
+        }
 
         // Build perspective polled services
         final PerspectivePolledService perspectivePolledService = new PerspectivePolledService(service.getNodeId(),
@@ -258,7 +256,7 @@ public class PerspectivePollerd implements SpringServiceDaemon, PerspectiveServi
                                                                                                servicePerspective.getPerspectiveLocation(),
                                                                                                node.getLocation().getLocationName(),
                                                                                                rrdRepository.orElse(null),
-                                                                                               thresholdingSession.orElse(null));
+                                                                                               thresholdingSession);
 
         // Build job for scheduler
         final JobDetail job = JobBuilder

--- a/features/telemetry/protocols/adapters/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractCollectionAdapter.java
+++ b/features/telemetry/protocols/adapters/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractCollectionAdapter.java
@@ -156,7 +156,7 @@ public abstract class AbstractCollectionAdapter extends AbstractAdapter {
             // Thresholding
             try {
                 if (isThresholdingEnabled.get()) {
-                    ThresholdingSession session = getSessionForAgent(result.getAgent(), repository);
+                    ThresholdingSession session = getSessionForAgent(result.getAgent());
                     session.accept(collectionSet);
                 }
             } catch (ThresholdInitializationException e) {
@@ -165,7 +165,7 @@ public abstract class AbstractCollectionAdapter extends AbstractAdapter {
         });
     }
 
-    private ThresholdingSession getSessionForAgent(CollectionAgent agent, RrdRepository repository) throws ThresholdInitializationException {
+    private ThresholdingSession getSessionForAgent(CollectionAgent agent) throws ThresholdInitializationException {
         if (thresholdingService == null) {
             // If we don't have a ThresholdingService,
             // we are running in the OSGi container (i.e. on a Sentinal) with no Thresholding Service Configured
@@ -181,7 +181,7 @@ public abstract class AbstractCollectionAdapter extends AbstractAdapter {
 
         ThresholdingSession session = agentThresholdingSessions.getIfPresent(sessionKey);
         if (session == null) {
-            session = thresholdingService.createSession(nodeId, hostAddress, serviceName, repository, EMPTY_SERVICE_PARAMETERS);
+            session = thresholdingService.createSession(nodeId, hostAddress, serviceName, EMPTY_SERVICE_PARAMETERS);
             agentThresholdingSessions.put(sessionKey, session);
         }
         return session;

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -60,7 +60,6 @@ import org.opennms.netmgt.collection.support.ConstantTimeKeeper;
 import org.opennms.netmgt.config.CollectdConfigFactory;
 import org.opennms.netmgt.config.DataCollectionConfigFactory;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
-import org.opennms.netmgt.dao.api.ResourceStorageDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
 import org.opennms.netmgt.model.OnmsIpInterface;
@@ -175,7 +174,7 @@ class CollectableService implements ReadyRunnable {
         m_repository=m_spec.getRrdRepository(m_params.getCollectionName());
 
         try {
-            m_thresholdingSession = thresholdingService.createSession(m_nodeId, getHostAddress(), m_spec.getServiceName(), m_repository, m_params);
+            m_thresholdingSession = thresholdingService.createSession(m_nodeId, getHostAddress(), m_spec.getServiceName(), m_params);
         } catch (ThresholdInitializationException e) {
             LOG.error("Error when initializing Thresholding. No Thresholding will be performed on this service.", e);
         }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptor.java
@@ -113,7 +113,7 @@ public class LatencyStoringServiceMonitorAdaptor implements ServiceMonitorAdapto
         RrdRepository repository = getRrdRepository(rrdPath);
 
         if (thresholds.equalsIgnoreCase("true")) {
-            applyThresholds(collectionSet, svc, dsName, repository);
+            applyThresholds(collectionSet, svc, dsName);
         } else {
             LOG.debug("storeResponseTime: Thresholds processing is not enabled. Check thresholding-enabled parameter on service definition");
         }
@@ -138,13 +138,12 @@ public class LatencyStoringServiceMonitorAdaptor implements ServiceMonitorAdapto
         collectionSet.visit(persister);
     }
 
-    private void applyThresholds(CollectionSet collectionSet, MonitoredService service, String dsName, RrdRepository repository) {
+    private void applyThresholds(CollectionSet collectionSet, MonitoredService service, String dsName) {
         try {
             if (m_thresholdingSession == null) {
                 m_thresholdingSession = m_thresholdingService.createSession(service.getNodeId(), 
                                                                             service.getIpAddr(),
                                                                             service.getSvcName(),
-                                                                            repository,
                                                                             EMPTY_SERVICE_PARAMS);
             }
             m_thresholdingSession.accept(collectionSet);

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdIntegrationTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdIntegrationTest.java
@@ -182,7 +182,7 @@ public class CollectdIntegrationTest {
 
         ThresholdingService mockThresholdingService = m_mockUtils.createMock(ThresholdingService.class);
         ThresholdingSession mockThresholdingSession = m_mockUtils.createMock(ThresholdingSession.class);
-        EasyMock.expect(mockThresholdingService.createSession(EasyMock.anyInt(), EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject(),
+        EasyMock.expect(mockThresholdingService.createSession(EasyMock.anyInt(), EasyMock.anyString(), EasyMock.anyString(),
                                                               EasyMock.anyObject())).andReturn(mockThresholdingSession);
         m_collectd.setThresholdingService(mockThresholdingService);
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdTest.java
@@ -321,8 +321,8 @@ public class CollectdTest {
         // Mock Thresholding
         ThresholdingService mockThresholdingService = m_easyMockUtils.createMock(ThresholdingService.class);
         ThresholdingSession mockThresholdingSession = m_easyMockUtils.createMock(ThresholdingSession.class);
-        EasyMock.expect(mockThresholdingService.createSession(EasyMock.anyInt(), EasyMock.anyString(), 
-                                                              EasyMock.anyString(), EasyMock.anyObject(), EasyMock.anyObject())).andReturn(mockThresholdingSession);
+        EasyMock.expect(mockThresholdingService.createSession(EasyMock.anyInt(), EasyMock.anyString(),
+                                                              EasyMock.anyString(), EasyMock.anyObject())).andReturn(mockThresholdingSession);
         mockThresholdingSession.accept(isA(CollectionSet.class));
         expectLastCall().anyTimes();
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/MockThresholdingService.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/MockThresholdingService.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.opennms.netmgt.collection.api.ServiceParameters;
-import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
 import org.opennms.netmgt.threshd.api.ThresholdingSessionKey;
@@ -43,7 +42,7 @@ public class MockThresholdingService implements ThresholdingService {
     private final ThresholdingSetPersister persister = mock(ThresholdingSetPersister.class);
     
     @Override
-    public ThresholdingSession createSession(int m_nodeId, String hostAddress, String serviceName, RrdRepository rrdRepository, ServiceParameters serviceParameters) {
+    public ThresholdingSession createSession(int m_nodeId, String hostAddress, String serviceName, ServiceParameters serviceParameters) {
         ThresholdingSession mockSession = mock(ThresholdingSession.class);
         when(mockSession.getKey()).thenReturn(mock(ThresholdingSessionKey.class));
         return mockSession;


### PR DESCRIPTION
While evaluating the thresholds resource-filter, the attribute have been
read from the RRD repository (as stored in strings.properties). This
will fail if the string is not persisted (because the collection set us
purely used for thresholding) or on the first thresholding run, if the
thresholding is executed before the persistence.

This is changed to use the values from the currently processed
collection set.

### Reviewer Remarks

This PR is split in two commits. The first commit contains the actual (very small) change. The second commit is cleanup of the (now unused) RRD repository from the thresholding API.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13945
