### PR TITLE
NMS-13729: Event configuration UI fails to persist logmsg dest changes

### DIFF
--- a/features/vaadin-snmp-events-and-metrics/src/main/java/org/opennms/features/vaadin/events/EventForm.java
+++ b/features/vaadin-snmp-events-and-metrics/src/main/java/org/opennms/features/vaadin/events/EventForm.java
@@ -34,6 +34,8 @@ import org.opennms.netmgt.xml.eventconf.LogDestType;
 import org.opennms.netmgt.xml.eventconf.Logmsg;
 import org.opennms.netmgt.xml.eventconf.Mask;
 
+import com.vaadin.v7.data.util.converter.Converter;
+import com.vaadin.v7.data.util.converter.StringToEnumConverter;
 import com.vaadin.v7.data.Property;
 import com.vaadin.v7.data.fieldgroup.BeanFieldGroup;
 import com.vaadin.v7.data.fieldgroup.FieldGroup.CommitException;
@@ -130,6 +132,7 @@ public class EventForm extends CustomComponent {
         logMsgDest.addItem("suppress");
         logMsgDest.addItem("donotpersist");
         logMsgDest.addItem("discardtraps");
+        logMsgDest.setConverter((Converter) new StringToEnumConverter());
         logMsgDest.setNullSelectionAllowed(false);
         logMsgDest.setRequired(true);
         eventLayout.addComponent(logMsgDest);

--- a/features/vaadin-snmp-events-and-metrics/src/test/java/org/opennms/features/vaadin/events/EventFormTest.java
+++ b/features/vaadin-snmp-events-and-metrics/src/test/java/org/opennms/features/vaadin/events/EventFormTest.java
@@ -85,7 +85,7 @@ public class EventFormTest {
         Field<?> logMsgDest = group.getField("logmsg.dest");
         Assert.assertNotNull(logMsgDest);
         Assert.assertTrue(logMsgDest instanceof ComboBox);
-        Assert.assertEquals(LogDestType.LOGNDISPLAY, logMsgDest.getValue());
+        Assert.assertEquals(LogDestType.LOGNDISPLAY, LogDestType.valueOf(logMsgDest.getValue().toString()));
 
         String eventUei = "uei.opennms.org/ietf/mplsTeStdMib/traps/mplsTunnelUp";
         Event event = dao.findByUei(eventUei);
@@ -95,7 +95,7 @@ public class EventFormTest {
         logMsgDest = group.getField("logmsg.dest");
         Assert.assertNotNull(logMsgDest);
         Assert.assertTrue(logMsgDest instanceof ComboBox);
-        Assert.assertEquals(event.getLogmsg().getDest(), logMsgDest.getValue());
+        Assert.assertEquals(event.getLogmsg().getDest(), LogDestType.valueOf(logMsgDest.getValue().toString()));
     }
 
 

--- a/features/vaadin-snmp-events-and-metrics/src/test/java/org/opennms/features/vaadin/events/EventFormTest.java
+++ b/features/vaadin-snmp-events-and-metrics/src/test/java/org/opennms/features/vaadin/events/EventFormTest.java
@@ -85,7 +85,7 @@ public class EventFormTest {
         Field<?> logMsgDest = group.getField("logmsg.dest");
         Assert.assertNotNull(logMsgDest);
         Assert.assertTrue(logMsgDest instanceof ComboBox);
-        Assert.assertEquals(LogDestType.LOGNDISPLAY, LogDestType.valueOf(logMsgDest.getValue().toString()));
+        Assert.assertEquals(LogDestType.LOGNDISPLAY, LogDestType.valueOf(logMsgDest.getValue().toString().toUpperCase()));
 
         String eventUei = "uei.opennms.org/ietf/mplsTeStdMib/traps/mplsTunnelUp";
         Event event = dao.findByUei(eventUei);
@@ -95,7 +95,7 @@ public class EventFormTest {
         logMsgDest = group.getField("logmsg.dest");
         Assert.assertNotNull(logMsgDest);
         Assert.assertTrue(logMsgDest instanceof ComboBox);
-        Assert.assertEquals(event.getLogmsg().getDest(), LogDestType.valueOf(logMsgDest.getValue().toString()));
+        Assert.assertEquals(event.getLogmsg().getDest(), LogDestType.valueOf(logMsgDest.getValue().toString().toUpperCase()));
     }
 
 


### PR DESCRIPTION
Added a converter to the field so the Combobox can bind properly with an Enum

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13729

