### PR TITLE
NMS-13887: Altered Karaf configuration to default to java.rmi.server.hostname

### DIFF
--- a/container/shared/src/main/resources/etc/org.apache.karaf.management.cfg
+++ b/container/shared/src/main/resources/etc/org.apache.karaf.management.cfg
@@ -21,9 +21,9 @@ rmiRegistryHost = 127.0.0.1
 rmiServerPort = 45444
 
 #
-# Host for RMI server
+# Host for RMI server, see NMS-13887 for details
 #
-rmiServerHost = 127.0.0.1
+rmiServerHost = ${java.rmi.server.hostname:-127.0.0.1}
 
 #
 # Name of the JAAS realm used for authentication


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13887

It seems that the behaviour was changed due to the Karaf upgrade. See this bug:

  https://issues.apache.org/jira/browse/KARAF-7096

...and the corresponding code change:

https://github.com/apache/karaf/pull/1343/files#diff-f0454a3d84e6d35695bb472ec1f21305455dcf489dc891ff08044f7a29d454eaR110

Workaround is to also set the `rmiServerHost` to the same value of `java.rmi.server.hostname` in `etc/org.apache.karaf.management.cfg`.