### PR TITLE
NMS-13928: automatically prune old feature branches from dockerhub

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -58,3 +58,11 @@ so it gets blown away anyway.  We should change this to store the `~/.npm`
 directory instead, as well as periodically clean it like we do for
 `~/.m2/repository`.
 
+### Weekly / cron triggered jobs
+
+Due to current setup trigger by cron is unavailable and has been replace by
+advanced setup in circleci GUI. Currently we have 2 independent weekly jobs:
+   - coverage-api for code quality coverage
+   - automation for devops operations like docker stale image pruning
+These jobs are enabled by setting  trigger-coverage-api / trigger-automation
+parameters as true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
             GC_LIST=$( hub-tool/hub-tool tag ls opennms/horizon | grep feature | grep inactive | cut -d" " -f1 )
             for image in $GC_LIST; do
               echo "Delete image $image"
-             "yes | hub-tool/hub-tool tag rm $image"
+             "/usr/bin/yes | hub-tool/hub-tool tag rm $image"
             done
 
   trigger-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,15 +105,14 @@ jobs:
             tar -xzf hub-tool-linux-amd64.tar.gz
             apk update
             apk add expect
-      - run:
-          name: use expect to login
-          shell: /usr/bin/expect
-          command: |
-            set timeout 10
+            expect_commands="
             spawn hub-tool/hub-tool login ${DOCKERHUB_LOGIN}
-            expect "Password:"
-            send "${DOCKERHUB_PASS}\n"
-      - run: hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
+            expect 'Password:'
+            send \"${DOCKERHUB_PASS}\n\"
+            interact"
+            expect -c "${expect_commands//
+            /;}"
+            hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
 
   trigger-coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,12 @@ jobs:
             interact"
             expect -c "${expect_commands//
             /;}"
-            hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
+            GC_LIST=$( hub-tool/hub-tool tag ls opennms/horizon | grep feature | grep inactive | cut -d" " -f1 )
+            which yes
+            for image in $GC_LIST; do
+              echo "Delete image $image"
+              echo "yes | hub-tool/hub-tool tag rm $image"
+            done
 
   trigger-coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - image: docker
     steps:
       - run:
-          name:  Docker GC
+          name:  Docker GC - remove inactive images on feature branches
           command: |
             wget https://github.com/docker/hub-tool/releases/download/v0.4.4/hub-tool-linux-amd64.tar.gz
             tar -xzf hub-tool-linux-amd64.tar.gz
@@ -113,7 +113,6 @@ jobs:
             expect -c "${expect_commands//
             /;}"
             GC_LIST=$( hub-tool/hub-tool tag ls opennms/horizon | grep feature | grep inactive | cut -d" " -f1 )
-            which yes
             for image in $GC_LIST; do
               echo "Delete image $image"
               echo "yes | hub-tool/hub-tool tag rm $image"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
             GC_LIST=$( hub-tool/hub-tool tag ls opennms/horizon | grep feature | grep inactive | cut -d" " -f1 )
             for image in $GC_LIST; do
               echo "Delete image $image"
-              echo "yes | hub-tool/hub-tool tag rm $image"
+             "yes | hub-tool/hub-tool tag rm $image"
             done
 
   trigger-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ jobs:
           command: |
             wget https://github.com/docker/hub-tool/releases/download/v0.4.4/hub-tool-linux-amd64.tar.gz
             tar -xzf hub-tool-linux-amd64.tar.gz
-            apt-get update
-            apt-get install expect
+            apk update
+            apk add expect
             /usr/bin/expect --help
             hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,12 @@ jobs:
     docker:
       - image: docker
     steps:
-      - run: echo "Hello World"
+      - run:
+          name:  Docker GC
+          command: |
+            wget https://github.com/docker/hub-tool/releases/download/v0.4.4/hub-tool-linux-amd64.tar.gz
+            tar -xzf hub-tool-linux-amd64.tar.gz
+            hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
 
   trigger-coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,9 @@ jobs:
       - run:
           name: use expect to login
           shell: /usr/bin/expect
-          command: |+
-            #!/usr/bin/expect
+          command: |
             set timeout 10
-            spawn hub-tool/hub-tool login DOCKERHUB_LOGIN
+            spawn hub-tool/hub-tool login ${DOCKERHUB_LOGIN}
             expect "Password:"
             send "${DOCKERHUB_PASS}\n"
       - run: hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,15 +103,7 @@ jobs:
           command: |
             wget https://github.com/docker/hub-tool/releases/download/v0.4.4/hub-tool-linux-amd64.tar.gz
             tar -xzf hub-tool-linux-amd64.tar.gz
-            # login from std in or env is not implemented https://github.com/docker/hub-tool/issues/176
-            # https://github.com/docker/hub-tool/pull/198
-            /usr/bin/expect <(cat << EOF
-            spawn hub-tool/hub-tool login ${DOCKERHUB_LOGIN}
-            expect "\033\[0;34mPassword: \033\[0m"
-            send "${DOCKERHUB_PASS}\n"
-            interact
-            EOF
-            )
+            /usr/bin/expect --help
             hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
 
   trigger-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,15 @@ parameters:
   trigger-prebuild:
     description: whether to trigger a pre-build evaluation
     type: boolean
-    default: true
+    default: false
   trigger-coverage-api:
     description: whether to trigger a code coverage build
     type: boolean
     default: false
+  trigger-automation:
+    description: whether to trigger garbage collection for older feature images
+    type: boolean
+    default: True
 
 setup: true
 
@@ -55,6 +59,7 @@ workflows:
       and:
         - equal: [ true, << pipeline.parameters.trigger-coverage-api >> ]
         - equal: [ false, << pipeline.parameters.trigger-prebuild >> ]
+        - equal: [ false, << pipeline.parameters.trigger-automation >> ]
     jobs:
       - trigger-path-filtering:
           base-revision: << pipeline.git.branch >>
@@ -66,6 +71,7 @@ workflows:
       and:
         - equal: [ false, << pipeline.parameters.trigger-coverage-api >> ]
         - equal: [ true, << pipeline.parameters.trigger-prebuild >> ]
+        - equal: [ false, << pipeline.parameters.trigger-automation >> ]
     jobs:
       - trigger-path-filtering:
           base-revision: << pipeline.git.branch >>
@@ -78,7 +84,22 @@ workflows:
             .circleci/.*      trigger-docs     true
             .circleci/.*      trigger-ui       true
 
+  automation:
+    when:
+      and:
+        - equal: [ false, << pipeline.parameters.trigger-coverage-api >> ]
+        - equal: [ false, << pipeline.parameters.trigger-prebuild >> ]
+        - equal: [ true, << pipeline.parameters.trigger-automation >> ]
+    jobs:
+      - docker_gc
+
 jobs:
+  docker_gc:
+    docker:
+      - image: docker
+    steps:
+      - run: echo "Hello World"
+
   trigger-coverage:
     docker:
       - image: cimg/python:3.10.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
             GC_LIST=$( hub-tool/hub-tool tag ls opennms/horizon | grep feature | grep inactive | cut -d" " -f1 )
             for image in $GC_LIST; do
               echo "Delete image $image"
-             "/usr/bin/yes | hub-tool/hub-tool tag rm $image"
+              /usr/bin/yes | hub-tool/hub-tool tag rm $image
             done
 
   trigger-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,12 +105,16 @@ jobs:
             tar -xzf hub-tool-linux-amd64.tar.gz
             apk update
             apk add expect
-            /usr/bin/expect <<EOF
+      - run:
+          name: use expect to login
+          shell: /usr/bin/expect
+          command: |+
+            #!/usr/bin/expect
+            set timeout 10
             spawn hub-tool/hub-tool login DOCKERHUB_LOGIN
             expect "Password:"
             send "${DOCKERHUB_PASS}\n"
-            EOF
-            hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
+      - run: hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
 
   trigger-coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,8 @@ jobs:
           command: |
             wget https://github.com/docker/hub-tool/releases/download/v0.4.4/hub-tool-linux-amd64.tar.gz
             tar -xzf hub-tool-linux-amd64.tar.gz
+            apt-get update
+            apt-get install expect
             /usr/bin/expect --help
             hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
     steps:
       - run:
           name:  Docker GC - remove inactive images on feature branches
+          # TODO replace expect when https://github.com/docker/hub-tool/pull/198 is merged
           command: |
             wget https://github.com/docker/hub-tool/releases/download/v0.4.4/hub-tool-linux-amd64.tar.gz
             tar -xzf hub-tool-linux-amd64.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,11 @@ jobs:
             tar -xzf hub-tool-linux-amd64.tar.gz
             apk update
             apk add expect
-            /usr/bin/expect --help
+            /usr/bin/expect <<EOF
+            spawn hub-tool/hub-tool login DOCKERHUB_LOGIN
+            expect "Password:"
+            send "${DOCKERHUB_PASS}\n"
+            EOF
             hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
 
   trigger-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
             GC_LIST=$( hub-tool/hub-tool tag ls opennms/horizon | grep feature | grep inactive | cut -d" " -f1 )
             for image in $GC_LIST; do
               echo "Delete image $image"
-              /usr/bin/yes | hub-tool/hub-tool tag rm $image
+              ( yes || true ) | hub-tool/hub-tool tag rm $image
             done
 
   trigger-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,15 @@ jobs:
           command: |
             wget https://github.com/docker/hub-tool/releases/download/v0.4.4/hub-tool-linux-amd64.tar.gz
             tar -xzf hub-tool-linux-amd64.tar.gz
+            # login from std in or env is not implemented https://github.com/docker/hub-tool/issues/176
+            # https://github.com/docker/hub-tool/pull/198
+            /usr/bin/expect <(cat << EOF
+            spawn hub-tool/hub-tool login ${DOCKERHUB_LOGIN}
+            expect "\033\[0;34mPassword: \033\[0m"
+            send "${DOCKERHUB_PASS}\n"
+            interact
+            EOF
+            )
             hub-tool/hub-tool tag ls opennms/horizon |grep feature | grep inactive
 
   trigger-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   trigger-prebuild:
     description: whether to trigger a pre-build evaluation
     type: boolean
-    default: false
+    default: true
   trigger-coverage-api:
     description: whether to trigger a code coverage build
     type: boolean
@@ -16,7 +16,7 @@ parameters:
   trigger-automation:
     description: whether to trigger garbage collection for older feature images
     type: boolean
-    default: True
+    default: false
 
 setup: true
 


### PR DESCRIPTION
I will switch back
https://github.com/OpenNMS/opennms/blob/66f1da5d3253cdd43ee3c264c7e922f8bb37ad6a/.circleci/config.yml#L11
and
https://github.com/OpenNMS/opennms/blob/66f1da5d3253cdd43ee3c264c7e922f8bb37ad6a/.circleci/config.yml#L19
as well as remove the echo to actually delete the image

### External References

https://issues.opennms.org/browse/NMS-13928

