### PR TITLE
NMS-13887: Altered Karaf configuration to default to java.rmi.server.hostname

### DIFF
--- a/container/shared/src/main/resources/etc/org.apache.karaf.management.cfg
+++ b/container/shared/src/main/resources/etc/org.apache.karaf.management.cfg
@@ -21,9 +21,9 @@ rmiRegistryHost = 127.0.0.1
 rmiServerPort = 45444
 
 #
-# Host for RMI server
+# Host for RMI server, see NMS-13887 for details
 #
-rmiServerHost = 127.0.0.1
+rmiServerHost = ${java.rmi.server.hostname:-127.0.0.1}
 
 #
 # Name of the JAAS realm used for authentication


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13887

This should also go into foundation-2022.