### PR TITLE
NMS-13900: fix `opennms status` when attach API is unavailable

### DIFF
--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -76,7 +76,7 @@ public class Controller {
     /**
      * The log4j category used to log debug messages and statements.
      */
-    private static final String LOG4J_CATEGORY = "manager";
+    static final String LOG4J_CATEGORY = "manager";
 
     /**
      * This is the name of the JVM that we try to connect to when we are invoking

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Invoker.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Invoker.java
@@ -267,7 +267,11 @@ public class Invoker {
             }
         }
 
-        LOG.debug("Invoking {} on object {}", invoke.getMethod(), mbean.getObjectName());
+        if ("status".equals(invoke.getMethod())) {
+            LOG.debug("Invoking {} on object {}", invoke.getMethod(), mbean.getObjectName());
+        } else {
+            LOG.info("Invoking {} on object {}", invoke.getMethod(), mbean.getObjectName());
+        }
         
 
         Object object;
@@ -283,7 +287,11 @@ public class Invoker {
             throw t;
         }
 
-	LOG.debug("Invocation {} successful for MBean {}", invoke.getMethod(), mbean.getObjectName());
+        if ("status".equals(invoke.getMethod())) {
+            LOG.debug("Invocation {} successful for MBean {}", invoke.getMethod(), mbean.getObjectName());
+        } else {
+            LOG.info("Invocation {} successful for MBean {}", invoke.getMethod(), mbean.getObjectName());
+        }
 
         return object;
     }

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Invoker.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Invoker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,8 +28,15 @@
 
 package org.opennms.netmgt.vmmgr;
 
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,6 +54,9 @@ import org.opennms.netmgt.config.service.InvokeAtType;
 import org.opennms.netmgt.config.service.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 /**
  * <p>
@@ -85,17 +95,18 @@ public class Invoker {
     private boolean m_reverse = false;
     private boolean m_failFast = true;
     private List<InvokerService> m_services;
+
+    private Path m_statusPath;
+    private static SignalHandler s_handler;
     
     /**
      * <p>Constructor for Invoker.</p>
      */
     public Invoker() {
-        
+        m_statusPath = Path.of(System.getProperty("opennms.home"), "logs", "status-check.txt");
+        this.registerSignalHandlerOnce();
     }
     
-    /**
-     * <p>instantiateClasses</p>
-     */
     public void instantiateClasses() {
 
         /*
@@ -117,7 +128,7 @@ public class Invoker {
                 Map<String,String> mdc = Logging.getCopyOfContextMap();
                 Object bean;
                 try {
-                    bean = clazz.newInstance();
+                    bean = clazz.getDeclaredConstructor().newInstance();
                 } finally {
                     Logging.setContextMap(mdc);
                 }
@@ -137,15 +148,55 @@ public class Invoker {
                     }
                 }
             } catch (Throwable t) {
-		LOG.error("An error occurred loading the mbean {} of type {}", service.getName(), service.getClassName(), t);
+                LOG.error("An error occurred loading the mbean {} of type {}", service.getName(), service.getClassName(), t);
                 invokerService.setBadThrowable(t);
             }
         }
     }
 
-    /**
-     * <p>getObjectInstances</p>
-     */
+    private void registerSignalHandlerOnce() {
+        if (s_handler != null) return;
+
+        try {
+            s_handler = Signal.handle(new Signal("USR1"), signal -> writeStatusUpdate());
+        } catch (final Throwable t) {
+            System.err.println("WARNING: failed to register service status signal handler");
+            t.printStackTrace();
+        }
+    }
+
+    private void writeStatusUpdate() {
+        if (m_statusPath == null) {
+            System.err.println("WARNING: status signal triggered, but no status path is configured!");
+            return;
+        }
+
+        final var output = new StringBuilder();
+
+        for (final var invokerService : getServices()) {
+            final var serviceName = invokerService.getService().getName();
+            for (final var invoke : invokerService.getService().getInvokes()) {
+                if ("status".equals(invoke.getMethod())) {
+                    try {
+                        Object result = invoke(invoke, invokerService.getMbean());
+                        output.append(serviceName).append("=").append(result.toString()).append("\n");
+                    } catch (final Throwable e) {
+                        System.err.println("ERROR: an error occurred while calling 'status' on " + serviceName);
+                        e.printStackTrace();
+                        output.append(serviceName).append("=").append("STATUS_CHECK_ERROR").append("\n");
+                    }
+                }
+            }
+        }
+
+        try {
+            Files.writeString(m_statusPath, output.toString(), Charset.defaultCharset(), CREATE, TRUNCATE_EXISTING);
+        } catch (final IOException e) {
+            System.err.println("ERROR: failed to write current status to " + m_statusPath.toString());
+            e.printStackTrace();
+        }
+    }
+
     public void getObjectInstances() {
         for (InvokerService invokerService : getServices()) {
             Service service = invokerService.getService();
@@ -321,6 +372,14 @@ public class Invoker {
         } finally {
             Logging.setContextMap(mdc);
         }
+    }
+
+    public Path getStatusPath() {
+        return m_statusPath;
+    }
+
+    public void setStatusPath(final Path statusPath) {
+        m_statusPath = statusPath;
     }
 
     /**

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Invoker.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Invoker.java
@@ -179,10 +179,11 @@ public class Invoker {
                 if ("status".equals(invoke.getMethod())) {
                     try {
                         Object result = invoke(invoke, invokerService.getMbean());
-                        output.append(serviceName).append("=").append(result.toString()).append("\n");
+                        output.append(StatusGetter.formatStatusEntry(serviceName, result.toString())).append("\n");
                     } catch (final Throwable e) {
                         System.err.println("ERROR: an error occurred while calling 'status' on " + serviceName);
                         e.printStackTrace();
+                        output.append(StatusGetter.formatStatusEntry(serviceName, "STATUS_CHECK_ERROR")).append("\n");
                         output.append(serviceName).append("=").append("STATUS_CHECK_ERROR").append("\n");
                     }
                 }

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/StatusGetter.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/StatusGetter.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class StatusGetter {
-
     private static final Logger LOG = LoggerFactory.getLogger(StatusGetter.class);
     public static final Pattern SERVICE_STATUS_PATTERN = Pattern.compile("Status: OpenNMS:Name=(\\S+) = (\\S+)");
 
@@ -64,6 +63,7 @@ public class StatusGetter {
         final LinkedHashMap<String, String> results = new LinkedHashMap<String, String>();
 
         try {
+            @SuppressWarnings("unchecked")
             final List<String> statusResults = (List<String>)m_controller.doInvokeOperation("status");
 
             /*
@@ -105,7 +105,6 @@ public class StatusGetter {
          * We want our output to look like this:
          *     OpenNMS.Eventd         : running
          */
-        String spaces = "                    ";
         int running = 0;
         int services = 0;
         for (final Entry<String, String> entry : results.entrySet()) {
@@ -117,8 +116,7 @@ public class StatusGetter {
                 running++;
             }
             if (m_controller.isVerbose()) {
-                System.out.println("OpenNMS." + daemon
-                        + spaces.substring(Math.min(daemon.length(),spaces.length()-1)) + ": " + status);
+                System.out.println(StatusGetter.formatStatusEntry(daemon, status));
             }
         }
 
@@ -130,4 +128,9 @@ public class StatusGetter {
             m_status = Status.RUNNING;
         }
     }
+
+	static String formatStatusEntry(final String service, final String status) {
+	    return String.format("%-35s : %s", service.replace(":", "."), status.toLowerCase());
+	}
+
 }

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -63,7 +63,8 @@ STATUS_WAIT=5
 # Number of times to do "opennms status" after stopping OpenNMS to see
 # if it has shut down completely.  Set to "0" to disable.  Between each
 # attempt we sleep for STATUS_WAIT seconds.
-STOP_TIMEOUT=10
+# Default is 3 minutes (36 * 5 seconds)
+STOP_TIMEOUT=36
 
 # Initial heap size (-Xms) in megabytes
 JAVA_INITIAL_HEAP_SIZE=""
@@ -173,7 +174,8 @@ isRunning() {
 }
 
 getPid(){
-	__pid=""
+	local __pid
+
 	if [ -f "$OPENNMS_PIDFILE" ]; then
 		__pid="$(cat "$OPENNMS_PIDFILE")"
 	fi
@@ -181,6 +183,19 @@ getPid(){
 		echo "$__pid"
 		return
 	fi
+
+	echo -1
+}
+
+findPid() {
+	local __matched_pid;
+
+	__matched_pid="$(pgrep -f _OPENNMS_LAUNCH 2>/dev/null || :)"
+	if [[ "$__matched_pid" =~ ^[0-9]+$ ]] && [ "$__matched_pid" -gt 0 ]; then
+		echo "$__matched_pid"
+		return
+	fi
+
 	echo -1
 }
 
@@ -567,6 +582,19 @@ doStop() {
 		echo "=== WARNING: Unable to Perform Complimentary Thread Dump ===" >> "$REDIRECT"
 	fi
 
+	if [ "$PID" -gt 0 ]; then
+		# OpenNMS registers a shutdown hook that calls `stop` directly
+		# there's no reason to do it programmatically unless we can't reach it any other way
+		kill "$PID"
+	else
+		APP_VM_PARMS=("${CONTROLLER_OPTIONS[@]}")
+		APP_PARMS_BEFORE=(-u "$JMX_URL" stop)
+		if [ -n "$SERVICE" ]; then
+			APP_PARMS_BEFORE+=("$SERVICE")
+		fi
+		runCmd "${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}"
+	fi
+
 	STATUS_ATTEMPTS=0
 	while [ "$STATUS_ATTEMPTS" -lt "$STOP_TIMEOUT" ]; do
 		doStatus "$@"
@@ -575,26 +603,11 @@ doStop() {
 			return 0
 		fi
 
-		# If there is a PID file for OpenNMS, specify the PID
-		PID="$(getPid)"
-
-		if [ "$PID" -gt 0 ]; then
-			# OpenNMS registers a shutdown hook that calls `stop` directly
-			# there's no reason to do it programmatically unless we can't reach it any other way
-			kill "$PID"
-		else
-			APP_VM_PARMS=("${CONTROLLER_OPTIONS[@]}")
-			APP_PARMS_BEFORE=(-u "$JMX_URL" stop)
-			if [ -n "$SERVICE" ]; then
-				APP_PARMS_BEFORE+=("$SERVICE")
-			fi
-			runCmd "${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}"
-		fi
-
 		sleep $STATUS_WAIT
 		((STATUS_ATTEMPTS++))
 	done
 
+	echo "WARNING: timed out waiting for OpenNMS to stop"
 	return 1
 }
 
@@ -631,56 +644,101 @@ doStatus(){
 		return $?
 	fi
 
-	# If there is a PID file for OpenNMS, specify the PID
+	_status_filename="${LOG_DIRECTORY}/status-check.txt"
+	_status_temp_filename="${_status_filename}.$$"
+
 	PID="$(getPid)"
-	if [ "$PID" -gt 0 ]; then
-		# see org.opennms.netmgt.vmmgr.Invoker, we register a custom
-		# signal handler to look for status requests
+	MATCHED_PID="$(findPid)"
+
+	if [ "${PID}" -gt 0 ]; then
+		# If we found a PID, validate it then trigger a status check
+
+		if [ "${MATCHED_PID}" -le 0 ]; then
+			# we didn't find -D_OPENNMS_LAUNCH running, assume the
+			# PID file is old and that OpenNMS is not running
+			return 3
+		fi
+
+		if [ "${PID}" -ne "${MATCHED_PID}" ]; then
+			echo "WARNING: 'pgrep -f _OPENNMS_LAUNCH' matched a different PID (${MATCHED_PID}) than found in ${OPENNMS_PIDFILE} (${PID}); something is not right"
+			return 1
+		fi
+
+		# First, we touch a temporary file to compare to when the status file is written out.
+		# We could use `find -newermt <datestamp>`, but this requires a new enough GNU find
+		# that I'm afraid to rely on it... This algorithm should work on any POSIX system.
+
+		touch "${_status_temp_filename}"
+
+		# [ file1 -nt file2 ] only has second-level granularity, make sure
+		# we have at least one second between the touch and the kill
+		sleep 1
+
+		# see org.opennms.netmgt.vmmgr.Invoker; we register a custom
+		# signal handler to trigger writing a current status update
+
 		kill -USR1 "$PID"
 
-		touch "/tmp/pre-check.$$"
+		# wait up to 30 seconds for a new status-check.txt file to have been written
 		SLEEP_COUNT=0
 		while [ "${SLEEP_COUNT}" -lt 30 ] && \
-			[ "${LOG_DIRECTORY}/pre-check.txt" -nt "${LOG_DIRECTORY}/status-check.txt" ]
+			[ "${_status_temp_filename}" -nt "${_status_filename}" ]
 		do
 			sleep 1
 			((SLEEP_COUNT++))
 		done
-		if [ "${LOG_DIRECTORY}/pre-check.txt" -ot "${LOG_DIRECTORY}/status-check.txt" ]; then
-			if [ "$VERBOSE" -gt 0 ]; then
-				# Input file is of the format OpenNMS.Name=ServiceName=status
-				# first we figure out the length of the longest service name
-				MAX_LENGTH=0
-				while read -r LINE; do
-					PRE="$(echo "$LINE" | cut -d= -f2)"
-					if [ "${#PRE}" -gt "${MAX_LENGTH}" ]; then
-						MAX_LENGTH="${#PRE}"
-					fi
-				done < "${LOG_DIRECTORY}/status-check.txt"
 
-				# then we print them out, spacing them based on that length
-				while read -r LINE; do
-					SERVICE="$(echo "$LINE" | cut -d= -f2)"
-					STATUS="$(echo "$LINE" | cut -d= -f3- | tr '[:upper:]' '[:lower:]')"
-					printf "OpenNMS.%-${MAX_LENGTH}s : %s\n" "$SERVICE" "$STATUS"
-				done < "${LOG_DIRECTORY}/status-check.txt"
+		# if a new status check file gets written, print the contents if $VERBOSE=1,
+		# and then parse the output to determine which exit code to use
+
+		if [ "${_status_filename}" -nt "${_status_temp_filename}" ]; then
+			if [ "$VERBOSE" -gt 0 ]; then
+				cat "${_status_filename}"
 			fi
+
+			_running_count="$(grep -i -c -E ' running$' "${_status_filename}")"
+			_starting_count="$(grep -i -c -E ' (start_pending|starting)$' "${_status_filename}")"
+			_total_count="$(wc -l < "${_status_filename}")"
+
+			if [ "${_total_count}" -eq 0 ]; then
+				rm "${_status_temp_filename}"
+
+				echo "WARNING: failed to determine running services from status check"
+				return 1
+			elif [ "${_starting_count}" -gt 0 ] || [ "${_running_count}" -lt "${_total_count}" ]; then
+				rm "${_status_temp_filename}"
+
+				# LSB: reserved for app-specific values
+				# we use this to indicate "partially running"
+				return 160
+			fi
+
+			rm "${_status_temp_filename}"
 			return 0
 		fi
-		rm "/tmp/pre-check.$$"
+
+		rm "${_status_temp_filename}"
+	elif [ "${MATCHED_PID}" -gt 0 ]; then
+		# we did not get a PID file through normal means, but we found a running OpenNMS anyway
+		# try to use the attach API and see if we can retrieve the status
+
+		echo "WARNING: PID file was missing but OpenNMS was found at ${MATCHED_PID}"
+
+		if [ "${VERBOSE}" -gt 0 ]; then
+			PARM_VERBOSE=("-v")
+		else
+			PARM_VERBOSE=()
+		fi
+
+		APP_VM_PARMS=("${CONTROLLER_OPTIONS[@]}")
+		APP_PARMS_BEFORE=(-p "${MATCHED_PID}" -u "${JMX_URL}" "${PARM_VERBOSE[@]}" status)
+		runCmd "${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "${BOOTSTRAP}" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}"
 	fi
 
-	if [ "$VERBOSE" -gt 0 ]; then
-		PARM_VERBOSE=("-v")
-	else
-		PARM_VERBOSE=()
-	fi
+	# if we make it this far, we couldn't find any PID, assume OpenNMS is not running
 
-	# if we don't know the PID or things fail, try falling back to using the attach API
-	APP_VM_PARMS=("${CONTROLLER_OPTIONS[@]}")
-	APP_PARMS_BEFORE=(-u "$JMX_URL" "${PARM_VERBOSE[@]}" status)
-	runCmd "${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}"
-
+	# LSB - service not running
+	return 3
 }
 
 FUNCTIONS_LOADED=0
@@ -732,7 +790,7 @@ JAVA_CMD=("$OPENNMS_HOME/bin/runjava" -r "${RUNJAVA_OPTIONS[@]}" --)
 BOOTSTRAP="$OPENNMS_HOME/lib/opennms_bootstrap.jar"
 
 MANAGER_OPTIONS=()
-#MANAGER_OPTIONS+=("-DOPENNMSLAUNCH")
+MANAGER_OPTIONS+=("-D_OPENNMS_LAUNCH")
 MANAGER_OPTIONS+=("-Dopennms.home=$OPENNMS_HOME")
 #MANAGER_OPTIONS+=("-Djcifs.properties=$OPENNMS_HOME/etc/jcifs.properties")
 MANAGER_OPTIONS+=("-XX:+HeapDumpOnOutOfMemoryError")

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -577,18 +577,19 @@ doStop() {
 
 		# If there is a PID file for OpenNMS, specify the PID
 		PID="$(getPid)"
-		if [ "$PID" -gt 0 ]; then
-			PARM_PID=("-p" "$PID")
-		else
-			PARM_PID=()
-		fi
 
-		APP_VM_PARMS=("${CONTROLLER_OPTIONS[@]}")
-		APP_PARMS_BEFORE=("${PARM_PID[@]}" -u "$JMX_URL" stop)
-		if [ -n "$SERVICE" ]; then
-			APP_PARMS_BEFORE+=("$SERVICE")
+		if [ "$PID" -gt 0 ]; then
+			# OpenNMS registers a shutdown hook that calls `stop` directly
+			# there's no reason to do it programmatically unless we can't reach it any other way
+			kill "$PID"
+		else
+			APP_VM_PARMS=("${CONTROLLER_OPTIONS[@]}")
+			APP_PARMS_BEFORE=(-u "$JMX_URL" stop)
+			if [ -n "$SERVICE" ]; then
+				APP_PARMS_BEFORE+=("$SERVICE")
+			fi
+			runCmd "${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}"
 		fi
-		runCmd "${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}"
 
 		sleep $STATUS_WAIT
 		((STATUS_ATTEMPTS++))
@@ -630,23 +631,56 @@ doStatus(){
 		return $?
 	fi
 
+	# If there is a PID file for OpenNMS, specify the PID
+	PID="$(getPid)"
+	if [ "$PID" -gt 0 ]; then
+		# see org.opennms.netmgt.vmmgr.Invoker, we register a custom
+		# signal handler to look for status requests
+		kill -USR1 "$PID"
+
+		touch "/tmp/pre-check.$$"
+		SLEEP_COUNT=0
+		while [ "${SLEEP_COUNT}" -lt 30 ] && \
+			[ "${LOG_DIRECTORY}/pre-check.txt" -nt "${LOG_DIRECTORY}/status-check.txt" ]
+		do
+			sleep 1
+			((SLEEP_COUNT++))
+		done
+		if [ "${LOG_DIRECTORY}/pre-check.txt" -ot "${LOG_DIRECTORY}/status-check.txt" ]; then
+			if [ "$VERBOSE" -gt 0 ]; then
+				# Input file is of the format OpenNMS.Name=ServiceName=status
+				# first we figure out the length of the longest service name
+				MAX_LENGTH=0
+				while read -r LINE; do
+					PRE="$(echo "$LINE" | cut -d= -f2)"
+					if [ "${#PRE}" -gt "${MAX_LENGTH}" ]; then
+						MAX_LENGTH="${#PRE}"
+					fi
+				done < "${LOG_DIRECTORY}/status-check.txt"
+
+				# then we print them out, spacing them based on that length
+				while read -r LINE; do
+					SERVICE="$(echo "$LINE" | cut -d= -f2)"
+					STATUS="$(echo "$LINE" | cut -d= -f3- | tr '[:upper:]' '[:lower:]')"
+					printf "OpenNMS.%-${MAX_LENGTH}s : %s\n" "$SERVICE" "$STATUS"
+				done < "${LOG_DIRECTORY}/status-check.txt"
+			fi
+			return 0
+		fi
+		rm "/tmp/pre-check.$$"
+	fi
+
 	if [ "$VERBOSE" -gt 0 ]; then
 		PARM_VERBOSE=("-v")
 	else
 		PARM_VERBOSE=()
 	fi
 
-	# If there is a PID file for OpenNMS, specify the PID
-	PID="$(getPid)"
-	if [ "$PID" -gt 0 ]; then
-		PARM_PID=("-p" "$PID")
-	else
-		PARM_PID=()
-	fi
-
+	# if we don't know the PID or things fail, try falling back to using the attach API
 	APP_VM_PARMS=("${CONTROLLER_OPTIONS[@]}")
-	APP_PARMS_BEFORE=("${PARM_PID[@]}" -u "$JMX_URL" "${PARM_VERBOSE[@]}" status)
+	APP_PARMS_BEFORE=(-u "$JMX_URL" "${PARM_VERBOSE[@]}" status)
 	runCmd "${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}"
+
 }
 
 FUNCTIONS_LOADED=0

--- a/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
@@ -85,12 +85,15 @@
     <logger name="org.opennms.netmgt.collectd.DefaultCollectdInstrumentation" additivity="false" level="INFO">
       <appender-ref ref="RoutingAppender"/>
     </logger>
-    <logger name="org.opennms.netmgt.vmmgr.Invoker" additivity="false" level="INFO">
+
+    <!-- write startup/shutdown logs to stdout or output.log as well as manager.log -->
+    <logger name="org.opennms.netmgt.vmmgr.Invoker" additivity="true" level="INFO">
       <appender-ref ref="console"/>
     </logger>
-    <logger name="org.opennms.netmgt.vmmgr.Manager" additivity="false" level="INFO">
+    <logger name="org.opennms.netmgt.vmmgr.Manager" additivity="true" level="INFO">
       <appender-ref ref="console"/>
     </logger>
+
     <!-- 
       Set the threshold for individual loggers that may be too chatty at the default 
       level for their prefix.

--- a/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
@@ -72,6 +72,11 @@
         </Route>
       </Routes>
     </Routing>
+    <Console name="console" target="SYSTEM_OUT" follow="true">
+      <PatternLayout>
+        <pattern>[%p] %m%n</pattern>
+      </PatternLayout>
+    </Console>
   </appenders>
 
   <loggers>
@@ -79,6 +84,12 @@
     <!-- we always want this at info for the instrumentation log reader -->
     <logger name="org.opennms.netmgt.collectd.DefaultCollectdInstrumentation" additivity="false" level="INFO">
       <appender-ref ref="RoutingAppender"/>
+    </logger>
+    <logger name="org.opennms.netmgt.vmmgr.Invoker" additivity="false" level="INFO">
+      <appender-ref ref="console"/>
+    </logger>
+    <logger name="org.opennms.netmgt.vmmgr.Manager" additivity="false" level="INFO">
+      <appender-ref ref="console"/>
     </logger>
     <!-- 
       Set the threshold for individual loggers that may be too chatty at the default 


### PR DESCRIPTION
Thanks to [a bug in the JDK](https://bugs.openjdk.java.net/browse/JDK-8226919) there is literally no way to work around the attach API not working other than to do this by completely other means.

My changes are as follows:

* log service status to STDOUT or `output.log` to make it easier for debugging startup when using systemctl (the last output will show in `systemctl status opennms`)
* implement a signal handler for `SIGUSR1` to dump status to a file for consumption by CLI tools (`SIGHUP` is already taken by the thread dump listener)
* update `$OPENNMS_HOME/bin/opennms` to use `kill -USR1` to trigger the status dump, and display the output
* while I was at it, `opennms stop` has the same issue, so I changed it to just use `kill` since the `Manager` implements a shutdown handler to safely exit anyway

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13900
