### PR TITLE
NMS-13783: Systemd startup uses legacy SysV init script

### DIFF
--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -546,7 +546,7 @@ echo "=== BUILDING ASSEMBLIES ==="
 	-Dinstall.version="%{version}-%{release}" \
 	-Ddist.name="%{name}-%{version}-%{release}.%{_arch}" \
 	-Dopennms.home="%{instprefix}" \
-	-Dinstall.init.dir="/etc/init.d" \
+	-Dinstall.init.dir="%{bindir}" \
 	-Dbuild=all \
 	-Dbuild.profile=full \
 	-Prun-expensive-tasks \

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -952,7 +952,7 @@ fi
 
 rm -f $ROOT_INST/etc/configured
 for dir in /etc /etc/rc.d; do
-	if [ -d "$dir" ]; then
+	if [ -d "${dir}/init.d" ]; then
 		ln -sf $ROOT_INST/bin/opennms $dir/init.d/opennms
 		break
 	fi


### PR DESCRIPTION
https://issues.opennms.org/browse/NMS-13783

It also disable create symlink if init.d not exist.
It have been tested on CentOS 9 & 7.9.2009.
