### PR TITLE
NMS-13835: Fix reflected XSS

### DIFF
--- a/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationRestService.java
+++ b/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationRestService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationRestService.java
+++ b/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationRestService.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.Response;
 
 import org.opennms.core.soa.ServiceRegistry;
 import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.utils.WebSecurityUtils;
 import org.opennms.features.geolocation.api.GeolocationConfiguration;
 import org.opennms.features.geolocation.api.GeolocationInfo;
 import org.opennms.features.geolocation.api.GeolocationQuery;
@@ -128,16 +129,18 @@ public class GeolocationRestService {
     }
 
     private static void validate(GeolocationQueryDTO query) throws InvalidQueryException {
-        // Validate Strategy
+        // Validate and sanitize Strategy
         if (query.getStrategy() != null) {
+            query.setStrategy(WebSecurityUtils.sanitizeString(query.getStrategy()));
             boolean valid = isValid(query.getStrategy(), NodeStatusCalculationStrategy.values());
             if (!valid) {
                 throw new InvalidQueryException("Strategy '" + query.getStrategy() + "' is not supported");
             }
         }
 
-        // Validate Severity
+        // Validate and sanitize Severity
         if (query.getSeverityFilter() != null) {
+            query.setSeverityFilter(WebSecurityUtils.sanitizeString(query.getSeverityFilter()));
             boolean valid = isValid(query.getSeverityFilter(), OnmsSeverity.values());
             if (!valid) {
                 throw new InvalidQueryException("Severity ' " + query.getSeverityFilter() + "' is not valid. Supported values are: " + Arrays.toString(OnmsSeverity.values()));

--- a/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
@@ -471,7 +471,7 @@ public abstract class Util extends Object {
             buffer.deleteCharAt(0);
         }
 
-        return buffer.toString();
+        return WebSecurityUtils.sanitizeString(buffer.toString());
     }
 
     public static enum IgnoreType {

--- a/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-web-api/src/main/java/org/opennms/web/utils/QueryParametersBuilder.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/utils/QueryParametersBuilder.java
@@ -28,6 +28,8 @@
 
 package org.opennms.web.utils;
 
+import org.opennms.core.utils.WebSecurityUtils;
+
 import static org.opennms.web.utils.UriInfoUtils.hasKey;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -44,14 +46,14 @@ public abstract class QueryParametersBuilder {
     public static QueryParameters buildFrom(MultivaluedMap<String, String> params) {
         final QueryParameters queryParameters = new QueryParameters();
         if (hasKey(params, "limit")) {
-            queryParameters.setLimit(Integer.valueOf(params.getFirst("limit").trim()));
+            queryParameters.setLimit(WebSecurityUtils.safeParseInt(params.getFirst("limit")));
         }
         if (hasKey(params, "offset")) {
-            queryParameters.setOffset(Integer.valueOf(params.getFirst("offset").trim()));
+            queryParameters.setOffset(WebSecurityUtils.safeParseInt(params.getFirst("offset")));
         }
         if (hasKey(params, "orderBy")) {
-            String orderBy = params.getFirst("orderBy").trim();
-            String order = params.getFirst("order");
+            String orderBy = WebSecurityUtils.sanitizeString(params.getFirst("orderBy").trim());
+            String order = WebSecurityUtils.sanitizeString(params.getFirst("order"));
             if (order != null) {
                 order = order.trim();
             }

--- a/opennms-web-api/src/main/java/org/opennms/web/utils/QueryParametersBuilder.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/utils/QueryParametersBuilder.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsRestService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsRestService.java
@@ -43,6 +43,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.core.utils.WebSecurityUtils;
 import org.opennms.netmgt.model.InetAddressTypeEditor;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.OnmsSeverityEditor;
@@ -117,21 +118,21 @@ public class OnmsRestService {
 	    builder.limit(defaultLimit);
 
     	if (params.containsKey("limit")) {
-    		builder.limit(Integer.valueOf(params.getFirst("limit")));
+    		builder.limit(WebSecurityUtils.safeParseInt(params.getFirst("limit")));
     		params.remove("limit");
     	}
     	if (params.containsKey("offset")) {
-    		builder.offset(Integer.valueOf(params.getFirst("offset")));
+    		builder.offset(WebSecurityUtils.safeParseInt(params.getFirst("offset")));
     		params.remove("offset");
     	}
 
 	    if(params.containsKey("orderBy")) {
 	    	builder.clearOrder();
-	    	builder.orderBy(params.getFirst("orderBy"));
+	    	builder.orderBy(WebSecurityUtils.sanitizeString(params.getFirst("orderBy")));
 			params.remove("orderBy");
 			
 			if(params.containsKey("order")) {
-				if("desc".equalsIgnoreCase(params.getFirst("order"))) {
+				if("desc".equalsIgnoreCase(WebSecurityUtils.sanitizeString(params.getFirst("order")))) {
 					builder.desc();
 				} else {
 					builder.asc();

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/admin/notifications/ChooseUeisController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/admin/notifications/ChooseUeisController.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/admin/notifications/ChooseUeisController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/admin/notifications/ChooseUeisController.java
@@ -43,6 +43,7 @@ import javax.servlet.http.HttpSession;
 
 import org.opennms.core.utils.BundleLists;
 import org.opennms.core.utils.ConfigFileConstants;
+import org.opennms.core.utils.WebSecurityUtils;
 import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.config.notifications.Notification;
 import org.opennms.netmgt.xml.eventconf.Event;
@@ -78,7 +79,7 @@ public class ChooseUeisController extends AbstractController {
     private Map<String, Object> createModel(Notification newNotice) throws FileNotFoundException,
             IOException {
         Map<String, Object> model = Maps.newHashMap();
-        model.put("title", newNotice.getName()!=null ? "Editing notice: " + newNotice.getName() : "");
+        model.put("title", newNotice.getName()!=null ? "Editing notice: " + WebSecurityUtils.sanitizeString(newNotice.getName()) : "");
         model.put("noticeUei", newNotice.getUei()!=null ? newNotice.getUei() : "");
         model.put("eventSelect", buildEventSelect(newNotice));
         return model;

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/admin/notifications/EventNoticesController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/admin/notifications/EventNoticesController.java
@@ -88,10 +88,6 @@ public class EventNoticesController extends AbstractController {
             return m_name;
         }
 
-        public String getEscapedName() {
-            return StringEscapeUtils.escapeJavaScript(m_name);
-        }
-
         public boolean getIsOn() {
             return "on".equalsIgnoreCase(m_notification.getStatus());
         }

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/admin/notifications/EventNoticesController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/admin/notifications/EventNoticesController.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/notification/noticeWizard/chooseUeis.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/notification/noticeWizard/chooseUeis.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2021 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/notification/noticeWizard/chooseUeis.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/notification/noticeWizard/chooseUeis.jsp
@@ -35,6 +35,8 @@
 	import="org.opennms.web.admin.notification.noticeWizard.*"
 %>
 
+<%@ taglib uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" prefix="e"%>
+
 <jsp:include page="/includes/bootstrap.jsp" flush="false" >
   <jsp:param name="title" value="Choose Event" />
   <jsp:param name="headTitle" value="Choose Event" />
@@ -158,7 +160,7 @@ $(document).ready(function() {
   </div>
 </div>
 
-<h2>${model.title}</h2>
+<h2>${e:forHtml(model.title)}</h2>
 
 <form method="post" name="events"
       action="admin/notification/noticeWizard/notificationWizard" >
@@ -182,7 +184,7 @@ $(document).ready(function() {
             </div>
             <div class="form-group">
               <label for="regexp" class="col-form-label">Regular Expression Field</label>
-              <input id="regexp" name="regexp" type="text" class="form-control" size="96" value="${model.noticeUei}" />
+              <input id="regexp" name="regexp" type="text" class="form-control" size="96" value="${e:forHtmlAttribute(model.noticeUei)}" />
             </div>
           </td>
         </tr>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/notification/noticeWizard/eventNotices.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/notification/noticeWizard/eventNotices.jsp
@@ -110,20 +110,20 @@
           <c:forEach items="${notifications}" var="notification">
           <tr>
             <td>
-              <input type="button" class="btn btn-secondary" value="Edit" onclick="javascript:editNotice('${e:forJavaScript(notification.escapedName)}')"/>
+              <input type="button" class="btn btn-secondary" value="Edit" onclick="javascript:editNotice('${e:forJavaScript(notification.name)}')"/>
             </td>
             <td>
-              <input type="button" class="btn btn-secondary" value="Delete"  onclick="javascript:deleteNotice('${e:forJavaScript(notification.escapedName)}')"/>
+              <input type="button" class="btn btn-secondary" value="Delete"  onclick="javascript:deleteNotice('${e:forJavaScript(notification.name)}')"/>
             </td>
             <td>
             <c:choose>
               <c:when test="${notification.isOn}">
-                <input type="radio" value="Off" onclick="javascript:setStatus('${e:forJavaScript(notification.escapedName)}','off')"/>Off
-                <input type="radio" value="On" CHECKED onclick="javascript:setStatus('${e:forJavaScript(notification.escapedName)}','on')"/>On
+                <input type="radio" value="Off" onclick="javascript:setStatus('${e:forJavaScript(notification.name)}','off')"/>Off
+                <input type="radio" value="On" CHECKED onclick="javascript:setStatus('${e:forJavaScript(notification.name)}','on')"/>On
               </c:when>
               <c:otherwise>
-                <input type="radio" value="Off" CHECKED onclick="javascript:setStatus('${e:forJavaScript(notification.escapedName)}','off')"/>Off
-                <input type="radio" value="On" onclick="javascript:setStatus('${e:forJavaScript(notification.escapedName)}','on')"/>On
+                <input type="radio" value="Off" CHECKED onclick="javascript:setStatus('${e:forJavaScript(notification.name)}','off')"/>Off
+                <input type="radio" value="On" onclick="javascript:setStatus('${e:forJavaScript(notification.name)}','on')"/>On
               </c:otherwise>
             </c:choose>
             </td>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/notification/noticeWizard/eventNotices.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/notification/noticeWizard/eventNotices.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/buildRule.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/buildRule.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/buildRule.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/buildRule.jsp
@@ -74,7 +74,7 @@
 
 </script>
 
-<h2><%=(newNotice.getName()!=null ? "Editing notice: " + newNotice.getName() + "<br/>" : "")%></h2>
+<h2><%=(newNotice.getName()!=null ? "Editing notice: " + WebSecurityUtils.sanitizeString(newNotice.getName()) + "<br/>" : "")%></h2>
 
 <form method="post" name="rule"
      action="admin/notification/noticeWizard/notificationWizard" >

--- a/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/notifsForUEI.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/notifsForUEI.jsp
@@ -52,7 +52,7 @@
 %>
 
 <%
-	String uei = WebSecurityUtils.sanitizeString(request.getParameter("uei"));
+	String uei = request.getParameter("uei");
 	Map<String, Notification> allNotifications=NotificationFactory.getInstance().getNotifications();
 	List<Notification> notifsForUEI=new ArrayList<>();
 	for(String key : allNotifications.keySet()) {
@@ -102,12 +102,12 @@
 <form action="admin/notification/noticeWizard/notificationWizard"  method="post" name="newNotificationForm">
 	<input type="hidden" name="sourcePage" value="<%=NotificationWizardServlet.SOURCE_PAGE_NOTIFS_FOR_UEI%>"/>
 	<input type="hidden" name="userAction" value="new"/>
-	<input type="hidden" name="uei" value="<%=uei%>"/>
+	<input type="hidden" name="uei" value="<%=WebSecurityUtils.sanitizeString(uei)%>"/>
 </form>
 
 <div class="card">
   <div class="card-header">
-    <span>Existing Notifications for UEI <%=uei%></span>
+    <span>Existing Notifications for UEI <%=WebSecurityUtils.sanitizeString(uei)%></span>
   </div>
       <table class="table table-sm">
       	 <tr><th>Name</th><th>Description</th><th>Rule</th><th>Destination path</th><th>Varbinds</th><th>Actions</th></tr>

--- a/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/notifsForUEI.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/notifsForUEI.jsp
@@ -38,6 +38,7 @@
 		org.opennms.netmgt.config.notifications.*
 	"
 %>
+<%@ page import="org.opennms.core.utils.WebSecurityUtils" %>
 
 <%!
     public void init() throws ServletException {
@@ -51,7 +52,7 @@
 %>
 
 <%
-	String uei=request.getParameter("uei");
+	String uei = WebSecurityUtils.sanitizeString(request.getParameter("uei"));
 	Map<String, Notification> allNotifications=NotificationFactory.getInstance().getNotifications();
 	List<Notification> notifsForUEI=new ArrayList<>();
 	for(String key : allNotifications.keySet()) {
@@ -118,10 +119,10 @@
           	}
       		%>
 	        <tr>
-	        	<td><%=notif.getName()%></td>
-	        	<td><%=notif.getDescription().orElse("")%></td>
+	        	<td><%=WebSecurityUtils.sanitizeString(notif.getName())%></td>
+	        	<td><%=WebSecurityUtils.sanitizeString(notif.getDescription().orElse(""))%></td>
 	        	<td><%=notif.getRule()%></td>
-	        	<td><%=notif.getDestinationPath()%></td>
+	        	<td><%=WebSecurityUtils.sanitizeString(notif.getDestinationPath())%></td>
 	        	<td><%=varbindDescription%></td>
 	        	<td><a href="javascript: void submitEditForm('<%=notif.getName()%>');">Edit</a></td>
 			</tr>

--- a/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/notifsForUEI.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/notifsForUEI.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/validateRule.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/validateRule.jsp
@@ -41,6 +41,7 @@
 		org.opennms.netmgt.config.notifications.*
 	"
 %>
+<%@ page import="org.opennms.core.utils.WebSecurityUtils" %>
 
 <%!
     public void init() throws ServletException {
@@ -88,7 +89,7 @@
   
 </script>
 
-<h2><%=(newNotice.getName()!=null ? "Editing notice: " + newNotice.getName() + "<br/>" : "")%></h2>
+<h2><%=(newNotice.getName()!=null ? "Editing notice: " + WebSecurityUtils.sanitizeString(newNotice.getName()) + "<br/>" : "")%></h2>
 
 <div class="row">
   <div class="col-md-12">

--- a/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/validateRule.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/noticeWizard/validateRule.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/graph/chooseresource.jsp
+++ b/opennms-webapp/src/main/webapp/graph/chooseresource.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/graph/chooseresource.jsp
+++ b/opennms-webapp/src/main/webapp/graph/chooseresource.jsp
@@ -29,7 +29,7 @@
 --%>
 
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-
+<%@ taglib uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" prefix="e"%>
 <%
   String node = request.getParameter("node");
   if (node == null) {
@@ -43,9 +43,9 @@
   }
   String reports = request.getParameter("reports");
   String endUrl = request.getParameter("endUrl");
-  pageContext.setAttribute("node", node == null ? "null" : "'" + node + "'");
-  pageContext.setAttribute("reports", reports == null ? "null" : "'" + reports + "'");
-  pageContext.setAttribute("endUrl", endUrl == null ? "null" : "'" + endUrl + "'");
+  pageContext.setAttribute("node", node == null ? "null" : node);
+  pageContext.setAttribute("reports", reports == null ? "null" : reports);
+  pageContext.setAttribute("endUrl", endUrl == null ? "null" : endUrl);
 %>
 
 <jsp:include page="/includes/bootstrap.jsp" flush="false" >
@@ -58,7 +58,7 @@
   <jsp:param name="breadcrumb" value="Choose" />
 </jsp:include>
 
-<div class="" ng-app="onms-resources" ng-controller="NodeResourcesCtrl" ng-init="init(${node},${reports},${endUrl})">
+<div class="" ng-app="onms-resources" ng-controller="NodeResourcesCtrl" ng-init="init('${e:forJavaScript(node)}','${e:forJavaScript(reports)}','${e:forJavaScript(endUrl)}')">
 
   <div growl></div>
 


### PR DESCRIPTION
Jira: https://issues.opennms.org/browse/NMS-13835

Some notes:

1. A lot of the detected XSS vulnerabilities were actually from exception messages, and currently are not interpreted by the browser as HTML. Right now this means they aren't actually vulnerabilities, but they will be detected by pentest tools as XSS vulns regardless. If the error messages are shown to the user without being sanitized, they could trigger script execution.  I solved this by sanitizing the user's input for fields like `limit`, `orderBy`, etc. This has side effects, are they acceptable?
- The `sanitizeInteger` method strips out any non-numeric characters, so an input of `limit=<script>alert(1)</script>` will be interpreted as `1` and proceed without an error.
- Error messages will now show sanitized strings. For example: `
Severity ' &lt;script&gt;alert(document.cookie)&lt;/script&gt;' is not valid. Supported values are: [INDETERMINATE, CLEARED, NORMAL, WARNING, MINOR, MAJOR, CRITICAL]`
2. The usage of both `forJavascript` and `escapedName` meant that the notification names were being sanitized twice. This caused an issue where if a notification had any sanitized characters, the notification would be impossible to edit/delete/update. Fixed this by using the name field, and running it through the forJavascript sanitizer once. I removed the escapedName field as it is now unused.