### PR TITLE
NMS-13970: DeviceConfigBackup REST API with Schedule info

### DIFF
--- a/container/bridge/rest/pom.xml
+++ b/container/bridge/rest/pom.xml
@@ -46,7 +46,7 @@
             <releases><enabled>true</enabled></releases>
             <id>opennms-repo</id>
             <name>OpenNMS Repository</name>
-            <url>http://maven.opennms.org/content/groups/opennms.org-release</url>
+            <url>https://maven.opennms.org/content/groups/opennms.org-release</url>
         </repository>
     </repositories>
 </project>

--- a/core/schema/src/main/liquibase/30.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/30.0.0/changelog.xml
@@ -33,6 +33,7 @@
             </column>
             <column name="created_time" type="timestamp"/>
             <column name="config_type" type="varchar(64)"/>
+            <column name="filename" type="varchar(1024)"/>
             <column name="failure_reason" type="varchar(1024)"/>
             <column name="last_succeeded" type="timestamp"/>
             <column name="last_failed" type="timestamp"/>

--- a/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfig.java
+++ b/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfig.java
@@ -35,8 +35,6 @@ import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -76,6 +74,9 @@ public class DeviceConfig implements Serializable {
 
     @Column(name = "config_type", nullable = false)
     private String configType;
+
+    @Column(name = "filename")
+    private String fileName;
 
     @Column(name = "failure_reason")
     private String failureReason;
@@ -140,9 +141,13 @@ public class DeviceConfig implements Serializable {
         return configType;
     }
 
+    public String getFileName() { return fileName; }
+
     public void setConfigType(String configType) {
         this.configType = configType;
     }
+
+    public void setFileName(String fileName) { this.fileName = fileName; }
 
     public String getFailureReason() {
         return failureReason;
@@ -181,12 +186,22 @@ public class DeviceConfig implements Serializable {
         if (this == o) return true;
         if (!(o instanceof DeviceConfig)) return false;
         DeviceConfig that = (DeviceConfig) o;
-        return ipInterface.equals(that.ipInterface) && Arrays.equals(config, that.config) && encoding.equals(that.encoding) && configType == that.configType && Objects.equals(failureReason, that.failureReason) && Objects.equals(createdTime, that.createdTime) && lastUpdated.equals(that.lastUpdated) && Objects.equals(lastFailed, that.lastFailed) && Objects.equals(lastSucceeded, that.lastSucceeded);
+        return
+            ipInterface.equals(that.ipInterface) &&
+            Arrays.equals(config, that.config) &&
+            encoding.equals(that.encoding) &&
+            configType == that.configType &&
+            fileName == that.fileName &&
+            Objects.equals(failureReason, that.failureReason) &&
+            Objects.equals(createdTime, that.createdTime) &&
+            lastUpdated.equals(that.lastUpdated) &&
+            Objects.equals(lastFailed, that.lastFailed) &&
+            Objects.equals(lastSucceeded, that.lastSucceeded);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(ipInterface, encoding, configType, failureReason, createdTime, lastUpdated, lastFailed, lastSucceeded);
+        int result = Objects.hash(ipInterface, encoding, configType, fileName, failureReason, createdTime, lastUpdated, lastFailed, lastSucceeded);
         result = 31 * result + Arrays.hashCode(config);
         return result;
     }

--- a/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfig.java
+++ b/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfig.java
@@ -184,19 +184,9 @@ public class DeviceConfig implements Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DeviceConfig)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
         DeviceConfig that = (DeviceConfig) o;
-        return
-            ipInterface.equals(that.ipInterface) &&
-            Arrays.equals(config, that.config) &&
-            encoding.equals(that.encoding) &&
-            configType == that.configType &&
-            fileName == that.fileName &&
-            Objects.equals(failureReason, that.failureReason) &&
-            Objects.equals(createdTime, that.createdTime) &&
-            lastUpdated.equals(that.lastUpdated) &&
-            Objects.equals(lastFailed, that.lastFailed) &&
-            Objects.equals(lastSucceeded, that.lastSucceeded);
+        return Objects.equals(createdTime, that.createdTime) && Objects.equals(lastUpdated, that.lastUpdated) && Objects.equals(lastFailed, that.lastFailed) && Objects.equals(lastSucceeded, that.lastSucceeded) && Objects.equals(encoding, that.encoding) && Objects.equals(configType, that.configType) && Objects.equals(fileName, that.fileName) && Objects.equals(failureReason, that.failureReason) && Objects.equals(ipInterface, that.ipInterface) && Arrays.equals(config, that.config);
     }
 
     @Override

--- a/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfigDao.java
+++ b/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfigDao.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DeviceConfigDao extends OnmsDao<DeviceConfig, Long> {
-
     List<DeviceConfig> findConfigsForInterfaceSortedByDate(OnmsIpInterface ipInterface, String configType);
 
     Optional<DeviceConfig> getLatestConfigForInterface(OnmsIpInterface ipInterface, String configType);
@@ -53,5 +52,4 @@ public interface DeviceConfigDao extends OnmsDao<DeviceConfig, Long> {
             String encoding,
             String reason
     );
-
 }

--- a/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
+++ b/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
@@ -61,6 +61,7 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
                 findObjects(DeviceConfig.class,
                         "from DeviceConfig dc where dc.ipInterface.id = ? AND configType = ? " +
                                 "ORDER BY lastUpdated DESC LIMIT 1", ipInterface.getId(), configType);
+
         if (deviceConfigs != null && !deviceConfigs.isEmpty()) {
             return Optional.of(deviceConfigs.get(0));
         }
@@ -135,6 +136,4 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
         saveOrUpdate(deviceConfig);
         LOG.warn("Persisted device config backup failure - ipInterface: {}; type: {}; reason: {}", ipInterface, configType, reason);
     }
-
-
 }

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigDTO.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigDTO.java
@@ -55,17 +55,17 @@ public class DeviceConfigDTO {
     /**
      * Date backup last succeeded, or null if no backups succeeded.
      * If the backup process succeeded but the configuration did not change, this date could be
-     * more recent than 'configStoredDate'.
+     * more recent than 'createdTime'.
      */
     private final Date lastSucceededDate;
 
     /** Date backup last failed, or null if no backups failed. */
     private final Date lastFailedDate;
 
-    /** Encoding of the config, either 'text' or 'binary'. Other values may include 'json' or 'xml'. */
+    /** Encoding of the config, possible values include 'text', 'binary', 'ascii', 'json', 'xml'. */
     private final String encoding;
 
-    /** The config type as a String, either 'Default' or 'Running'. */
+    /** The device configuration type, either 'default' or 'running'. */
     private final String configType;
 
     /** Filename of the configuration data as received from the device. */

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigDTO.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigDTO.java
@@ -30,40 +30,160 @@ package org.opennms.features.deviceconfig.rest.api;
 
 import java.util.Date;
 
+/**
+ * DTO for response value of DeviceConfigRestService.
+ * 'final' properties are retrieved directly from 'device_config' table.
+ * Other properties are calculated or from other data sources.
+ * The actual configuration data is retrieved separately using this object's 'id' field.
+ */
 public class DeviceConfigDTO {
-
+    /** Database id of 'device_config' table entry */
     private final long id;
+
+    /** Database id of 'ipinterface' table entry */
     private final int ipInterfaceId;
-    private final byte[] config;
-    private final String encoding;
+
+    /** IP address as a string */
+    private final String ipAddress;
+
+    /** Date backup config data was last stored. */
     private final Date createdTime;
 
-    public DeviceConfigDTO(long id, int ipInterfaceId, byte[] config, String encoding, Date createdTime) {
+    /** Date of last backup attempt. */
+    private final Date lastUpdatedDate;
+
+    /**
+     * Date backup last succeeded, or null if no backups succeeded.
+     * If the backup process succeeded but the configuration did not change, this date could be
+     * more recent than 'configStoredDate'.
+     */
+    private final Date lastSucceededDate;
+
+    /** Date backup last failed, or null if no backups failed. */
+    private final Date lastFailedDate;
+
+    /** Encoding of the config, either 'text' or 'binary'. Other values may include 'json' or 'xml'. */
+    private final String encoding;
+
+    /** The config type as a String, either 'Default' or 'Running'. */
+    private final String configType;
+
+    /** Filename of the configuration data as received from the device. */
+    private final String fileName;
+
+    /** Failure reason description, if there was a backup failure. */
+    private final String failureReason;
+
+    /** Device name. Currently this is actually the nodeLabel. */
+    private String deviceName;
+
+    /** Database id of corresponding node table entry. */
+    private Integer nodeId;
+
+    /** Label/name of the corresponding node object. */
+    private String nodeLabel;
+
+    /** Location, from node. */
+    private String location;
+
+    /** Operating system of corresponding node. */
+    private String operatingSystem;
+
+    /** True if there are any successful backups */
+    private boolean isSuccessfulBackup;
+
+    /** Description of most recent backup status. 'success', 'failure'. May add others like 'paused', 'storing'. */
+    private String backupStatus;
+
+    /** Estimate of next scheduled backup date. */
+    private Date nextScheduledBackupDate;
+
+    /** Friendly description of backup schedule interval, parsed from cron schedule data. */
+    private String scheduledInterval;
+
+    public DeviceConfigDTO(
+        long id,
+        int ipInterfaceId,
+        String ipAddress,
+        Date createdTime,
+        Date lastUpdated,
+        Date lastSucceeded,
+        Date lastFailed,
+        String encoding,
+        String configType,
+        String fileName,
+        String failureReason
+    ) {
         this.id = id;
         this.ipInterfaceId = ipInterfaceId;
-        this.config = config;
-        this.encoding = encoding;
+        this.ipAddress = ipAddress;
         this.createdTime = createdTime;
+        this.lastUpdatedDate = lastUpdated;
+        this.lastSucceededDate = lastSucceeded;
+        this.lastFailedDate = lastFailed;
+        this.encoding = encoding;
+        this.configType = configType;
+        this.fileName = fileName;
+        this.failureReason = failureReason;
     }
 
     public long getId() {
         return id;
     }
 
-    public int getIpInterfaceId() {
-        return ipInterfaceId;
-    }
+    public int getIpInterfaceId() { return this.ipInterfaceId; }
 
+    public String getIpAddress() { return this.ipAddress; }
 
-    public byte[] getConfig() {
-        return config;
-    }
+    public Date getCreatedTime() { return this.createdTime; }
 
-    public String getEncoding() {
-        return encoding;
-    }
+    public Date getLastUpdatedDate() { return this.lastUpdatedDate; }
 
-    public Date getCreatedTime() {
-        return createdTime;
-    }
+    public Date getLastSucceededDate() { return this.lastSucceededDate; }
+
+    public Date getLastFailedDate() { return this.lastFailedDate; }
+
+    public String getEncoding() { return this.encoding; }
+
+    public String getConfigType() { return this.configType; }
+
+    public String getFileName() { return this.fileName; }
+
+    public String getFailureReason() { return this.failureReason; }
+
+    public String getDeviceName(){ return this.deviceName; }
+
+    public Integer getNodeId() { return this.nodeId; }
+
+    public String getNodeLabel() { return this.nodeLabel; }
+
+    public String getLocation() { return this.location; }
+
+    public String getOperatingSystem() { return this.operatingSystem; }
+
+    public boolean getIsSuccessfulBackup() { return this.isSuccessfulBackup; }
+
+    public String getBackupStatus() { return this.backupStatus; }
+
+    public Date getNextScheduledBackupDate() { return this.nextScheduledBackupDate; }
+
+    public String getScheduledInterval() { return this.scheduledInterval; }
+
+    public void setDeviceName(String name) { this.deviceName = name; }
+
+    public void setNodeId(Integer id) { this.nodeId = id; }
+
+    public void setNodeLabel(String label) { this.nodeLabel = label; }
+
+    public void setLocation(String location) { this.location = location; }
+
+    public void setOperatingSystem(String os) { this.operatingSystem = os; }
+
+    public void setIsSuccessfulBackup(boolean b) { this.isSuccessfulBackup = b; }
+
+    public void setBackupStatus(String status) { this.backupStatus = status; }
+
+    public void setNextScheduledBackupDate(Date date) { this.nextScheduledBackupDate = date; }
+
+    public void setScheduledInterval(String interval) { this.scheduledInterval = interval; }
 }

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigRestService.java
@@ -31,6 +31,7 @@ package org.opennms.features.deviceconfig.rest.api;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -40,32 +41,39 @@ import javax.ws.rs.core.Response;
 
 @Path("/device-config")
 public interface DeviceConfigRestService {
+    public static final String DEVICE_CONFIG_SERVICE_PREFIX = "DeviceConfig";
 
-    // paging, filter by ipaddressId, created time, device type
-    // order by created time (asc, desc)
+    // paging, filter by ipaddressId, last updated time, config created time, last succeeded, last failed, config type
+    // order by last updated time (asc, desc)
 
     /**
-     * Gets a list of device configs.
+     * Gets a list of device configs along with backup schedule information.
      * @param limit used for paging; defaults to 10
      * @param offset used for paging; defaults to 0
-     * @param orderBy used for paging; defaults to "version"
+     * @param orderBy used for paging; defaults to "lastUpdated"
      * @param order used for paging; defaults to "desc"
+     * @param deviceName filter results by device name
+     * @param ipAddress filter results by device IP address
      * @param ipInterfaceId database id of OnmsIpInterface instance
-     * @param createdAfter epoche millis
-     * @param createdBefore epoche millis
-     * @return
+     * @param configType Configuration type, 'default' or 'running'
+     * @param createdAfter If set, only return items with saved backup after this date in epoch millis
+     * @param createdBefore If set, only return items with saved backup before this date in epoch millis
+     * @return Json response containing a list of device configs in the
+     *      shape of {@link org.opennms.features.deviceconfig.rest.api.DeviceConfigDTO }
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     Response getDeviceConfigs(
-            @QueryParam("limit") @DefaultValue("10") Integer limit,
-            @QueryParam("offset") @DefaultValue("0") Integer offset,
-            @QueryParam("orderBy") @DefaultValue("lastUpdated") String orderBy,
-            @QueryParam("order") @DefaultValue("desc") String order,
-
-            @QueryParam("ipInterfaceId") Integer ipInterfaceId,
-            @QueryParam("createdAfter") Long createdAfter,
-            @QueryParam("createdBefore") Long createdBefore
+        @QueryParam("limit") @DefaultValue("10") Integer limit,
+        @QueryParam("offset") @DefaultValue("0") Integer offset,
+        @QueryParam("orderBy") @DefaultValue("lastUpdated") String orderBy,
+        @QueryParam("order") @DefaultValue("desc") String order,
+        @QueryParam("deviceName") String deviceName,
+        @QueryParam("ipAddress") String ipAddress,
+        @QueryParam("ipInterfaceId") Integer ipInterfaceId,
+        @QueryParam("configType") String configType,
+        @QueryParam("createdAfter") Long createdAfter,
+        @QueryParam("createdBefore") Long createdBefore
     );
 
     @GET
@@ -76,4 +84,18 @@ public interface DeviceConfigRestService {
     @Path("{id}")
     void deleteDeviceConfig(@PathParam("id") long id);
 
+    /**
+     * Download the most recent backup configuration for a single device.
+     */
+    @GET
+    @Path("/download/{id}")
+    Response downloadDeviceConfig(@PathParam("id") long id);
+
+    /**
+     * Download a zip file containing the most recent backup configurations for multiple devices.
+     * POST will be Json
+     */
+    @POST
+    @Path("/download")
+    Response downloadDeviceConfigs();
 }

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -29,7 +29,12 @@
 package org.opennms.features.deviceconfig.rest.impl;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -63,7 +63,12 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
     private static final String REQUISITION_CONTEXT = "requisition";
     private static final String SCHEDULE_METADATA_KEY = "schedule";
 
-    private static final Set<String> VALID_ORDER_BY_KEYS = Set.of("lastupdated", "devicename", "createdtime", "ipaddress");
+    private static final Map<String,String> ORDERBY_QUERY_PROPERTY_MAP = Map.of(
+        "lastupdated", "lastUpdated",
+        "devicename", "ipInterface.node.label",
+        "createdtime", "createdTime",
+        "ipaddress", "ipInterface.ipAddr"
+    );
 
     private final DeviceConfigDao deviceConfigDao;
     private final MonitoredServiceDao monitoredServiceDao;
@@ -245,18 +250,8 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         // Sorting
         orderBy = orderBy != null ? orderBy.toLowerCase(Locale.ROOT) : null;
 
-        if (!Strings.isNullOrEmpty(orderBy) && VALID_ORDER_BY_KEYS.contains(orderBy)) {
-            String orderByToUse = orderBy;
-
-            if (orderBy.equals("devicename")) {
-                orderByToUse = "ipInterface.node.label";
-            } else if (orderBy.equals("ipaddress")) {
-                orderByToUse = "ipInterface.ipAddr";
-            } else if (orderBy.equals("lastupdated")) {
-                orderByToUse = "lastUpdated";
-            } else if (orderBy.equals("createdtime")) {
-                orderByToUse = "createdTime";
-            }
+        if (!Strings.isNullOrEmpty(orderBy) && ORDERBY_QUERY_PROPERTY_MAP.containsKey(orderBy)) {
+            String orderByToUse = ORDERBY_QUERY_PROPERTY_MAP.get(orderBy);
 
             boolean isOrderAscending = Strings.isNullOrEmpty(order) || !"desc".equals(order);
             criteriaBuilder.orderBy(orderByToUse, isOrderAscending);

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -28,25 +28,58 @@
 
 package org.opennms.features.deviceconfig.rest.impl;
 
-import java.util.Date;
+import java.time.Duration;
+import java.util.*;
 import java.util.stream.Collectors;
-
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
+import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
+import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.features.deviceconfig.persistence.api.ConfigType;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfig;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigDTO;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigRestService;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMetaData;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.web.utils.ResponseUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultDeviceConfigRestService.class);
+    private static final String REQUISITION_CONTEXT = "requisition";
+    private static final String SCHEDULE_METADATA_KEY = "schedule";
+
+    private static final Set<String> VALID_ORDER_BY_KEYS = Set.of("lastupdated", "devicename", "createdtime", "ipaddress");
 
     private final DeviceConfigDao deviceConfigDao;
+    private final MonitoredServiceDao monitoredServiceDao;
 
-    public DefaultDeviceConfigRestService(DeviceConfigDao deviceConfigDao) {
+    private static class ScheduleInfo {
+        private final Date nextScheduledBackup;
+        private final String scheduleInterval;
+
+        public Date getNextScheduledBackup() { return this.nextScheduledBackup; }
+
+        public String getScheduleInterval() { return this.scheduleInterval; }
+
+        public ScheduleInfo(Date nextScheduledBackup, String scheduleInterval) {
+            this.nextScheduledBackup = nextScheduledBackup;
+            this.scheduleInterval = scheduleInterval;
+        }
+    }
+
+    public DefaultDeviceConfigRestService(DeviceConfigDao deviceConfigDao, MonitoredServiceDao monitoredServiceDao) {
         this.deviceConfigDao = deviceConfigDao;
+        this.monitoredServiceDao = monitoredServiceDao;
     }
 
     @Override
@@ -55,43 +88,38 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             Integer offset,
             String orderBy,
             String order,
+            String deviceName,
+            String ipAddress,
             Integer ipInterfaceId,
+            String configType,
             Long createdAfter,
             Long createdBefore
     ) {
-        var criteriaBuilder = new CriteriaBuilder(DeviceConfig.class);
+        var criteria = getCriteria(limit, offset, orderBy, order, deviceName, ipAddress, ipInterfaceId, configType, createdAfter, createdBefore);
 
-        if (limit != null) {
-            criteriaBuilder.limit(limit);
-        }
-        if (offset != null) {
-            criteriaBuilder.offset(offset);
-        }
-        if (orderBy != null) {
-            criteriaBuilder.orderBy(orderBy, "asc".equals(order));
-        }
+        // find DeviceConfig items in device_config database as per filter/sort criteria
+        List<DeviceConfig> deviceConfigs = deviceConfigDao.findMatching(criteria);
 
-        if (ipInterfaceId != null) {
-            criteriaBuilder.eq("ipInterface.id", ipInterfaceId);
-        }
+        // do initial conversion to DTO with DeviceConfig data
+        List<DeviceConfigDTO> dtos = deviceConfigs.stream().map(DefaultDeviceConfigRestService::createDeviceConfigDto).collect(Collectors.toList());
 
-        if (createdAfter != null) {
-            criteriaBuilder.ge("createdTime", new Date(createdAfter));
-        }
+        // Get ipInterface Ids for current set of device configs
+        List<Integer> ipInterfaceIds = dtos.stream().map(d -> d.getIpInterfaceId()).distinct().collect(Collectors.toList());
 
-        if (createdBefore != null) {
-            criteriaBuilder.le("createdTime", new Date(createdBefore));
-        }
+        // Get the services matching the above device config records
+        List<OnmsMonitoredService> services = getDeviceConfigServices(ipInterfaceIds);
 
-        var criteria = criteriaBuilder.toCriteria();
+        // Get a list of services per ipInterfaceId so we can correlate with DeviceConfig data
+        Map<Integer, List<OnmsMonitoredService>> serviceMap =
+            services.stream().collect(Collectors.groupingBy(OnmsMonitoredService::getIpInterfaceId));
 
-        var deviceConfigs = deviceConfigDao.findMatching(criteria);
-        var dtos = deviceConfigs.stream().map(DefaultDeviceConfigRestService::deviceConfigDto).collect(Collectors.toList());
+        populateScheduleInfo(dtos, serviceMap);
 
         if (limit != null || offset != null) {
             criteria.setLimit(null);
             criteria.setOffset(null);
-            var total = deviceConfigDao.countMatching(criteria);
+            final int total = deviceConfigDao.countMatching(criteria);
+
             return ResponseUtils.createResponse(dtos, offset, total);
         } else {
             if (dtos.isEmpty()) {
@@ -102,10 +130,74 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         }
     }
 
+    /** Get DeviceConfig-related OnmsMonitoredServices for the given ip interface ids. */
+    private List<OnmsMonitoredService> getDeviceConfigServices(List<Integer> ipInterfaceIds) {
+        List<OnmsMonitoredService> services = monitoredServiceDao.findByServiceTypeAndIpInterfaceId(DEVICE_CONFIG_SERVICE_PREFIX, ipInterfaceIds);
+
+        return services;
+    }
+
+    /**
+     * Find corresponding service for each DTO (based on IP address and config type) and
+     * update DTO schedule information based on service metadata.
+     */
+    private void populateScheduleInfo(List<DeviceConfigDTO> dtos, Map<Integer, List<OnmsMonitoredService>> serviceMap) {
+        final Date currentDate = new Date();
+
+        for (DeviceConfigDTO dto : dtos) {
+            if (serviceMap.containsKey((Integer) dto.getIpInterfaceId())) {
+                final List<OnmsMonitoredService> serviceList = serviceMap.get((Integer) dto.getIpInterfaceId());
+
+                final String configType = Strings.isNullOrEmpty(dto.getConfigType()) ? ConfigType.Default : dto.getConfigType();
+                final String serviceName = DEVICE_CONFIG_SERVICE_PREFIX + "-" + configType;
+
+                final Optional<String> scheduleValue = getScheduleValue(serviceList, serviceName);
+
+                if (scheduleValue.isPresent()) {
+                    final ScheduleInfo scheduleInfo = getScheduleInfo(currentDate, scheduleValue.get());
+
+                    dto.setNextScheduledBackupDate(scheduleInfo.getNextScheduledBackup());
+                    dto.setScheduledInterval(scheduleInfo.getScheduleInterval());
+                }
+            }
+        }
+    }
+
+    public static Optional<String> getScheduleValue(final List<OnmsMonitoredService> serviceList, final String serviceName) {
+        final var matchingService =
+            serviceList.stream()
+            .filter(x -> x.getServiceName().equalsIgnoreCase(serviceName))
+            .findFirst();
+
+        if (matchingService.isPresent()) {
+            return getScheduleMetaDataValue(matchingService.get().getMetaData());
+        }
+
+        return Optional.empty();
+    }
+
+    public static Optional<String> getScheduleMetaDataValue(final List<OnmsMetaData> metaData) {
+        final var entry = metaData.stream()
+            .filter(m -> m.getContext().equals(REQUISITION_CONTEXT) && m.getKey().equals((SCHEDULE_METADATA_KEY)))
+            .map(m -> m.getValue())
+            .findFirst();
+
+        return entry;
+    }
+
+    private ScheduleInfo getScheduleInfo(Date current, String schedulePattern) {
+        // TODO: parse out cron-style schedulePattern and determine values
+
+        final Date nextScheduledBackup = Date.from(current.toInstant().plus(Duration.ofHours(25)));
+        final String scheduleInterval = schedulePattern;
+
+        return new ScheduleInfo(nextScheduledBackup, scheduleInterval);
+    }
+
     @Override
     public DeviceConfigDTO getDeviceConfig(long id) {
         var dc = deviceConfigDao.get(id);
-        return deviceConfigDto(dc);
+        return createDeviceConfigDto(dc);
     }
 
     @Override
@@ -113,13 +205,113 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         deviceConfigDao.delete(id);
     }
 
-    private static DeviceConfigDTO deviceConfigDto(DeviceConfig deviceConfig) {
-        return new DeviceConfigDTO(
-                deviceConfig.getId(),
-                deviceConfig.getIpInterface().getId(),
-                deviceConfig.getConfig(),
-                deviceConfig.getEncoding(),
-                deviceConfig.getCreatedTime()
+    @Override
+    public Response downloadDeviceConfig(@PathParam("id") long id) {
+        throw new UnsupportedOperationException("downloadDeviceConfig not yet implemented.");
+    }
+
+    @Override
+    public Response downloadDeviceConfigs() {
+        throw new UnsupportedOperationException("downloadDeviceConfigs not yet implemented.");
+    }
+
+    private Criteria getCriteria(
+        Integer limit,
+        Integer offset,
+        String orderBy,
+        String order,
+        String deviceName,
+        String ipAddress,
+        Integer ipInterfaceId,
+        String configType,
+        Long createdAfter,
+        Long createdBefore
+    ) {
+        var criteriaBuilder = new CriteriaBuilder(DeviceConfig.class);
+
+        if (limit != null) {
+            criteriaBuilder.limit(limit);
+        }
+
+        if (offset != null) {
+            criteriaBuilder.offset(offset);
+        }
+
+        // Sorting
+        orderBy = orderBy != null ? orderBy.toLowerCase(Locale.ROOT) : null;
+
+        if (!Strings.isNullOrEmpty(orderBy) && VALID_ORDER_BY_KEYS.contains(orderBy)) {
+            String orderByToUse = orderBy;
+
+            if (orderBy.equals("devicename")) {
+                orderByToUse = "ipInterface.node.label";
+            } else if (orderBy.equals("ipaddress")) {
+                orderByToUse = "ipInterface.ipAddr";
+            } else if (orderBy.equals("lastupdated")) {
+                orderByToUse = "lastUpdated";
+            } else if (orderBy.equals("createdtime")) {
+                orderByToUse = "createdTime";
+            }
+
+            boolean isOrderAscending = Strings.isNullOrEmpty(order) || !"desc".equals(order);
+            criteriaBuilder.orderBy(orderByToUse, isOrderAscending);
+        } else {
+            // default sort order
+            criteriaBuilder.orderBy("lastUpdated", false);
+        }
+
+        // Filtering
+        if (!Strings.isNullOrEmpty(deviceName)) {
+            criteriaBuilder.ilike("ipInterface.node.label", deviceName);
+        }
+
+        if (!Strings.isNullOrEmpty(ipAddress)) {
+            criteriaBuilder.ilike("ipInterface.ipAddr", ipAddress);
+        }
+
+        if (ipInterfaceId != null) {
+            criteriaBuilder.eq("ipInterface.id", ipInterfaceId);
+        }
+
+        if (StringUtils.isNoneBlank(configType)) {
+            criteriaBuilder.ilike("configType", configType);
+        }
+
+        if (createdAfter != null) {
+            criteriaBuilder.ge("createdTime", new Date(createdAfter));
+        }
+
+        if (createdBefore != null) {
+            criteriaBuilder.le("createdTime", new Date(createdBefore));
+        }
+
+        return criteriaBuilder.toCriteria();
+    }
+
+    private static DeviceConfigDTO createDeviceConfigDto(DeviceConfig deviceConfig) {
+        var dto = new DeviceConfigDTO(
+            deviceConfig.getId(),
+            deviceConfig.getIpInterface().getId(),
+            InetAddressUtils.str(deviceConfig.getIpInterface().getIpAddress()),
+            deviceConfig.getCreatedTime(),
+            deviceConfig.getLastUpdated(),
+            deviceConfig.getLastSucceeded(),
+            deviceConfig.getLastFailed(),
+            deviceConfig.getEncoding(),
+            deviceConfig.getConfigType(),
+            deviceConfig.getFileName(),
+            deviceConfig.getFailureReason()
         );
+
+        OnmsIpInterface ipInterface = deviceConfig.getIpInterface();
+        OnmsNode node = ipInterface.getNode();
+
+        dto.setNodeId(node.getId());
+        dto.setNodeLabel(node.getLabel());
+        dto.setDeviceName(node.getLabel());
+        dto.setLocation(node.getLocation().getLocationName());
+        dto.setOperatingSystem(node.getOperatingSystem());
+
+        return dto;
     }
 }

--- a/features/device-config/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/device-config/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -2,11 +2,12 @@
   xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd"
 >
-
     <reference id="deviceConfigDao" interface="org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao" availability="mandatory"/>
+    <reference id="monitoredServiceDao" interface="org.opennms.netmgt.dao.api.MonitoredServiceDao" availability="mandatory"/>
 
     <bean id="defaultDeviceConfigRestService" class="org.opennms.features.deviceconfig.rest.impl.DefaultDeviceConfigRestService">
         <argument ref="deviceConfigDao" />
+        <argument ref="monitoredServiceDao" />
     </bean>
 
     <service interface="org.opennms.features.deviceconfig.rest.api.DeviceConfigRestService" ref="defaultDeviceConfigRestService">
@@ -14,5 +15,4 @@
             <entry key="application-path" value="/rest" />
         </service-properties>
     </service>
-
 </blueprint>

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
@@ -35,7 +35,10 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceScheduleIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceScheduleIT.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *     http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.deviceconfig.rest.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.features.deviceconfig.persistence.api.ConfigType;
+import org.opennms.features.deviceconfig.persistence.api.DeviceConfig;
+import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
+import org.opennms.features.deviceconfig.rest.api.DeviceConfigDTO;
+import org.opennms.features.deviceconfig.rest.api.DeviceConfigRestService;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.ServiceTypeDao;
+import org.opennms.netmgt.model.*;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+    "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+    "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+    "classpath:/META-INF/opennms/applicationContext-soa.xml",
+    "classpath:/META-INF/opennms/applicationContext-dao.xml",
+    "classpath*:/META-INF/opennms/component-dao.xml",
+    "classpath:/META-INF/opennms/mockEventIpcManager.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class DefaultDeviceConfigRestServiceScheduleIT {
+    @Autowired
+    private NodeDao nodeDao;
+
+    @Autowired
+    private DeviceConfigDao deviceConfigDao;
+
+    @Autowired
+    private ServiceTypeDao serviceTypeDao;
+
+    @Autowired
+    private MonitoredServiceDao monitoredServiceDao;
+
+    private DeviceConfigRestService deviceConfigRestService;
+
+    @Before
+    public void before() {
+        deviceConfigRestService = new DefaultDeviceConfigRestService(deviceConfigDao, monitoredServiceDao);
+    }
+
+    @After
+    public void after() {
+    }
+
+    @Test
+    @Transactional
+    public void testGetDeviceConfigsWithScheduleInfo() {
+        final int RECORD_COUNT = 3;
+
+        // Add nodes, interfaces, services
+        List<OnmsIpInterface> ipInterfaces = populateDeviceConfigServiceInfo();
+        Assert.assertEquals(RECORD_COUNT, ipInterfaces.size());
+
+        List<Integer> ipInterfaceIds = ipInterfaces.stream().map(OnmsIpInterface::getId).collect(Collectors.toList());
+
+        List<OnmsMonitoredService> services =
+            monitoredServiceDao.findByServiceTypeAndIpInterfaceId(DeviceConfigRestService.DEVICE_CONFIG_SERVICE_PREFIX, ipInterfaceIds);
+        Assert.assertEquals(RECORD_COUNT, services.size());
+
+        // Add DeviceConfig entries mapped to ipInterfaces and services
+        deviceConfigDao.saveOrUpdate(createDeviceConfig(1, ipInterfaces.get(0), "default"));
+        deviceConfigDao.saveOrUpdate(createDeviceConfig(2, ipInterfaces.get(1), "default"));
+        deviceConfigDao.saveOrUpdate(createDeviceConfig(3, ipInterfaces.get(2), "running"));
+
+        Date currentDate = new Date();
+        List<DeviceConfigDTO> responseList = getDeviceConfigs(10, 0, "lastUpdated", "asc", null, null, null, null, null, null);
+
+        Assert.assertEquals(RECORD_COUNT, responseList.size());
+
+        List<String> expectedConfigTypes = List.of("default", "default", "running");
+        List<String> expectedScheduleIntervals = List.of("daily", "weekly", "monthly");
+
+        for (int i = 0; i < RECORD_COUNT; i++) {
+            DeviceConfigDTO dto = responseList.get(i);
+            final int version = i + 1;
+
+            Assert.assertEquals(ipInterfaceIds.get(i).intValue(), dto.getIpInterfaceId());
+            assertThat(expectedConfigTypes.get(i).equalsIgnoreCase(dto.getConfigType()), is(true));
+            Assert.assertEquals(Integer.toString(version), dto.getEncoding());
+            Assert.assertEquals(createdTime(version), dto.getCreatedTime().getTime());
+            Assert.assertEquals(createdTime(version), dto.getLastUpdatedDate().getTime());
+            Assert.assertEquals(createdTime(version), dto.getLastSucceededDate().getTime());
+            Assert.assertNull(dto.getLastFailedDate());
+            Assert.assertNull(dto.getFailureReason());
+            Assert.assertEquals(expectedScheduleIntervals.get(i), dto.getScheduledInterval());
+            assertThat(dto.getNextScheduledBackupDate().after(currentDate), is(true));
+        }
+    }
+
+    private List<OnmsIpInterface> populateDeviceConfigServiceInfo() {
+        List<OnmsIpInterface> ipInterfaces = new ArrayList<>();
+        NetworkBuilder builder = new NetworkBuilder();
+
+        List<String> nodeNames = List.of("dcb-1", "dcb-2", "dcb-3");
+        List<String> foreignIds = List.of("21", "22", "23");
+        List<String> ipAddresses = List.of("192.168.3.1", "192.168.3.2", "192.168.3.3");
+        List<String> serviceNames = List.of(
+            DeviceConfigRestService.DEVICE_CONFIG_SERVICE_PREFIX + "-" + ConfigType.Default,
+            DeviceConfigRestService.DEVICE_CONFIG_SERVICE_PREFIX + "-" + ConfigType.Default,
+            DeviceConfigRestService.DEVICE_CONFIG_SERVICE_PREFIX + "-" + "running");
+
+        List<String> scheduleIntervals = List.of("daily", "weekly", "monthly");
+
+        for (int i = 0; i < 3; i++) {
+            builder.addNode(nodeNames.get(i)).setForeignSource("imported:").setForeignId(foreignIds.get(i)).setType(OnmsNode.NodeType.ACTIVE);
+            builder.addInterface(ipAddresses.get(i)).setIsManaged("M").setIsSnmpPrimary("P");
+            builder.addService(addOrGetServiceType(serviceNames.get(i)));
+            builder.setServiceMetaDataEntry("requisition", "schedule", scheduleIntervals.get(i));
+            nodeDao.saveOrUpdate(builder.getCurrentNode());
+
+            OnmsIpInterface ipInterface = builder.getCurrentNode().getIpInterfaceByIpAddress(ipAddresses.get(i));
+            ipInterfaces.add(ipInterface);
+        }
+
+        return ipInterfaces;
+    }
+
+    private OnmsServiceType addOrGetServiceType(final String serviceName) {
+        OnmsServiceType serviceType = serviceTypeDao.findByName(serviceName);
+
+        if (serviceType == null) {
+            serviceType = new OnmsServiceType(serviceName);
+            serviceTypeDao.save(serviceType);
+            serviceTypeDao.flush();
+        }
+
+        return serviceType;
+    }
+
+    private List<DeviceConfigDTO> getDeviceConfigs(
+        Integer limit,
+        Integer offset,
+        String orderBy,
+        String order,
+        String deviceName,
+        String ipAddress,
+        Integer ipInterfaceId,
+        String configType,
+        Long createdAfter,
+        Long createdBefore
+    ) {
+        var response = deviceConfigRestService.getDeviceConfigs(limit, offset, orderBy, order, deviceName, ipAddress, ipInterfaceId, configType, createdAfter, createdBefore);
+        if (response.hasEntity()) {
+            return (List<DeviceConfigDTO>) response.getEntity();
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private static DeviceConfig createDeviceConfig(int version, OnmsIpInterface ipInterface1, String configType) {
+        Date date = new Date(createdTime(version));
+
+        var dc = new DeviceConfig();
+        dc.setConfig(new byte[version]);
+        dc.setLastUpdated(date);
+        dc.setLastSucceeded(date);
+        dc.setCreatedTime(date);
+        dc.setEncoding(String.valueOf(version));
+        dc.setIpInterface(ipInterface1);
+        dc.setConfigType(configType);
+
+        return dc;
+    }
+
+    private static long createdTime(int num) {
+        return num * 1000L * 60 * 60 * 24;
+    }
+}

--- a/features/opennms-osgi-core-rest/pom.xml
+++ b/features/opennms-osgi-core-rest/pom.xml
@@ -62,7 +62,7 @@
             <releases><enabled>true</enabled></releases>
             <id>opennms-repo</id>
             <name>OpenNMS Repository</name>
-            <url>http://maven.opennms.org/content/groups/opennms.org-release</url>
+            <url>https://maven.opennms.org/content/groups/opennms.org-release</url>
         </repository>
     </repositories>
 </project>

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoredServiceDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoredServiceDao.java
@@ -120,4 +120,6 @@ public interface MonitoredServiceDao extends LegacyOnmsDao<OnmsMonitoredService,
     OnmsMonitoredService getPrimaryService(Integer nodeId, String svcName);
 
     List<OnmsMonitoredService> findByNode(final int nodeId);
+
+    List<OnmsMonitoredService> findByServiceTypeAndIpInterfaceId(String serviceTypePrefix, List<Integer> ipInterfaceIds);
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockMonitoredServiceDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockMonitoredServiceDao.java
@@ -183,4 +183,9 @@ public class MockMonitoredServiceDao extends AbstractMockDao<OnmsMonitoredServic
                  .filter(svc -> svc.getNodeId() == nodeId)
                  .collect(Collectors.toList());
     }
+
+    @Override
+    public List<OnmsMonitoredService> findByServiceTypeAndIpInterfaceId(String serviceTypePrefix, List<Integer> ipInterfaceIds) {
+        throw new UnsupportedOperationException("Not yet implemented!");
+    }
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/UnimplementedMonitoredServiceDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/UnimplementedMonitoredServiceDao.java
@@ -155,7 +155,6 @@ public class UnimplementedMonitoredServiceDao implements MonitoredServiceDao {
         throw new UnsupportedOperationException("Not yet implemented!");
     }
 
-
     @Override
     public Set<OnmsMonitoredService> findByApplication(OnmsApplication application) {
         throw new UnsupportedOperationException("Not yet implemented!");
@@ -168,6 +167,11 @@ public class UnimplementedMonitoredServiceDao implements MonitoredServiceDao {
 
     @Override
     public List<OnmsMonitoredService> findByNode(int nodeId) {
+        throw new UnsupportedOperationException("Not yet implemented!");
+    }
+
+    @Override
+    public List<OnmsMonitoredService> findByServiceTypeAndIpInterfaceId(String serviceTypePrefix, List<Integer> ipInterfaceIds) {
         throw new UnsupportedOperationException("Not yet implemented!");
     }
 }

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/NetworkBuilder.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/NetworkBuilder.java
@@ -387,7 +387,7 @@ public class NetworkBuilder {
 
     public void setServiceMetaDataEntry(final String context, final String key, final String value) {
         if (m_currentMonSvc != null) {
-            m_currentNode.addMetaData(context, key, value);
+            m_currentMonSvc.addMetaData(context, key, value);
         }
     }
 


### PR DESCRIPTION
NMS-13970: DeviceConfigBackup REST API with Schedule info

Initial version of updated REST API that gets device config backup schedule info from Service metadata. Actual parsing of cron-style schedule pattern data will occur in subsequent PR.

'DeviceConfig' entries are retrieved as per sorting/filtering parameters, then the corresponding service schedule data is retrieved and mapped to the DTOs.

A separate integration test for the schedule part only was created as the DB setup is significantly different than the IT for the sort/filter part of the REST service.

Jira: https://issues.opennms.org/browse/NMS-13970