### PR TITLE
NMS-14011: Fix flaky smoke-test testRestHealthServiceOnSentinel

### DIFF
--- a/features/sentinel/runInPlace.sh
+++ b/features/sentinel/runInPlace.sh
@@ -54,8 +54,8 @@ set_instance_specific_configuration() {
   #tcp6       0      0 :::38287                :::*                    LISTEN      23306/java
   #### RMI Registry - Set in 'etc/org.apache.karaf.management.cfg' via rmiRegistryPort=1299 and the serviceUrl
   #tcp6       0      0 127.0.0.1:1399          :::*                    LISTEN      23306/java
-  #### Jetty - Set in 'etc/org.ops4j.pax.web.cfg' via :org.osgi.service.http.port=8181
-  #tcp6       0      0 :::8181                 :::*                    LISTEN      23306/java
+  #### Jetty - Set in 'etc/org.ops4j.pax.web.cfg' via :org.osgi.service.http.port=8191
+  #tcp6       0      0 :::8191                 :::*                    LISTEN      23306/java
   #### Random port use for Karaf management - Stored in 'data/port'
   #tcp6       0      0 127.0.0.1:34947         :::*                    LISTEN      23306/java
   #### RMI Server - Set in 'etc/org.apache.karaf.management.cfg' via rmiServerPort=45444 and the serviceUrl
@@ -66,7 +66,7 @@ set_instance_specific_configuration() {
   #udp6       0      0 :::1514                 :::*                                23306/java
 
   JAVA_DEBUG_PORT=$((6005 + offset))
-  JETTY_PORT=$((8181 + offset))
+  JETTY_PORT=$((8191 + offset))
   RMI_REGISTRY_PORT=$((1399 + offset))
   RMI_SERVER_PORT=$((46444 + offset))
   SNMP_TRAP_PORT=$((1162 + offset))

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -82,7 +82,7 @@ public class SentinelContainer extends GenericContainer implements KarafContaine
     private static final Logger LOG = LoggerFactory.getLogger(SentinelContainer.class);
     private static final int SENTINEL_DEBUG_PORT = 5005;
     private static final int SENTINEL_SSH_PORT = 8301;
-    private static final int SENTINEL_JETTY_PORT = 8181;
+    private static final int SENTINEL_JETTY_PORT = 8191;
     static final String ALIAS = "sentinel";
 
     private final StackModel model;


### PR DESCRIPTION
Using different ports for Sentinel and Minion in case this could be causing issues when running both containers on the same VM with same mapped port.


* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14011

