### PR TITLE
NMS-13947 Cache node artifacts

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -53,12 +53,9 @@ docker image load -i sentinel.oci
 
 ### Cache node artifacts
 
-We're are caching `node_modules` in `core/web-assets` with
-`npm --prefer-offline --no-progress install`.
-In conjunction with this we added caching of the `~/.npm/_cacache`
-directory. As a future improvements we should use `npm ci` for releases
-and `npm --prefer-offline --no-progress install` for dev.
-
+`node_modules` in `core/web-assets` does not need to be cached because we
+use `npm --prefer-offline --no-progress ci` which delete `node_modules` so
+ we cache the `~/.npm` directory.
 ### Weekly / cron triggered jobs
 
 Due to current setup trigger by cron is unavailable and has been replace by

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -54,10 +54,9 @@ docker image load -i sentinel.oci
 ### Cache node artifacts
 
 We're are caching `node_modules` in `core/web-assets` with
-`npm --prefer-offline --no-progress install`.
+`"install-deps": "npm --prefer-offline --no-progress install"`.
 In conjunction with this we added caching of the `~/.npm/_cacache`
 directory. As a future improvements we should use `npm ci` for releases
-and `npm --prefer-offline --no-progress install` for dev.
 
 ### Weekly / cron triggered jobs
 

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -57,6 +57,7 @@ We're are caching `node_modules` in `core/web-assets` with
 `"install-deps": "npm --prefer-offline --no-progress install"`.
 In conjunction with this we added caching of the `~/.npm/_cacache`
 directory. As a future improvements we should use `npm ci` for releases
+and `npm --prefer-offline --no-progress install` for dev.
 
 ### Weekly / cron triggered jobs
 

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -53,10 +53,10 @@ docker image load -i sentinel.oci
 
 ### Cache node artifacts
 
-We're currently caching `node_modules` in `core/web-assets`, but we use `npm ci`
-so it gets blown away anyway.  We should change this to store the `~/.npm`
-directory instead, as well as periodically clean it like we do for
-`~/.m2/repository`.
+We're are caching `node_modules` in `core/web-assets` with
+`"install-deps": "npm --prefer-offline --no-progress install"`.
+In conjunction with this we added caching of the `~/.npm/_cacache`
+directory. As a future improvements we should use `npm ci` for releases
 
 ### Weekly / cron triggered jobs
 

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -54,7 +54,7 @@ docker image load -i sentinel.oci
 ### Cache node artifacts
 
 We're are caching `node_modules` in `core/web-assets` with
-`"install-deps": "npm --prefer-offline --no-progress install"`.
+`npm --prefer-offline --no-progress install`.
 In conjunction with this we added caching of the `~/.npm/_cacache`
 directory. As a future improvements we should use `npm ci` for releases
 and `npm --prefer-offline --no-progress install` for dev.

--- a/.circleci/main/@main.yml
+++ b/.circleci/main/@main.yml
@@ -137,13 +137,13 @@ commands:
             command: find core/web-assets -name package\*.json -o -name bower.json | grep -v /target/ | sort -u | xargs cat > nodejs-dependency-json-cache.key
         - restore_cache:
             keys:
-              - nodejs-dependencies-v2-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
-              - nodejs-dependencies-v2-{{ checksum "pom-version-cache.key" }}-
+              - nodejs-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
+              - nodejs-dependencies-v3-{{ checksum "pom-version-cache.key" }}-
   save-nodejs-cache:
     description: "NodeJS: Save cache"
     steps:
       - save_cache:
-          key: nodejs-dependencies-v2-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
+          key: nodejs-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
           paths:
             - ~/.npm/_cacache
             - core/web-assets/node_modules

--- a/.circleci/main/@main.yml
+++ b/.circleci/main/@main.yml
@@ -145,6 +145,7 @@ commands:
       - save_cache:
           key: nodejs-dependencies-v2-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
           paths:
+            - ~/.npm/_cacache
             - core/web-assets/node_modules
   restore-sonar-cache:
       description: "Sonar: Restore sonar cache"

--- a/.circleci/main/@main.yml
+++ b/.circleci/main/@main.yml
@@ -145,8 +145,7 @@ commands:
       - save_cache:
           key: nodejs-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
           paths:
-            - ~/.npm/_cacache
-            - core/web-assets/node_modules
+            - ~/.npm
   restore-sonar-cache:
       description: "Sonar: Restore sonar cache"
       steps:


### PR DESCRIPTION
### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-13947

Result from build

```
Found a cache from build 116381 at nodejs-dependencies-v3-TeS0v4mbHi8haIv8yCeudjEOHL0qYe5eJEWhFZc31QU=-+2yB_AKHtGBvqsbqWIq9Np3cJU10qRpnWpDWQSeX2WU=
Size: 191 MiB
Cached paths:
  * /root/.npm/_cacache
  * /root/project/core/web-assets/node_modules
```
