### PR TITLE
NMS-13845: TLS: Diffie-Hellman Key Exchange Insufficient DH Group Str…

### DIFF
--- a/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
+++ b/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
@@ -70,20 +70,8 @@
     <Set name="sslSessionTimeout"><Property name="jetty.sslContext.sslSessionTimeout" default="-1"/></Set>
     <Set name="ExcludeCipherSuites">
       <Array type="java.lang.String">
-        <Item>SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA</Item>
-        <Item>SSL_DHE_DSS_WITH_DES_CBC_SHA</Item>
-        <Item>SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
-        <Item>SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA</Item>
-        <Item>SSL_DHE_RSA_WITH_DES_CBC_SHA</Item>
-        <Item>SSL_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
-        <Item>SSL_RSA_EXPORT_WITH_RC4_40_MD5</Item>
-        <Item>SSL_RSA_WITH_3DES_EDE_CBC_SHA</Item>
-        <Item>SSL_RSA_WITH_DES_CBC_SHA</Item>
-        <Item>TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
-        <Item>TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA</Item>
-        <Item>TLS_DHE_RSA_WITH_AES_128_CBC_SHA</Item>
-        <Item>TLS_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
-        <Item>TLS_RSA_WITH_DES_CBC_SHA</Item>
+        <Item>.*_CBC_.*</Item>
+        <Item>.*_DHE_.*</Item>
      </Array>
     </Set>
     <Call name="addExcludeProtocols">


### PR DESCRIPTION
…ength Vulnerability

Backport SSL/TLS cipher exclusion from jetty configuration
l


* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13845

