### PR TITLE
NMS-13939: Fix node interfaces REST API allowing creation of multiple primary SNMP interfaces

### DIFF
--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionInterface.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionInterface.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2021 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -395,10 +395,11 @@ public class RequisitionInterface implements Comparable<RequisitionInterface> {
         m_status = value;
     }
 
-    public void validate() throws ValidationException {
+    public void validate(RequisitionNode node) throws ValidationException {
         if (m_ipAddress == null) {
             throw new ValidationException("Requisition interface 'ip-addr' is a required attribute!");
         }
+
         if (m_monitoredServices != null) {
             Set<String> serviceNameSet = new HashSet<>();
             for (final RequisitionMonitoredService svc : m_monitoredServices) {
@@ -406,6 +407,17 @@ public class RequisitionInterface implements Comparable<RequisitionInterface> {
                 if (!serviceNameSet.add(svc.getServiceName())) {
                     throw new ValidationException("Duplicate service name: " + svc.getServiceName());
                 }
+            }
+        }
+
+        // there can be only one primary interface per node
+        if (m_snmpPrimary == PrimaryType.PRIMARY) {
+            long otherPrimaryInterfaces = node.getInterfaces().stream()
+                    .filter(iface -> PrimaryType.PRIMARY == iface.getSnmpPrimary())
+                    .filter(iface -> !iface.getIpAddr().equals(this.getIpAddr()))
+                    .count();
+            if (otherPrimaryInterfaces > 0) {
+                throw new ValidationException("Node foreign ID (" + node.getForeignId() + ") contains multiple primary interfaces. Maximum one is allowed.");
             }
         }
     }

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionNode.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionNode.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -543,11 +543,7 @@ public class RequisitionNode {
         }
         if (m_interfaces != null) {
             for (final RequisitionInterface iface : m_interfaces) {
-                iface.validate();
-            }
-            // there can be only one primary interface per node
-            if(m_interfaces.stream().filter(iface -> PrimaryType.PRIMARY == iface.m_snmpPrimary).count() > 1) {
-                throw new ValidationException("Node foreign ID (" + m_foreignId + ") contains multiple primary interfaces. Maximum one is allowed.");
+                iface.validate(this);
             }
         }
         if (m_categories != null) {

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/requisition/RequisitionInterfaceTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/requisition/RequisitionInterfaceTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.persist.requisition;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.netmgt.model.PrimaryType;
+
+import javax.xml.bind.ValidationException;
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+
+public class RequisitionInterfaceTest {
+
+    private RequisitionInterface iface;
+
+    private RequisitionNode nodeMock;
+
+    @Before
+    public void setUp() {
+        MockLogAppender.setupLogging();
+
+        iface = new RequisitionInterface();
+        iface.setIpAddr("0.0.0.0");
+
+        nodeMock = Mockito.mock(RequisitionNode.class);
+        when(nodeMock.getInterfaces()).thenReturn(Collections.emptyList());
+    }
+
+    @Test
+    public void testRequisitionInterfaceValid() throws ValidationException {
+        iface.validate(nodeMock);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testRequisitionInterfaceIpAddrInvalid() throws ValidationException {
+        iface = new RequisitionInterface(); // Get a new instance with a null ipAddr
+        iface.validate(nodeMock);
+    }
+
+    @Test
+    public void testRequisitionInterfaceValidatesServices() throws ValidationException {
+        RequisitionMonitoredService serviceMock = Mockito.mock(RequisitionMonitoredService.class);
+
+        when(serviceMock.getServiceName()).thenReturn("foo");
+
+        iface.getMonitoredServices().add(serviceMock);
+
+        iface.validate(nodeMock);
+        Mockito.verify(serviceMock).validate();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testRequisitionInterfaceValidatesServiceDuplicates() throws ValidationException {
+        RequisitionMonitoredService serviceMock1 = Mockito.mock(RequisitionMonitoredService.class);
+        RequisitionMonitoredService serviceMock2 = Mockito.mock(RequisitionMonitoredService.class);
+
+        when(serviceMock1.getServiceName()).thenReturn("foo");
+        when(serviceMock2.getServiceName()).thenReturn("foo");
+
+        iface.getMonitoredServices().add(serviceMock1);
+        iface.getMonitoredServices().add(serviceMock2);
+
+        iface.validate(nodeMock);
+    }
+
+    @Test
+    public void testRequisitionInterfaceExistingPrimarySNMPSameInterface() throws ValidationException {
+        RequisitionInterface ifaceMock = Mockito.mock(RequisitionInterface.class);
+        when(ifaceMock.getSnmpPrimary()).thenReturn(PrimaryType.PRIMARY);
+        when(ifaceMock.getIpAddr()).thenReturn("0.0.0.0"); // Same as tested object, duplication check should pass
+        when(nodeMock.getInterfaces()).thenReturn(Collections.singletonList(ifaceMock));
+
+        iface.setSnmpPrimary(PrimaryType.PRIMARY);
+        iface.validate(nodeMock);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testRequisitionInterfaceValidatesPrimarySNMPDuplicates() throws ValidationException {
+        RequisitionInterface ifaceMock = Mockito.mock(RequisitionInterface.class);
+
+        when(ifaceMock.getSnmpPrimary()).thenReturn(PrimaryType.PRIMARY);
+        when(ifaceMock.getIpAddr()).thenReturn("1.1.1.1"); // Different from tested object, duplication check should fail
+        when(nodeMock.getInterfaces()).thenReturn(Collections.singletonList(ifaceMock));
+
+        iface.setSnmpPrimary(PrimaryType.PRIMARY);
+        iface.validate(nodeMock);
+    }
+}

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/requisition/RequisitionNodeTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/requisition/RequisitionNodeTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.persist.requisition;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opennms.core.test.MockLogAppender;
+
+import javax.xml.bind.ValidationException;
+
+public class RequisitionNodeTest {
+
+    private RequisitionNode node;
+
+    @Before
+    public void setUp() {
+        MockLogAppender.setupLogging();
+
+        node = new RequisitionNode();
+        node.setNodeLabel("nodeLabel");
+        node.setForeignId("foreignId");
+    }
+
+    @Test
+    public void testRequisitionNodeValid() throws ValidationException {
+        node.validate();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testRequisitionNodeLabelValidation() throws ValidationException {
+        node.setNodeLabel(null);
+        node.validate();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testRequisitionNodeForeignIdValidation() throws ValidationException {
+        node.setForeignId(null);
+        node.validate();
+    }
+
+    @Test
+    public void testRequisitionNodeValidatesInterfaces() throws ValidationException {
+        RequisitionInterface ifaceMock = Mockito.mock(RequisitionInterface.class);
+
+        node.getInterfaces().add(ifaceMock);
+
+        node.validate();
+        Mockito.verify(ifaceMock).validate(node);
+    }
+
+    @Test
+    public void testRequisitionNodeValidatesCategories() throws ValidationException {
+        RequisitionCategory categoryMock = Mockito.mock(RequisitionCategory.class);
+
+        node.getCategories().add(categoryMock);
+
+        node.validate();
+        Mockito.verify(categoryMock).validate();
+    }
+
+    @Test
+    public void testRequisitionNodeValidatesAssets() throws ValidationException {
+        RequisitionAsset assetMock = Mockito.mock(RequisitionAsset.class);
+
+        node.getAssets().add(assetMock);
+
+        node.validate();
+        Mockito.verify(assetMock).validate();
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
@@ -493,7 +493,8 @@ public class RequisitionRestService extends OnmsRestService {
     @Transactional
     public Response addOrReplaceInterface(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, RequisitionInterface iface) {
         try {
-            iface.validate();
+            final RequisitionNode node = m_accessService.getNode(foreignSource, foreignId);
+            iface.validate(node);
         } catch (final ValidationException e) {
             LOG.debug("error validating incoming interface '{}'", iface, e);
             throw getException(Status.BAD_REQUEST, e.getMessage());


### PR DESCRIPTION
* Checks the other interfaces of a node to prevent duplicates
* Adds tests for RequisitionNode and RequisitionInterface validation

JIRA: https://issues.opennms.org/browse/NMS-13939