### PR TITLE
NMS-13990: DeviceConfigBackup Rest API for downloading config data

### DIFF
--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -87,7 +87,7 @@ export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 export MAVEN_OPTS="$MAVEN_OPTS -Xmx8g -XX:ReservedCodeCacheSize=1g"
 
 # Set higher open files limit
-ulimit -n 20480
+ulimit -n 65536
 
 
 echo "#### Building Assembly Dependencies"

--- a/.circleci/scripts/smoke.sh
+++ b/.circleci/scripts/smoke.sh
@@ -51,7 +51,7 @@ done
 export MAVEN_OPTS="-Xmx1g -Xms1g"
 
 # Set higher open files limit
-ulimit -n 20480
+ulimit -n 65536
 
 cd ~/project/smoke-test
 if [ $SUITE = "minimal" ]; then

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -91,6 +91,9 @@
     <feature name="commons-collections" version="${commonsCollectionsVersion}" description="Apache :: commons-collections">
         <bundle>mvn:commons-collections/commons-collections/${commonsCollectionsVersion}</bundle>
     </feature>
+    <feature name="commons-compress" version="1.21" description="Apache :: commons-compress">
+        <bundle>mvn:org.apache.commons/commons-compress/1.21</bundle>
+    </feature>
     <feature name="commons-configuration" version="${commonsConfigurationVersion}" description="Apache :: commons-configuration">
         <feature>commons-beanutils</feature>
         <feature>commons-codec</feature>
@@ -1918,6 +1921,7 @@
     </feature>
 
     <feature name="opennms-deviceconfig-rest" description="OpenNMS :: Features :: Device Config :: Rest" version="${project.version}">
+        <feature>commons-compress</feature>
         <feature>opennms-osgi-core-rest</feature>
         <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.rest/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/${project.version}</bundle>

--- a/features/device-config/api/pom.xml
+++ b/features/device-config/api/pom.xml
@@ -29,4 +29,30 @@
             </plugin>
         </plugins>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commonsCompressVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigUtil.java
+++ b/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigUtil.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.deviceconfig.service;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+
+import com.google.common.base.Strings;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.lang3.ArrayUtils;
+
+public class DeviceConfigUtil {
+
+    public static byte[] decompressGzipToBytes(byte[] source) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(source))) {
+
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gis.read(buffer)) > 0) {
+                output.write(buffer, 0, len);
+            }
+        }
+
+        return output.toByteArray();
+    }
+
+    public static byte[] tarGzipMultipleFiles(Map<String, byte[]> fileNameToDataMap) throws IOException {
+        if (fileNameToDataMap == null || fileNameToDataMap.isEmpty()) {
+            return null;
+        }
+
+        byte[] tarBytes = tarMultipleFiles(fileNameToDataMap);
+        var byteOutputStream = new ByteArrayOutputStream();
+
+        try (var gzipOut = new GzipCompressorOutputStream(byteOutputStream)) {
+            gzipOut.write(tarBytes);
+        }
+
+        return byteOutputStream.toByteArray();
+    }
+
+    public static Map<String, byte[]> unTarGzipMultipleFiles(byte[] tarGzipData) throws IOException {
+        if (tarGzipData == null) {
+            return new HashMap<>();
+        }
+
+        var result = new HashMap<String, byte[]>();
+        var byteArrayInputStream = new ByteArrayInputStream(tarGzipData);
+        var gzipInputStream = new GZIPInputStream(byteArrayInputStream);
+
+        try (var tarInputStream = new TarArchiveInputStream(gzipInputStream)) {
+            TarArchiveEntry tarEntry = null;
+            final int BUFLEN = 1024;
+            byte[] buffer = new byte[BUFLEN];
+
+            while ((tarEntry = tarInputStream.getNextTarEntry()) != null) {
+                if (tarEntry.isFile()) {
+                    String fileName = tarEntry.getName();
+
+                    var byteOutput = new ByteArrayOutputStream();
+
+                    try (var bufOut = new BufferedOutputStream(byteOutput)) {
+                        int len = 0;
+
+                        while ((len = tarInputStream.read(buffer)) != -1) {
+                            bufOut.write(buffer, 0, len);
+                        }
+                    }
+
+                    byte[] bytesRead = byteOutput.toByteArray();
+                    result.put(fileName, bytesRead);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public static byte[] tarMultipleFiles(Map<String, byte[]> fileNameToDataMap) throws IOException {
+        var byteOutputStream = new ByteArrayOutputStream();
+
+        try (var tarOut = new TarArchiveOutputStream(byteOutputStream)) {
+            for (Map.Entry<String, byte[]> entry : fileNameToDataMap.entrySet()) {
+                if (!Strings.isNullOrEmpty(entry.getKey()) && entry.getValue() != null) {
+                    var archiveEntry = new TarArchiveEntry(entry.getKey());
+                    archiveEntry.setName(entry.getKey());
+                    archiveEntry.setSize(entry.getValue().length);
+
+                    tarOut.putArchiveEntry(archiveEntry);
+                    tarOut.write(entry.getValue());
+                    tarOut.closeArchiveEntry();
+                }
+            }
+        }
+
+        return byteOutputStream.toByteArray();
+    }
+}

--- a/features/device-config/api/src/test/java/org/opennms/features/deviceconfig/service/DeviceConfigUtilTest.java
+++ b/features/device-config/api/src/test/java/org/opennms/features/deviceconfig/service/DeviceConfigUtilTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.deviceconfig.service;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DeviceConfigUtilTest {
+
+    @Test
+    public void gzipMultipleFilesNullTest() {
+        byte[] result = null;
+
+        try {
+            result = DeviceConfigUtil.tarGzipMultipleFiles(null);
+        } catch (IOException e) {
+            Assert.fail("IOException thrown when fileNameToDataMap argument was null");
+        }
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void gzipMultipleFilesEmptyTest() {
+        byte[] result = null;
+
+        try {
+            result = DeviceConfigUtil.tarGzipMultipleFiles(new HashMap<String, byte[]>());
+        } catch (IOException e) {
+            Assert.fail("IOException thrown when fileNameToDataMap argument was empty");
+        }
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void gzipMultipleFilesAndExtractTest() {
+        var keys = List.of("one.cfg", "two.cfg", "three.cfg", "four.cfg");
+        var values = List.of(new byte[] { 1 }, new byte[] { 2 }, new byte[] { 3 }, new byte[] { 4 });
+
+        Map<String,byte[]> fileNameToDataMap =
+            IntStream.range(0, keys.size()).boxed().collect(Collectors.toMap(keys::get, values::get));
+
+        byte[] result = null;
+
+        try {
+            result = DeviceConfigUtil.tarGzipMultipleFiles(fileNameToDataMap);
+        } catch (IOException e) {
+            Assert.fail("IOException thrown during gzipMultipleFiles");
+        }
+
+        Assert.assertNotNull(result);
+
+        Map<String,byte[]> resultMap = null;
+
+        try {
+            resultMap = DeviceConfigUtil.unTarGzipMultipleFiles(result);
+        } catch (IOException e) {
+            Assert.fail("IOException throw during untarGzipMultipleFiles");
+        }
+
+        final Map<String,byte[]> finalResultMap = resultMap;
+        Assert.assertNotNull(finalResultMap);
+        Assert.assertEquals(4, finalResultMap.size());
+        Assert.assertTrue(keys.stream().allMatch(finalResultMap::containsKey));
+
+        for (int index : IntStream.range(0, keys.size()).toArray()) {
+            String key = keys.get(index);
+            byte[] value = values.get(index);
+            Assert.assertArrayEquals(finalResultMap.get(key), value);
+        }
+    }
+}

--- a/features/device-config/rest/pom.xml
+++ b/features/device-config/rest/pom.xml
@@ -35,11 +35,6 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opennms.features.device-config.persistence</groupId>
-            <artifactId>org.opennms.features.device-config.persistence.api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-model</artifactId>
             <version>${project.version}</version>
@@ -54,8 +49,25 @@
             <artifactId>opennms-web-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.opennms.core.test-api</groupId>
+            <artifactId>org.opennms.core.test-api.lib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core.test-api</groupId>
+            <artifactId>org.opennms.core.test-api.db</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core.test-api</groupId>
+            <artifactId>org.opennms.core.test-api.services</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.features.device-config</groupId>
             <artifactId>org.opennms.features.device-config.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.features.device-config.persistence</groupId>
+            <artifactId>org.opennms.features.device-config.persistence.api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -69,26 +81,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.opennms.features.collection</groupId>
-            <artifactId>org.opennms.features.collection.persistence.rrd</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opennms.core.test-api</groupId>
-            <artifactId>org.opennms.core.test-api.lib</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opennms.core.test-api</groupId>
-            <artifactId>org.opennms.core.test-api.db</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-dao-mock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.opennms.core.test-api</groupId>
-            <artifactId>org.opennms.core.test-api.services</artifactId>
+            <groupId>org.opennms.features.collection</groupId>
+            <artifactId>org.opennms.features.collection.persistence.rrd</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.opennms.features.device-config.persistence</groupId>

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigRestService.java
@@ -46,8 +46,14 @@ import javax.ws.rs.core.Response;
 public interface DeviceConfigRestService {
     public static final String DEVICE_CONFIG_SERVICE_PREFIX = "DeviceConfig";
 
-    // paging, filter by ipaddressId, last updated time, config created time, last succeeded, last failed, config type
-    // order by last updated time (asc, desc)
+    /**
+     * Get device config info for a single item, by DeviceConfig id.
+     * @param id database id of device config
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("{id : \\d+}")
+    Response getDeviceConfig(@PathParam("id") long id);
 
     /**
      * Gets a list of device configs along with backup schedule information.
@@ -79,29 +85,22 @@ public interface DeviceConfigRestService {
         @QueryParam("createdBefore") Long createdBefore
     );
 
-    @GET
-    @Path("{id}")
-    DeviceConfigDTO getDeviceConfig(@PathParam("id") long id);
-
+    /**
+     * Delete a single device config.
+     * @param id
+     */
     @DELETE
-    @Path("{id}")
+    @Path("{id : \\d+}")
     void deleteDeviceConfig(@PathParam("id") long id);
 
     /**
-     * Download the most recent backup configuration for a single device.
+     * Download configurations for the given id or comma-separated list of ids.
+     * Single configurations will be returned as a single file.
+     * Multiple configurations will be returned inside a .tgz file.
      */
     @GET
-    @Path("/download/{id}")
-    Response downloadDeviceConfig(@PathParam("id") long id);
-
-    /**
-     * Download a zip file containing the most recent backup configurations for multiple devices.
-     * POST will be Json
-     */
-    @POST
     @Path("/download")
-    Response downloadDeviceConfigs();
-
+    Response downloadDeviceConfig(@QueryParam("id") @DefaultValue("") String id);
 
     @POST
     @Path("/backup")

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -28,16 +28,26 @@
 
 package org.opennms.features.deviceconfig.rest.impl;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.ws.rs.PathParam;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +61,7 @@ import org.opennms.features.deviceconfig.rest.BackupRequestDTO;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigDTO;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigRestService;
 import org.opennms.features.deviceconfig.service.DeviceConfigService;
+import org.opennms.features.deviceconfig.service.DeviceConfigUtil;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMetaData;
@@ -97,6 +108,26 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         this.deviceConfigService = deviceConfigService;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public Response getDeviceConfig(long id) {
+        final var dc = deviceConfigDao.get(id);
+
+        if (dc == null) {
+            return Response.noContent().build();
+        }
+
+        DeviceConfigDTO dto = createDeviceConfigDto(dc);
+        final List<DeviceConfigDTO> dtos = List.of(dto);
+
+        final Map<Integer, List<OnmsMonitoredService>> serviceMap = getServiceMapForDTOs(dtos);
+        populateScheduleInfo(dtos, serviceMap);
+        dto = dtos.get(0);
+
+        return Response.ok(dto).build();
+    }
+
+    /** {@inheritDoc} */
     @Override
     public Response getDeviceConfigs(
             Integer limit,
@@ -113,21 +144,12 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         var criteria = getCriteria(limit, offset, orderBy, order, deviceName, ipAddress, ipInterfaceId, configType, createdAfter, createdBefore);
 
         // find DeviceConfig items in device_config database as per filter/sort criteria
-        List<DeviceConfig> deviceConfigs = deviceConfigDao.findMatching(criteria);
+        final List<DeviceConfig> deviceConfigs = deviceConfigDao.findMatching(criteria);
 
         // do initial conversion to DTO with DeviceConfig data
-        List<DeviceConfigDTO> dtos = deviceConfigs.stream().map(DefaultDeviceConfigRestService::createDeviceConfigDto).collect(Collectors.toList());
+        final List<DeviceConfigDTO> dtos = deviceConfigs.stream().map(DefaultDeviceConfigRestService::createDeviceConfigDto).collect(Collectors.toList());
 
-        // Get ipInterface Ids for current set of device configs
-        List<Integer> ipInterfaceIds = dtos.stream().map(d -> d.getIpInterfaceId()).distinct().collect(Collectors.toList());
-
-        // Get the services matching the above device config records
-        List<OnmsMonitoredService> services = getDeviceConfigServices(ipInterfaceIds);
-
-        // Get a list of services per ipInterfaceId so we can correlate with DeviceConfig data
-        Map<Integer, List<OnmsMonitoredService>> serviceMap =
-            services.stream().collect(Collectors.groupingBy(OnmsMonitoredService::getIpInterfaceId));
-
+        final Map<Integer, List<OnmsMonitoredService>> serviceMap = getServiceMapForDTOs(dtos);
         populateScheduleInfo(dtos, serviceMap);
 
         if (limit != null || offset != null) {
@@ -145,11 +167,162 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public void deleteDeviceConfig(long id) {
+        deviceConfigDao.delete(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Response downloadDeviceConfig(String id) {
+        LOG.debug("In downloadDeviceConfig");
+
+        if (Strings.isNullOrEmpty(id)) {
+            LOG.debug("empty or null id supplied by request");
+            return Response.noContent().build();
+        }
+
+        final String idParamPattern = "\\d+(, ?\\d+)*";
+        var pattern = Pattern.compile(idParamPattern);
+        var matcher = pattern.matcher(id);
+
+        if (!matcher.matches()) {
+            LOG.debug("invalid id param supplied by request");
+            return Response.status(Status.BAD_REQUEST).entity("Invalid 'id' parameter").build();
+        }
+
+        List<Long> ids = Arrays.stream(id.split(","))
+            .filter(s -> !Strings.isNullOrEmpty(s))
+            .map(s -> Long.parseLong(s))
+            .collect(Collectors.toList());
+
+        if (ids.isEmpty()) {
+            LOG.debug("no ids supplied by request");
+            return Response.noContent().build();
+        }
+
+        if (ids.size() == 1) {
+            return downloadSingleDeviceConfig(ids.get(0));
+        } else {
+            return downloadMultipleDeviceCofigs(ids);
+        }
+    }
+
+    private Response downloadSingleDeviceConfig(Long id) {
+        final DeviceConfig dc = deviceConfigDao.get(id);
+
+        if (dc == null || dc.getConfig() == null || dc.getConfig().length == 0) {
+            LOG.debug("could not find device config data for id: {}", id);
+            return Response.noContent().build();
+        }
+
+        final var outputStream = new ByteArrayOutputStream();
+        outputStream.write(dc.getConfig(), 0, dc.getConfig().length);
+
+        final String fileName = createDownloadFileName(dc);
+
+        // TODO: Update MIME type, charset based on 'encoding'
+        return Response.ok().type("text/plain;charset=UTF-8")
+            .header("Content-Disposition", "inline; filename=" + fileName)
+            .header("Pragma", "public")
+            .header("Cache-Control", "cache")
+            .header("Cache-Control", "must-revalidate")
+            .entity(outputStream.toByteArray()).build();
+    }
+
+    private Response downloadMultipleDeviceCofigs(List<Long> ids) {
+        final Map<String, byte[]> fileNameToDataMap = ids.stream()
+            .map(id -> deviceConfigDao.get(id))
+            .filter(dc -> dc != null && dc.getConfig() != null && dc.getConfig().length > 0)
+            .collect(Collectors.toMap(dc -> createDownloadFileName(dc), dc -> dc.getConfig()));
+
+        if (fileNameToDataMap.isEmpty()) {
+            LOG.debug("no config data found for request");
+            return Response.noContent().build();
+        }
+
+        byte[] gzipBytes = null;
+
+        try {
+            gzipBytes = DeviceConfigUtil.tarGzipMultipleFiles(fileNameToDataMap);
+        } catch (IOException e) {
+            var message = "Error compressing multiple files for download.";
+            LOG.error(message, e);
+            throw getException(Status.INTERNAL_SERVER_ERROR, message);
+        }
+
+        // TODO: better file name; check if all same node then use common nodelabel; add timestamp
+        final var currentTime = new Date();
+        final var formatter = new SimpleDateFormat("YYYYMMdd-HHmmss");
+        final String timestamp = formatter.format(currentTime);
+        final String fileName = "device-configs-" + timestamp + ".tar.gz";
+
+        return Response.ok().type("application/gzip")
+            .header("Content-Disposition", "inline; filename=" + fileName)
+            .header("Pragma", "public")
+            .header("Cache-Control", "cache")
+            .header("Cache-Control", "must-revalidate")
+            .entity(gzipBytes).build();
+    }
+
+    public static Optional<String> getScheduleValue(final List<OnmsMonitoredService> serviceList, final String serviceName) {
+        final var matchingService =
+            serviceList.stream()
+                .filter(x -> x.getServiceName().equalsIgnoreCase(serviceName))
+                .findFirst();
+
+        if (matchingService.isPresent()) {
+            return getScheduleMetaDataValue(matchingService.get().getMetaData());
+        }
+
+        return Optional.empty();
+    }
+
+    public static Optional<String> getScheduleMetaDataValue(final List<OnmsMetaData> metaData) {
+        final var entry = metaData.stream()
+            .filter(m -> m.getContext().equals(REQUISITION_CONTEXT) && m.getKey().equals((SCHEDULE_METADATA_KEY)))
+            .map(m -> m.getValue())
+            .findFirst();
+
+        return entry;
+    }
+
+    public static String createDownloadFileName(
+        final String deviceName, String ipAddress, String configType, Date createdTime) {
+        final var formatter = new SimpleDateFormat("YYYYMMdd-HHmmss");
+
+        final var items = List.of(
+            !Strings.isNullOrEmpty(deviceName) ? deviceName : "device",
+            !Strings.isNullOrEmpty(ipAddress) ? ipAddress.replace('.', '_') : "ipaddress",
+            !Strings.isNullOrEmpty(configType) ? configType : "default",
+            formatter.format(createdTime)
+        );
+
+        final String fileName = String.join("-", items) + ".cfg";
+
+        return fileName;
+    }
+
     /** Get DeviceConfig-related OnmsMonitoredServices for the given ip interface ids. */
     private List<OnmsMonitoredService> getDeviceConfigServices(List<Integer> ipInterfaceIds) {
-        List<OnmsMonitoredService> services = monitoredServiceDao.findByServiceTypeAndIpInterfaceId(DEVICE_CONFIG_SERVICE_PREFIX, ipInterfaceIds);
+        final List<OnmsMonitoredService> services = monitoredServiceDao.findByServiceTypeAndIpInterfaceId(DEVICE_CONFIG_SERVICE_PREFIX, ipInterfaceIds);
 
         return services;
+    }
+
+    private Map<Integer, List<OnmsMonitoredService>> getServiceMapForDTOs(List<DeviceConfigDTO> dtos) {
+        // Get ipInterface Ids for DTOs
+        final List<Integer> ipInterfaceIds = dtos.stream().map(d -> d.getIpInterfaceId()).distinct().collect(Collectors.toList());
+
+        // Get the services matching the above device config records
+        final List<OnmsMonitoredService> services = getDeviceConfigServices(ipInterfaceIds);
+
+        // Get a list of services per ipInterfaceId so we can correlate with DeviceConfig data
+        final Map<Integer, List<OnmsMonitoredService>> serviceMap =
+            services.stream().collect(Collectors.groupingBy(OnmsMonitoredService::getIpInterfaceId));
+
+        return serviceMap;
     }
 
     /**
@@ -178,56 +351,12 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         }
     }
 
-    public static Optional<String> getScheduleValue(final List<OnmsMonitoredService> serviceList, final String serviceName) {
-        final var matchingService =
-            serviceList.stream()
-            .filter(x -> x.getServiceName().equalsIgnoreCase(serviceName))
-            .findFirst();
-
-        if (matchingService.isPresent()) {
-            return getScheduleMetaDataValue(matchingService.get().getMetaData());
-        }
-
-        return Optional.empty();
-    }
-
-    public static Optional<String> getScheduleMetaDataValue(final List<OnmsMetaData> metaData) {
-        final var entry = metaData.stream()
-            .filter(m -> m.getContext().equals(REQUISITION_CONTEXT) && m.getKey().equals((SCHEDULE_METADATA_KEY)))
-            .map(m -> m.getValue())
-            .findFirst();
-
-        return entry;
-    }
-
     private ScheduleInfo getScheduleInfo(Date current, String schedulePattern) {
         // TODO: parse out cron-style schedulePattern and determine values
-
         final Date nextScheduledBackup = Date.from(current.toInstant().plus(Duration.ofHours(25)));
         final String scheduleInterval = schedulePattern;
 
         return new ScheduleInfo(nextScheduledBackup, scheduleInterval);
-    }
-
-    @Override
-    public DeviceConfigDTO getDeviceConfig(long id) {
-        var dc = deviceConfigDao.get(id);
-        return createDeviceConfigDto(dc);
-    }
-
-    @Override
-    public void deleteDeviceConfig(long id) {
-        deviceConfigDao.delete(id);
-    }
-
-    @Override
-    public Response downloadDeviceConfig(@PathParam("id") long id) {
-        throw new UnsupportedOperationException("downloadDeviceConfig not yet implemented.");
-    }
-
-    @Override
-    public Response downloadDeviceConfigs() {
-        throw new UnsupportedOperationException("downloadDeviceConfigs not yet implemented.");
     }
 
     @Override
@@ -306,6 +435,10 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         return criteriaBuilder.toCriteria();
     }
 
+    private WebApplicationException getException(final Status status, final String message) {
+        return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(message).build());
+    }
+
     private static DeviceConfigDTO createDeviceConfigDto(DeviceConfig deviceConfig) {
         var dto = new DeviceConfigDTO(
             deviceConfig.getId(),
@@ -321,8 +454,13 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             deviceConfig.getFailureReason()
         );
 
-        OnmsIpInterface ipInterface = deviceConfig.getIpInterface();
-        OnmsNode node = ipInterface.getNode();
+        // determine backup status, not handling all cases for now
+        boolean backupSuccess = determineBackupSuccess(deviceConfig);
+        dto.setIsSuccessfulBackup(backupSuccess);
+        dto.setBackupStatus(backupSuccess ? "success" : "failure");
+
+        final OnmsIpInterface ipInterface = deviceConfig.getIpInterface();
+        final OnmsNode node = ipInterface.getNode();
 
         dto.setNodeId(node.getId());
         dto.setNodeLabel(node.getLabel());
@@ -331,5 +469,20 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         dto.setOperatingSystem(node.getOperatingSystem());
 
         return dto;
+    }
+
+    private static boolean determineBackupSuccess(DeviceConfig deviceConfig) {
+        return
+            deviceConfig.getLastSucceeded() != null &&
+            (deviceConfig.getLastSucceeded().getTime() == deviceConfig.getLastUpdated().getTime() ||
+             deviceConfig.getLastSucceeded().after(deviceConfig.getLastUpdated()));
+    }
+
+    private static String createDownloadFileName(DeviceConfig dc) {
+        OnmsIpInterface ipInterface = dc.getIpInterface();
+        String ipAddress = InetAddressUtils.str(ipInterface.getIpAddress());
+        String deviceName = ipInterface.getNode().getLabel();
+
+        return createDownloadFileName(deviceName, ipAddress, dc.getConfigType(), dc.getCreatedTime());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1642,6 +1642,7 @@
     <commonsBeanutilsVersion>1.9.4</commonsBeanutilsVersion>
     <commonsCodecVersion>1.10</commonsCodecVersion>
     <commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
+    <commonsCompressVersion>1.21</commonsCompressVersion>
     <commonsConfigurationVersion>1.6</commonsConfigurationVersion>
     <commonsCsvVersion>1.5</commonsCsvVersion>
     <commonsDigesterVersion>2.1</commonsDigesterVersion>


### PR DESCRIPTION
Rest API for downloading the actual device config backup configuration data.

Pass comma-separated `id` query parameters with the `device_config` id.

- `GET /rest/device-config/download?id=1` downloads a single file, with encoding as per the file (for now, `text/plain`)
- `GET /rest/device-config/download?id=1,2,3` downloads a single `.tar.gz` file with the configuration files for ids 1, 2 and 3 inside.

Incorporated tar/gzip helpers in `DeviceConfigUtil` class.

Jira: https://issues.opennms.org/browse/NMS-13990

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/13990

