### PR TITLE
NMS-14039: determine IP address for TFTP server

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1893,6 +1893,7 @@
     <feature name="opennms-deviceconfig-monitor" description="OpenNMS :: Features :: Device Config :: Monitor" version="${project.version}">
         <feature>opennms-deviceconfig-tftp</feature>
         <feature>quartz</feature>
+        <feature>opennms-util</feature>
         <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.ssh-scripting/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.retrieval/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.monitor/${project.version}</bundle>

--- a/features/device-config/ssh-scripting/pom.xml
+++ b/features/device-config/ssh-scripting/pom.xml
@@ -47,6 +47,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-util</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
@@ -35,6 +35,7 @@ import java.io.PipedOutputStream;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -59,9 +60,26 @@ public class SshScriptingServiceImpl implements SshScriptingService {
 
     private static Logger LOG = LoggerFactory.getLogger(SshScriptingServiceImpl.class);
 
-    public static final String TFTP_SERVER_IPV4_ADDRESS_PROPERTY = "org.opennms.features.deviceconfig.tftpServerIPv4Address";
-    public static final String TFTP_SERVER_IPV6_ADDRESS_PROPERTY = "org.opennms.features.deviceconfig.tftpServerIPv6Address";
-    public static String SCRIPT_VAR_TFTP_SERVER_IP = "tftpServerIp";
+    public static final String SCRIPT_VAR_TFTP_SERVER_IP = "tftpServerIp";
+
+    private InetAddress tftpServerIPv4Address;
+    private InetAddress tftpServerIPv6Address;
+
+    public void setTftpServerIPv4Address(final String tftpServerIPv4Address) throws UnknownHostException {
+        if (!Strings.isNullOrEmpty(tftpServerIPv4Address)) {
+            this.tftpServerIPv4Address = InetAddress.getByName(tftpServerIPv4Address);
+        } else {
+            this.tftpServerIPv4Address = null;
+        }
+    }
+
+    public void setTftpServerIPv6Address(final String tftpServerIPv6Address) throws UnknownHostException {
+        if (!Strings.isNullOrEmpty(tftpServerIPv6Address)) {
+            this.tftpServerIPv6Address = InetAddress.getByName(tftpServerIPv6Address);
+        } else {
+            this.tftpServerIPv6Address = null;
+        }
+    }
 
     @Override
     public Optional<Failure> execute(
@@ -79,7 +97,7 @@ public class SshScriptingServiceImpl implements SshScriptingService {
                 ),
                 statements -> {
                     try {
-                        try (var sshInteraction = new SshInteractionImpl(user, password, host, port, vars, timeout)) {
+                        try (var sshInteraction = new SshInteractionImpl(user, password, host, port, vars, timeout, tftpServerIPv4Address, tftpServerIPv6Address)) {
                             for (var statement : statements) {
                                 try {
                                     statement.execute(sshInteraction);
@@ -132,7 +150,9 @@ public class SshScriptingServiceImpl implements SshScriptingService {
                 String host,
                 int port,
                 Map<String, String> vars,
-                Duration timeout
+                Duration timeout,
+                InetAddress tftpServerIPv4Address,
+                InetAddress tftpServerIPv6Address
         ) throws Exception {
             sshClient = SshClient.setUpDefaultClient();
             sshClient.start();
@@ -142,22 +162,23 @@ public class SshScriptingServiceImpl implements SshScriptingService {
                         .verify(timeout)
                         .getSession();
 
+                // we use the remote address to check whether we have to use the IPv4 or IPv6 property
                 final InetAddress remoteAddress = ((InetSocketAddress) session.getRemoteAddress()).getAddress();
-
-                final String ipAddress;
-
-                if (remoteAddress instanceof Inet4Address) {
-                    ipAddress = System.getProperties().getProperty(TFTP_SERVER_IPV4_ADDRESS_PROPERTY);
-                } else {
-                    ipAddress = System.getProperties().getProperty(TFTP_SERVER_IPV6_ADDRESS_PROPERTY);
-                }
 
                 final InetAddress localAddress;
 
-                if (!Strings.isNullOrEmpty(ipAddress)) {
-                    localAddress = InetAddress.getByName(ipAddress);
+                if (remoteAddress instanceof Inet4Address) {
+                    if (tftpServerIPv4Address != null) {
+                        localAddress = tftpServerIPv4Address;
+                    } else {
+                        localAddress = ((InetSocketAddress) session.getLocalAddress()).getAddress();
+                    }
                 } else {
-                    localAddress = ((InetSocketAddress) session.getLocalAddress()).getAddress();
+                    if (tftpServerIPv6Address != null) {
+                        localAddress = tftpServerIPv6Address;
+                    } else {
+                        localAddress = ((InetSocketAddress) session.getLocalAddress()).getAddress();
+                    }
                 }
 
                 try {

--- a/features/device-config/ssh-scripting/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/device-config/ssh-scripting/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,7 +4,23 @@
     xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
     xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
+    <cm:property-placeholder id="sshScriptingServiceProperties" persistent-id="org.opennms.features.deviceconfig.sshscripting" update-strategy="reload">
+        <cm:default-properties>
+            <!--
+            The device config backup feature allows the retrieval of network device configurations by using the TFTP
+            protocol. To achieve this, a TFTP server needs to be started on the OpenNMS instance or on a minion. Normally
+            the IP address to use is determined by picking the interface address that the operating system will use to reach
+            the destination device. In the case of a dockerized minion running not in host networking mode, the IP address
+            cannot be automatically determined. In this case this property can be set to specify the IP address to be used.
+            -->
+            <cm:property name="tftpServerIPv4Address" value=""/>
+            <cm:property name="tftpServerIPv6Address" value=""/>
+        </cm:default-properties>
+    </cm:property-placeholder>
+
     <bean id="sshScriptingService" class="org.opennms.features.deviceconfig.sshscripting.impl.SshScriptingServiceImpl">
+        <property name="tftpServerIPv4Address" value="${tftpServerIPv4Address}" />
+        <property name="tftpServerIPv6Address" value="${tftpServerIPv6Address}" />
     </bean>
 
     <service ref="sshScriptingService" interface="org.opennms.features.deviceconfig.sshscripting.SshScriptingService"/>

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -865,3 +865,10 @@ org.opennms.newts.nan_on_counter_wrap=true
 # By default this property is not used and empty.
 # org.opennms.netmgt.search.info=
 
+# The device config backup feature allows the retrieval of network device configurations by using the TFTP
+# protocol. To achieve this, a TFTP server needs to be started on the OpenNMS instance or on a minion. Normally
+# the IP address to use is determined by picking the interface address that the operating system will use to reach
+# the destination device. In the case of a dockerized minion running not in host networking mode, the Ip address
+# cannot be automatically determined. In this case this property can be set to specify the IP address to be used.
+# org.opennms.features.deviceconfig.tftpServerIPv4Address=
+# org.opennms.features.deviceconfig.tftpServerIPv6Address=

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -864,11 +864,3 @@ org.opennms.newts.nan_on_counter_wrap=true
 #
 # By default this property is not used and empty.
 # org.opennms.netmgt.search.info=
-
-# The device config backup feature allows the retrieval of network device configurations by using the TFTP
-# protocol. To achieve this, a TFTP server needs to be started on the OpenNMS instance or on a minion. Normally
-# the IP address to use is determined by picking the interface address that the operating system will use to reach
-# the destination device. In the case of a dockerized minion running not in host networking mode, the Ip address
-# cannot be automatically determined. In this case this property can be set to specify the IP address to be used.
-# org.opennms.features.deviceconfig.tftpServerIPv4Address=
-# org.opennms.features.deviceconfig.tftpServerIPv6Address=


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-14039

I implemented another approach. With the original code it wasn't possible to connect to any IPv6 devices, since getLocalAddress() also return "0.0.0.0" in this case.

The new idea is to establish the SSH connection and use the session's endpoint addresses. In the case the SSH session cannot be established, we also have no need for the correct TFTP address. This seems to work a lot more reliable than the original approach.

For running inside a docker container two new properties were introduced to specify the IP address for both protocols.

The minion appliance uses the host network mode. So, in this case the code will give us the right IP addresses.