### PR TITLE
Improve docker instructions when running as non-root with persistent config directory

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,12 +1,10 @@
 name: horizon
 version: '29-SNAPSHOT'
 title: Horizon
-prerelease: true
 asciidoc:
   attributes:
     full-display-version: '29.0.7-SNAPSHOT'
     experimental: true
-    prerelease: true
     source-language: asciidoc@
     xrefstyle: short@
     compatible-centos7: '7.x'

--- a/docs/modules/deployment/pages/core/docker/core.adoc
+++ b/docs/modules/deployment/pages/core/docker/core.adoc
@@ -17,15 +17,16 @@ vi docker-compose.yml
 ---
 version: '3'
 
-volumes:
-  data-opennms: {}<1>
+volumes:<1>
+  data-opennms: {}
+  data-config: {}
 
 services:
   horizon:<2>
     image: opennms/horizon:{docker-version-tag}<3>
     container_name: horizon
-    environment:<4>
-      TZ: 'America/New_York'
+    environment:
+      TZ: 'America/New_York'<4>
       POSTGRES_HOST: 'my-database-host'<5>
       POSTGRES_PORT: 5432
       POSTGRES_USER: 'postgres'
@@ -35,27 +36,29 @@ services:
       OPENNMS_DBPASS: 'my-opennms-db-password'
     volumes:<6>
       - data-opennms:/opennms-data
-      - ./etc:/opt/opennms/etc<7>
+      - data-config:/opt/opennms/etc
     command: ["-s"]
-    ports:<8>
+    ports:<7>
       - '8980:8980/tcp'
       - '8101:8101/tcp'
     healthcheck:
-      test: [ 'CMD', 'curl', '-f', '-I', 'http://localhost:8980/opennms/login.jsp' ]<9>
+      test: [ 'CMD', 'curl', '-f', '-I', 'http://localhost:8980/opennms/login.jsp' ]<8>
       interval: 1m
       timeout: 5s
       retries: 3
 ----
 
-<1> Volume definitions to persist the {page-component-title} Core data; for example, RRD files and PDF reports.
+<1> Volume definitions to persist the {page-component-title} Core data and configuration files
 <2> The {page-component-title} Core instance service is named `horizon` with a friendly `container_name`.
 <3> Image reference using the {page-component-title} container image with the Core services.
 <4> Set the time zone and the postgres credentials to initialize the database that the {page-component-title} Core instance uses. To list all available time zones, use `timedatectl list-timezones`.
 <5> Set the host or IP address of the host that runs the PostgreSQL database.
-<6> Persist performance data PDF reports in a volume.
-<7> Mount the volumes for data persistence and bind mount the configuration in a local directory.
-<8> Publish ports to access the web UI and the Karaf shell.
-<9> Run an internal health check against the web UI to verify service health status.
+<6> Mount directories to store RRD files, PDF reports, and configuration files in a persistent volume.
+<7> Publish ports to access the web UI and the Karaf shell.
+<8> Run an internal health check against the web UI to verify service health status.
+
+TIP: The process inside the container runs as a non-privileged user with user id `10001`.
+     If you want the configuration files in a bind mount on your local host system, make sure you set permissions and ownership accordingly with `chown 10001:10001 ./path/to/my/config-dir`.
 
 .Validate your Docker Compose file
 [source, console]

--- a/docs/modules/deployment/pages/core/docker/core.adoc
+++ b/docs/modules/deployment/pages/core/docker/core.adoc
@@ -55,7 +55,7 @@ services:
 TIP: The process inside the container runs as a non-privileged user with user id `10001`.
      If you want the configuration files in a bind mount on your local host system, make sure you set permissions and ownership accordingly with `chown 10001:10001 ./path/to/my/config-dir`.
 
-TIP: If you want to run a release candidate or a different version, you can use the public image tags from our repository on <<link:https://hub.docker.com/repository/docker/opennms/horizon/tags, DockerHub>>.
+TIP: To run a release candidate or a different version, use the public image tags from our repository on <<link:https://hub.docker.com/repository/docker/opennms/horizon/tags, DockerHub>>.
 
 .Validate your Docker Compose file
 [source, console]

--- a/docs/modules/deployment/pages/core/docker/core.adoc
+++ b/docs/modules/deployment/pages/core/docker/core.adoc
@@ -1,8 +1,3 @@
-:docker-version-tag: bleeding
-ifeval::["{prerelease}" == "false"]
-:docker-version-tag: {page-component-version}
-endif::[]
-
 .Create a project directory for {page-component-title} Core and create a `docker-compose.yml` file.
 [source, console]
 ----
@@ -23,7 +18,7 @@ volumes:<1>
 
 services:
   horizon:<2>
-    image: opennms/horizon:{docker-version-tag}<3>
+    image: opennms/horizon:{page-component-version}<3>
     container_name: horizon
     environment:
       TZ: 'America/New_York'<4>
@@ -59,6 +54,8 @@ services:
 
 TIP: The process inside the container runs as a non-privileged user with user id `10001`.
      If you want the configuration files in a bind mount on your local host system, make sure you set permissions and ownership accordingly with `chown 10001:10001 ./path/to/my/config-dir`.
+
+TIP: If you want to run a release candidate or a different version, you can use the public image tags from our repository on <<link:https://hub.docker.com/repository/docker/opennms/horizon/tags, DockerHub>>.
 
 .Validate your Docker Compose file
 [source, console]

--- a/docs/modules/deployment/pages/core/docker/core.adoc
+++ b/docs/modules/deployment/pages/core/docker/core.adoc
@@ -43,7 +43,7 @@ services:
       retries: 3
 ----
 
-<1> Volume definitions to persist the {page-component-title} Core data and configuration files
+<1> Volume definitions to persist the {page-component-title} Core data and configuration files.
 <2> The {page-component-title} Core instance service is named `horizon` with a friendly `container_name`.
 <3> Image reference using the {page-component-title} container image with the Core services.
 <4> Set the time zone and the postgres credentials to initialize the database that the {page-component-title} Core instance uses. To list all available time zones, use `timedatectl list-timezones`.

--- a/docs/modules/deployment/pages/core/docker/core.adoc
+++ b/docs/modules/deployment/pages/core/docker/core.adoc
@@ -52,7 +52,7 @@ services:
 <7> Publish ports to access the web UI and the Karaf shell.
 <8> Run an internal health check against the web UI to verify service health status.
 
-TIP: The process inside the container runs as a non-privileged user with user id `10001`.
+NOTE: The process inside the container runs as a non-privileged user with user id `10001`.
      If you want the configuration files in a bind mount on your local host system, make sure you set permissions and ownership accordingly with `chown 10001:10001 ./path/to/my/config-dir`.
 
 TIP: To run a release candidate or a different version, use the public image tags from our repository on <<link:https://hub.docker.com/repository/docker/opennms/horizon/tags, DockerHub>>.

--- a/docs/modules/operation/pages/flows/sentinel/message-broker/activemq.adoc
+++ b/docs/modules/operation/pages/flows/sentinel/message-broker/activemq.adoc
@@ -31,8 +31,7 @@ config:update
 
 <1> A location string is used to assign the Sentinel to a monitoring location with Minions.
 <2> Unique identifier used as a node label for monitoring the Sentinel instance within {page-component-title).
-<3> Base URL for the web UI, which provides the REST endpoints.
-<4> URL that points to ActiveMQ broker.
+<3> URL that points to ActiveMQ broker.
 
 .Configure the credentials and exit Karaf shell
 [source, karaf]

--- a/docs/modules/operation/pages/flows/sentinel/message-broker/kafka.adoc
+++ b/docs/modules/operation/pages/flows/sentinel/message-broker/kafka.adoc
@@ -30,7 +30,6 @@ config:update
 
 <1> A location string is used to assign the Sentinel to a monitoring location with Minions.
 <2> Unique identifier used as a node label for monitoring the Sentinel instance within {page-component-title).
-<3> Base URL for the web UI, which provides the REST endpoints.
 
 .Configure Sentinel as Kafka consumer for flow messages
 [source, karaf]


### PR DESCRIPTION
With running as a non-root user we have to make sure the etc directory has permissions set to a user with user id 10001. As a safe default, I've introduced a persistent volume that has automatically the correct permissions. I've created a tip that explains that you need to make sure to set the correct permission in case you want to use a bind mount from your local filesystem into the container.

I've removed the prerelease variable, we only publish docs for a released version, so we can make it less complicated here.

Fixed build warnings with missing callouts which are leftover when we removed the REST endpoint and used the Twin API instead.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?
