### PR TITLE
NMS-14047: DCB Rest API: Parse and display cron schedule info

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -134,6 +134,9 @@
     <feature name="commons-net" version="${commonsNetVersion}" description="Apache :: commons-net">
         <bundle>mvn:commons-net/commons-net/${commonsNetVersion}</bundle>
     </feature>
+    <feature name="cron-parser-core" version="${cronParserCoreVersion}" description="Redhogs :: cron-parser-core">
+        <bundle>wrap:mvn:net.redhogs.cronparser/cron-parser-core/${cronParserCoreVersion}</bundle>
+    </feature>
     <feature name="dnsjava" version="${dnsjavaVersion}" description="dnsjava">
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dnsjava/${dnsjavaVersion}</bundle>
     </feature>
@@ -1902,6 +1905,21 @@
         <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.monitor/${project.version}</bundle>
     </feature>
 
+    <feature name="opennms-deviceconfig-rest" description="OpenNMS :: Features :: Device Config :: Rest" version="${project.version}">
+        <feature>commons-compress</feature>
+        <feature>cron-parser-core</feature>
+        <feature>opennms-osgi-core-rest</feature>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.rest/${project.version}</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/${project.version}</bundle>
+    </feature>
+
+    <feature name="opennms-deviceconfig-service" description="OpenNMS :: Features :: Device Config :: Service" version="${project.version}">
+        <feature>opennms-deviceconfig-tftp</feature>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/${project.version}</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.monitor-adaptor/${project.version}</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.service/${project.version}</bundle>
+    </feature>
+
     <!-- common module for sink client and server -->
     <feature name="opennms-deviceconfig-sink-module" description="OpenNMS :: Features :: Device Config :: Sink :: Common" version="${project.version}">
         <feature>opennms-deviceconfig-deps</feature>
@@ -1921,20 +1939,6 @@
         <bundle>mvn:org.opennms.features.device-config.sink/org.opennms.features.device-config.sink.dispatcher/${project.version}</bundle>
     </feature>
 
-    <feature name="opennms-deviceconfig-rest" description="OpenNMS :: Features :: Device Config :: Rest" version="${project.version}">
-        <feature>commons-compress</feature>
-        <feature>opennms-osgi-core-rest</feature>
-        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.rest/${project.version}</bundle>
-        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/${project.version}</bundle>
-    </feature>
-
-    <feature name="opennms-deviceconfig-service" description="OpenNMS :: Features :: Device Config :: Service" version="${project.version}">
-        <feature>opennms-deviceconfig-tftp</feature>
-        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/${project.version}</bundle>
-        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.monitor-adaptor/${project.version}</bundle>
-        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.service/${project.version}</bundle>
-    </feature>
-
     <feature name="opennms-health-rest-service" description="OpenNMS :: Feature :: Health :: ReST Service" version="${project.version}">
         <feature>org.json</feature>
         <feature>opennms-health-rest</feature>
@@ -1942,5 +1946,4 @@
         <feature version="${cxfVersion}">cxf-jaxrs</feature>
         <bundle>mvn:org.opennms.core.health/org.opennms.core.health.rest-cxf/${project.version}</bundle>
     </feature>
-
 </features>

--- a/features/device-config/api/pom.xml
+++ b/features/device-config/api/pom.xml
@@ -29,30 +29,4 @@
             </plugin>
         </plugins>
     </build>
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>${commonsCompressVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigUtil.java
+++ b/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigUtil.java
@@ -28,20 +28,10 @@
 
 package org.opennms.features.deviceconfig.service;
 
-import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.zip.GZIPInputStream;
-
-import com.google.common.base.Strings;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
-import org.apache.commons.lang3.ArrayUtils;
 
 public class DeviceConfigUtil {
 
@@ -58,77 +48,5 @@ public class DeviceConfigUtil {
         }
 
         return output.toByteArray();
-    }
-
-    public static byte[] tarGzipMultipleFiles(Map<String, byte[]> fileNameToDataMap) throws IOException {
-        if (fileNameToDataMap == null || fileNameToDataMap.isEmpty()) {
-            return null;
-        }
-
-        byte[] tarBytes = tarMultipleFiles(fileNameToDataMap);
-        var byteOutputStream = new ByteArrayOutputStream();
-
-        try (var gzipOut = new GzipCompressorOutputStream(byteOutputStream)) {
-            gzipOut.write(tarBytes);
-        }
-
-        return byteOutputStream.toByteArray();
-    }
-
-    public static Map<String, byte[]> unTarGzipMultipleFiles(byte[] tarGzipData) throws IOException {
-        if (tarGzipData == null) {
-            return new HashMap<>();
-        }
-
-        var result = new HashMap<String, byte[]>();
-        var byteArrayInputStream = new ByteArrayInputStream(tarGzipData);
-        var gzipInputStream = new GZIPInputStream(byteArrayInputStream);
-
-        try (var tarInputStream = new TarArchiveInputStream(gzipInputStream)) {
-            TarArchiveEntry tarEntry = null;
-            final int BUFLEN = 1024;
-            byte[] buffer = new byte[BUFLEN];
-
-            while ((tarEntry = tarInputStream.getNextTarEntry()) != null) {
-                if (tarEntry.isFile()) {
-                    String fileName = tarEntry.getName();
-
-                    var byteOutput = new ByteArrayOutputStream();
-
-                    try (var bufOut = new BufferedOutputStream(byteOutput)) {
-                        int len = 0;
-
-                        while ((len = tarInputStream.read(buffer)) != -1) {
-                            bufOut.write(buffer, 0, len);
-                        }
-                    }
-
-                    byte[] bytesRead = byteOutput.toByteArray();
-                    result.put(fileName, bytesRead);
-                }
-            }
-        }
-
-        return result;
-    }
-
-    public static byte[] tarMultipleFiles(Map<String, byte[]> fileNameToDataMap) throws IOException {
-        var byteOutputStream = new ByteArrayOutputStream();
-
-        try (var tarOut = new TarArchiveOutputStream(byteOutputStream)) {
-            for (Map.Entry<String, byte[]> entry : fileNameToDataMap.entrySet()) {
-                if (!Strings.isNullOrEmpty(entry.getKey()) && entry.getValue() != null) {
-                    var archiveEntry = new TarArchiveEntry(entry.getKey());
-                    archiveEntry.setName(entry.getKey());
-                    archiveEntry.setSize(entry.getValue().length);
-
-                    tarOut.putArchiveEntry(archiveEntry);
-                    tarOut.write(entry.getValue());
-                    tarOut.closeArchiveEntry();
-                }
-            }
-        }
-
-        return byteOutputStream.toByteArray();
     }
 }

--- a/features/device-config/monitor/src/main/java/org/opennms/features/deviceconfig/monitors/DeviceConfigMonitor.java
+++ b/features/device-config/monitor/src/main/java/org/opennms/features/deviceconfig/monitors/DeviceConfigMonitor.java
@@ -106,13 +106,7 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
 
         final Date lastRun = new Date(getKeyedLong(parameters, LAST_RETRIEVAL, 0L));
         final String cronSchedule = getKeyedString(parameters, SCHEDULE, DEFAULT_CRON_SCHEDULE);
-
-        final Trigger trigger = TriggerBuilder.newTrigger()
-                .withSchedule(CronScheduleBuilder.cronSchedule(cronSchedule))
-                .startAt(lastRun)
-                .build();
-
-        final Date nextRun = trigger.getFireTimeAfter(lastRun);
+        final Date nextRun = getNextRunDate(cronSchedule, lastRun);
 
         if (!triggeredPoll && !nextRun.before(new Date())) {
             return PollStatus.unknown("Skipping. Next retrieval scheduled for " + nextRun);
@@ -164,6 +158,15 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
 
     public void setRetriever(Retriever retriever) {
         this.retriever = retriever;
+    }
+
+    private Date getNextRunDate(String cronSchedule, Date lastRun) {
+        final Trigger trigger = TriggerBuilder.newTrigger()
+            .withSchedule(CronScheduleBuilder.cronSchedule(cronSchedule))
+            .startAt(lastRun)
+            .build();
+
+        return trigger.getFireTimeAfter(lastRun);
     }
 
     private String getObjectAsStringFromParams(Map<String, Object> params, String key) {

--- a/features/device-config/rest/pom.xml
+++ b/features/device-config/rest/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.redhogs.cronparser</groupId>
+            <artifactId>cron-parser-core</artifactId>
+            <version>${cronParserCoreVersion}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-model</artifactId>
             <version>${project.version}</version>
@@ -69,6 +74,11 @@
             <groupId>org.opennms.features.device-config.persistence</groupId>
             <artifactId>org.opennms.features.device-config.persistence.api</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+            <version>${quartzVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>

--- a/features/device-config/rest/pom.xml
+++ b/features/device-config/rest/pom.xml
@@ -31,6 +31,10 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
@@ -38,6 +42,15 @@
             <groupId>net.redhogs.cronparser</groupId>
             <artifactId>cron-parser-core</artifactId>
             <version>${cronParserCoreVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commonsCompressVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
@@ -110,6 +123,11 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/CompressionUtils.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/CompressionUtils.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.deviceconfig.rest.impl;
+
+import com.google.common.base.Strings;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+
+public class CompressionUtils {
+    public static byte[] tarGzipMultipleFiles(Map<String, byte[]> fileNameToDataMap) throws IOException {
+        if (fileNameToDataMap == null || fileNameToDataMap.isEmpty()) {
+            return null;
+        }
+
+        byte[] tarBytes = tarMultipleFiles(fileNameToDataMap);
+        var byteOutputStream = new ByteArrayOutputStream();
+
+        try (var gzipOut = new GzipCompressorOutputStream(byteOutputStream)) {
+            gzipOut.write(tarBytes);
+        }
+
+        return byteOutputStream.toByteArray();
+    }
+
+    public static Map<String, byte[]> unTarGzipMultipleFiles(byte[] tarGzipData) throws IOException {
+        if (tarGzipData == null) {
+            return new HashMap<>();
+        }
+
+        var result = new HashMap<String, byte[]>();
+        var byteArrayInputStream = new ByteArrayInputStream(tarGzipData);
+        var gzipInputStream = new GZIPInputStream(byteArrayInputStream);
+
+        try (var tarInputStream = new TarArchiveInputStream(gzipInputStream)) {
+            TarArchiveEntry tarEntry = null;
+            final int BUFLEN = 1024;
+            byte[] buffer = new byte[BUFLEN];
+
+            while ((tarEntry = tarInputStream.getNextTarEntry()) != null) {
+                if (tarEntry.isFile()) {
+                    String fileName = tarEntry.getName();
+
+                    var byteOutput = new ByteArrayOutputStream();
+
+                    try (var bufOut = new BufferedOutputStream(byteOutput)) {
+                        int len = 0;
+
+                        while ((len = tarInputStream.read(buffer)) != -1) {
+                            bufOut.write(buffer, 0, len);
+                        }
+                    }
+
+                    byte[] bytesRead = byteOutput.toByteArray();
+                    result.put(fileName, bytesRead);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public static byte[] tarMultipleFiles(Map<String, byte[]> fileNameToDataMap) throws IOException {
+        var byteOutputStream = new ByteArrayOutputStream();
+
+        try (var tarOut = new TarArchiveOutputStream(byteOutputStream)) {
+            for (Map.Entry<String, byte[]> entry : fileNameToDataMap.entrySet()) {
+                if (!Strings.isNullOrEmpty(entry.getKey()) && entry.getValue() != null) {
+                    var archiveEntry = new TarArchiveEntry(entry.getKey());
+                    archiveEntry.setName(entry.getKey());
+                    archiveEntry.setSize(entry.getValue().length);
+
+                    tarOut.putArchiveEntry(archiveEntry);
+                    tarOut.write(entry.getValue());
+                    tarOut.closeArchiveEntry();
+                }
+            }
+        }
+
+        return byteOutputStream.toByteArray();
+    }
+}

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -63,7 +63,6 @@ import org.opennms.features.deviceconfig.rest.BackupRequestDTO;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigDTO;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigRestService;
 import org.opennms.features.deviceconfig.service.DeviceConfigService;
-import org.opennms.features.deviceconfig.service.DeviceConfigUtil;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMetaData;
@@ -72,6 +71,8 @@ import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.web.utils.ResponseUtils;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -228,7 +229,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
 
         // TODO: Update MIME type, charset based on 'encoding'
         return Response.ok().type("text/plain;charset=UTF-8")
-            .header("Content-Disposition", "inline; filename=" + fileName)
+            .header("Content-Disposition", "attachment; filename=" + fileName)
             .header("Pragma", "public")
             .header("Cache-Control", "cache")
             .header("Cache-Control", "must-revalidate")
@@ -249,7 +250,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         byte[] gzipBytes = null;
 
         try {
-            gzipBytes = DeviceConfigUtil.tarGzipMultipleFiles(fileNameToDataMap);
+            gzipBytes = CompressionUtils.tarGzipMultipleFiles(fileNameToDataMap);
         } catch (IOException e) {
             var message = "Error compressing multiple files for download.";
             LOG.error(message, e);
@@ -263,7 +264,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         final String fileName = "device-configs-" + timestamp + ".tar.gz";
 
         return Response.ok().type("application/gzip")
-            .header("Content-Disposition", "inline; filename=" + fileName)
+            .header("Content-Disposition", "attachment; filename=" + fileName)
             .header("Pragma", "public")
             .header("Cache-Control", "cache")
             .header("Cache-Control", "must-revalidate")
@@ -366,7 +367,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             return new ScheduleInfo(null, "unknown");
         }
 
-        final Date nextScheduledBackup = cronExpression.getNextValidTimeAfter(current);
+        final Date nextScheduledBackup = getNextRunDate(schedulePattern, current);
 
         return new ScheduleInfo(nextScheduledBackup, cronDescription);
     }
@@ -449,6 +450,16 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
 
     private WebApplicationException getException(final Status status, final String message) {
         return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(message).build());
+    }
+
+    // This method's implementation should be the same as in DeviceConfigMonitor
+    private Date getNextRunDate(String cronSchedule, Date lastRun) {
+        final Trigger trigger = TriggerBuilder.newTrigger()
+            .withSchedule(CronScheduleBuilder.cronSchedule(cronSchedule))
+            .startAt(lastRun)
+            .build();
+
+        return trigger.getFireTimeAfter(lastRun);
     }
 
     private static DeviceConfigDTO createDeviceConfigDto(DeviceConfig deviceConfig) {

--- a/features/device-config/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/device-config/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,7 +4,6 @@
 >
     <reference id="deviceConfigDao" interface="org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao" availability="mandatory"/>
     <reference id="monitoredServiceDao" interface="org.opennms.netmgt.dao.api.MonitoredServiceDao" availability="mandatory"/>
-
     <reference id="deviceConfigService" interface="org.opennms.features.deviceconfig.service.DeviceConfigService" availability="mandatory"/>
 
     <bean id="defaultDeviceConfigRestService"

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/CompressionUtilsTest.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/CompressionUtilsTest.java
@@ -26,7 +26,7 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.features.deviceconfig.service;
+package org.opennms.features.deviceconfig.rest.impl;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -38,14 +38,14 @@ import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class DeviceConfigUtilTest {
+public class CompressionUtilsTest {
 
     @Test
     public void gzipMultipleFilesNullTest() {
         byte[] result = null;
 
         try {
-            result = DeviceConfigUtil.tarGzipMultipleFiles(null);
+            result = CompressionUtils.tarGzipMultipleFiles(null);
         } catch (IOException e) {
             Assert.fail("IOException thrown when fileNameToDataMap argument was null");
         }
@@ -58,7 +58,7 @@ public class DeviceConfigUtilTest {
         byte[] result = null;
 
         try {
-            result = DeviceConfigUtil.tarGzipMultipleFiles(new HashMap<String, byte[]>());
+            result = CompressionUtils.tarGzipMultipleFiles(new HashMap<String, byte[]>());
         } catch (IOException e) {
             Assert.fail("IOException thrown when fileNameToDataMap argument was empty");
         }
@@ -77,7 +77,7 @@ public class DeviceConfigUtilTest {
         byte[] result = null;
 
         try {
-            result = DeviceConfigUtil.tarGzipMultipleFiles(fileNameToDataMap);
+            result = CompressionUtils.tarGzipMultipleFiles(fileNameToDataMap);
         } catch (IOException e) {
             Assert.fail("IOException thrown during gzipMultipleFiles");
         }
@@ -87,7 +87,7 @@ public class DeviceConfigUtilTest {
         Map<String,byte[]> resultMap = null;
 
         try {
-            resultMap = DeviceConfigUtil.unTarGzipMultipleFiles(result);
+            resultMap = CompressionUtils.unTarGzipMultipleFiles(result);
         } catch (IOException e) {
             Assert.fail("IOException throw during untarGzipMultipleFiles");
         }

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceScheduleIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceScheduleIT.java
@@ -28,6 +28,19 @@
 
 package org.opennms.features.deviceconfig.rest.impl;
 
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
+import net.redhogs.cronparser.CronExpressionDescriptor;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -38,6 +51,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.mockito.Mockito;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
@@ -57,17 +71,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
     "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
@@ -80,6 +83,20 @@ import java.util.stream.Collectors;
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase
 public class DefaultDeviceConfigRestServiceScheduleIT {
+    private static final int RECORD_COUNT = 3;
+
+    private static final List<String> CRON_SCHEDULES = List.of(
+        "0 15 10 ? * *",
+        "0 * 14 * * ?",
+        "0 15 10 ? * 6#3"
+    );
+
+    private static final List<String> EXPECTED_CRON_SCHEDULE_DESCRIPTIONS = List.of(
+        "At 10:15 am",
+        "Every minute, at 2:00 pm",
+        "At 10:15 am, on the third Saturday of the month"
+    );
+
     @Autowired
     private NodeDao nodeDao;
 
@@ -107,8 +124,6 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
     @Test
     @Transactional
     public void testGetDeviceConfigsWithScheduleInfo() {
-        final int RECORD_COUNT = 3;
-
         // Add nodes, interfaces, services
         List<OnmsIpInterface> ipInterfaces = populateDeviceConfigServiceInfo();
         Assert.assertEquals(RECORD_COUNT, ipInterfaces.size());
@@ -131,7 +146,6 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
         Assert.assertEquals(RECORD_COUNT, responseList.size());
 
         List<String> expectedConfigTypes = List.of("default", "default", "running");
-        List<String> expectedScheduleIntervals = List.of("daily", "weekly", "monthly");
 
         for (int i = 0; i < RECORD_COUNT; i++) {
             DeviceConfigDTO dto = responseList.get(i);
@@ -145,7 +159,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
             Assert.assertEquals(createdTime(version), dto.getLastSucceededDate().getTime());
             Assert.assertNull(dto.getLastFailedDate());
             Assert.assertNull(dto.getFailureReason());
-            Assert.assertEquals(expectedScheduleIntervals.get(i), dto.getScheduledInterval());
+            Assert.assertEquals(EXPECTED_CRON_SCHEDULE_DESCRIPTIONS.get(i), dto.getScheduledInterval());
             assertThat(dto.getNextScheduledBackupDate().after(currentDate), is(true));
         }
     }
@@ -177,8 +191,6 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
     @Test
     @Transactional
     public void testDownloadSingleDeviceConfig() {
-        final int RECORD_COUNT = 3;
-
         // Add nodes, interfaces, services
         List<OnmsIpInterface> ipInterfaces = populateDeviceConfigServiceInfo();
         Assert.assertEquals(RECORD_COUNT, ipInterfaces.size());
@@ -212,8 +224,6 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
     @Test
     @Transactional
     public void testDownloadMultipleDeviceConfigs() {
-        final int RECORD_COUNT = 3;
-
         // Add nodes, interfaces, services
         List<OnmsIpInterface> ipInterfaces = populateDeviceConfigServiceInfo();
         Assert.assertEquals(RECORD_COUNT, ipInterfaces.size());
@@ -297,11 +307,11 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
 
         List<String> scheduleIntervals = List.of("daily", "weekly", "monthly");
 
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < RECORD_COUNT; i++) {
             builder.addNode(nodeNames.get(i)).setForeignSource("imported:").setForeignId(foreignIds.get(i)).setType(OnmsNode.NodeType.ACTIVE);
             builder.addInterface(ipAddresses.get(i)).setIsManaged("M").setIsSnmpPrimary("P");
             builder.addService(addOrGetServiceType(serviceNames.get(i)));
-            builder.setServiceMetaDataEntry("requisition", "schedule", scheduleIntervals.get(i));
+            builder.setServiceMetaDataEntry("requisition", "schedule", CRON_SCHEDULES.get(i));
             nodeDao.saveOrUpdate(builder.getCurrentNode());
 
             OnmsIpInterface ipInterface = builder.getCurrentNode().getIpInterfaceByIpAddress(ipAddresses.get(i));

--- a/pom.xml
+++ b/pom.xml
@@ -1657,6 +1657,7 @@
     <commonsNetVersion>3.8.0</commonsNetVersion>
     <commonsValidatorVersion>1.6</commonsValidatorVersion>
     <concurrentTreesVersion>2.5.0</concurrentTreesVersion>
+    <cronParserCoreVersion>3.5</cronParserCoreVersion>
     <c3p0Version>0.9.5.4</c3p0Version>
     <curatorVersion>3.2.1</curatorVersion>
     <cxfVersion>3.4.5</cxfVersion>


### PR DESCRIPTION
Parse cron schedule info from DCB Service metadata and return `nextScheduledBackup` and `scheduledInterval` in API.

Additionally:

- moved functions requiring Apache `commons-compress` from `DeviceConfigUtil` to `rest` module `CompressionUtils` class.
- Fixed device config download to have `Content-Disposition` of `attachment` so browser will download as file instead of inline text

Jira: https://issues.opennms.org/browse/NMS-14047

