### PR TITLE
NMS-14082: DCB Add 'config' as string in Rest API response

### DIFF
--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigDTO.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigDTO.java
@@ -34,7 +34,7 @@ import java.util.Date;
  * DTO for response value of DeviceConfigRestService.
  * 'final' properties are retrieved directly from 'device_config' table.
  * Other properties are calculated or from other data sources.
- * The actual configuration data is retrieved separately using this object's 'id' field.
+ * Configuration data itself is returned as text.
  */
 public class DeviceConfigDTO {
     /** Database id of 'device_config' table entry */
@@ -43,7 +43,7 @@ public class DeviceConfigDTO {
     /** Database id of 'ipinterface' table entry */
     private final int ipInterfaceId;
 
-    /** IP address as a string */
+    /** IP address as a text string */
     private final String ipAddress;
 
     /** Date backup config data was last stored. */
@@ -70,6 +70,9 @@ public class DeviceConfigDTO {
 
     /** Filename of the configuration data as received from the device. */
     private final String fileName;
+
+    /** Configuration data as a string */
+    private final String config;
 
     /** Failure reason description, if there was a backup failure. */
     private final String failureReason;
@@ -112,6 +115,7 @@ public class DeviceConfigDTO {
         String encoding,
         String configType,
         String fileName,
+        String config,
         String failureReason
     ) {
         this.id = id;
@@ -124,6 +128,7 @@ public class DeviceConfigDTO {
         this.encoding = encoding;
         this.configType = configType;
         this.fileName = fileName;
+        this.config = config;
         this.failureReason = failureReason;
     }
 
@@ -148,6 +153,8 @@ public class DeviceConfigDTO {
     public String getConfigType() { return this.configType; }
 
     public String getFileName() { return this.fileName; }
+
+    public String getConfig() { return config; }
 
     public String getFailureReason() { return this.failureReason; }
 

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -30,6 +30,8 @@ package org.opennms.features.deviceconfig.rest.impl;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
@@ -466,7 +468,11 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
     }
 
     private static DeviceConfigDTO createDeviceConfigDto(DeviceConfig deviceConfig) {
+        // TODO: Handle different character encodings and also binary data
         try {
+            String config =
+                deviceConfig.getConfigType() == null ? "" : new String(deviceConfig.getConfig(), StandardCharsets.UTF_8);
+
             var dto = new DeviceConfigDTO(
                     deviceConfig.getId(),
                     deviceConfig.getIpInterface().getId(),
@@ -478,6 +484,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
                     deviceConfig.getEncoding(),
                     deviceConfig.getConfigType(),
                     deviceConfig.getFileName(),
+                    config,
                     deviceConfig.getFailureReason()
             );
 

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
@@ -207,7 +207,7 @@ public class DefaultDeviceConfigRestServiceIT {
             assertThat(res, hasSize(VERSIONS));
 
             assertThat(
-                res.stream().map(DeviceConfigDTO::getCreatedTime).map(Date::getTime).collect(toList()),
+                res.stream().map(DeviceConfigDTO::getLastBackupDate).map(Date::getTime).collect(toList()),
                 contains(IntStream.range(0, VERSIONS).map(i -> VERSIONS - i - 1).boxed().map(DefaultDeviceConfigRestServiceIT::createdTime).toArray()));
         }
     }
@@ -220,7 +220,7 @@ public class DefaultDeviceConfigRestServiceIT {
             assertThat(res, hasSize(VERSIONS));
 
             assertThat(
-                res.stream().map(DeviceConfigDTO::getCreatedTime).map(Date::getTime).collect(toList()),
+                res.stream().map(DeviceConfigDTO::getLastBackupDate).map(Date::getTime).collect(toList()),
                 contains(IntStream.range(0, VERSIONS).boxed().map(DefaultDeviceConfigRestServiceIT::createdTime).toArray()));
         }
     }
@@ -235,7 +235,7 @@ public class DefaultDeviceConfigRestServiceIT {
                 assertThat(res, hasSize(limit));
 
                 assertThat(
-                    res.stream().map(DeviceConfigDTO::getCreatedTime).map(Date::getTime).collect(toList()),
+                    res.stream().map(DeviceConfigDTO::getLastBackupDate).map(Date::getTime).collect(toList()),
                     contains(IntStream.range(0, limit).boxed().map(DefaultDeviceConfigRestServiceIT::createdTime).toArray()));
             }
             {
@@ -245,7 +245,7 @@ public class DefaultDeviceConfigRestServiceIT {
                 assertThat(res, hasSize(limit));
 
                 assertThat(
-                    res.stream().map(DeviceConfigDTO::getCreatedTime).map(Date::getTime).collect(toList()),
+                    res.stream().map(DeviceConfigDTO::getLastBackupDate).map(Date::getTime).collect(toList()),
                     contains(IntStream.range(offset, offset + limit).boxed().map(DefaultDeviceConfigRestServiceIT::createdTime).toArray()));
             }
         }

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
@@ -28,6 +28,7 @@
 
 package org.opennms.features.deviceconfig.rest.impl;
 
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.everyItem;
@@ -170,7 +171,6 @@ public class DefaultDeviceConfigRestServiceIT {
         }
     }
 
-
     @Test
     @Transactional
     public void filterOnCreatedTime() {
@@ -205,8 +205,10 @@ public class DefaultDeviceConfigRestServiceIT {
         for (var itf : interfaces) {
             var res = getDeviceConfigs(null, null, "createdTime", "desc", null, null, itf.getId(), null, null, null);
             assertThat(res, hasSize(VERSIONS));
-            assertThat(res.stream().map(DeviceConfigDTO::getEncoding).collect(Collectors.toList()),
-                    contains(IntStream.range(0, VERSIONS).map(v -> VERSIONS - 1 - v).boxed().map(String::valueOf).toArray()));
+
+            assertThat(
+                res.stream().map(DeviceConfigDTO::getCreatedTime).map(Date::getTime).collect(toList()),
+                contains(IntStream.range(0, VERSIONS).map(i -> VERSIONS - i - 1).boxed().map(DefaultDeviceConfigRestServiceIT::createdTime).toArray()));
         }
     }
 
@@ -216,9 +218,10 @@ public class DefaultDeviceConfigRestServiceIT {
         for (var itf : interfaces) {
             var res = getDeviceConfigs(null, null, "createdTime", "asc", null, null, itf.getId(), null, null, null);
             assertThat(res, hasSize(VERSIONS));
-            assertThat(res.stream().map(DeviceConfigDTO::getEncoding).collect(Collectors.toList()), contains(IntStream.range(0, VERSIONS).boxed()
-                    .map(String::valueOf).toArray()));
 
+            assertThat(
+                res.stream().map(DeviceConfigDTO::getCreatedTime).map(Date::getTime).collect(toList()),
+                contains(IntStream.range(0, VERSIONS).boxed().map(DefaultDeviceConfigRestServiceIT::createdTime).toArray()));
         }
     }
 
@@ -227,19 +230,23 @@ public class DefaultDeviceConfigRestServiceIT {
     public void sortAscWithLimitAndOffset() {
         for (var itf : interfaces) {
             {
-                var limit = 5;
+                final int limit = 5;
                 var res = getDeviceConfigs(limit, 0, "createdTime", "asc", null, null, itf.getId(), null, null, null);
                 assertThat(res, hasSize(limit));
-                assertThat(res.stream().map(DeviceConfigDTO::getEncoding).collect(Collectors.toList()), contains(IntStream.range(0, limit).boxed()
-                        .map(String::valueOf).toArray()));
+
+                assertThat(
+                    res.stream().map(DeviceConfigDTO::getCreatedTime).map(Date::getTime).collect(toList()),
+                    contains(IntStream.range(0, limit).boxed().map(DefaultDeviceConfigRestServiceIT::createdTime).toArray()));
             }
             {
-                var limit = 5;
-                var offset = 10;
+                final int limit = 5;
+                final int offset = 10;
                 var res = getDeviceConfigs(limit, offset, "createdTime", "asc", null, null, itf.getId(), null, null, null);
                 assertThat(res, hasSize(limit));
-                assertThat(res.stream().map(DeviceConfigDTO::getEncoding).collect(Collectors.toList()), contains(IntStream.range(offset, offset + limit).boxed()
-                        .map(String::valueOf).toArray()));
+
+                assertThat(
+                    res.stream().map(DeviceConfigDTO::getCreatedTime).map(Date::getTime).collect(toList()),
+                    contains(IntStream.range(offset, offset + limit).boxed().map(DefaultDeviceConfigRestServiceIT::createdTime).toArray()));
             }
         }
     }
@@ -262,7 +269,6 @@ public class DefaultDeviceConfigRestServiceIT {
         response = deviceConfigRestService.triggerDeviceConfigBackup(dto);
         assertThat(response.getStatusInfo().toEnum(), Matchers.is(Response.Status.BAD_REQUEST));
         assertThat(response.getEntity(), Matchers.is(message));
-
     }
 
     private OnmsIpInterface populateIpInterfaceAndGet(int num) {
@@ -281,7 +287,7 @@ public class DefaultDeviceConfigRestServiceIT {
         var dc = new DeviceConfig();
         dc.setConfig(new byte[version]);
         dc.setCreatedTime(new Date(createdTime(version)));
-        dc.setEncoding(String.valueOf(version));
+        dc.setEncoding(DefaultDeviceConfigRestService.DEFAULT_ENCODING);
         dc.setIpInterface(ipInterface1);
         dc.setServiceName("DeviceConfig-default");
         dc.setLastUpdated(new Date(createdTime(version)));
@@ -289,6 +295,6 @@ public class DefaultDeviceConfigRestServiceIT {
     }
 
     private static long createdTime(int num) {
-        return num * 1000l * 60 * 60 * 24;
+        return num * 1000L * 60 * 60 * 24;
     }
 }


### PR DESCRIPTION
DCB: Add 'config' as a string in the 'device-config' Rest API response

- use 'encoding' if supplied
- basic handling of binary data (returns hex representation of binary data)
- updates Rest integration test to use hamcrest matchers

It's expected we will need to make additional adjustments after testing with different kinds of text encoding or binary data.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14082

