### PR TITLE
NMS-14081: Changes based on demo feedback

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build --base=/opennms/ui/",
     "serve": "vite preview",
-    "test": "uvu -r tsm tests",
+    "test": "vitest run",
     "lint": "eslint --ignore-path ../.gitignore --ext .ts,.vue .",
     "lint:fix": "eslint --ignore-path ../.gitignore --ext .ts,.vue . --fix",
     "format": "prettier --ignore-path ../.gitignore --write \"**/*.+(ts)\""
@@ -68,14 +68,15 @@
     "@typescript-eslint/parser": "^5.12.0",
     "@vitejs/plugin-vue": "^2.2.0",
     "@vue-leaflet/vue-leaflet": "^0.6.1",
+    "@vue/test-utils": "^2.0.0-rc.17",
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-vue": "^8.5.0",
+    "happy-dom": "^2.47.0",
     "prettier": "^2.3.2",
-    "tsm": "^2.1.4",
     "typescript": "^4.5.5",
-    "uvu": "^0.5.3",
     "vite": "^2.8.4",
+    "vitest": "^0.6.1",
     "vue-eslint-parser": "^8.0.1",
     "vue-tsc": "^0.31.4"
   }

--- a/ui/src/components/Common/Toast.vue
+++ b/ui/src/components/Common/Toast.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="toast" :class="getToastClass()">
+    <div class="message">
+      <div class="icon">
+        <FeatherIcon
+          class="icon-inner"
+          :icon="toastMessage.hasError ? Edit : CheckCircle"
+          :class="getIconClass()"
+        />
+      </div>
+      <div class="basic">{{ toastMessage.basic }}</div>
+      <div class="detail">{{ toastMessage.detail }}</div>
+      <div class="close">
+        <FeatherButton icon="Cancel" text @click="closeToast">
+          <FeatherIcon class="close-icon" :icon="Cancel" />
+        </FeatherButton>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts" setup>
+import { computed, reactive, watch } from 'vue'
+import { useStore } from 'vuex'
+import { FeatherIcon } from '@featherds/icon'
+import { FeatherButton } from '@featherds/button'
+import Edit from '@featherds/icon/action/Edit'
+import CheckCircle from '@featherds/icon/action/CheckCircle'
+import Cancel from '@featherds/icon/navigation/Cancel'
+const store = useStore()
+/**
+ * Local State
+ */
+const toastMessage = computed(() => store.state.notificationModule.toast)
+const toastState = reactive({ isOpen: false, toastTimeout: 0 })
+watch(toastMessage, () => {
+  toastState.isOpen = true
+  clearTimeout(toastState.toastTimeout)
+  toastState.toastTimeout = window.setTimeout(() => {
+    toastState.isOpen = false
+  }, 5000)
+})
+/**
+ * Cloase the Toast Message
+ */
+const closeToast = () => {
+  toastState.isOpen = false
+  clearTimeout(toastState.toastTimeout)
+}
+/**
+ * Helper method to get all the toast classes in a clean way
+ */
+const getToastClass = () => {
+  let classes = ''
+  if (toastState.isOpen) {
+    classes += 'toast-open '
+  }
+  if (toastMessage.value.hasErrors) {
+    classes += 'toast-errors '
+  }
+  return classes
+}
+/**
+ * Helper method to get all the icon class in a clean way.
+ */
+const getIconClass = () => {
+  return toastMessage.value.hasErrors ? 'icon-errors ' : ''
+}
+</script>
+<style lang="scss" scoped>
+@import "@featherds/styles/mixins/typography";
+@import "@featherds/styles/mixins/elevation";
+.icon-inner {
+  color: var($success);
+  font-size: 32px;
+}
+.toast {
+  @include elevation(6);
+  color: var($surface);
+  max-width: 1154px;
+  height: 56px;
+  background-color: var($secondary);
+  position: fixed;
+  bottom: 8px;
+  left: 320px;
+  width: 50%;
+  border-radius: 5px;
+  transform: translateY(76px);
+  transition: transform ease-in-out 0.3s, opacity ease-in-out 0.2s;
+  opacity: 0;
+  z-index: 5;
+}
+.toast-open {
+  opacity: 1;
+  transform: translateY(0px);
+}
+.toast-errors {
+  background-color: var($error);
+}
+.message {
+  @include body-large();
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 20px;
+  width: 100%;
+}
+.basic {
+  font-weight: 700;
+  color: var($surface);
+  margin-left: 8px;
+}
+.detail {
+  color: var($background);
+  margin-left: 8px;
+}
+.close {
+  margin-right: 25px;
+  margin-left: auto;
+}
+.close-icon {
+  color: var($surface);
+}
+.icon-errors {
+  color: black;
+}
+</style>

--- a/ui/src/components/Device/DCBGroupFilters.vue
+++ b/ui/src/components/Device/DCBGroupFilters.vue
@@ -32,7 +32,7 @@
         :key="option"
         @click="onGroupByOptionClick('status', option)"
       >
-        <div class="option" :class="option.replace(' ', '')">{{ option }}</div>
+        <div class="option" :class="option.replace(' ', '').toLowerCase()">{{ option }}</div>
       </FeatherDropdownItem>
     </FeatherDropdown>
 
@@ -105,6 +105,7 @@ const onGroupByOptionClick = (groupBy: string, value: string) => {
       height: 36px;
       line-height: 2.5;
       padding-left: 15px;
+      text-transform: capitalize;
     }
     .btn {
       width: 100%;

--- a/ui/src/components/Device/DCBModal.vue
+++ b/ui/src/components/Device/DCBModal.vue
@@ -25,7 +25,7 @@ defineProps({
 const modalDeviceConfigBackup = computed<DeviceConfigBackup>(() => store.state.deviceModule.modalDeviceConfigBackup)
 
 const labels = reactive({
-  title: '',
+  title: 'DCB',
   close: 'Close'
 })
 

--- a/ui/src/components/Device/DCBModal.vue
+++ b/ui/src/components/Device/DCBModal.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed, reactive, watchEffect } from 'vue'
 import { FeatherDialog } from '@featherds/dialog'
 import { DeviceConfigBackup } from '@/types/deviceConfig'
 import { useStore } from 'vuex'
@@ -24,15 +24,17 @@ defineProps({
 
 const modalDeviceConfigBackup = computed<DeviceConfigBackup>(() => store.state.deviceModule.modalDeviceConfigBackup)
 
-// TODO: Open feather PR to fix issue for reactive modal labels
-const labels = ref({
-  title: 'DeviceName: ...',
+const labels = reactive({
+  title: '',
   close: 'Close'
 })
+
+watchEffect(() => labels.title = modalDeviceConfigBackup.value.deviceName)
 </script>
 
 <style scoped lang="scss">
 .content {
+  min-height: 300px;
   min-width: 500px;
   position: relative;
 }

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -15,6 +15,7 @@
         <div>Configurations:</div>
         <div class="btn-container">
           <FeatherButton
+            data-test="view-history-btn"
             @click="onViewHistory"
             :disabled="(!all && selectedDeviceConfigIds.length !== 1) || (all && deviceConfigBackups.length !== 1)"
             text
@@ -26,6 +27,7 @@
           </FeatherButton>
 
           <FeatherButton
+            data-test="download-btn"
             @click="onDownload"
             :disabled="(selectedDeviceConfigIds.length === 0 && !all) || (all && !deviceConfigBackups.length)"
             text
@@ -37,6 +39,7 @@
           </FeatherButton>
 
           <FeatherButton
+            data-test="backup-now-btn"
             @click="onBackupNow"
             :disabled="(selectedDeviceConfigIds.length === 0 && !all) || (all && !deviceConfigBackups.length)"
             text
@@ -57,7 +60,7 @@
       <thead>
         <tr>
           <th>
-            <FeatherCheckbox v-model="all" @update:modelValue="selectAll" />
+            <FeatherCheckbox v-model="all" @update:modelValue="selectAll" data-test="all-checkbox" />
           </th>
           <FeatherSortHeader
             scope="col"
@@ -123,7 +126,7 @@
             />
           </td>
           <td>
-            <router-link :to="`/node/${config.id}`">{{ config.deviceName }}</router-link>
+            <router-link :to="`/node/${config.nodeId}`">{{ config.deviceName }}</router-link>
           </td>
           <td>{{ config.ipAddress }}</td>
           <td>{{ config.location }}</td>
@@ -147,10 +150,10 @@
   </div>
   <DCBModal @close="dcbModalVisible = false" :visible="dcbModalVisible">
     <template v-slot:content>
-      <DCBModalLastBackupContent
-        v-if="dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalLastBackupContent"
+      <DCBModalViewHistoryContentVue
+        v-if="dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalViewHistoryContent"
       />
-      <DCBModalViewHistoryContentVue v-else />
+      <DCBModalLastBackupContent v-else />
     </template>
   </DCBModal>
 </template>
@@ -244,8 +247,13 @@ const selectAll = () => {
   if (all.value) {
     store.dispatch('deviceModule/setSelectedIds', 'all')
   } else {
-    store.dispatch('deviceModule/setSelectedIds', selectedDeviceConfigIds.value)
+    clearAllSelectedDevices()
   }
+}
+
+const clearAllSelectedDevices = () => {
+  selectedDeviceConfigBackups.value = {}
+  store.dispatch('deviceModule/setSelectedIds', selectedDeviceConfigIds.value)
 }
 
 const selectCheckbox = (config: DeviceConfigBackup) => {

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -126,24 +126,25 @@
             />
           </td>
           <td>
-            <router-link :to="`/node/${config.nodeId}`">{{ config.deviceName }}</router-link>
+            <router-link :to="`/node/${config.nodeId}`" target="_blank">{{ config.deviceName }}</router-link>
           </td>
           <td>{{ config.ipAddress }}</td>
           <td>{{ config.location }}</td>
-          <td v-date>{{ config.lastSucceededDate }}</td>
-          <td
-            v-date
-            class="last-backup-date pointer"
-            @click="onLastBackupDateClick(config)"
-          >{{ config.lastUpdatedDate }}</td>
+          <td class="last-backup-date pointer" @click="onLastBackupDateClick(config)">
+            <span v-date>{{ config.lastSucceededDate }}</span>
+            <FeatherButton icon="View">
+              <FeatherIcon :icon="ViewDetails" />
+            </FeatherButton>
+          </td>
+          <td v-date>{{ config.lastUpdatedDate }}</td>
           <td>
             <div
-              :class="config.backupStatus.replace(' ', '')"
+              :class="config.backupStatus.replace(' ', '').toLowerCase()"
               class="option"
             >{{ config.backupStatus }}</div>
           </td>
-          <td v-date>{{ config.scheduleDate }}</td>
-          <td>{{ config.scheduleInterval }}</td>
+          <td v-date>{{ config.nextScheduledBackupDate }}</td>
+          <td>{{ config.scheduledInterval }}</td>
         </tr>
       </tbody>
     </table>
@@ -170,6 +171,7 @@ import { FeatherIcon } from '@featherds/icon'
 import History from '@featherds/icon/action/Restore'
 import Download from '@featherds/icon/action/DownloadFile'
 import Backup from '@featherds/icon/action/Cycle'
+import ViewDetails from '@featherds/icon/action/ViewDetails'
 import DCBSearch from '@/components/Device/DCBSearch.vue'
 import DCBModal from './DCBModal.vue'
 import DCBModalLastBackupContent from './DCBModalLastBackupContent.vue'
@@ -324,6 +326,7 @@ onMounted(() => {
       height: 43px;
       line-height: 3.5;
       padding-left: 15px;
+      text-transform: capitalize;
     }
   }
 

--- a/ui/src/components/Device/DCBTableStatusDropdown.vue
+++ b/ui/src/components/Device/DCBTableStatusDropdown.vue
@@ -11,7 +11,7 @@
       :key="option"
       @click="filterByStatus(option)"
     >
-      <div class="option" :class="option.replace(' ', '')">{{ option }}</div>
+      <div class="option" :class="option.replace(' ', '').toLowerCase()">{{ option }}</div>
     </FeatherDropdownItem>
   </FeatherDropdown>
 </template>
@@ -47,6 +47,7 @@ const filterByStatus = (value: string) => {
   height: 36px;
   line-height: 2.5;
   padding-left: 15px;
+  text-transform: capitalize;
 }
 </style>
 

--- a/ui/src/components/Layout/NavigationRail.vue
+++ b/ui/src/components/Layout/NavigationRail.vue
@@ -43,7 +43,7 @@
         :class="{ selected: isSelected('/device-config-backup') }"
         href="#/device-config-backup"
         :icon="MinionProfiles"
-        title="Device Management"
+        title="Configuration Management"
       />
 
       <!-- loop plugin menu items -->

--- a/ui/src/components/Nodes/NodeAvailabilityGraph.vue
+++ b/ui/src/components/Nodes/NodeAvailabilityGraph.vue
@@ -52,14 +52,14 @@ const startTime = ref(getUnixTime(sub(now, { days: 1 })))
 const endTime = ref(getUnixTime(now))
 const width = ref(200)
 const timeline = ref<any>(null)
-const recalculateWidth = () => {
+const recalculateWidth = debounce(() => {
   width.value = timeline.value.clientWidth - 60
-}
+}, 100)
 
 onMounted(async () => {
   store.dispatch('nodesModule/getNodeAvailabilityPercentage', nodeId.value)
   recalculateWidth()
-  window.addEventListener('resize', debounce(recalculateWidth, 100))
+  window.addEventListener('resize', recalculateWidth)
 })
 
 const availability = computed(() => store.state.nodesModule.availability)

--- a/ui/src/containers/DeviceConfigBackup.vue
+++ b/ui/src/containers/DeviceConfigBackup.vue
@@ -7,12 +7,13 @@
             <p class="title">Device Configuration</p>
             <DCBTable />
           </div>
-          <div class="filters-container">
+          <div v-if="false" class="filters-container">
             <DCBGroupFilters />
           </div>
         </div>
       </div>
     </div>
+    <Toast />
   </div>
 </template>
 
@@ -21,6 +22,7 @@ import { onMounted } from 'vue'
 import { useStore } from 'vuex'
 import DCBTable from '@/components/Device/DCBTable.vue'
 import DCBGroupFilters from '@/components/Device/DCBGroupFilters.vue'
+import Toast from '@/components/Common/Toast.vue'
 
 const store = useStore()
 
@@ -35,19 +37,19 @@ onMounted(() => store.dispatch('deviceModule/getDeviceConfigBackups'))
   background: $color;
   background: linear-gradient(90deg, $color 1%, rgba(255, 255, 255, 0) 9%);
 }
-:deep(.Success) {
+:deep(.success) {
   @include status-bar(var($success));
 }
-:deep(.Failed) {
+:deep(.failed) {
   @include status-bar(var($error));
 }
-:deep(.InProgress) {
+:deep(.inprogress) {
   @include status-bar(var($warning));
 }
-:deep(.Paused) {
+:deep(.paused) {
   @include status-bar(var($primary-variant));
 }
-:deep(.NoBackup) {
+:deep(.nobackup) {
   @include status-bar(var($secondary-variant));
 }
 

--- a/ui/src/hooks/useDownload.ts
+++ b/ui/src/hooks/useDownload.ts
@@ -1,10 +1,12 @@
+import { AxiosResponse, AxiosResponseHeaders } from 'axios'
+
 const useDownload = () => {
   /**
    * Download a file from a binary response
    *
-   * @param   {data: BinaryType, headers: Headers}  file  response from the server
+   * @param   {AxiosResponse}  file  response from the server
    */
-  const downloadFile = (file: { data: BinaryType; headers: Headers }): void => {
+  const downloadFile = (file: AxiosResponse): void => {
     const name = getNameFromHeaders(file.headers)
     const extension = name.split('.').pop() || ''
     const blob = generateBlob(file, extension)
@@ -22,9 +24,9 @@ export default useDownload
  * @param   {Headers}  headers  headers from the server
  * @return  {string}            filename
  */
-const getNameFromHeaders = (headers: Headers): string => {
+const getNameFromHeaders = (headers: AxiosResponseHeaders): string => {
   let name = ''
-  const disposition = (<any>headers)['content-disposition']
+  const disposition = (<AxiosResponseHeaders>headers)['content-disposition']
 
   if (disposition && disposition.indexOf('attachment') !== -1) {
     const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/
@@ -44,8 +46,8 @@ const getNameFromHeaders = (headers: Headers): string => {
  * @param   {string}   extension filename extension
  * @return  {Blob}               file object
  */
-const generateBlob = (file: { data: BinaryType; headers: Headers }, extension: string): Blob => {
-  const contentType = (<any>file.headers)['content-type']
+const generateBlob = (file: AxiosResponse, extension: string): Blob => {
+  const contentType = (<AxiosResponseHeaders>file.headers)['content-type']
 
   // stringify if it's a JSON file
   if (extension.toLowerCase() === 'json') {

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,8 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
 import Nodes from '@/containers/Nodes.vue'
-import NodeDetails from '@/containers/NodeDetails.vue'
+import DeviceConfigBackup from '@/containers/DeviceConfigBackup.vue'
 import FileEditor from '@/containers/FileEditor.vue'
-import Logs from '@/containers/Logs.vue'
 import Resources from '@/components/Resources/Resources.vue'
 import Graphs from '@/components/Resources/Graphs.vue'
 
@@ -17,7 +16,7 @@ const router = createRouter({
     {
       path: '/node/:id',
       name: 'Node Details',
-      component: NodeDetails
+      component: () => import('@/containers/NodeDetails.vue')
     },
     {
       path: '/plugins/:extensionId/:resourceRootPath/:moduleFileName',
@@ -33,7 +32,7 @@ const router = createRouter({
     {
       path: '/logs',
       name: 'Logs',
-      component: Logs
+      component: () => import('@/containers/Logs.vue')
     },
     {
       path: '/map',
@@ -82,7 +81,7 @@ const router = createRouter({
     {
       path: '/device-config-backup',
       name: 'DeviceConfigBackup',
-      component: () => import('@/containers/DeviceConfigBackup.vue')
+      component: DeviceConfigBackup
     },
     {
       path: '/:pathMatch(.*)*', // catch other paths and redirect

--- a/ui/src/services/deviceService.ts
+++ b/ui/src/services/deviceService.ts
@@ -17,19 +17,18 @@ const getDeviceConfigBackups = async (queryParameters: DeviceConfigQueryParams):
 const downloadDeviceConfigs = async (deviceIds: number[]) => {
   const queryString = `?id=${deviceIds.join(',')}`
   try {
-    const resp = await rest.get(`${endpoint}/download${queryString}`)
-    return resp.data
+    return await rest.get(`${endpoint}/download${queryString}`)
   } catch (err) {
-    return {}
+    return false
   }
 }
 
-const backupDeviceConfig = async (deviceConfig: DeviceConfigBackup) => {
+const backupDeviceConfig = async ({ ipAddress, location, configType }: DeviceConfigBackup) => {
   try {
-    const resp = await rest.post(`${endpoint}/backup`, deviceConfig)
+    const resp = await rest.post(`${endpoint}/backup`, { ipAddress, location, configType })
     return resp.data
   } catch (err) {
-    return {}
+    return false
   }
 }
 

--- a/ui/src/store/device/actions.ts
+++ b/ui/src/store/device/actions.ts
@@ -31,17 +31,37 @@ const getAndMergeDeviceConfigBackups = async (context: ContextWithState) => {
 const downloadSelectedDevices = async (contextWithState: ContextWithState) => {
   const ids = contextWithState.state.selectedIds
   const file = await API.downloadDeviceConfigs(ids)
-  downloadFile(file)
+  if (file) downloadFile(file)
 }
 
 const backupSelectedDevices = async (contextWithState: ContextWithState) => {
   const ids = contextWithState.state.selectedIds
   const configs = contextWithState.state.deviceConfigBackups
+  contextWithState.dispatch('spinnerModule/setSpinnerState', true, { root: true })
 
   if (ids.length === 1) {
     const config = getDeviceConfigBackupObjById(configs, ids[0])
-    return await API.backupDeviceConfig(config)
+    const success = await API.backupDeviceConfig(config)
+    contextWithState.dispatch('spinnerModule/setSpinnerState', false, { root: true })
+
+    if (success) {
+      const successToast = {
+        basic: 'Success!',
+        detail: 'Device backup successful.',
+        hasErrors: false
+      }
+      contextWithState.dispatch('notificationModule/setToast', successToast, { root: true })
+    } else {
+      const failedToast = {
+        basic: 'Failed:',
+        detail: 'Device backup unsuccessful.',
+        hasErrors: true
+      }
+      contextWithState.dispatch('notificationModule/setToast', failedToast, { root: true })
+    }
+
   } else {
+    contextWithState.dispatch('spinnerModule/setSpinnerState', false, { root: true })
     // backup multiple configs?
   }
 }

--- a/ui/src/store/device/actions.ts
+++ b/ui/src/store/device/actions.ts
@@ -59,7 +59,6 @@ const backupSelectedDevices = async (contextWithState: ContextWithState) => {
       }
       contextWithState.dispatch('notificationModule/setToast', failedToast, { root: true })
     }
-
   } else {
     contextWithState.dispatch('spinnerModule/setSpinnerState', false, { root: true })
     // backup multiple configs?

--- a/ui/src/store/device/state.ts
+++ b/ui/src/store/device/state.ts
@@ -15,8 +15,8 @@ const state: State = {
   deviceConfigBackupQueryParams: { offset: 0, limit: 20 },
   modalDeviceConfigBackup: {} as DeviceConfigBackup,
   selectedIds: [],
-  vendorOptions: ['Aruba', 'Cisco', 'Juniper', 'OpenNMS'],
-  backupStatusOptions: ['Success', 'Failed', 'Paused', 'No Backup', 'In Progress'],
+  vendorOptions: [],
+  backupStatusOptions: ['success', 'failed', 'paused', 'no backup', 'in progress'],
   osImageOptions: []
 }
 

--- a/ui/src/store/notification/actions.ts
+++ b/ui/src/store/notification/actions.ts
@@ -1,9 +1,14 @@
-import { VuexContext, Notification } from '@/types'
+import { VuexContext, Notification, Toast } from '@/types'
 
 const setNotification = (context: VuexContext, notification: Notification): void => {
   context.commit('SET_NOTIFICATION', notification)
 }
 
+const setToast = (context: VuexContext, toast: Toast): void => {
+  context.commit('SET_TOAST_INFO', toast)
+}
+
 export default {
-  setNotification
+  setNotification,
+  setToast
 }

--- a/ui/src/store/notification/mutations.ts
+++ b/ui/src/store/notification/mutations.ts
@@ -1,10 +1,15 @@
 import { State } from './state'
-import { Notification } from '@/types'
+import { Notification, Toast } from '@/types'
 
 const SET_NOTIFICATION = (state: State, notification: Notification): void => {
   state.notification = notification
 }
 
+const SET_TOAST_INFO = (state: State, toast: Toast): void => {
+  state.toast = toast
+}
+
 export default {
-  SET_NOTIFICATION
+  SET_NOTIFICATION,
+  SET_TOAST_INFO
 }

--- a/ui/src/store/notification/state.ts
+++ b/ui/src/store/notification/state.ts
@@ -1,11 +1,17 @@
-import { NotificationSeverity, Notification } from '@/types'
+import { NotificationSeverity, Notification, Toast } from '@/types'
 
 export interface State {
   notification: Notification
+  toast: Toast
 }
 
 const state: State = {
-  notification: { msg: '', severity: NotificationSeverity.ERROR }
+  notification: { msg: '', severity: NotificationSeverity.ERROR },
+  toast: {
+    basic: '',
+    detail: '',
+    hasErrors: false
+  }
 }
 
 export default state

--- a/ui/src/types/deviceConfig.d.ts
+++ b/ui/src/types/deviceConfig.d.ts
@@ -11,8 +11,7 @@ export interface DeviceConfigBackup {
   lastSucceededDate: string
   lastFailedDate: string
   backupStatus: string
-  scheduleDate: string
-  scheduleInterval: string
+  scheduledInterval: string
   fileName: string
   failureReason: string
   encoding: string

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -457,3 +457,9 @@ export interface Plugin {
   moduleFileName: string
   resourceRootPath: string
 }
+
+export interface Toast {
+  basic: string
+  detail: string
+  hasErrors: boolean
+}

--- a/ui/tests/deviceConfigBackup.test.ts
+++ b/ui/tests/deviceConfigBackup.test.ts
@@ -1,0 +1,111 @@
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import dateFormatDirective from '@/directives/v-date'
+import DCB from '@/containers/DeviceConfigBackup.vue'
+import store from '@/store'
+import { test, expect } from 'vitest'
+
+const mockDeviceConfigBackups = [
+  {
+    id: 123,
+    deviceName: 'Cisco-7201',
+    location: 'location',
+    ipAddress: '10.21.10.81',
+    lastSucceededDate: '1643831118973',
+    lastUpdatedDate: '1643831118973',
+    backupStatus: 'Success',
+    scheduleDate: '1643831118973',
+    scheduleInterval: 'daily',
+    config: 'mock config',
+    configType: 'running'
+  },
+  {
+    id: 12,
+    deviceName: 'Aruba-7003-1',
+    location: 'location',
+    ipAddress: '10.21.10.81',
+    lastSucceededDate: '1643831118973',
+    lastUpdatedDate: '1643831118973',
+    backupStatus: 'Failed',
+    scheduleDate: '1643831118973',
+    scheduleInterval: 'daily',
+    config: 'mock config',
+    configType: 'default'
+  }
+]
+
+store.commit('deviceModule/SAVE_DEVICE_CONFIG_BACKUPS', mockDeviceConfigBackups)
+
+const wrapper = mount(DCB, {
+  global: {
+    plugins: [store],
+    directives: {
+      date: dateFormatDirective
+    },
+    stubs: {
+      RouterLink: RouterLinkStub
+    }
+  }
+})
+
+test('action btns enable and disable correctly', async () => {
+  const viewHistoryBtn = wrapper.get('[data-test="view-history-btn"]')
+  const downloadBtn = wrapper.get('[data-test="download-btn"]')
+  const backupNowBtn = wrapper.get('[data-test="backup-now-btn"]')
+  const checkboxes = wrapper.findAll('.device-config-checkbox')
+  const firstDeviceConfig = wrapper.find('.device-config-checkbox > .feather-checkbox')
+  const allCheckbox = wrapper.find('[data-test="all-checkbox"] > .feather-checkbox')
+
+  // two DCB mock records
+  expect(checkboxes.length).toBe(2)
+
+  // all actions init disabled
+  expect(viewHistoryBtn.attributes('aria-disabled')).toBe('true')
+  expect(downloadBtn.attributes('aria-disabled')).toBe('true')
+  expect(backupNowBtn.attributes('aria-disabled')).toBe('true')
+  expect(allCheckbox.attributes('aria-checked')).toBe('false')
+
+  // select first config
+  await firstDeviceConfig.trigger('click')
+  expect(viewHistoryBtn.attributes('aria-disabled')).toBeUndefined()
+  expect(downloadBtn.attributes('aria-disabled')).toBeUndefined()
+  expect(backupNowBtn.attributes('aria-disabled')).toBeUndefined()
+
+  // select 'all devices' checkbox
+  await allCheckbox.trigger('click')
+
+  expect(allCheckbox.attributes('aria-checked')).toBe('true')
+  expect(viewHistoryBtn.attributes('aria-disabled')).toBe('true')
+  expect(downloadBtn.attributes('aria-disabled')).toBeUndefined()
+  expect(backupNowBtn.attributes('aria-disabled')).toBeUndefined()
+
+  // change 'all devices' to false
+  await allCheckbox.trigger('click')
+
+  // all actions back to disabled
+  expect(viewHistoryBtn.attributes('aria-disabled')).toBe('true')
+  expect(downloadBtn.attributes('aria-disabled')).toBe('true')
+  expect(backupNowBtn.attributes('aria-disabled')).toBe('true')
+  expect(allCheckbox.attributes('aria-checked')).toBe('false')
+})
+
+test('the modal opens and displays the config property', async () => {
+  const viewHistoryBtn = wrapper.get('[data-test="view-history-btn"]')
+  const lastBackupDateBtn = wrapper.get('.last-backup-date')
+  const firstDeviceConfig = wrapper.find('.device-config-checkbox > .feather-checkbox')
+  const dialog = wrapper.get('.feather-dialog')
+  const closeModalBtn = wrapper.get('[data-ref-id="dialog-close"]')
+  const dialogContent = wrapper.get('.dialog-content > .content')
+
+  expect(dialog.attributes('style')).toBe('display: none;')
+
+  await lastBackupDateBtn.trigger('click')
+  expect(dialog.attributes('style')).not.toBe('display: none;')
+  expect(dialogContent.text()).toBe('mock config')
+
+  await closeModalBtn.trigger('click')
+  expect(dialog.attributes('style')).toBe('display: none;')
+
+  await firstDeviceConfig.trigger('click')
+  await viewHistoryBtn.trigger('click')
+  expect(dialog.attributes('style')).not.toBe('display: none;')
+})

--- a/ui/tests/deviceConfigBackup.test.ts
+++ b/ui/tests/deviceConfigBackup.test.ts
@@ -3,8 +3,9 @@ import dateFormatDirective from '@/directives/v-date'
 import DCB from '@/containers/DeviceConfigBackup.vue'
 import store from '@/store'
 import { test, expect } from 'vitest'
+import { DeviceConfigBackup } from '@/types/deviceConfig'
 
-const mockDeviceConfigBackups = [
+const mockDeviceConfigBackups: DeviceConfigBackup[] = [
   {
     id: 123,
     deviceName: 'Cisco-7201',
@@ -12,11 +13,21 @@ const mockDeviceConfigBackups = [
     ipAddress: '10.21.10.81',
     lastSucceededDate: '1643831118973',
     lastUpdatedDate: '1643831118973',
-    backupStatus: 'Success',
-    scheduleDate: '1643831118973',
-    scheduleInterval: 'daily',
-    config: 'mock config',
-    configType: 'running'
+    backupStatus: 'success',
+    nextScheduledBackupDate: '1643831118973',
+    scheduledInterval: 'daily',
+    config: 'mock cisco config',
+    configType: 'running',
+    ipInterfaceId: 1,
+    createdTime: '1643831118973',
+    lastFailedDate: '1643831118973',
+    fileName: 'filename',
+    failureReason: 'reason',
+    encoding: '',
+    nodeId: 1,
+    nodeLabel: 'node1',
+    operatingSystem: '',
+    isSuccessfulBackup: true
   },
   {
     id: 12,
@@ -25,11 +36,21 @@ const mockDeviceConfigBackups = [
     ipAddress: '10.21.10.81',
     lastSucceededDate: '1643831118973',
     lastUpdatedDate: '1643831118973',
-    backupStatus: 'Failed',
-    scheduleDate: '1643831118973',
-    scheduleInterval: 'daily',
-    config: 'mock config',
-    configType: 'default'
+    backupStatus: 'failed',
+    nextScheduledBackupDate: '1643831118973',
+    scheduledInterval: 'daily',
+    config: 'mock aruba config',
+    configType: 'default',
+    ipInterfaceId: 1,
+    createdTime: '1643831118973',
+    lastFailedDate: '1643831118973',
+    fileName: 'filename',
+    failureReason: 'reason',
+    encoding: '',
+    nodeId: 1,
+    nodeLabel: 'node1',
+    operatingSystem: '',
+    isSuccessfulBackup: true
   }
 ]
 
@@ -66,13 +87,14 @@ test('action btns enable and disable correctly', async () => {
 
   // select first config
   await firstDeviceConfig.trigger('click')
+  // all btns should be enabled
   expect(viewHistoryBtn.attributes('aria-disabled')).toBeUndefined()
   expect(downloadBtn.attributes('aria-disabled')).toBeUndefined()
   expect(backupNowBtn.attributes('aria-disabled')).toBeUndefined()
 
   // select 'all devices' checkbox
   await allCheckbox.trigger('click')
-
+  // the view history btn should be disabled. Dwnld / backup btns enabled
   expect(allCheckbox.attributes('aria-checked')).toBe('true')
   expect(viewHistoryBtn.attributes('aria-disabled')).toBe('true')
   expect(downloadBtn.attributes('aria-disabled')).toBeUndefined()
@@ -80,7 +102,6 @@ test('action btns enable and disable correctly', async () => {
 
   // change 'all devices' to false
   await allCheckbox.trigger('click')
-
   // all actions back to disabled
   expect(viewHistoryBtn.attributes('aria-disabled')).toBe('true')
   expect(downloadBtn.attributes('aria-disabled')).toBe('true')
@@ -88,24 +109,31 @@ test('action btns enable and disable correctly', async () => {
   expect(allCheckbox.attributes('aria-checked')).toBe('false')
 })
 
-test('the modal opens and displays the config property', async () => {
+test('the modal opens and displays the config property and device title', async () => {
   const viewHistoryBtn = wrapper.get('[data-test="view-history-btn"]')
   const lastBackupDateBtn = wrapper.get('.last-backup-date')
-  const firstDeviceConfig = wrapper.find('.device-config-checkbox > .feather-checkbox')
+  const deviceConfigCheckboxes = wrapper.findAll('.device-config-checkbox')
+  const secondDeviceConfig = deviceConfigCheckboxes[1].get('.feather-checkbox')
   const dialog = wrapper.get('.feather-dialog')
   const closeModalBtn = wrapper.get('[data-ref-id="dialog-close"]')
   const dialogContent = wrapper.get('.dialog-content > .content')
+  const headerText = wrapper.get('[data-ref-id="feather-dialog-header"]')
 
+  // modal starts hidden
   expect(dialog.attributes('style')).toBe('display: none;')
 
+  // clicks the first backup date link
   await lastBackupDateBtn.trigger('click')
+  //expect cisco config and title
   expect(dialog.attributes('style')).not.toBe('display: none;')
-  expect(dialogContent.text()).toBe('mock config')
+  expect(dialogContent.text()).toBe('mock cisco config')
+  expect(headerText.text()).toBe('Cisco-7201')
 
   await closeModalBtn.trigger('click')
   expect(dialog.attributes('style')).toBe('display: none;')
 
-  await firstDeviceConfig.trigger('click')
+  // click second device config checkbox and then view hitory btn
+  await secondDeviceConfig.trigger('click')
   await viewHistoryBtn.trigger('click')
   expect(dialog.attributes('style')).not.toBe('display: none;')
 })

--- a/ui/tests/fileEditor.test.ts
+++ b/ui/tests/fileEditor.test.ts
@@ -1,7 +1,6 @@
-import { filesToFolders, sortFilesAndFolders, getExtensionFromFilenameSafely } from '../src/components/FileEditor/utils'
+import { filesToFolders, sortFilesAndFolders, getExtensionFromFilenameSafely } from '@/components/FileEditor/utils'
 import { IFile } from '../src/store/fileEditor/state'
-import { test } from 'uvu'
-import * as assert from 'uvu/assert'
+import { assert, test, expect } from 'vitest'
 
 test('Creating folders', () => {
   const sample: string[] = [
@@ -40,8 +39,7 @@ test('Creating folders', () => {
     ]
   }
 
-  assert.type(filesToFolders, 'function')
-  assert.equal(filesToFolders(sample), result)
+  expect(filesToFolders(sample)).toEqual(result)
 })
 
 test('Sorting folders and files', () => {
@@ -60,16 +58,12 @@ test('Sorting folders and files', () => {
   const firstFolder = sorted[0].name
   const secondFolderFirstFile = (sorted[1] as Required<IFile>).children[0].name
 
-  assert.type(sortFilesAndFolders, 'function')
-  assert.is(firstFolder, 'Atest')
-  assert.is(secondFolderFirstFile, 'A')
+  assert.equal(firstFolder, 'Atest')
+  assert.equal(secondFolderFirstFile, 'A')
 })
 
 test('Getting the file extension', () => {
-  assert.type(getExtensionFromFilenameSafely, 'function')
   assert.equal(getExtensionFromFilenameSafely('test'), '')
   assert.equal(getExtensionFromFilenameSafely('test.xml'), 'xml')
   assert.equal(getExtensionFromFilenameSafely('test.properties'), 'properties')
 })
-
-test.run()

--- a/ui/tests/map.test.ts
+++ b/ui/tests/map.test.ts
@@ -1,18 +1,14 @@
-import { numericSeverityLevel } from '../src/components/Map/utils'
-import { test } from 'uvu'
-import * as assert from 'uvu/assert'
+import { numericSeverityLevel } from '@/components/Map/utils'
+import { assert, test } from 'vitest'
 
 const isGreater = (a: number, b: number) => {
   assert.equal(a > b, true)
 }
 
 test('Ensure precedence', () => {
-  assert.type(numericSeverityLevel, 'function')
   assert.equal(numericSeverityLevel(undefined), 0)
   isGreater(numericSeverityLevel('CRITICAL'), numericSeverityLevel('MAJOR'))
   isGreater(numericSeverityLevel('MAJOR'), numericSeverityLevel('MINOR'))
   isGreater(numericSeverityLevel('MINOR'), numericSeverityLevel('WARNING'))
   isGreater(numericSeverityLevel('WARNING'), numericSeverityLevel('NORMAL'))
 })
-
-test.run()

--- a/ui/tests/queryParameters.test.ts
+++ b/ui/tests/queryParameters.test.ts
@@ -1,7 +1,6 @@
-import { queryParametersHandler } from '../src/services/serviceHelpers'
-import { QueryParameters } from '../src/types'
-import { test } from 'uvu'
-import * as assert from 'uvu/assert'
+import { queryParametersHandler } from '@/services/serviceHelpers'
+import { QueryParameters } from '@/types'
+import { assert, test } from 'vitest'
 
 const testEndpoint = 'my-endpoint'
 
@@ -14,8 +13,5 @@ const testQueryParams: QueryParameters = {
 const expectedResult = 'my-endpoint?search=val1&order=asc&orderBy=property'
 
 test('The query parameter handler', () => {
-  assert.type(queryParametersHandler, 'function')
   assert.equal(queryParametersHandler(testQueryParams, testEndpoint), expectedResult)
 })
-
-test.run()

--- a/ui/tests/resourceGraphs.test.ts
+++ b/ui/tests/resourceGraphs.test.ts
@@ -1,7 +1,6 @@
 import { PrintStatement } from '@/types'
-import { test } from 'uvu'
-import * as assert from 'uvu/assert'
-import { tokenizeStatement, TOKENS, formatStatement } from '../src/components/Resources/utils/LegendFormatter'
+import { assert, test } from 'vitest'
+import { tokenizeStatement, TOKENS, formatStatement } from '@/components/Resources/utils/LegendFormatter'
 
 test('Tokenizing a statement', () => {
   let tokens = tokenizeStatement('Max  : %8.2lf %s\\n')
@@ -61,5 +60,3 @@ test('Format statement', () => {
   assert.equal(renderer.texts[1].trim(), '1.02k')
   assert.equal(renderer.texts[4], '\n')
 })
-
-test.run()

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -22,5 +22,9 @@ export default defineConfig({
   ],
   define: {
     'process.env': process.env
+  },
+  test: {
+    globals: true,
+    environment: 'happy-dom',
   }
 })

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -25,6 +25,6 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: 'happy-dom',
+    environment: 'happy-dom'
   }
 })

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -407,6 +407,25 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
+  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
+
+"@types/concat-stream@^1.6.0":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@types/concat-stream/-/concat-stream-1.6.1.tgz#24bcfc101ecf68e886aaedce60dfd74b632a1b74"
+  integrity sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/d3-array@*":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.0.2.tgz#71c35bca8366a40d1b8fce9279afa4a77fb0065d"
@@ -617,6 +636,13 @@
     "@types/d3-transition" "*"
     "@types/d3-zoom" "*"
 
+"@types/form-data@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
+  integrity sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=
+  dependencies:
+    "@types/node" "*"
+
 "@types/geojson@*":
   version "7946.0.8"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
@@ -651,10 +677,25 @@
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.2.tgz#cb2dbf10da2f41cf20bd91fb5f89b67540c282f7"
   integrity sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ==
 
-"@types/node@^17.0.18":
+"@types/node@*", "@types/node@^17.0.18":
   version "17.0.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
   integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
+
+"@types/node@^10.0.3":
+  version "10.17.60"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+
+"@types/node@^8.0.0":
+  version "8.10.66"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
+  integrity sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==
+
+"@types/qs@^6.2.31":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
 "@types/splitpanes@^2.2.1":
   version "2.2.1"
@@ -922,6 +963,11 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.31.tgz#c90de7126d833dcd3a4c7534d534be2fb41faa4e"
   integrity sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ==
 
+"@vue/test-utils@^2.0.0-rc.17":
+  version "2.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.17.tgz#e6dcf5b5bd3ae23595bdb154b9b578ebcdffd698"
+  integrity sha512-7LHZKsFRV/HqDoMVY+cJamFzgHgsrmQFalROHC5FMWrzPzd+utG5e11krj1tVsnxYufGA2ABShX4nlcHXED+zQ==
+
 "@vueuse/core@^7.7.0":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-7.7.1.tgz#fc284f4103de73c7fb79bc06579d8066790db511"
@@ -997,7 +1043,7 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-asap@~2.0.3:
+asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -1006,6 +1052,16 @@ assert-never@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.2.1.tgz#11f0e363bf146205fb08193b5c7b90f4d1cf44fe"
   integrity sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 axios@^0.26.0:
   version "0.26.1"
@@ -1066,6 +1122,11 @@ btoa@^1.2.1:
   resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
   integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 buffer@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
@@ -1086,6 +1147,24 @@ callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+caseless@^0.12.0, caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chai@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
+  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -1114,6 +1193,11 @@ chartjs-plugin-zoom@^1.2.0:
   dependencies:
     hammerjs "^2.0.8"
 
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
+
 "chokidar@>=3.0.0 <4.0.0":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -1141,6 +1225,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@7, commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
@@ -1150,6 +1241,16 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+concat-stream@^1.6.0, concat-stream@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 constantinople@^4.0.1:
   version "4.0.1"
@@ -1168,6 +1269,11 @@ core-js-pure@^3.20.2:
   version "3.21.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.1.tgz#8c4d1e78839f5f46208de7230cebfb72bc3bdb51"
   integrity sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cross-fetch@^3.1.5:
   version "3.1.5"
@@ -1208,6 +1314,11 @@ css-what@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
   integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
 csso@^4.2.0:
   version "4.2.0"
@@ -1482,6 +1593,13 @@ debug@^4.1.1, debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -1499,15 +1617,10 @@ delaunator@5:
   dependencies:
     robust-predicates "^3.0.0"
 
-dequal@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
-  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
-
-diff@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1676,7 +1789,7 @@ esbuild-windows-arm64@0.14.25:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz#8b243cbbad8a86cf98697da9ccb88c05df2ef458"
   integrity sha512-4ype9ERiI45rSh+R8qUoBtaj6kJvUOI7oVLhKqPEpcF4Pa5PpT3hm/mXAyotJHREkHpM87PAJcA442mLnbtlNA==
 
-esbuild@^0.14.0, esbuild@^0.14.14:
+esbuild@^0.14.14:
   version "0.14.25"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.25.tgz#ddb9d47b91ca76abb7d850ce3dfed0bc3dc88d16"
   integrity sha512-4JHEIOMNFvK09ziiL+iVmldIhLbn49V4NAVo888tcGFKedEZY/Y8YapfStJ6zSE23tzYPKxqKwQBnQoIO0BI/Q==
@@ -1914,6 +2027,15 @@ form-data-encoder@^1.4.3:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.1.tgz#ac80660e4f87ee0d3d3c3638b7da8278ddb8ec96"
   integrity sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==
 
+form-data@^2.2.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 formdata-node@^4.0.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-4.3.2.tgz#0262e94931e36db7239c2b08bdb6aaf18ec47d21"
@@ -1942,6 +2064,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
 get-intrinsic@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -1950,6 +2077,11 @@ get-intrinsic@^1.0.2:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-port@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
+  integrity sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -2001,6 +2133,19 @@ hammerjs@^2.0.8:
   resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
   integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
 
+happy-dom@^2.47.0:
+  version "2.47.0"
+  resolved "https://registry.yarnpkg.com/happy-dom/-/happy-dom-2.47.0.tgz#3262e8b5d2007aba54bddbc72fd546418d9f5680"
+  integrity sha512-z9hhLZry8KcF9nx6lrfErDeq1Vkvlx99Qu8JfG4+Cet8XYm5RMBC+T/oOD/WBN/ivdeN/e/ugv+L6lUR+MV+/g==
+  dependencies:
+    css.escape "^1.5.1"
+    he "^1.1.1"
+    node-fetch "^2.6.1"
+    sync-request "^6.1.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -2025,6 +2170,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+he@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 htmlparser2@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-7.2.0.tgz#8817cdea38bbc324392a90b1990908e81a65f5a5"
@@ -2034,6 +2184,30 @@ htmlparser2@^7.2.0:
     domhandler "^4.2.2"
     domutils "^2.8.0"
     entities "^3.0.1"
+
+http-basic@^8.1.1:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/http-basic/-/http-basic-8.1.3.tgz#a7cabee7526869b9b710136970805b1004261bbf"
+  integrity sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==
+  dependencies:
+    caseless "^0.12.0"
+    concat-stream "^1.6.2"
+    http-response-object "^3.0.1"
+    parse-cache-control "^1.0.1"
+
+http-response-object@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.2.tgz#7f435bb210454e4360d074ef1f989d5ea8aa9810"
+  integrity sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==
+  dependencies:
+    "@types/node" "^10.0.3"
+
+iconv-lite@0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@0.6:
   version "0.6.3"
@@ -2083,7 +2257,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2150,6 +2324,11 @@ is-regex@^1.0.3:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -2194,11 +2373,6 @@ jstransformer@1.0.0:
   dependencies:
     is-promise "^2.0.0"
     promise "^7.0.1"
-
-kleur@^4.0.3:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.4.tgz#8c202987d7e577766d039a8cd461934c01cda04d"
-  integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
 
 klona@^2.0.4:
   version "2.0.5"
@@ -2247,6 +2421,11 @@ lit@^2.2.0:
     lit-element "^3.2.0"
     lit-html "^2.2.0"
 
+local-pkg@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.1.tgz#e7b0d7aa0b9c498a1110a5ac5b00ba66ef38cfff"
+  integrity sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -2256,6 +2435,13 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+loupe@^2.3.1:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
+  dependencies:
+    get-func-name "^2.0.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -2294,17 +2480,24 @@ micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
-mri@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
-  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@2.1.2:
   version "2.1.2"
@@ -2331,7 +2524,7 @@ node-domexception@1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@2.6.7:
+node-fetch@2.6.7, node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -2386,6 +2579,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-cache-control@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
+  integrity sha1-juqz5U+laSD+Fro493+iGqzC104=
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -2405,6 +2603,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -2440,12 +2643,24 @@ prismjs@^1.26.0:
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 promise@^7.0.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
   dependencies:
     asap "~2.0.3"
+
+promise@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
+  integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
+  dependencies:
+    asap "~2.0.6"
 
 pug-attrs@^3.0.0:
   version "3.0.0"
@@ -2560,7 +2775,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.10.2:
+qs@^6.10.2, qs@^6.4.0:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
@@ -2588,6 +2803,19 @@ rapidoc@^9.1.4:
     lit "^2.2.0"
     marked "^4.0.12"
     prismjs "^1.26.0"
+
+readable-stream@^2.2.2:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -2661,14 +2889,12 @@ rw@1:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
-sade@^1.7.3:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
-  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
-  dependencies:
-    mri "^1.1.0"
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-"safer-buffer@>= 2.1.2 < 3.0.0":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -2748,6 +2974,13 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -2805,10 +3038,53 @@ swagger-client@^3.18.4:
     traverse "~0.6.6"
     url "~0.11.0"
 
+sync-request@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-6.1.0.tgz#e96217565b5e50bbffe179868ba75532fb597e68"
+  integrity sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==
+  dependencies:
+    http-response-object "^3.0.1"
+    sync-rpc "^1.2.1"
+    then-request "^6.0.0"
+
+sync-rpc@^1.2.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/sync-rpc/-/sync-rpc-1.3.6.tgz#b2e8b2550a12ccbc71df8644810529deb68665a7"
+  integrity sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==
+  dependencies:
+    get-port "^3.1.0"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+then-request@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/then-request/-/then-request-6.0.2.tgz#ec18dd8b5ca43aaee5cb92f7e4c1630e950d4f0c"
+  integrity sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==
+  dependencies:
+    "@types/concat-stream" "^1.6.0"
+    "@types/form-data" "0.0.33"
+    "@types/node" "^8.0.0"
+    "@types/qs" "^6.2.31"
+    caseless "~0.12.0"
+    concat-stream "^1.6.0"
+    form-data "^2.2.0"
+    http-basic "^8.1.1"
+    http-response-object "^3.0.1"
+    promise "^8.0.0"
+    qs "^6.4.0"
+
+tinypool@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.2.tgz#5b1d5f5bb403afac8c67000047951ce76342fda7"
+  integrity sha512-fvtYGXoui2RpeMILfkvGIgOVkzJEGediv8UJt7TxdAOY8pnvUkFg/fkvqTfXG9Acc9S17Cnn1S4osDc2164guA==
+
+tinyspy@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.0.tgz#51bcc198173385c50416df791cd10c192078cb36"
+  integrity sha512-c5uFHqtUp74R2DJE3/Efg0mH5xicmgziaQXMm/LvuuZn3RdpADH32aEGDRyCzObXT1DNfwDMqRQ/Drh1MlO12g==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -2842,13 +3118,6 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tsm@^2.1.4:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tsm/-/tsm-2.2.1.tgz#3e78e86a03b2f569c20cff4a9f66c4ec8fce65fc"
-  integrity sha512-qvJB0baPnxQJolZru11mRgGTdNlx17WqgJnle7eht3Vhb+VUR4/zFA5hFl6NqRe7m8BD9w/6yu0B2XciRrdoJA==
-  dependencies:
-    esbuild "^0.14.0"
-
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -2863,10 +3132,20 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.5.5:
   version "4.6.2"
@@ -2893,15 +3172,10 @@ url@~0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-uvu@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.3.tgz#3d83c5bc1230f153451877bfc7f4aea2392219ae"
-  integrity sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==
-  dependencies:
-    dequal "^2.0.0"
-    diff "^5.0.0"
-    kleur "^4.0.3"
-    sade "^1.7.3"
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -2916,7 +3190,7 @@ vite-svg-loader@^3.1.2:
     "@vue/compiler-sfc" "^3.2.20"
     svgo "^2.7.0"
 
-vite@^2.8.4:
+vite@^2.7.10, vite@^2.8.4:
   version "2.8.6"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.6.tgz#32d50e23c99ca31b26b8ccdc78b1d72d4d7323d3"
   integrity sha512-e4H0QpludOVKkmOsRyqQ7LTcMUDF3mcgyNU4lmi0B5JUbe0ZxeBBl8VoZ8Y6Rfn9eFKYtdXNPcYK97ZwH+K2ug==
@@ -2927,6 +3201,19 @@ vite@^2.8.4:
     rollup "^2.59.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+vitest@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.6.1.tgz#d2cbe55c7c48b5a34c3561bb16d8646c3824d5aa"
+  integrity sha512-rgHgTO3xHCrbgmqYdUz4ViO0g2ekHeOfV60J6+1c6Ypzk1EqCE2sN8IpF4TDGs6BOvWIsVd/ob5c6U4Ozzu92g==
+  dependencies:
+    "@types/chai" "^4.3.0"
+    "@types/chai-subset" "^1.3.3"
+    chai "^4.3.6"
+    local-pkg "^0.4.1"
+    tinypool "^0.1.2"
+    tinyspy "^0.3.0"
+    vite "^2.7.10"
 
 void-elements@^3.1.0:
   version "3.1.0"
@@ -3130,6 +3417,23 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
+  dependencies:
+    iconv-lite "0.4.24"
+
+whatwg-mimetype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
- Switching the test runner here to Vitest - this is a new now officially recommended way to test with Vite. Works with @vue/test-utils.
- Grabs the Toast component from the provisiond branch, to be used as a Common component going forward.
- Use toast for backup success / fail indicator.
- Link moved to Last Backup Date.
- Added ViewDetails Feather Icon on Last Backup Date.
- Hid "Group By" panel.
- Fix display color / capitalize status
- Fix / Display Schedule info properties
- Increase min-height of DCBModal to 300px
- Fix / return resp instead of resp.data for download
- Fix backup API call parameters
- Open new tab for node name link
- Change title on nav rail to Configuration Management
- Fix device name reactivity/display in DCBModal

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14081

