### PR TITLE
NMS-14100: Install hostname cli tool manually

### DIFF
--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE_VERSION="11.0.14.0.9-b8239"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as horizon-base
 
-ARG REQUIRED_RPMS="rrdtool jrrd2 jicmp jicmp6 R-core rsync perl-XML-Twig perl-libwww-perl jq diffutils"
+ARG REQUIRED_RPMS="rrdtool jrrd2 jicmp jicmp6 R-core rsync perl-XML-Twig perl-libwww-perl jq diffutils hostname"
 
 ARG REPO_KEY_URL="https://yum.opennms.org/OPENNMS-GPG-KEY"
 ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel8.noarch.rpm"

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE_VERSION="11.0.14.0.9-b8239"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as sentinel-base
 
-ARG REQUIRED_RPMS="wget gettext openssh-clients"
+ARG REQUIRED_RPMS="hostname wget gettext openssh-clients"
 
 ARG REPO_KEY_URL="https://yum.opennms.org/OPENNMS-GPG-KEY"
 ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel8.noarch.rpm"


### PR DESCRIPTION
Install hostname CLI tool manually with CentOS 8 stream as a requirement for the k8s POC.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14100

