### PR TITLE
NMS-14116:  Get monitor/collector without resolving future

### DIFF
--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/ServiceCollectorRegistry.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/ServiceCollectorRegistry.java
@@ -37,11 +37,6 @@ import java.util.concurrent.CompletableFuture;
  * @author jwhite
  */
 public interface ServiceCollectorRegistry {
-    /**
-     * @deprecated use {@link #getCollectorFutureByClassName(String)} instead.
-     */
-    @Deprecated
-    ServiceCollector getCollectorByClassName(String className);
 
     CompletableFuture<ServiceCollector> getCollectorFutureByClassName(String className);
 

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/DefaultServiceCollectorRegistry.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/DefaultServiceCollectorRegistry.java
@@ -112,11 +112,6 @@ public class DefaultServiceCollectorRegistry implements ServiceCollectorRegistry
     }
 
     @Override
-    public synchronized ServiceCollector getCollectorByClassName(String className) {
-        return getCollectorFutureByClassName(className).completeOnTimeout(null, 100, TimeUnit.MILLISECONDS).join();
-    }
-
-    @Override
     public synchronized CompletableFuture<ServiceCollector> getCollectorFutureByClassName(String className) {
         CompletableFuture<ServiceCollector> future = m_collectorsByClassName.get(className);
         if(future == null) {

--- a/features/collection/client-rpc/src/main/java/org/opennms/netmgt/collection/client/rpc/CollectorClientRpcModule.java
+++ b/features/collection/client-rpc/src/main/java/org/opennms/netmgt/collection/client/rpc/CollectorClientRpcModule.java
@@ -69,7 +69,7 @@ public class CollectorClientRpcModule extends AbstractXmlRpcModule<CollectorRequ
     @Override
     public CompletableFuture<CollectorResponseDTO> execute(CollectorRequestDTO request) {
         final String className = request.getClassName();
-        final ServiceCollector collector = serviceCollectorRegistry.getCollectorByClassName(className);
+        final ServiceCollector collector = serviceCollectorRegistry.getCollectorFutureByClassName(className).getNow(null);
         if (collector == null) {
             throw new IllegalArgumentException("No collector found with class name '" + className + "'.");
         }

--- a/features/collection/client-rpc/src/main/java/org/opennms/netmgt/collection/client/rpc/CollectorRequestBuilderImpl.java
+++ b/features/collection/client-rpc/src/main/java/org/opennms/netmgt/collection/client/rpc/CollectorRequestBuilderImpl.java
@@ -92,7 +92,7 @@ public class CollectorRequestBuilderImpl implements CollectorRequestBuilder {
     @Override
     public CollectorRequestBuilder withCollectorClassName(String className) {
         this.className = className;
-        this.serviceCollector = client.getRegistry().getCollectorByClassName(className);
+        this.serviceCollector = client.getRegistry().getCollectorFutureByClassName(className).getNow(null);
         return this;
     }
 

--- a/features/collection/shell-commands/src/main/java/org/opennms/netmgt/collection/commands/CollectCommand.java
+++ b/features/collection/shell-commands/src/main/java/org/opennms/netmgt/collection/commands/CollectCommand.java
@@ -127,7 +127,7 @@ public class CollectCommand implements Action {
 
     @Override
     public Void execute() {
-        final ServiceCollector collector = serviceCollectorRegistry.getCollectorByClassName(className);
+        final ServiceCollector collector = serviceCollectorRegistry.getCollectorFutureByClassName(className).getNow(null);
         if (collector == null) {
             System.out.printf("No collector found with class name '%s'. Aborting.\n", className);
             return null;

--- a/features/collection/test-api/src/main/java/org/opennms/netmgt/collection/test/api/CollectorComplianceTest.java
+++ b/features/collection/test-api/src/main/java/org/opennms/netmgt/collection/test/api/CollectorComplianceTest.java
@@ -203,7 +203,7 @@ public abstract class CollectorComplianceTest {
     }
 
     private ServiceCollector getCollector() {
-        return serviceCollectorRegistry.getCollectorByClassName(collectorClass.getCanonicalName());
+        return serviceCollectorRegistry.getCollectorFutureByClassName(collectorClass.getCanonicalName()).getNow(null);
     }
 
     private ServiceCollector getNewCollector() {

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/ServiceMonitorRegistry.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/ServiceMonitorRegistry.java
@@ -38,12 +38,6 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface ServiceMonitorRegistry {
 
-    /**
-     * @deprecated use {@link #getMonitorFutureByClassName(String)} instead.
-     */
-    @Deprecated
-    ServiceMonitor getMonitorByClassName(String className);
-
     CompletableFuture<ServiceMonitor> getMonitorFutureByClassName(String className);
 
     Set<String> getMonitorClassNames();

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/support/DefaultServiceMonitorRegistry.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/support/DefaultServiceMonitorRegistry.java
@@ -110,14 +110,7 @@ public class DefaultServiceMonitorRegistry implements ServiceMonitorRegistry {
             m_monitorsByClassName.remove(className);
         }
     }
-
-
-
-    @Override
-    public synchronized ServiceMonitor getMonitorByClassName(String className) {
-        return getMonitorFutureByClassName(className).completeOnTimeout(null, 100, TimeUnit.MILLISECONDS).join();
-    }
-
+    
     @Override
     public synchronized CompletableFuture<ServiceMonitor> getMonitorFutureByClassName(String className) {
         CompletableFuture<ServiceMonitor> future = m_monitorsByClassName.get(className);

--- a/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerClientRpcModule.java
+++ b/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerClientRpcModule.java
@@ -63,7 +63,7 @@ public class PollerClientRpcModule extends AbstractXmlRpcModule<PollerRequestDTO
     @Override
     public CompletableFuture<PollerResponseDTO> execute(PollerRequestDTO request) {
         final String className = request.getClassName();
-        final ServiceMonitor monitor = serviceMonitorRegistry.getMonitorByClassName(className);
+        final ServiceMonitor monitor = serviceMonitorRegistry.getMonitorFutureByClassName(className).getNow(null);
         if (monitor == null) {
             return CompletableFuture.completedFuture(new PollerResponseDTO(PollStatus.unknown("No monitor found with class name '" + className + "'.")));
         }

--- a/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerRequestBuilderImpl.java
+++ b/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerRequestBuilderImpl.java
@@ -95,7 +95,7 @@ public class PollerRequestBuilderImpl implements PollerRequestBuilder {
     @Override
     public PollerRequestBuilder withMonitorClassName(String className) {
         this.className = className;
-        this.serviceMonitor = client.getRegistry().getMonitorByClassName(className);
+        this.serviceMonitor = client.getRegistry().getMonitorFutureByClassName(className).getNow(null);
         return this;
     }
 


### PR DESCRIPTION
Small update to not use `getCollectorByClassName` and `getMonitorByClassName`.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14116

