### PR TITLE
NMS-14117: add karaf config with rmi hostname fix from NMS-13887

### DIFF
--- a/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.management.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.management.cfg
@@ -1,0 +1,150 @@
+
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# The properties in this file define the configuration of Apache Karaf's JMX Management
+#
+
+#
+# Port number for RMI registry connection
+#
+rmiRegistryPort = 1099
+
+#
+# Host for RMI registry
+#
+rmiRegistryHost = 127.0.0.1
+
+#
+# Port number for RMI connector server connection
+#
+rmiServerPort = 44444
+
+#
+# Host for RMI connector server
+#
+rmiServerHost = ${java.rmi.server.hostname:-127.0.0.1}
+
+#
+# Name of the JAAS realm used for authentication
+#
+jmxRealm = karaf
+
+#
+# The service URL for the JMX RMI connector
+#
+serviceUrl = service:jmx:rmi://${rmiServerHost}:${rmiServerPort}/jndi/rmi://${rmiRegistryHost}:${rmiRegistryPort}/karaf-${karaf.name}
+
+#
+# JMXMP connector enabled
+# NB: if you enable JMXMP, don't forget to add opendmk_jmxremote_optional jar in lib/boot folder
+#
+jmxmpEnabled = false
+
+#
+# JMXMP connector host name
+#
+jmxmpHost = 127.0.0.1
+
+#
+# JMXMP connector port number
+#
+jmxmpPort = 9999
+
+#
+# JMXMP connector service URL
+#
+jmxmpServiceUrl = service:jmx:jmxmp://${jmxmpHost}:${jmxmpPort}
+
+#
+# Whether any threads started for the JMXConnectorServer should be started as daemon threads
+#
+daemon = true
+
+#
+# Whether the JMXConnectorServer should be started in a separate thread
+#
+threaded = true
+
+#
+# The ObjectName used to register the JMX RMI connector
+#
+objectName = connector:name=rmi
+
+#
+# The ObjectName used to register the JMXMP connector
+#
+jmxmpObjectName = connector:name=jmxmp
+
+#
+# Timeout to lookup for the keystore in case of SSL authentication usage
+#
+#keyStoreAvailabilityTimeout = 5000
+
+#
+# The type of authentication
+#
+#authenticatorType = password
+
+#
+# Enable or not SSL/TLS
+#
+#secured = false
+
+#
+# Secure algorithm to use
+#
+#secureAlgorithm = default
+
+#
+# Secure protocol to use
+#
+#secureProtocol = TLS
+
+#
+# Keystore to use for secure mode
+#
+#keyStore = karaf.ks
+
+#
+# Alias of the key to use in the keystore
+#
+#keyAlias = karaf
+
+#
+# Truststore to use for secure mode
+#
+#trustStore = karaf.ts
+
+#
+# Create the JMX RMI registry
+#
+#createRmiRegistry = true
+
+#
+# Locate the JMX RMI registry
+#
+#locateRmiRegistry = true
+
+#
+# Locate an existing MBean server if possible (usefull when Karaf is embedded)
+#
+#locateExistingMBeanServerIfPossible = true
+


### PR DESCRIPTION
This merges the fix from NMS-13887 into the Horizon container.
The original fix only applied to Minion and Sentinel.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14117

