### PR TITLE
NMS-14123: Sentinel debian package fail to install

### DIFF
--- a/opennms-assemblies/sentinel/src/main/filtered/debian/opennms-sentinel.postinst
+++ b/opennms-assemblies/sentinel/src/main/filtered/debian/opennms-sentinel.postinst
@@ -8,7 +8,6 @@ SENTINELHOME="/usr/share/sentinel"
 SENTINELDATA="/var/lib/sentinel"
 SENTINELLOG="/var/log/sentinel"
 
-rm -rf "${SENTINELHOME}/data"/* || true
 
 if [ ! -f "${ETCDIR}/host.key" ]; then
 	ssh-keygen -m PEM -t rsa -N "" -b 4096 -f "${ETCDIR}/host.key"
@@ -16,6 +15,9 @@ if [ ! -f "${ETCDIR}/host.key" ]; then
 fi
 
 "${SENTINELHOME}/bin/update-package-permissions" "opennms-sentinel"
+
+# move behind fix permission to prevent error in fix permission
+rm -rf "${SENTINELHOME}/data"/* || true
 
 # Remove the directory used as the local Maven repo cache
 rm -rf "${SENTINELHOME}/.local"


### PR DESCRIPTION
[jira/NMS-14123](https://issues.opennms.org/browse/NMS-14123)

It is cause by the file remove earlier than fix permission. And, the file list is obtain from debian package. So chown will exit with non 0 status code.