### PR TITLE
NMS-14089: DCB: Create UI for comparing 2 backup configurations

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@types/d3": "^7.1.0",
+    "@types/diff": "^5.0.2",
     "@types/leaflet": "^1.7.9",
     "@types/leaflet.markercluster": "^1.4.6",
     "@types/lodash": "^4.14.180",

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,6 +52,7 @@
     "splitpanes": "^3.1.1",
     "vite-svg-loader": "^3.1.2",
     "vue": "^3.2.29",
+    "vue-diff": "^1.1.4",
     "vue-router": "4",
     "vue3-ace-editor": "^2.2.2",
     "vuex": "^4.0.2"
@@ -69,17 +70,17 @@
     "@vitejs/plugin-vue": "^2.2.4",
     "@vue-leaflet/vue-leaflet": "^0.6.1",
     "@vue/test-utils": "^2.0.0-rc.17",
-    "happy-dom": "^2.47.0",
-    "vitest": "^0.6.1",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-vue": "^8.5.0",
+    "happy-dom": "^2.47.0",
     "prettier": "^2.6.0",
     "tsm": "^2.1.4",
     "typescript": "^4.6.2",
     "unplugin-auto-import": "^0.6.6",
     "uvu": "^0.5.3",
     "vite": "^2.8.6",
+    "vitest": "^0.6.1",
     "vue-eslint-parser": "^8.3.0",
     "vue-tsc": "^0.33.7"
   }

--- a/ui/src/components/Device/DCBDiff.vue
+++ b/ui/src/components/Device/DCBDiff.vue
@@ -1,0 +1,32 @@
+<template>
+   <Diff
+    :prev="config1.config"
+    :current="config2.config"
+    :theme="theme"
+  />
+</template>
+
+<script setup lang="ts">
+import { DeviceConfigBackup } from '@/types/deviceConfig'
+import { PropType } from 'vue'
+import {useStore} from 'vuex'
+
+const store = useStore()
+
+defineProps({
+  config1: {
+    type: Object as PropType<DeviceConfigBackup>,
+    required: true
+  },
+  config2: {
+    type: Object as PropType<DeviceConfigBackup>,
+    required: true
+  }
+})
+
+const theme = computed(() => {
+  const theme = store.state.appModule.theme
+  if (theme === 'open-dark') return 'dark'
+  return 'light'
+})
+</script>

--- a/ui/src/components/Device/DCBDiff.vue
+++ b/ui/src/components/Device/DCBDiff.vue
@@ -1,16 +1,11 @@
 <template>
-   <Diff
-    :prev="config1.config"
-    :current="config2.config"
-    :theme="theme"
-    :mode="mode"
-  />
+  <Diff :prev="config1.config" :current="config2.config" :theme="theme" :mode="mode" />
 </template>
 
 <script setup lang="ts">
 import { DeviceConfigBackup } from '@/types/deviceConfig'
 import { PropType } from 'vue'
-import {useStore} from 'vuex'
+import { useStore } from 'vuex'
 
 const store = useStore()
 

--- a/ui/src/components/Device/DCBDiff.vue
+++ b/ui/src/components/Device/DCBDiff.vue
@@ -3,6 +3,7 @@
     :prev="config1.config"
     :current="config2.config"
     :theme="theme"
+    :mode="mode"
   />
 </template>
 
@@ -21,6 +22,10 @@ defineProps({
   config2: {
     type: Object as PropType<DeviceConfigBackup>,
     required: true
+  },
+  mode: {
+    type: String,
+    default: 'split'
   }
 })
 

--- a/ui/src/components/Device/DCBModal.vue
+++ b/ui/src/components/Device/DCBModal.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- eslint-disable-next-line vue/no-mutating-props -->
-  <FeatherDialog v-model="visible" :labels="labels" @update:modelValue="$emit('close')">
+  <FeatherDialog v-model="visible" relative :labels="labels" @update:modelValue="$emit('close')">
     <div class="content">
       <slot name="content" />
     </div>

--- a/ui/src/components/Device/DCBModalConfigDiffContent.vue
+++ b/ui/src/components/Device/DCBModalConfigDiffContent.vue
@@ -1,0 +1,142 @@
+<template>
+  <FeatherButton class="dwnld-btn" icon="Download config" @click="onCompare">
+    <FeatherIcon :icon="Compare" />
+  </FeatherButton>
+
+  <div class="flex-container" v-if="!isCompareView">
+    <FeatherCheckboxGroup label="Default" vertical>
+      <div class="history-dates-column">
+        <FeatherCheckbox
+          class="history-date"
+          v-for="config of defaultConfigTypeBackups"
+          :key="config.id"
+          @update:modelValue="onCheckbox(config)"
+          :modelValue="selectedConfigs[config.id]"
+        >
+          <span v-date>{{ config.lastBackupDate }}</span>
+        </FeatherCheckbox>
+      </div>
+    </FeatherCheckboxGroup>
+
+    <FeatherCheckboxGroup label="Running" vertical v-if="otherConfigTypeBackups.length">
+      <div class="history-dates-column">
+        <FeatherCheckbox
+          class="history-date"
+          v-for="config of otherConfigTypeBackups"
+          :key="config.id"
+          @update:modelValue="onCheckbox(config)"
+          :modelValue="selectedConfigs[config.id]"
+        >
+          <span v-date>{{ config.lastBackupDate }}</span>
+        </FeatherCheckbox>
+      </div>
+    </FeatherCheckboxGroup>
+  </div>
+
+  <DCBDiff :config1="config1" :config2="config2" v-if="config1 && config2 && isCompareView" />
+</template>
+
+<script setup lang="ts">
+import DCBDiff from './DCBDiff.vue'
+import { useStore } from 'vuex'
+import { DeviceConfigBackup } from '@/types/deviceConfig'
+import { FeatherCheckbox, FeatherCheckboxGroup } from '@featherds/checkbox'
+import { FeatherButton } from '@featherds/button'
+import { FeatherIcon } from '@featherds/icon'
+import Compare from '@featherds/icon/action/ContentCopy'
+
+
+const store = useStore()
+
+const selectedConfigs = ref<Record<number, boolean>>({})
+const config1 = ref<DeviceConfigBackup | null>(null)
+const config2 = ref<DeviceConfigBackup | null>(null)
+const isCompareView = ref(false)
+
+const historyModalBackups = computed<DeviceConfigBackup[]>(() => store.state.deviceModule.historyModalBackups)
+const defaultConfigTypeBackups = computed<DeviceConfigBackup[]>(() => historyModalBackups.value.filter((config) => config.configType === 'default'))
+const otherConfigTypeBackups = computed<DeviceConfigBackup[]>(() => historyModalBackups.value.filter((config) => config.configType !== 'default'))
+
+const onCompare = () => isCompareView.value = true
+
+const onCheckbox = (config: DeviceConfigBackup) => {
+  setConfig(config)
+
+  // reset checkboxes
+  for (const key in selectedConfigs.value) {
+    selectedConfigs.value[key] = false
+  }
+
+  // set configs as selected
+  if (config1.value) {
+    selectedConfigs.value[config1.value.id] = true
+  }
+
+  if (config2.value) {
+    selectedConfigs.value[config2.value.id] = true
+  }
+}
+
+const setConfig = (config: DeviceConfigBackup) => {
+  // if there is a config1, compare ids
+  if (config1.value && config1.value.id === config.id) {
+    // if they match, clear config
+    config1.value = null
+    return
+  }
+
+  // if there is a config2 and the ids match
+  if (config2.value && config2.value.id === config.id) {
+    // clear config two
+    config2.value = null
+    return
+  }
+
+
+  // if there is no config1, add it.
+  if (!config1.value) {
+    config1.value = config
+    return
+  }
+
+
+  // if there is no config2, compare incoming configType
+  if (!config2.value && config1.value.configType === config.configType) {
+    // if types the same, add to config2
+    config2.value = config
+    return
+  }
+
+  // hits only if config1 & config2 and types match
+  // or types do not match. Equivalent of first selection.
+  config1.value = config
+  config2.value = null
+  return
+}
+
+const getHistoryBackups = () => store.dispatch('deviceModule/getHistoryByIpInterface')
+onMounted(() => getHistoryBackups())
+</script>
+
+<style scoped lang="scss">
+@import "@featherds/styles/themes/variables";
+@import "@featherds/styles/mixins/typography";
+.flex-container {
+  display: flex;
+  max-width: 1000px;
+  max-height: calc(100vh - 400px);
+  overflow: auto;
+  padding-left: 15px;
+
+  .history-dates-column {
+    display: flex;
+    flex-direction: column;
+    white-space: nowrap;
+
+    .history-date {
+      @include body-small;
+      color: var($primary);
+    }
+  }
+}
+</style>

--- a/ui/src/components/Device/DCBModalConfigDiffContent.vue
+++ b/ui/src/components/Device/DCBModalConfigDiffContent.vue
@@ -1,10 +1,35 @@
 <template>
-  <FeatherButton class="dwnld-btn" icon="Download config" @click="onCompare">
+  <FeatherButton
+    class="compare-btn"
+    icon="Compare configs"
+    @click="onCompare"
+    v-if="!isCompareView"
+    :disabled="!config1 || !config2"
+  >
     <FeatherIcon :icon="Compare" />
   </FeatherButton>
 
+  <FeatherButton class="return-btn" icon="Return" @click="onReturn" v-if="isCompareView">
+    <FeatherIcon :icon="Restore" />
+  </FeatherButton>
+
+  <FeatherButton class="dwnld-btn" icon="Download configs" @click="onDownload" v-if="isCompareView">
+    <FeatherIcon :icon="Download" />
+  </FeatherButton>
+
+  <p class="select-msg" v-if="numberOfSelectedConfigs < 2">Select two dates to compare.</p>
+
+  <FeatherChipList condensed label="Compare selected configurations.">
+    <FeatherChip v-if="config1">
+      <span v-date>{{ config1.lastBackupDate }}</span>
+    </FeatherChip>
+    <FeatherChip v-if="config2">
+      <span v-date>{{ config2.lastBackupDate }}</span>
+    </FeatherChip>
+  </FeatherChipList>
+
   <div class="flex-container" v-if="!isCompareView">
-    <FeatherCheckboxGroup label="Default" vertical>
+    <FeatherCheckboxGroup label="Startup" vertical>
       <div class="history-dates-column">
         <FeatherCheckbox
           class="history-date"
@@ -33,7 +58,9 @@
     </FeatherCheckboxGroup>
   </div>
 
-  <DCBDiff :config1="config1" :config2="config2" v-if="config1 && config2 && isCompareView" />
+  <div class="compare-container">
+    <DCBDiff :config1="config1" :config2="config2" v-if="config1 && config2 && isCompareView" />
+  </div>  
 </template>
 
 <script setup lang="ts">
@@ -41,10 +68,13 @@ import DCBDiff from './DCBDiff.vue'
 import { useStore } from 'vuex'
 import { DeviceConfigBackup } from '@/types/deviceConfig'
 import { FeatherCheckbox, FeatherCheckboxGroup } from '@featherds/checkbox'
+import { FeatherChip, FeatherChipList } from '@featherds/chips'
 import { FeatherButton } from '@featherds/button'
 import { FeatherIcon } from '@featherds/icon'
 import Compare from '@featherds/icon/action/ContentCopy'
-
+import Restore from '@featherds/icon/action/Restore'
+import Download from '@featherds/icon/action/DownloadFile'
+import { orderBy } from 'lodash'
 
 const store = useStore()
 
@@ -56,13 +86,30 @@ const isCompareView = ref(false)
 const historyModalBackups = computed<DeviceConfigBackup[]>(() => store.state.deviceModule.historyModalBackups)
 const defaultConfigTypeBackups = computed<DeviceConfigBackup[]>(() => historyModalBackups.value.filter((config) => config.configType === 'default'))
 const otherConfigTypeBackups = computed<DeviceConfigBackup[]>(() => historyModalBackups.value.filter((config) => config.configType !== 'default'))
+const numberOfSelectedConfigs = computed<number>(() => Object.values(selectedConfigs.value).filter((val) => val).length)
 
 const onCompare = () => isCompareView.value = true
+const onReturn = () => isCompareView.value = false
+const onDownload = () => store.dispatch('deviceModule/downloadByConfig', [config1.value, config2.value])
 
 const onCheckbox = (config: DeviceConfigBackup) => {
   setConfig(config)
+  updateCheckboxes()
+  orderByDates()
+}
 
-  // reset checkboxes
+const orderByDates = () => {
+  // must have both configs to order
+  if (config1.value && config2.value) {
+    // order so that config1 is the 'previous' or 'older' version
+    const orderedByDate = orderBy([config1.value, config2.value], 'lastBackupDate', 'asc')
+    config1.value = orderedByDate[0]
+    config2.value = orderedByDate[1]
+  }
+}
+
+const updateCheckboxes = () => {
+  // clear all checkboxes
   for (const key in selectedConfigs.value) {
     selectedConfigs.value[key] = false
   }
@@ -92,13 +139,11 @@ const setConfig = (config: DeviceConfigBackup) => {
     return
   }
 
-
   // if there is no config1, add it.
   if (!config1.value) {
     config1.value = config
     return
   }
-
 
   // if there is no config2, compare incoming configType
   if (!config2.value && config1.value.configType === config.configType) {
@@ -138,5 +183,29 @@ onMounted(() => getHistoryBackups())
       color: var($primary);
     }
   }
+}
+
+.compare-container {
+  max-width: 1000px;
+  max-height: calc(100vh - 400px);
+  overflow: auto;
+}
+.select-msg {
+  @include body-small;
+  color: var($primary);
+  padding-left: 15px;
+}
+
+.compare-btn,
+.return-btn {
+  position: absolute;
+  right: 35px;
+  top: 7px;
+}
+
+.dwnld-btn {
+  position: absolute;
+  right: 70px;
+  top: 7px;
 }
 </style>

--- a/ui/src/components/Device/DCBModalLastBackupContent.vue
+++ b/ui/src/components/Device/DCBModalLastBackupContent.vue
@@ -1,8 +1,16 @@
 <template>
-  <div class="content">{{ modalDeviceConfigBackup.config }}</div>
+  <div class="content">
+    <!-- We can use the diff editor display for a single config -->
+    <DCBDiff
+      :config1="modalDeviceConfigBackup"
+      :config2="modalDeviceConfigBackup"
+      :mode="'unified'"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
+import DCBDiff from './DCBDiff.vue'
 import { DeviceConfigBackup } from '@/types/deviceConfig'
 import { useStore } from 'vuex'
 

--- a/ui/src/components/Device/DCBModalViewHistoryContent.vue
+++ b/ui/src/components/Device/DCBModalViewHistoryContent.vue
@@ -1,10 +1,14 @@
 <template>
+  <FeatherButton class="compare-btn" icon="Compare configs" @click="$emit('onCompare')">
+    <FeatherIcon :icon="Compare" />
+  </FeatherButton>
+
   <FeatherButton class="dwnld-btn" icon="Download config" @click="onDownload">
     <FeatherIcon :icon="Download" />
   </FeatherButton>
 
   <div class="flex-container">
-    <div class="history-dates-column" v-if="hasOnlyDefaultConfigs || selectedTab === 'default'">
+    <div class="history-dates-column" v-if="hasOnlyDefaultConfigs">
       <div
         v-date
         class="history-date pointer"
@@ -14,28 +18,55 @@
       >{{ config.lastBackupDate }}</div>
     </div>
 
-    <div class="history-dates-column" v-if="selectedTab !== 'default'">
-      <div
-        v-date
-        class="history-date pointer"
-        v-for="config of otherConfigTypeBackups"
-        :key="config.id"
-        @click="setSelectedConfig(config)"
-      >{{ config.lastBackupDate }}</div>
+    <div v-if="selectedConfig && hasOnlyDefaultConfigs">
+      <div class="config-display-container">
+        <!-- We can use the diff editor display for a single config -->
+        <DCBDiff :config1="selectedConfig" :config2="selectedConfig" :mode="'unified'" />
+      </div>
     </div>
-
-    <div v-if="selectedConfig && hasOnlyDefaultConfigs">{{ selectedConfig.config }}</div>
 
     <FeatherTabContainer class="tabs" v-if="!hasOnlyDefaultConfigs">
       <template v-slot:tabs>
-        <FeatherTab @click="setSelectedTab('default')">Startup Configuration</FeatherTab>
-        <FeatherTab @click="setSelectedTab('running')">Running Configuration</FeatherTab>
+        <FeatherTab @click="onTabClick('default')">Startup Configuration</FeatherTab>
+        <FeatherTab @click="onTabClick('running')">Running Configuration</FeatherTab>
       </template>
+
+      <!-- Startup config tab content -->
       <FeatherTabPanel>
-        <div v-if="selectedConfig">{{ selectedConfig.config }}</div>
+        <div v-if="selectedConfig" class="flex">
+          <div class="history-dates-column">
+            <div
+              v-date
+              class="history-date pointer"
+              v-for="config of defaultConfigTypeBackups"
+              :key="config.id"
+              @click="setSelectedConfig(config)"
+            >{{ config.lastBackupDate }}</div>
+          </div>
+          <div class="config-display-container">
+            <!-- We can use the diff editor display for a single config -->
+            <DCBDiff :config1="selectedConfig" :config2="selectedConfig" :mode="'unified'" />
+          </div>
+        </div>
       </FeatherTabPanel>
+
+      <!-- Running config tab content -->
       <FeatherTabPanel>
-        <div v-if="selectedConfig">{{ selectedConfig.config }}</div>
+        <div v-if="selectedConfig" class="flex">
+          <div class="history-dates-column">
+            <div
+              v-date
+              class="history-date pointer"
+              v-for="config of otherConfigTypeBackups"
+              :key="config.id"
+              @click="setSelectedConfig(config)"
+            >{{ config.lastBackupDate }}</div>
+          </div>
+          <div class="config-display-container">
+            <!-- We can use the diff editor display for a single config -->
+            <DCBDiff :config1="selectedConfig" :config2="selectedConfig" :mode="'unified'" />
+          </div>
+        </div>
       </FeatherTabPanel>
     </FeatherTabContainer>
   </div>
@@ -46,11 +77,12 @@ import { FeatherButton } from '@featherds/button'
 import { FeatherIcon } from '@featherds/icon'
 import { FeatherTab, FeatherTabContainer, FeatherTabPanel } from '@featherds/tabs'
 import Download from '@featherds/icon/action/DownloadFile'
+import Compare from '@featherds/icon/action/ContentCopy'
 import { useStore } from 'vuex'
 import { DeviceConfigBackup, defaultConfig, runningConfig } from '@/types/deviceConfig'
+import DCBDiff from './DCBDiff.vue'
 
 const store = useStore()
-const selectedTab = ref<defaultConfig | runningConfig>('default')
 const selectedConfig = ref<DeviceConfigBackup>()
 
 const historyModalBackups = computed<DeviceConfigBackup[]>(() => store.state.deviceModule.historyModalBackups)
@@ -61,16 +93,13 @@ const hasOnlyDefaultConfigs = computed<boolean>(() => historyModalBackups.value.
 const onDownload = () => store.dispatch('deviceModule/downloadByConfig', selectedConfig.value)
 const getHistoryBackups = () => store.dispatch('deviceModule/getHistoryByIpInterface')
 const setSelectedConfig = (config: DeviceConfigBackup) => selectedConfig.value = config
-const setSelectedTab = (configType: defaultConfig | runningConfig) => {
-  selectedTab.value = configType
-
+const onTabClick = (configType: defaultConfig | runningConfig) => {
   if (configType === 'default') {
     setSelectedConfig(defaultConfigTypeBackups.value[0])
   } else {
     setSelectedConfig(otherConfigTypeBackups.value[0])
   }
 }
-const historyColumnMarginTop = computed<string>(() => hasOnlyDefaultConfigs.value ? '0px' : '45px')
 
 watch(defaultConfigTypeBackups, (defaultConfigTypeBackups) => {
   if (defaultConfigTypeBackups) {
@@ -84,6 +113,10 @@ onMounted(() => getHistoryBackups())
 <style scoped lang="scss">
 @import "@featherds/styles/themes/variables";
 @import "@featherds/styles/mixins/typography";
+
+.flex {
+  display: flex;
+}
 .flex-container {
   display: flex;
   max-width: 1000px;
@@ -95,7 +128,6 @@ onMounted(() => getHistoryBackups())
     flex-direction: column;
     white-space: nowrap;
     margin-right: 15px;
-    margin-top: v-bind(historyColumnMarginTop);
 
     .history-date {
       @include body-small;
@@ -103,9 +135,19 @@ onMounted(() => getHistoryBackups())
     }
   }
 }
+
+.config-display-container {
+  display: block;
+}
 .dwnld-btn {
   position: absolute;
-  right: 36px;
-  top: -77px;
+  right: 70px;
+  top: -55px;
+}
+
+.compare-btn {
+  position: absolute;
+  right: 35px;
+  top: -55px;
 }
 </style>

--- a/ui/src/components/Device/DCBModalViewHistoryContent.vue
+++ b/ui/src/components/Device/DCBModalViewHistoryContent.vue
@@ -53,14 +53,13 @@ const store = useStore()
 const selectedTab = ref<defaultConfig | runningConfig>('default')
 const selectedConfig = ref<DeviceConfigBackup>()
 
-const modalDeviceConfigBackup = computed<DeviceConfigBackup>(() => store.state.deviceModule.modalDeviceConfigBackup)
 const historyModalBackups = computed<DeviceConfigBackup[]>(() => store.state.deviceModule.historyModalBackups)
 const defaultConfigTypeBackups = computed<DeviceConfigBackup[]>(() => historyModalBackups.value.filter((config) => config.configType === 'default'))
 const otherConfigTypeBackups = computed<DeviceConfigBackup[]>(() => historyModalBackups.value.filter((config) => config.configType !== 'default'))
 const hasOnlyDefaultConfigs = computed<boolean>(() => historyModalBackups.value.length === defaultConfigTypeBackups.value.length)
 
 const onDownload = () => store.dispatch('deviceModule/downloadByConfig', selectedConfig.value)
-const getHistoryBackups = () => store.dispatch('deviceModule/getHistoryByIpInterface', modalDeviceConfigBackup.value.ipInterfaceId)
+const getHistoryBackups = () => store.dispatch('deviceModule/getHistoryByIpInterface')
 const setSelectedConfig = (config: DeviceConfigBackup) => selectedConfig.value = config
 const setSelectedTab = (configType: defaultConfig | runningConfig) => {
   selectedTab.value = configType

--- a/ui/src/components/Device/DCBModalViewHistoryContent.vue
+++ b/ui/src/components/Device/DCBModalViewHistoryContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <FeatherButton class="compare-btn" icon="Compare configs" @click="$emit('onCompare')">
+  <FeatherButton class="compare-btn" icon="Compare configs" @click="emit('onCompare')">
     <FeatherIcon :icon="Compare" />
   </FeatherButton>
 
@@ -82,13 +82,20 @@ import { useStore } from 'vuex'
 import { DeviceConfigBackup, defaultConfig, runningConfig } from '@/types/deviceConfig'
 import DCBDiff from './DCBDiff.vue'
 
+const emit = defineEmits(['onCompare'])
+
 const store = useStore()
 const selectedConfig = ref<DeviceConfigBackup>()
 
+const modalDeviceConfigBackup = computed<DeviceConfigBackup>(() => store.state.deviceModule.modalDeviceConfigBackup)
 const historyModalBackups = computed<DeviceConfigBackup[]>(() => store.state.deviceModule.historyModalBackups)
 const defaultConfigTypeBackups = computed<DeviceConfigBackup[]>(() => historyModalBackups.value.filter((config) => config.configType === 'default'))
 const otherConfigTypeBackups = computed<DeviceConfigBackup[]>(() => historyModalBackups.value.filter((config) => config.configType !== 'default'))
-const hasOnlyDefaultConfigs = computed<boolean>(() => historyModalBackups.value.length === defaultConfigTypeBackups.value.length)
+const hasOnlyDefaultConfigs = computed<boolean>(() => {
+  return Boolean(modalDeviceConfigBackup.value.configType === 'default' ||
+    (defaultConfigTypeBackups.value.length === historyModalBackups.value.length)
+  )
+})
 
 const onDownload = () => store.dispatch('deviceModule/downloadByConfig', selectedConfig.value)
 const getHistoryBackups = () => store.dispatch('deviceModule/getHistoryByIpInterface')

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -163,13 +163,15 @@
   </div>
   <DCBModal @close="dcbModalVisible = false" :visible="dcbModalVisible">
     <template v-slot:content>
-      <DCBModalViewHistoryContentVue
-        v-if="dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalViewHistoryContent"
+      <DCBModalViewHistoryContentVue @onCompare="onCompare"
+        v-if="dcbModalVisible && dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalViewHistoryContent"
       />
       <DCBModalLastBackupContent
-        v-else-if="dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalLastBackupContent"
+        v-if="dcbModalVisible && dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalLastBackupContent"
       />
-      <DCBModalConfigDiffContent v-else />
+      <DCBModalConfigDiffContent
+        v-if="dcbModalVisible && dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalConfigDiffContent"
+      />
     </template>
   </DCBModal>
 </template>

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -49,6 +49,18 @@
             </template>
             Backup Now
           </FeatherButton>
+
+          <FeatherButton
+            data-test="compare-btn"
+            @click="onCompare"
+            :disabled="(!all && selectedDeviceConfigIds.length !== 1) || (all && deviceConfigBackups.length !== 1)"
+            text
+          >
+            <template v-slot:icon>
+              <FeatherIcon :icon="Compare" />
+            </template>
+            Compare
+          </FeatherButton>
         </div>
       </div>
     </div>
@@ -154,7 +166,10 @@
       <DCBModalViewHistoryContentVue
         v-if="dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalViewHistoryContent"
       />
-      <DCBModalLastBackupContent v-else />
+      <DCBModalLastBackupContent
+        v-else-if="dcbModalContentComponentName === DCBModalContentComponentNames.DCBModalLastBackupContent"
+      />
+      <DCBModalConfigDiffContent v-else />
     </template>
   </DCBModal>
 </template>
@@ -170,16 +185,19 @@ import History from '@featherds/icon/action/Restore'
 import Download from '@featherds/icon/action/DownloadFile'
 import Backup from '@featherds/icon/action/Cycle'
 import ViewDetails from '@featherds/icon/action/ViewDetails'
+import Compare from '@featherds/icon/action/ContentCopy'
 import DCBSearch from '@/components/Device/DCBSearch.vue'
 import DCBModal from './DCBModal.vue'
 import DCBModalLastBackupContent from './DCBModalLastBackupContent.vue'
 import DCBModalViewHistoryContentVue from './DCBModalViewHistoryContent.vue'
+import DCBModalConfigDiffContent from './DCBModalConfigDiffContent.vue'
 import { DeviceConfigBackup, DeviceConfigQueryParams } from '@/types/deviceConfig'
 import DCBTableStatusDropdown from './DCBTableStatusDropdown.vue'
 
 enum DCBModalContentComponentNames {
   DCBModalLastBackupContent = 'DCBModalLastBackupContent',
-  DCBModalViewHistoryContent = 'DCBModalViewHistoryContent'
+  DCBModalViewHistoryContent = 'DCBModalViewHistoryContent',
+  DCBModalConfigDiffContent = 'DCBModalConfigDiffContent'
 }
 
 const store = useStore()
@@ -266,6 +284,11 @@ const onBackupNow = () => store.dispatch('deviceModule/backupSelectedDevices')
 
 const onViewHistory = () => {
   dcbModalContentComponentName.value = DCBModalContentComponentNames.DCBModalViewHistoryContent
+  dcbModalVisible.value = true
+}
+
+const onCompare = () => {
+  dcbModalContentComponentName.value = DCBModalContentComponentNames.DCBModalConfigDiffContent
   dcbModalVisible.value = true
 }
 

--- a/ui/src/directives/v-date.ts
+++ b/ui/src/directives/v-date.ts
@@ -1,4 +1,5 @@
 import { format as fnsFormat } from 'date-fns-tz'
+import { parseISO } from 'date-fns'
 import { AppInfo } from '@/types'
 import store from '@/store'
 
@@ -13,7 +14,8 @@ const formatString = computed<string>(
 
 const dateFormatDirective = {
   mounted(el: Element) {
-    const date = Number(el.innerHTML) || el.innerHTML
+    if (!el.innerHTML) return
+    const date = Number(el.innerHTML) || parseISO(el.innerHTML)
     if (!date) return
     const formattedDate = fnsFormat(date, formatString.value, { timeZone: timeZone.value })
     el.innerHTML = formattedDate

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -2,14 +2,18 @@ import { createApp, h } from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
+import VueDiff from 'vue-diff'
 
 import '@featherds/styles'
+
+import 'vue-diff/dist/index.css'
 
 import dateFormatDirective from './directives/v-date'
 
 createApp({
   render: () => h(App)
 })
+  .use(VueDiff)
   .use(router)
   .use(store)
   .directive('date', dateFormatDirective)

--- a/ui/src/store/device/actions.ts
+++ b/ui/src/store/device/actions.ts
@@ -24,8 +24,9 @@ const getDeviceConfigBackups = async (context: ContextWithState) => {
   context.dispatch('spinnerModule/setSpinnerState', false, { root: true })
 }
 
-const getHistoryByIpInterface = async (context: VuexContext, ipInterfaceId: number) => {
-  const historyModalBackups = await API.getHistoryByIpInterface(ipInterfaceId)
+const getHistoryByIpInterface = async (context: ContextWithState) => {
+  const modalDeviceConfigIpInterface = context.state.modalDeviceConfigBackup.ipInterfaceId
+  const historyModalBackups = await API.getHistoryByIpInterface(modalDeviceConfigIpInterface)
   context.commit('SET_HISTORY_MODAL_BACKUPS', historyModalBackups)
 }
 

--- a/ui/src/store/device/actions.ts
+++ b/ui/src/store/device/actions.ts
@@ -37,9 +37,19 @@ const getAndMergeDeviceConfigBackups = async (context: ContextWithState) => {
   context.dispatch('spinnerModule/setSpinnerState', false, { root: true })
 }
 
-const downloadByConfig = async (context: VuexContext, config: DeviceConfigBackup) => {
-  const file = await API.downloadDeviceConfigs([config.id])
-  if (file) downloadFile(file)
+const downloadByConfig = async (context: VuexContext, config: DeviceConfigBackup | DeviceConfigBackup[]) => {
+  const isSingleDeviceBackup = (config: DeviceConfigBackup | DeviceConfigBackup[]): config is DeviceConfigBackup => {
+    return (config as DeviceConfigBackup).id !== undefined
+  }
+
+  if (isSingleDeviceBackup(config)) {
+    const file = await API.downloadDeviceConfigs([config.id])
+    if (file) downloadFile(file)
+  } else {
+    const ids = config.map((x) => x.id)
+    const file = await API.downloadDeviceConfigs(ids)
+    if (file) downloadFile(file)
+  }
 }
 
 const downloadSelectedDevices = async (contextWithState: ContextWithState) => {

--- a/ui/src/store/device/actions.ts
+++ b/ui/src/store/device/actions.ts
@@ -25,9 +25,11 @@ const getDeviceConfigBackups = async (context: ContextWithState) => {
 }
 
 const getHistoryByIpInterface = async (context: ContextWithState) => {
+  context.dispatch('spinnerModule/setSpinnerState', true, { root: true })
   const modalDeviceConfigIpInterface = context.state.modalDeviceConfigBackup.ipInterfaceId
   const historyModalBackups = await API.getHistoryByIpInterface(modalDeviceConfigIpInterface)
   context.commit('SET_HISTORY_MODAL_BACKUPS', historyModalBackups)
+  context.dispatch('spinnerModule/setSpinnerState', false, { root: true })
 }
 
 const getAndMergeDeviceConfigBackups = async (context: ContextWithState) => {
@@ -42,6 +44,8 @@ const downloadByConfig = async (context: VuexContext, config: DeviceConfigBackup
     return (config as DeviceConfigBackup).id !== undefined
   }
 
+  context.dispatch('spinnerModule/setSpinnerState', true, { root: true })
+
   if (isSingleDeviceBackup(config)) {
     const file = await API.downloadDeviceConfigs([config.id])
     if (file) downloadFile(file)
@@ -50,12 +54,18 @@ const downloadByConfig = async (context: VuexContext, config: DeviceConfigBackup
     const file = await API.downloadDeviceConfigs(ids)
     if (file) downloadFile(file)
   }
+
+  context.dispatch('spinnerModule/setSpinnerState', false, { root: true })
 }
 
 const downloadSelectedDevices = async (contextWithState: ContextWithState) => {
+  contextWithState.dispatch('spinnerModule/setSpinnerState', true, { root: true })
+
   const ids = contextWithState.state.selectedIds
   const file = await API.downloadDeviceConfigs(ids)
   if (file) downloadFile(file)
+
+  contextWithState.dispatch('spinnerModule/setSpinnerState', false, { root: true })
 }
 
 const backupSelectedDevices = async (contextWithState: ContextWithState) => {

--- a/ui/src/types/deviceConfig.d.ts
+++ b/ui/src/types/deviceConfig.d.ts
@@ -15,7 +15,7 @@ export interface DeviceConfigBackup {
   fileName: string
   failureReason: string
   encoding: string
-  configType?: defaultConfig | runningConfig
+  configType: defaultConfig | runningConfig
   nodeId: number
   nodeLabel: string
   operatingSystem: string

--- a/ui/tests/deviceConfigBackup.test.ts
+++ b/ui/tests/deviceConfigBackup.test.ts
@@ -110,32 +110,3 @@ test('action btns enable and disable correctly', async () => {
   expect(backupNowBtn.attributes('aria-disabled')).toBe('true')
   expect(allCheckbox.attributes('aria-checked')).toBe('false')
 })
-
-test('the modal opens and displays the config property and device title', async () => {
-  const viewHistoryBtn = wrapper.get('[data-test="view-history-btn"]')
-  const lastBackupDateBtn = wrapper.get('.last-backup-date')
-  const deviceConfigCheckboxes = wrapper.findAll('.device-config-checkbox')
-  const secondDeviceConfig = deviceConfigCheckboxes[1].get('.feather-checkbox')
-  const dialog = wrapper.get('.feather-dialog')
-  const closeModalBtn = wrapper.get('[data-ref-id="dialog-close"]')
-  const dialogContent = wrapper.get('.dialog-content > .content')
-  const headerText = wrapper.get('[data-ref-id="feather-dialog-header"]')
-
-  // modal starts hidden
-  expect(dialog.attributes('style')).toBe('display: none;')
-
-  // clicks the first backup date link
-  await lastBackupDateBtn.trigger('click')
-  //expect cisco config and title
-  expect(dialog.attributes('style')).not.toBe('display: none;')
-  expect(dialogContent.text()).toBe('mock cisco config')
-  expect(headerText.text()).toBe('Device Name: Cisco-7201')
-
-  await closeModalBtn.trigger('click')
-  expect(dialog.attributes('style')).toBe('display: none;')
-
-  // click second device config checkbox and then view hitory btn
-  await secondDeviceConfig.trigger('click')
-  await viewHistoryBtn.trigger('click')
-  expect(dialog.attributes('style')).not.toBe('display: none;')
-})

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -952,6 +952,14 @@
   resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.17.tgz#e6dcf5b5bd3ae23595bdb154b9b578ebcdffd698"
   integrity sha512-7LHZKsFRV/HqDoMVY+cJamFzgHgsrmQFalROHC5FMWrzPzd+utG5e11krj1tVsnxYufGA2ABShX4nlcHXED+zQ==
 
+"@vueuse/core@^4.7.0":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-4.11.2.tgz#d4f54bd38e7c289c6f6357992c02423774cb26d9"
+  integrity sha512-4A17XvKXpMR6829EVWvrdSKEeAjTWaiC3+xh51KEtlyCwvWQwZ0xwKDrbMj+e15ANxjHrTw/0bJVaWDfPQt/Pw==
+  dependencies:
+    "@vueuse/shared" "4.11.2"
+    vue-demi "*"
+
 "@vueuse/core@^8.1.2":
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-8.1.2.tgz#3153d4766b07a648bfbdd01559e8d3b20fda6eb5"
@@ -965,6 +973,13 @@
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-8.1.2.tgz#4e0707de7575ff265484c122f2b85f40f11c43c7"
   integrity sha512-LrPtdiYMleygnGmz8mEmYI9h4Eyo+/igxZWNrwuPnqvL9pIO+8eUpBgPLH5GowKv3Nu0LPZSXSIuaWVJBSU1Cg==
+
+"@vueuse/shared@4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-4.11.2.tgz#1d56e08937600e3e65abf76f27cb4a1bc182adfd"
+  integrity sha512-vTbTi6ou7ljH3CkKVoaIaCAoWB5T1ewSogpL6VnO1duMPNuiv7x8K/LunMbnTg4tVyt6QwaiCuEq/kyS6AUBRg==
+  dependencies:
+    vue-demi "*"
 
 "@vueuse/shared@8.1.2":
   version "8.1.2"
@@ -1597,6 +1612,11 @@ dequal@^2.0.0:
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
   integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
+diff-match-patch@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
+
 diff@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
@@ -2136,6 +2156,11 @@ he@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@^11.4.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.5.0.tgz#00abb7ed926491adbdabc93a4f3fd2b88b451b4a"
+  integrity sha512-SM6WDj5/C+VfIY8pZ6yW6Xa0Fm1tniYVYWYW1Q/DcMnISZFrC3aQAZZZFAAZtybKNrGId3p/DNbFTtcTXXgYBw==
 
 http-basic@^8.1.1:
   version "8.1.3"
@@ -3126,6 +3151,15 @@ vue-demi@*:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.12.4.tgz#420dd17628f95f1bbce1102ad3c51074713a8049"
   integrity sha512-ztPDkFt0TSUdoq1ZI6oD730vgztBkiByhUW7L1cOTebiSBqSYfSQgnhYakYigBkyAybqCTH7h44yZuDJf2xILQ==
+
+vue-diff@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/vue-diff/-/vue-diff-1.1.4.tgz#3964291f1402232ebaffba407cd125946933978e"
+  integrity sha512-wEedtiWLqraxRlDQnlLSS9k86WyEhZl5d1EzhA826lAyAW93y72bcyOUsdcqDvJsUQK2ThXQ2nNYGGwH3FStwg==
+  dependencies:
+    "@vueuse/core" "^4.7.0"
+    diff-match-patch "^1.0.5"
+    highlight.js "^11.4.0"
 
 vue-eslint-parser@^8.0.1, vue-eslint-parser@^8.3.0:
   version "8.3.0"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -618,6 +618,11 @@
     "@types/d3-transition" "*"
     "@types/d3-zoom" "*"
 
+"@types/diff@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-5.0.2.tgz#dd565e0086ccf8bc6522c6ebafd8a3125c91c12b"
+  integrity sha512-uw8eYMIReOwstQ0QKF0sICefSy8cNO/v7gOTiIy9SbwuHyEecJUm7qlgueOO5S1udZ5I/irVydHVwMchgzbKTg==
+
 "@types/form-data@0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"


### PR DESCRIPTION
- Adds vue-diff plugin and modal content component for displaying diff
- Fixes modal position on screen, relative to parent
- Displays config in a more 'editor-like' view, with line numbers
- Fixes position of modal download btn
- Fixes view history content so that dates are within their respective tabs, as per prototype

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14089

