### PR TITLE
NMS-14147: DCB Endpoint Renaming

### DIFF
--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigRestService.java
@@ -55,10 +55,11 @@ public interface DeviceConfigRestService {
 
     /**
      * Gets a list of device configs along with backup schedule information.
+     *
      * @param limit used for paging; defaults to 10
      * @param offset used for paging; defaults to 0
-     * @param orderBy used for paging; defaults to "lastUpdated"
-     * @param order used for paging; defaults to "desc"
+     * @param orderBy used for sorting. Valid values are 'lastUpdated', 'deviceName', 'lastBackup' and 'ipAddress'. Defaults to 'lastUpdated'
+     * @param order used for sorting; valid values are 'asc' and 'desc', defaults to 'desc'
      * @param deviceName filter results by device name. Should use 'searchTerm' instead.
      * @param ipAddress filter results by device IP address. Should use 'searchTerm' instead.
      * @param ipInterfaceId database id of OnmsIpInterface instance. This will retrieve a record history.
@@ -84,6 +85,38 @@ public interface DeviceConfigRestService {
         @QueryParam("createdAfter") Long createdAfter,
         @QueryParam("createdBefore") Long createdBefore
     );
+
+    /**
+     * Gets the most recent device config for each device / config type combination.
+     * Typically called by UI to get latest status.
+     *
+     * @param limit used for paging; defaults to 10
+     * @param offset used for paging; defaults to 0
+     * @param orderBy used for sorting. Valid values are 'lastUpdated', 'deviceName', 'lastBackup' and 'ipAddress'. Defaults to 'lastUpdated'
+     * @param order used for sorting; valid values are 'asc' and 'desc', defaults to 'desc'
+     * @param searchTerm A search term, currently to search by device name or IP address.
+     * @return
+     */
+    @GET
+    @Path("/latest")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getLatestDeviceConfigsForDeviceAndConfigType(
+        @QueryParam("limit") @DefaultValue("10") Integer limit,
+        @QueryParam("offset") @DefaultValue("0") Integer offset,
+        @QueryParam("orderBy") @DefaultValue("lastUpdated") String orderBy,
+        @QueryParam("order") @DefaultValue("desc") String order,
+        @QueryParam("search") String searchTerm
+    );
+
+    /**
+     * Get a list of device configs for a given IP interface id.
+     * This is a history of configs for a particular device.
+     * Returns all config types.
+     */
+    @GET
+    @Path("/interface/{id : \\d+}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getDeviceConfigsByInterface(@PathParam("id") Integer ipInterfaceId);
 
     /**
      * Delete a single device config.

--- a/ui/src/services/deviceService.ts
+++ b/ui/src/services/deviceService.ts
@@ -8,7 +8,7 @@ const endpoint = 'device-config'
 
 const getDeviceConfigBackups = async (queryParameters: DeviceConfigQueryParams): Promise<AxiosResponse | false> => {
   try {
-    const endpointWithQueryString = queryParametersHandler(queryParameters, endpoint)
+    const endpointWithQueryString = queryParametersHandler(queryParameters, `${endpoint}/latest`)
     return await rest.get(endpointWithQueryString)
   } catch (err) {
     return false
@@ -54,7 +54,7 @@ const getOsImageOptions = async (): Promise<string[]> => {
 
 const getHistoryByIpInterface = async (ipInterfaceId: number): Promise<DeviceConfigBackup[]> => {
   try {
-    const resp: { data: DeviceConfigBackup[] } = await rest.get(`${endpoint}?ipInterfaceId=${ipInterfaceId}`)
+    const resp: { data: DeviceConfigBackup[] } = await rest.get(`${endpoint}/interface/${ipInterfaceId}`)
     const devicesWithBackupDate = resp.data.filter((device) => device.lastBackupDate)
     return orderBy(devicesWithBackupDate, 'lastBackupDate', 'desc')
   } catch (err) {


### PR DESCRIPTION
Update Device Config Backup Rest APIs to make their purpose more clear and to clean up the code a bit.

- `device-config` with query params will return *all* records with the given query params for filter/sort/limit/offset
- `device-config/latest` will return only the latest record per ipinterface/configType (by lastUpdated) for the given query. This is the API used by the main UI table to get the latest status across all devices
- `device-config/interface/{ipInterfaceId}` returns a history of records for the given `ipInterfaceId`, basically the history for one device. UI will need to partition between config types

Also added an integration test plus cleaned test code up a bit.

In addition, this PR updates the UI with the new endpoints.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14147

