### PR TITLE
NMS-14151: DCB fix backup in Rest API and UI

### DIFF
--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigDTO.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigDTO.java
@@ -93,6 +93,9 @@ public class DeviceConfigDTO {
     /** Location, from node. */
     private String location;
 
+    /** Service name */
+    private String serviceName;
+
     /** Operating system of corresponding node. */
     private String operatingSystem;
 
@@ -120,7 +123,8 @@ public class DeviceConfigDTO {
         String configType,
         String fileName,
         String config,
-        String failureReason
+        String failureReason,
+        String serviceName
     ) {
         this.id = id;
         this.monitoredServiceId = monitoredServiceId;
@@ -134,6 +138,7 @@ public class DeviceConfigDTO {
         this.fileName = fileName;
         this.config = config;
         this.failureReason = failureReason;
+        this.serviceName = serviceName;
     }
 
     public long getId() {
@@ -172,6 +177,8 @@ public class DeviceConfigDTO {
 
     public String getLocation() { return this.location; }
 
+    public String getServiceName() { return this.serviceName; }
+
     public String getOperatingSystem() { return this.operatingSystem; }
 
     public boolean getIsSuccessfulBackup() { return this.isSuccessfulBackup; }
@@ -191,6 +198,8 @@ public class DeviceConfigDTO {
     public void setNodeLabel(String label) { this.nodeLabel = label; }
 
     public void setLocation(String location) { this.location = location; }
+
+    public void setServiceName(String name) { this.serviceName = name; }
 
     public void setOperatingSystem(String os) { this.operatingSystem = os; }
 

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -442,7 +442,8 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             queryResult.getConfigType(),
             queryResult.getFilename(),
             config,
-            queryResult.getFailureReason()
+            queryResult.getFailureReason(),
+            queryResult.getServiceName()
         );
 
         // determine backup status, not handling all cases for now
@@ -479,7 +480,8 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             deviceConfig.getConfigType(),
             deviceConfig.getFileName(),
             config,
-            deviceConfig.getFailureReason()
+            deviceConfig.getFailureReason(),
+            deviceConfig.getServiceName()
         );
 
         // determine backup status, not handling all cases for now

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -41,7 +41,7 @@
           <FeatherButton
             data-test="backup-now-btn"
             @click="onBackupNow"
-            :disabled="(selectedDeviceConfigIds.length === 0 && !all) || (all && !deviceConfigBackups.length)"
+            :disabled="(!all && selectedDeviceConfigIds.length !== 1) || (all && deviceConfigBackups.length !== 1)"
             text
           >
             <template v-slot:icon>

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -149,7 +149,7 @@
           <td>{{ config.ipAddress }}</td>
           <td>{{ config.location }}</td>
           <td class="last-backup-date pointer" @click="onLastBackupDateClick(config)">
-            <span v-date>{{ config.lastSucceededDate }}</span>
+            <span v-date>{{ config.lastBackupDate }}</span>
             <FeatherButton icon="View" v-if="config.lastBackupDate">
               <FeatherIcon :icon="ViewDetails" />
             </FeatherButton>

--- a/ui/src/services/deviceService.ts
+++ b/ui/src/services/deviceService.ts
@@ -18,7 +18,7 @@ const getDeviceConfigBackups = async (queryParameters: DeviceConfigQueryParams):
 const downloadDeviceConfigs = async (deviceIds: number[]) => {
   const queryString = `?id=${deviceIds.join(',')}`
   try {
-    return await rest.get(`${endpoint}/download${queryString}`)
+    return await rest.get(`${endpoint}/download${queryString}`, { responseType: 'blob' })
   } catch (err) {
     return false
   }

--- a/ui/src/services/deviceService.ts
+++ b/ui/src/services/deviceService.ts
@@ -24,9 +24,8 @@ const downloadDeviceConfigs = async (deviceIds: number[]) => {
   }
 }
 
-const backupDeviceConfig = async ({ ipAddress, location, configType }: DeviceConfigBackup) => {
+const backupDeviceConfig = async ({ ipAddress, location, serviceName }: DeviceConfigBackup) => {
   try {
-    const serviceName = `DeviceConfig-${configType}`
     const resp = await rest.post(`${endpoint}/backup`, { ipAddress, location, serviceName })
     return resp.data
   } catch (err) {

--- a/ui/src/services/deviceService.ts
+++ b/ui/src/services/deviceService.ts
@@ -27,7 +27,7 @@ const downloadDeviceConfigs = async (deviceIds: number[]) => {
 const backupDeviceConfig = async ({ ipAddress, location, serviceName }: DeviceConfigBackup) => {
   try {
     const resp = await rest.post(`${endpoint}/backup`, { ipAddress, location, serviceName })
-    return resp.data
+    return resp
   } catch (err) {
     return false
   }

--- a/ui/src/store/device/actions.ts
+++ b/ui/src/store/device/actions.ts
@@ -75,8 +75,9 @@ const backupSelectedDevices = async (contextWithState: ContextWithState) => {
 
   if (ids.length === 1) {
     const config = getDeviceConfigBackupObjById(configs, ids[0])
-    const success = await API.backupDeviceConfig(config)
+    const resp = await API.backupDeviceConfig(config)
     contextWithState.dispatch('spinnerModule/setSpinnerState', false, { root: true })
+    const success = resp && (resp.status === 200 || resp.status === 202)
 
     if (success) {
       const successToast = {

--- a/ui/src/types/deviceConfig.d.ts
+++ b/ui/src/types/deviceConfig.d.ts
@@ -23,6 +23,7 @@ export interface DeviceConfigBackup {
   nextScheduledBackupDate: number
   config: string
   monitoredServiceId: number
+  serviceName: string
 }
 
 export interface DeviceConfigQueryParams extends QueryParameters {

--- a/ui/tests/deviceConfigBackup.test.ts
+++ b/ui/tests/deviceConfigBackup.test.ts
@@ -28,7 +28,8 @@ const mockDeviceConfigBackups: DeviceConfigBackup[] = [
     nodeLabel: 'node1',
     operatingSystem: '',
     isSuccessfulBackup: true,
-    monitoredServiceId: 1
+    monitoredServiceId: 1,
+    serviceName: 'DeviceConfig-running'
   },
   {
     id: 12,
@@ -52,7 +53,8 @@ const mockDeviceConfigBackups: DeviceConfigBackup[] = [
     nodeLabel: 'node1',
     operatingSystem: '',
     isSuccessfulBackup: true,
-    monitoredServiceId: 1
+    monitoredServiceId: 1,
+    serviceName: 'DeviceConfig-default'
   }
 ]
 
@@ -96,11 +98,11 @@ test('action btns enable and disable correctly', async () => {
 
   // select 'all devices' checkbox
   await allCheckbox.trigger('click')
-  // the view history btn should be disabled. Dwnld / backup btns enabled
+  // the view history and backup btns should be disabled. Dwnld btn enabled
   expect(allCheckbox.attributes('aria-checked')).toBe('true')
   expect(viewHistoryBtn.attributes('aria-disabled')).toBe('true')
   expect(downloadBtn.attributes('aria-disabled')).toBeUndefined()
-  expect(backupNowBtn.attributes('aria-disabled')).toBeUndefined()
+  expect(backupNowBtn.attributes('aria-disabled')).toBe('true')
 
   // change 'all devices' to false
   await allCheckbox.trigger('click')


### PR DESCRIPTION
Device Configuration backup (triggered from UI) not working correctly due to mismatch in serviceName used.

Rest APIs should return 'serviceName'. UI should use this service name in 'device-config/backup' call

UI should accept 202 response from 'backup' API call and display 'successToast'

UI should only display "Backup Now" when a single item is selected (no multiple backups at this time)

UI should display value from 'lastBackupDate' for "Last Backup" column

Fix download file issue in UI

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14151

