### PR TITLE
NMS-14016: Run as non-privileged user with ambient capabilities

### DIFF
--- a/container/shared/src/main/resources/etc/container.init
+++ b/container/shared/src/main/resources/etc/container.init
@@ -24,7 +24,6 @@ SYSCONFDIR="@SYSCONFDIR@"
 RUNAS="@RUNAS@"
 STOP_RETRIES=10
 STOP_WAIT=5
-PING_REQUIRED=FALSE
 PIDFILE="@PIDFILE@"
 
 export NAME DESC PATH
@@ -75,22 +74,6 @@ export RUNAS JAVA_MIN_MEM JAVA_MAX_MEM MAX_FD JAVA_HOME JAVA JAVA_DEBUG_OPTS JAV
 # export any local configurable variables
 export NAME DESC PATH CONTAINER_HOME SYSCONFDIR STOP_RETRIES STOP_WAIT
 
-run_as() {
-	if [ "$(id -n -u)" "!=" "$RUNAS" ]; then
-		DAEMON="$(daemon --user="$RUNAS" true >/dev/null 2>&1 && command -v daemon)"
-		RUNUSER="$(runuser -u "$RUNAS" true 2>/dev/null && command -v runuser)"
-		if [ -n "$DAEMON" ]; then
-			"$DAEMON" --user="$RUNAS" "$@" >/dev/null 2>&1
-		elif [ -n "$RUNUSER" ] && [ -x "$RUNUSER" ]; then
-			"$RUNUSER" -u "$RUNAS" "$@"
-		else
-			/usr/bin/sudo -u "$RUNAS" "$@"
-		fi
-	else
-		"$@"
-	fi
-}
-
 check_upgrade_files() {
 	for EXTENSION in rpmnew rpmsave dpkg-dist; do
 		if [ "$(find "$CONTAINER_HOME" -name \*."$EXTENSION" 2>/dev/null | wc -l)" -gt 0 ]; then
@@ -139,7 +122,7 @@ is_running() {
 }
 
 stop_process() {
-	run_as "$CONTAINER_HOME"/bin/stop >/dev/null
+	"$CONTAINER_HOME"/bin/stop >/dev/null
 }
 
 kill_process() {
@@ -168,21 +151,11 @@ case "$COMMAND" in
 			exit $?
 		fi
 
-		case "$PING_REQUIRED" in
-			[Tt][Rr][Uu][Ee])
-				# LSB 4 = insufficient privilege
-				"$CONTAINER_HOME/bin/ensure-user-ping.sh" "$RUNAS" || exit 4
-				;;
-			*)
-				QUIET=true "$CONTAINER_HOME/bin/ensure-user-ping.sh" "$RUNAS" || :
-				;;
-		esac
-
 		if [ ! -d "$CONTAINER_HOME/data/tmp" ]; then
 			install -d -m 755 -o "$RUNAS" -g "$RUNAS" "$CONTAINER_HOME/data/tmp"
 		fi
 		chown -R "$RUNAS:$RUNAS" "$CONTAINER_HOME/data/"
-		run_as "$CONTAINER_HOME"/bin/start
+		"$CONTAINER_HOME"/bin/start
 		sleep 5
 		RET="$?"
 
@@ -269,7 +242,7 @@ case "$COMMAND" in
 		;;
 
 	status)
-		run_as "$CONTAINER_HOME"/bin/status >/dev/null
+		"$CONTAINER_HOME"/bin/status >/dev/null
 		RETVAL="$?"
 		if [ $RETVAL -eq 0 ]; then
 			echo "$DESC is running."

--- a/container/shared/src/main/resources/etc/container.service
+++ b/container/shared/src/main/resources/etc/container.service
@@ -4,7 +4,7 @@ Requires=network.target network-online.target
 After=network.target network-online.target
 
 [Service]
-User=root
+User=@RUNAS@
 EnvironmentFile=-@SYSCONFDIR@/@NAME_LC@
 
 PIDFile=@PIDFILE@
@@ -12,6 +12,8 @@ Type=forking
 
 ExecStart=@INITDIR@/@NAME_LC@ start
 ExecStop=@INITDIR@/@NAME_LC@ stop
+
+AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This will switch the horizon, sentinel, and minion services over to run as their non-privileged users from the start instead of dropping down from root to start the process. This allows them to use ambient capabilities defined in the service definition file.

`CAP_NET_BIND_SERVICE` allows binding to privileged ports (for syslog and snmp).
`CAP_NET_RAW` allows creating raw sockets for icmp.

`ensure-user-ping.sh` was removed from the `init.d` start script because:
1. It needs root permissions, which the script no longer has
2. With the `NET_CAP_RAW` capability, the service can now open ICMP sockets without modifying `net.ipv4.ping_group_range`
3. This script is already run when installing RPMs / debian packages. See [minion](https://github.com/OpenNMS/opennms/blob/develop/opennms-assemblies/minion/src/main/filtered/debian/opennms-minion.postinst#L31), [sentinel](https://github.com/OpenNMS/opennms/blob/develop/opennms-assemblies/sentinel/src/main/filtered/debian/opennms-sentinel.postinst#L29), and [horizon](https://github.com/OpenNMS/opennms/blob/develop/debian/opennms-common.postinst#L39) debian install scripts, as well as [minion](https://github.com/OpenNMS/opennms/blob/develop/tools/packages/minion/minion.spec#L276), [sentinel](https://github.com/OpenNMS/opennms/blob/develop/tools/packages/sentinel/sentinel.spec#L221), and [horizon](https://github.com/OpenNMS/opennms/blob/develop/tools/packages/opennms/opennms.spec#L991) RPM install specs.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14016

