### PR TITLE
NMS-14163: Monitor should return poll status based on last retrieval

### DIFF
--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -435,41 +435,47 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
     }
 
     private DeviceConfigDTO createDeviceConfigDto(DeviceConfigQueryResult queryResult) {
-        Pair<String,String> pair = configToText(queryResult.getEncoding(), queryResult.getConfig());
-        final String encoding = pair.getLeft();
-        final String config = pair.getRight();
 
-        var dto = new DeviceConfigDTO(
-            queryResult.getId(),
-            queryResult.getMonitoredServiceId(),
-            queryResult.getIpAddr(),
-            queryResult.getCreatedTime(),
-            queryResult.getLastUpdated(),
-            queryResult.getLastSucceeded(),
-            queryResult.getLastFailed(),
-            encoding,
-            queryResult.getConfigType(),
-            queryResult.getFilename(),
-            config,
-            queryResult.getFailureReason(),
-            queryResult.getServiceName()
-        );
+        try {
+            Pair<String, String> pair = configToText(queryResult.getEncoding(), queryResult.getConfig());
+            final String encoding = pair.getLeft();
+            final String config = pair.getRight();
 
-        // determine backup status, not handling all cases for now
-        boolean backupSuccess = determineBackupSuccess(queryResult.getLastSucceeded(), queryResult.getLastUpdated());
-        dto.setIsSuccessfulBackup(backupSuccess);
-        dto.setBackupStatus(backupSuccess ? BACKUP_STATUS_SUCCESS : BACKUP_STATUS_FAILED);
+            var dto = new DeviceConfigDTO(
+                    queryResult.getId(),
+                    queryResult.getMonitoredServiceId(),
+                    queryResult.getIpAddr(),
+                    queryResult.getCreatedTime(),
+                    queryResult.getLastUpdated(),
+                    queryResult.getLastSucceeded(),
+                    queryResult.getLastFailed(),
+                    encoding,
+                    queryResult.getConfigType(),
+                    queryResult.getFilename(),
+                    config,
+                    queryResult.getFailureReason(),
+                    queryResult.getServiceName()
+            );
 
-        dto.setIpInterfaceId(queryResult.getIpInterfaceId());
-        dto.setNodeId(queryResult.getNodeId());
-        dto.setNodeLabel(queryResult.getNodeLabel());
-        dto.setDeviceName(queryResult.getNodeLabel());
-        dto.setLocation(queryResult.getLocation());
-        dto.setOperatingSystem(queryResult.getOperatingSystem());
+            // determine backup status, not handling all cases for now
+            boolean backupSuccess = determineBackupSuccess(queryResult.getLastSucceeded(), queryResult.getLastUpdated());
+            dto.setIsSuccessfulBackup(backupSuccess);
+            dto.setBackupStatus(backupSuccess ? BACKUP_STATUS_SUCCESS : BACKUP_STATUS_FAILED);
 
-        populateScheduleInfo(dto);
+            dto.setIpInterfaceId(queryResult.getIpInterfaceId());
+            dto.setNodeId(queryResult.getNodeId());
+            dto.setNodeLabel(queryResult.getNodeLabel());
+            dto.setDeviceName(queryResult.getNodeLabel());
+            dto.setLocation(queryResult.getLocation());
+            dto.setOperatingSystem(queryResult.getOperatingSystem());
 
-        return dto;
+            populateScheduleInfo(dto);
+            return dto;
+        } catch (Exception e) {
+            LOG.error("Exception while creating DTO for Rest", e);
+        }
+
+        return null;
     }
 
     private DeviceConfigDTO createDeviceConfigDto(DeviceConfig deviceConfig) {


### PR DESCRIPTION

Currently, Monitor Service status always gives out Unknown status when it doesn't fetch config.
Instead this will change monitor to reflect last known config retrieval status.

This will enable manual retrieval related success/failures to be reflected in Monitor Service Status.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14163

