### PR TITLE
NMS-14167: DCB device_config table add 'status', update 'last_updated'

### DIFF
--- a/core/schema/src/main/liquibase/30.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/30.0.0/changelog.xml
@@ -45,4 +45,32 @@
             </column>
         </createTable>
     </changeSet>
+
+    <changeSet author="stheleman" id="30.0.0-device-config-lastupdated-nullable">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="NO">
+                SELECT is_nullable FROM information_schema.columns
+                WHERE table_schema = 'public'
+                AND table_name = 'device_config'
+                AND column_name = 'last_updated'
+            </sqlCheck>
+        </preConditions>
+        <dropNotNullConstraint tableName="device_config" columnName="last_updated" columnDataType="timestamp"/>
+    </changeSet>
+
+    <changeSet author="stheleman" id="30.0.0-device-config-add-column-status">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM information_schema.columns
+                WHERE table_schema = 'public'
+                AND table_name = 'device_config'
+                AND column_name = 'status'
+            </sqlCheck>
+        </preConditions>
+        <addColumn tableName="device_config">
+            <column name="status" type="varchar(20)" defaultValue="NONE">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfigStatus.java
+++ b/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfigStatus.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.deviceconfig.persistence.api;
+
+public enum DeviceConfigStatus {
+    NONE,
+    SUCCESS,
+    FAILED
+}

--- a/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
+++ b/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
@@ -78,7 +78,7 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
     @Override
     public List<DeviceConfig> findConfigsForInterfaceSortedByDate(OnmsIpInterface ipInterface, String serviceName) {
 
-        return find("from DeviceConfig dc where dc.ipInterface.id = ? AND serviceName = ? ORDER BY lastUpdated DESC",
+        return find("from DeviceConfig dc where dc.lastUpdated is not null AND dc.ipInterface.id = ? AND serviceName = ? ORDER BY lastUpdated DESC",
                 ipInterface.getId(), serviceName);
     }
 
@@ -86,7 +86,7 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
     public Optional<DeviceConfig> getLatestConfigForInterface(OnmsIpInterface ipInterface, String serviceName) {
         List<DeviceConfig> deviceConfigs =
                 findObjects(DeviceConfig.class,
-                        "from DeviceConfig dc where dc.ipInterface.id = ? AND serviceName = ? " +
+                        "from DeviceConfig dc where dc.lastUpdated is not null AND dc.ipInterface.id = ? AND serviceName = ? " +
                                 "ORDER BY lastUpdated DESC LIMIT 1", ipInterface.getId(), serviceName);
 
         if (deviceConfigs != null && !deviceConfigs.isEmpty()) {

--- a/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
+++ b/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
@@ -36,13 +36,12 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.google.common.base.Strings;
-import org.hibernate.Criteria;
 import org.hibernate.SQLQuery;
 import org.hibernate.transform.ResultTransformer;
-import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfig;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigQueryResult;
+import org.opennms.features.deviceconfig.persistence.api.DeviceConfigStatus;
 import org.opennms.netmgt.dao.hibernate.AbstractDaoHibernate;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
@@ -247,6 +246,7 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
             lastDeviceConfig.setLastUpdated(currentTime);
             lastDeviceConfig.setLastSucceeded(currentTime);
             lastDeviceConfig.setFileName(fileName);
+            lastDeviceConfig.setStatus(DeviceConfigStatus.SUCCESS);
             saveOrUpdate(lastDeviceConfig);
             LOG.debug("Device config did not change - ipInterface: {}; service: {}; type: {}", ipInterface, serviceName, configType);
         } else if (lastDeviceConfig != null
@@ -258,6 +258,7 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
             lastDeviceConfig.setLastUpdated(currentTime);
             lastDeviceConfig.setLastSucceeded(currentTime);
             lastDeviceConfig.setFailureReason(null);
+            lastDeviceConfig.setStatus(DeviceConfigStatus.SUCCESS);
             saveOrUpdate(lastDeviceConfig);
             LOG.info("Persisted device config - ipInterface: {}; service: {}; type: {}", ipInterface, serviceName, configType);
         } else {
@@ -272,6 +273,7 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
             deviceConfig.setConfigType(configType);
             deviceConfig.setLastUpdated(currentTime);
             deviceConfig.setLastSucceeded(currentTime);
+            deviceConfig.setStatus(DeviceConfigStatus.SUCCESS);
             saveOrUpdate(deviceConfig);
             LOG.info("Persisted changed device config - ipInterface: {}; service: {}; type: {}", ipInterface, serviceName, configType);
         }
@@ -302,6 +304,7 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
         deviceConfig.setFailureReason(reason);
         deviceConfig.setLastFailed(currentTime);
         deviceConfig.setLastUpdated(currentTime);
+        deviceConfig.setStatus(DeviceConfigStatus.FAILED);
         saveOrUpdate(deviceConfig);
         LOG.warn("Persisted device config backup failure - ipInterface: {}; service: {}; type: {}; reason: {}", ipInterface, serviceName, configType, reason);
     }

--- a/features/device-config/persistence/impl/src/test/java/org/opennms/features/deviceconfig/persistence/DeviceConfigDaoIT.java
+++ b/features/device-config/persistence/impl/src/test/java/org/opennms/features/deviceconfig/persistence/DeviceConfigDaoIT.java
@@ -40,6 +40,7 @@ import org.opennms.features.deviceconfig.persistence.api.ConfigType;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfig;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigQueryResult;
+import org.opennms.features.deviceconfig.persistence.api.DeviceConfigStatus;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.model.NetworkBuilder;
 import org.opennms.netmgt.model.OnmsIpInterface;
@@ -99,6 +100,7 @@ public class DeviceConfigDaoIT {
         deviceConfig.setLastUpdated(currentDate);
         deviceConfig.setCreatedTime(currentDate);
         deviceConfig.setLastSucceeded(currentDate);
+        deviceConfig.setStatus(DeviceConfigStatus.SUCCESS);
         deviceConfig.setConfigType(ConfigType.Default);
         deviceConfigDao.saveOrUpdate(deviceConfig);
 
@@ -112,6 +114,7 @@ public class DeviceConfigDaoIT {
         Assert.assertEquals(currentDate, deviceConfig.getCreatedTime());
         Assert.assertEquals(currentDate, deviceConfig.getLastUpdated());
         Assert.assertEquals(currentDate, deviceConfig.getLastSucceeded());
+        Assert.assertEquals(DeviceConfigStatus.SUCCESS, deviceConfig.getStatus());
         Assert.assertNull(deviceConfig.getLastFailed());
     }
 
@@ -199,6 +202,8 @@ public class DeviceConfigDaoIT {
             deviceConfig.setCreatedTime(Date.from(Instant.now().plusSeconds(i * 60)));
             deviceConfig.setConfigType(ConfigType.Default);
             deviceConfig.setLastUpdated(Date.from(Instant.now().plusSeconds(i * 60)));
+            deviceConfig.setLastSucceeded(deviceConfig.getLastUpdated());
+            deviceConfig.setStatus(DeviceConfig.determineBackupStatus(deviceConfig));
             deviceConfigDao.saveOrUpdate(deviceConfig);
         }
     }
@@ -212,6 +217,7 @@ public class DeviceConfigDaoIT {
         deviceConfig.setLastUpdated(Date.from(Instant.now().plus(2, HOURS)));
         deviceConfig.setLastFailed(Date.from(Instant.now().plus(2, HOURS)));
         deviceConfig.setFailureReason("Not able to connect to SSHServer");
+        deviceConfig.setStatus(DeviceConfig.determineBackupStatus(deviceConfig));
         deviceConfigDao.saveOrUpdate(deviceConfig);
     }
 

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -62,6 +62,7 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfig;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigQueryResult;
+import org.opennms.features.deviceconfig.persistence.api.DeviceConfigStatus;
 import org.opennms.features.deviceconfig.rest.BackupRequestDTO;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigDTO;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigRestService;
@@ -79,8 +80,6 @@ import com.google.common.collect.Maps;
 
 public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultDeviceConfigRestService.class);
-    public static final String BACKUP_STATUS_SUCCESS = "success";
-    public static final String BACKUP_STATUS_FAILED = "failed";
     public static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
     public static final String BINARY_ENCODING = "binary";
 
@@ -259,7 +258,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         if (ids.size() == 1) {
             return downloadSingleDeviceConfig(ids.get(0));
         } else {
-            return downloadMultipleDeviceCofigs(ids);
+            return downloadMultipleDeviceConfigs(ids);
         }
     }
 
@@ -285,7 +284,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             .entity(outputStream.toByteArray()).build();
     }
 
-    private Response downloadMultipleDeviceCofigs(List<Long> ids) {
+    private Response downloadMultipleDeviceConfigs(List<Long> ids) {
         final Map<String, byte[]> fileNameToDataMap = ids.stream()
             .map(deviceConfigDao::get)
             .filter(dc -> dc != null && dc.getConfig() != null && dc.getConfig().length > 0)
@@ -458,10 +457,9 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             queryResult.getServiceName()
         );
 
-        // determine backup status, not handling all cases for now
-        boolean backupSuccess = determineBackupSuccess(queryResult.getLastSucceeded(), queryResult.getLastUpdated());
-        dto.setIsSuccessfulBackup(backupSuccess);
-        dto.setBackupStatus(backupSuccess ? BACKUP_STATUS_SUCCESS : BACKUP_STATUS_FAILED);
+        DeviceConfigStatus backupStatus = DeviceConfig.determineBackupStatus(queryResult.getLastUpdated(), queryResult.getLastSucceeded());
+        dto.setIsSuccessfulBackup(backupStatus.equals(DeviceConfigStatus.SUCCESS));
+        dto.setBackupStatus(backupStatus.name().toLowerCase(Locale.ROOT));
 
         dto.setIpInterfaceId(queryResult.getIpInterfaceId());
         dto.setNodeId(queryResult.getNodeId());
@@ -496,10 +494,9 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             deviceConfig.getServiceName()
         );
 
-        // determine backup status, not handling all cases for now
-        boolean backupSuccess = determineBackupSuccess(deviceConfig.getLastSucceeded(), deviceConfig.getLastUpdated());
-        dto.setIsSuccessfulBackup(backupSuccess);
-        dto.setBackupStatus(backupSuccess ? BACKUP_STATUS_SUCCESS : BACKUP_STATUS_FAILED);
+        DeviceConfigStatus backupStatus = DeviceConfig.determineBackupStatus(deviceConfig);
+        dto.setIsSuccessfulBackup(backupStatus.equals(DeviceConfigStatus.SUCCESS));
+        dto.setBackupStatus(backupStatus.name().toLowerCase(Locale.ROOT));
 
         final OnmsIpInterface ipInterface = deviceConfig.getIpInterface();
         final OnmsNode node = ipInterface.getNode();
@@ -570,17 +567,6 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         return
             !Strings.isNullOrEmpty(encoding) && Charset.isSupported(encoding)
             ? Charset.forName(encoding) : Charset.defaultCharset();
-    }
-
-    /**
-     * Currently, backup status is {@link BACKUP_STATUS_SUCCESS} if a backup config exists
-     * for this device and there have been no failures since last backup,
-     * otherwise status is {@link BACKUP_STATUS_FAILED}.
-     */
-    private static boolean determineBackupSuccess(Date lastSucceeded, Date lastUpdated) {
-        return
-            lastSucceeded != null &&
-            lastSucceeded.getTime() >= lastUpdated.getTime();
     }
 
     private static String createDownloadFileName(DeviceConfig dc) {

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
@@ -312,6 +312,8 @@ public class DefaultDeviceConfigRestServiceIT {
         dc.setIpInterface(ipInterface1);
         dc.setServiceName("DeviceConfig-default");
         dc.setLastUpdated(new Date(createdTime(version)));
+        dc.setStatus(DeviceConfig.determineBackupStatus(dc));
+
         return dc;
     }
 

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceScheduleIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceScheduleIT.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -65,6 +66,7 @@ import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfig;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
+import org.opennms.features.deviceconfig.persistence.api.DeviceConfigStatus;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigDTO;
 import org.opennms.features.deviceconfig.rest.api.DeviceConfigRestService;
 import org.opennms.features.deviceconfig.service.DeviceConfigService;
@@ -221,7 +223,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
                 assertThat(dto.getFailureReason(), nullValue());
                 assertThat(dto.getConfig(), equalTo(CONFIG_STRINGS.get(i)));
                 assertThat(dto.getOperatingSystem(), equalTo(expectedOperatingSystems.get(i)));
-                assertThat(dto.getBackupStatus(), equalTo(DefaultDeviceConfigRestService.BACKUP_STATUS_SUCCESS));
+                assertThat(dto.getBackupStatus(), equalTo(DeviceConfigStatus.SUCCESS.name().toLowerCase(Locale.ROOT)));
                 assertThat(dto.getScheduledInterval().get(SERVICE_NAMES.get(i)),
                     equalTo(EXPECTED_CRON_SCHEDULE_DESCRIPTIONS.get(i)));
                 assertThat(dto.getNextScheduledBackupDate().after(currentDate), is(true));
@@ -254,7 +256,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
                 assertThat(dto.getLastFailedDate(), nullValue());
                 assertThat(dto.getFailureReason(), nullValue());
                 assertThat(dto.getOperatingSystem(), equalTo(expectedOperatingSystems.get(1)));
-                assertThat(dto.getBackupStatus(), equalTo(DefaultDeviceConfigRestService.BACKUP_STATUS_SUCCESS));
+                assertThat(dto.getBackupStatus(), equalTo(DeviceConfigStatus.SUCCESS.name().toLowerCase(Locale.ROOT)));
                 assertThat(dto.getScheduledInterval().get(SERVICE_NAMES.get(1)),
                     equalTo(EXPECTED_CRON_SCHEDULE_DESCRIPTIONS.get(1)));
                 assertThat(dto.getNextScheduledBackupDate().after(currentDate), is(true));
@@ -377,7 +379,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
                 assertThat(dto.getFailureReason(), nullValue());
                 assertThat(dto.getConfig(), equalTo(CONFIG_STRINGS.get(1)));
                 assertThat(dto.getOperatingSystem(), equalTo(expectedOperatingSystems.get(1)));
-                assertThat(dto.getBackupStatus(), equalTo(DefaultDeviceConfigRestService.BACKUP_STATUS_SUCCESS));
+                assertThat(dto.getBackupStatus(), equalTo(DeviceConfigStatus.SUCCESS.name().toLowerCase(Locale.ROOT)));
                 assertThat(dto.getScheduledInterval().get(SERVICE_NAMES.get(1)),
                     equalTo(EXPECTED_CRON_SCHEDULE_DESCRIPTIONS.get(1)));
                 assertThat(dto.getNextScheduledBackupDate().after(currentDate), is(true));
@@ -458,7 +460,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
             IntStream.range(0, RECORD_COUNT).forEach(i -> {
                 DeviceConfigDTO dto = responseList.get(i);
                 assertThat(dto.getLastUpdatedDate().getTime(), equalTo(dates.get(i).getTime()));
-                assertThat(dto.getBackupStatus(), equalTo(DefaultDeviceConfigRestService.BACKUP_STATUS_FAILED));
+                assertThat(dto.getBackupStatus(), equalTo(DeviceConfigStatus.FAILED.name().toLowerCase(Locale.ROOT)));
                 assertThat(dto.getFailureReason(), equalTo(failureReasons.get(i)));
             });
         });
@@ -735,6 +737,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
         dc.setIpInterface(ipInterface1);
         dc.setServiceName(serviceName);
         dc.setConfigType(configType);
+        dc.setStatus(DeviceConfig.determineBackupStatus(dc));
 
         return dc;
     }


### PR DESCRIPTION
NMS-14167: DCB device_config table add 'status', drop 'last_updated', non-nullable constraint

Part of NMS-14167, database updates and minimal fixes only.

'status' is an enum, having possible values 'NONE', 'SUCCESS', 'FAILED'. 'NONE' denotes that backup has not yet been attempted. In this case, 'last_updated' would be null.

DeviceConfig class contains a helper method, 'determineBackupStatus' which can be used to determine backup status from DeviceConfig dates.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14167

