### PR TITLE
NMS-14032: do not fail on directories that do not need write

### DIFF
--- a/opennms-install/src/test/java/org/opennms/install/InstallerTest.java
+++ b/opennms-install/src/test/java/org/opennms/install/InstallerTest.java
@@ -34,11 +34,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.Set;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.opennms.bootstrap.FilesystemPermissionValidator;
 import org.opennms.test.DaoTestConfigBean;
 import org.springframework.util.FileSystemUtils;
 
@@ -51,20 +54,33 @@ public class InstallerTest {
     @Before
     public void setUp() throws Exception {
         opennmsHome = Paths.get("target/test-classes/opennmsconf");
+        etcDir = opennmsHome.resolve("etc");
         FileSystemUtils.deleteRecursively(opennmsHome.toFile());
 
-        etcDir = opennmsHome.resolve("etc");
-        Files.createDirectories(etcDir);
+        for (var dir : Arrays.asList("etc", "data", "deploy", "instances", "lib", "logs", "share", "system")) {
+            Files.createDirectories(opennmsHome.resolve(dir));
+        }
+
+        Files.writeString(etcDir.resolve("opennms.properties"), "");
+        Files.writeString(etcDir.resolve("rrd-configuration.properties"), "");
 
         System.setProperty("skip-native", "true");
         System.setProperty("install.dir", opennmsHome.toString());
-        System.setProperty("install.etc.dir", etcDir.toString());
+        System.setProperty("install.etc.dir", opennmsHome.resolve("etc").toString());
 
         final DaoTestConfigBean bean = new DaoTestConfigBean();
         bean.setRelativeHomeDirectory(opennmsHome.toString());
         bean.afterPropertiesSet();
 
         installer = new Installer();
+
+        // FilesystemPermissionValidator.VERBOSE = true;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        FileSystemUtils.deleteRecursively(opennmsHome.toFile());
+        FilesystemPermissionValidator.VERBOSE = false;
     }
 
     @Test
@@ -136,6 +152,14 @@ public class InstallerTest {
         final var lol = lolDir.resolve("42042042042042042042042042042042031337");
         Files.writeString(lol, "");
         Files.setPosixFilePermissions(lol, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_READ, PosixFilePermission.OTHERS_READ));
+
+        installer.verifyFilesAndDirectories();
+    }
+
+    @Test
+    public void testRunasLostAndFoundDirectory() throws Exception {
+        final var lostFoundDir = Files.createDirectories(opennmsHome.resolve("share").resolve("lost+found"));
+        Files.setPosixFilePermissions(lostFoundDir, Set.of());
 
         installer.verifyFilesAndDirectories();
     }


### PR DESCRIPTION
This PR makes a couple of changes to how the installer does validation for writeability.

* change to using `Files.walk` and an iterator, so that it can continue even if there is an exception reading from a directory or file, as long as that directory or file is ignored
* only check `etc`, `data`, `instances`, `logs`, and `share`, since any other directories shouldn't need to be written to

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14032
