### PR TITLE
NMS-14184: Grafana dashboard box links are no longer valid in Grafana 8.4

### DIFF
--- a/opennms-webapp/src/main/webapp/includes/grafana-box.jsp
+++ b/opennms-webapp/src/main/webapp/includes/grafana-box.jsp
@@ -70,7 +70,7 @@
     String errorMessage = null;
     String responseString = null;
 
-    if (!grafanaBasePath.startsWith("/")) {
+    if (!grafanaBasePath.startsWith("/")  && !grafanaBasePath.trim().isEmpty()) {
         grafanaBasePath = "/" + grafanaBasePath;
     }
 
@@ -141,7 +141,7 @@
                 }
                 if (showDashboard) {
                     if (limit < 1 || count++ < limit) {
-                        $('#dashboardlist').append('<a href="<%=grafanaProtocol%>://<%=grafanaHostname%>:<%=grafanaPort%><%=grafanaBasePath%>/dashboard/' + val['uri'] + '"><span class="fa fa-signal" aria-hidden="true"></span>&nbsp;' + val['title'] + "</a><br/>");
+                        $('#dashboardlist').append('<a href="<%=grafanaProtocol%>://<%=grafanaHostname%>:<%=grafanaPort%><%=grafanaBasePath%>' + val['url'] + '"><span class="fa fa-signal" aria-hidden="true"></span>&nbsp;' + val['title'] + "</a><br/>");
                     }
                 }
             };


### PR DESCRIPTION
Seems the uri was obsolete since grafana version 5 as mentioned in the response sample
https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/


* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14184

