### PR TITLE
NMS-14200:  Wait for roles to load before checking route access

### DIFF
--- a/ui/src/composables/useRole.ts
+++ b/ui/src/composables/useRole.ts
@@ -10,6 +10,7 @@ const enum Roles {
 type Role = typeof Roles[keyof typeof Roles];
 
 const roles = computed(() => store.state.authModule.whoAmi.roles)
+const rolesAreLoaded = computed(() => store.state.authModule.loaded)
 
 const hasOneOf = (...rolesToCheck: Role[]) =>{
   for (const role of rolesToCheck) {
@@ -24,7 +25,7 @@ const useRole = () => {
   const adminRole = computed<boolean>(() => hasOneOf(Roles.ROLE_ADMIN))
   const dcbRole = computed<boolean>(() => hasOneOf(Roles.ROLE_ADMIN, Roles.ROLE_REST, Roles.ROLE_DEVICE_CONFIG_BACKUP))
 
-  return { adminRole, dcbRole }
+  return { adminRole, dcbRole, rolesAreLoaded }
 }
 
 export default useRole

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -7,7 +7,7 @@ import Graphs from '@/components/Resources/Graphs.vue'
 import useRole from '@/composables/useRole'
 import useSnackbar from '@/composables/useSnackbar'
 
-const { adminRole, dcbRole } = useRole()
+const { adminRole, dcbRole, rolesAreLoaded } = useRole()
 const { showSnackBar } = useSnackbar()
 
 const router = createRouter({
@@ -34,10 +34,15 @@ const router = createRouter({
       name: 'FileEditor',
       component: FileEditor,
       beforeEnter: (to, from) => {
-        if (!adminRole.value) {
-          showSnackBar({ msg: 'No route access.'})
-          return from.path
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'No role access to file editor.' })
+            router.push(from.path)
+          }
         }
+
+        if (rolesAreLoaded.value) checkRoles()
+        else whenever(rolesAreLoaded, () => checkRoles())
       },
     },
     {
@@ -45,10 +50,15 @@ const router = createRouter({
       name: 'Logs',
       component: () => import('@/containers/Logs.vue'),
       beforeEnter: (to, from) => {
-        if (!adminRole.value) {
-          showSnackBar({ msg: 'No route access.'})
-          return from.path
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'No role access to logs.' })
+            router.push(from.path)
+          }
         }
+
+        if (rolesAreLoaded.value) checkRoles()
+        else whenever(rolesAreLoaded, () => checkRoles())
       },
     },
     {
@@ -100,10 +110,15 @@ const router = createRouter({
       name: 'DeviceConfigBackup',
       component: DeviceConfigBackup,
       beforeEnter: (to, from) => {
-        if (!dcbRole.value) {
-          showSnackBar({ msg: 'No route access.'})
-          return from.path
+        const checkRoles = () => {
+          if (!dcbRole.value) {
+            showSnackBar({ msg: 'No role access to DCB.' })
+            router.push(from.path)
+          }
         }
+
+        if (rolesAreLoaded.value) checkRoles()
+        else whenever(rolesAreLoaded, () => checkRoles())
       },
     },
     {

--- a/ui/src/store/auth/mutations.ts
+++ b/ui/src/store/auth/mutations.ts
@@ -3,6 +3,7 @@ import { State } from './state'
 
 const SAVE_WHO_AM_I_TO_STATE = (state: State, whoAmi: WhoAmIResponse) => {
   state.whoAmi = whoAmi
+  state.loaded = true
 }
 
 export default {

--- a/ui/src/store/auth/state.ts
+++ b/ui/src/store/auth/state.ts
@@ -2,12 +2,14 @@ import { WhoAmIResponse } from '@/types'
 
 export interface State {
   whoAmi: WhoAmIResponse
+  loaded: boolean
 }
 
 const state: State = {
   whoAmi: {
     roles: [] as string[]
-  } as WhoAmIResponse
+  } as WhoAmIResponse,
+  loaded: false
 }
 
 export default state


### PR DESCRIPTION
Routes were loading before API response with roles was returned.
On a first load, this will wait until the roles are available until loading a protected route.

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14200
