### PR TITLE
NMS-14218: Masked credentials should be ignored in update

### DIFF
--- a/features/scv/rest/src/test/java/org/opennms/features/scv/rest/ScvRestServiceIT.java
+++ b/features/scv/rest/src/test/java/org/opennms/features/scv/rest/ScvRestServiceIT.java
@@ -29,7 +29,6 @@
 package org.opennms.features.scv.rest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -62,6 +61,7 @@ public class ScvRestServiceIT {
         File keystoreFile = new File(tempFolder.getRoot(), "scv.jce");
         SecureCredentialsVault scv = new JCEKSSecureCredentialsVault(keystoreFile.getAbsolutePath(), "OpenNMS@22");
         scvRestService = new DefaultScvRestService(scv);
+        // Create alias
         String alias = "juniper-vsrx";
         var credentialDTO = new CredentialsDTO(alias, "horizon", "OpenNMS");
         Map<String, String> attributes = new HashMap<>();
@@ -71,10 +71,13 @@ public class ScvRestServiceIT {
         attributes.put("pass1", "2021");
         attributes.put("pass2", "2022");
         attributes.put("pass3", "2023");
+
+        // Test POST
         credentialDTO.setAttributes(attributes);
         Response posted = scvRestService.addCredentials(credentialDTO);
-        Assert.assertEquals(posted.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+        Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), posted.getStatus());
 
+        // Test Get for credentials
         var response = scvRestService.getCredentials(alias);
         Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
         var entity = response.getEntity();
@@ -84,32 +87,61 @@ public class ScvRestServiceIT {
         var result = ((CredentialsDTO) entity);
         Assert.assertEquals(credentialDTO.getUsername(), result.getUsername());
         Assert.assertEquals(credentialDTO.getAlias(), result.getAlias());
+        Assert.assertEquals(result.getAttributes().size(), attributes.size());
 
+        // Test Get for alias
         var aliasesResult = scvRestService.getAliases();
         Assert.assertEquals(aliasesResult.getStatus(), Response.Status.OK.getStatusCode());
-
         Set<String> aliases = ((Set<String>) aliasesResult.getEntity());
         Assert.assertThat(aliases, Matchers.contains(alias));
 
-        credentialDTO.setUsername("meridian");
-        credentialDTO.setPassword("OpenNMS@2022");
-        var putResponse = scvRestService.editCredentials(alias, credentialDTO);
-        Assert.assertEquals(putResponse.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+        // Test edit ( PUT)
+        CredentialsDTO updatedCredentials = new CredentialsDTO();
+        updatedCredentials.setAlias(alias);
+        updatedCredentials.setUsername("meridian");
+        updatedCredentials.setPassword("OpenNMS@22");
+        updatedCredentials.getAttributes().put("user3", "minion@3");
+        updatedCredentials.getAttributes().put("pass4", "2024");
+        var putResponse = scvRestService.editCredentials(alias, updatedCredentials);
+        Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), putResponse.getStatus());
 
+        // Test Get ( to test updated credentials)
         var updatedResponse = scvRestService.getCredentials(alias);
-        var updatedCreds = ((CredentialsDTO) updatedResponse.getEntity());
-        Assert.assertEquals(credentialDTO.getUsername(), updatedCreds.getUsername());
-        Assert.assertEquals(credentialDTO.getAlias(), updatedCreds.getAlias());
+        var updatedCredsResponse = ((CredentialsDTO) updatedResponse.getEntity());
+        Assert.assertEquals(updatedCredentials.getUsername(), updatedCredsResponse.getUsername());
+        Assert.assertEquals(updatedCredentials.getAlias(), updatedCredsResponse.getAlias());
+        Assert.assertEquals(updatedCredentials.getAttributes().size(), updatedCredsResponse.getAttributes().size());
 
+
+        // Test edit ( PUT) with masked password.
+        CredentialsDTO updatedCredentialsWithMaskPassword = new CredentialsDTO();
+        updatedCredentialsWithMaskPassword.setAlias(alias);
+        updatedCredentialsWithMaskPassword.setUsername("meridian1");
+        updatedCredentialsWithMaskPassword.setPassword(updatedCredsResponse.getPassword());
+        updatedCredentialsWithMaskPassword.getAttributes().put("user4", "minion4");
+        putResponse = scvRestService.editCredentials(alias, updatedCredentialsWithMaskPassword);
+        Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), putResponse.getStatus());
+
+        // Test Get ( to test updated credentials)
+        updatedResponse = scvRestService.getCredentials(alias);
+        updatedCredsResponse = ((CredentialsDTO) updatedResponse.getEntity());
+
+        // When using masked password, username/password doesn't get updated.
+        Assert.assertEquals(updatedCredentials.getUsername(), updatedCredsResponse.getUsername());
+        // But attributes may be updated.
+        Assert.assertEquals(updatedCredentialsWithMaskPassword.getAttributes().size(), updatedCredsResponse.getAttributes().size());
+
+        // Add another alias and test.
         String alias1 = "another-device";
         credentialDTO = new CredentialsDTO(alias1, "horizon", "OpenNMS");
         scvRestService.addCredentials(credentialDTO);
-        Assert.assertEquals(posted.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+        Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), posted.getStatus());
 
         aliasesResult = scvRestService.getAliases();
-        Assert.assertEquals(aliasesResult.getStatus(), Response.Status.OK.getStatusCode());
+        Assert.assertEquals(Response.Status.OK.getStatusCode(), aliasesResult.getStatus());
 
         aliases = ((Set<String>) aliasesResult.getEntity());
         Assert.assertThat(aliases, Matchers.contains(alias1, alias));
     }
+
 }


### PR DESCRIPTION
PUT: should ignore updating username/password whenever password is masked.
         will overwrite attributes and username/password in PUT ( should have existing credentials).
         username/password can be null in update, attributes not in the request will be deleted.

POST: will handle new credentials whenever alias doesn't exist.

masked password check ( any thing with more than two **)

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14218

