### PR TITLE
NMS-14208: upgrade Groovy to latest 2.x

### DIFF
--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -187,6 +187,7 @@
     <!-- Newts -->
     <feature name="sentinel-newts" description="OpenNMS :: Sentinel :: Newts" version="${project.version}">
         <feature>sentinel-core</feature>
+        <feature>groovy</feature>
         <feature>guava</feature>
         <feature>opennms-measurements-api</feature>
         <feature>opennms-collection-api</feature>
@@ -201,9 +202,6 @@
         <bundle dependency="true">mvn:org.apache.commons/commons-pool2/2.4.2</bundle>
         <bundle dependency="true">mvn:redis.clients/jedis/2.8.1</bundle>
         <bundle dependency="true">mvn:args4j/args4j/${args4jVersion}</bundle>
-
-        <!-- Add Groovy Script Engine -->
-        <bundle dependency="true">mvn:org.codehaus.groovy/groovy-all/${groovyVersion}</bundle>
 
         <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.persistence.osgi/${project.version}</bundle>
         <bundle>mvn:org.opennms.features/org.opennms.features.newts/${project.version}</bundle>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -144,6 +144,35 @@
         <bundle>mvn:org.eclipse.gemini.blueprint/gemini-blueprint-extender/${eclipseGeminiVersion}</bundle>
         <bundle>mvn:org.eclipse.gemini.blueprint/gemini-blueprint-io/${eclipseGeminiVersion}</bundle>
     </feature>
+    <feature name="groovy" version="${groovyVersion}" description="Groovy">
+        <bundle>mvn:org.codehaus.groovy/groovy/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-ant/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-bsf/${groovyVersion}</bundle>
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-cli-commons/${groovyVersion}</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-cli-picocli/${groovyVersion}</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-console/${groovyVersion}</bundle> -->
+        <bundle>mvn:org.codehaus.groovy/groovy-datetime/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-dateutil/${groovyVersion}</bundle>
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-docgenerator/${groovyVersion}</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-groovydoc/${groovyVersion}</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-groovysh/${groovyVersion}</bundle> -->
+        <bundle>mvn:org.codehaus.groovy/groovy-jaxb/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-jmx/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-json/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-jsr223/${groovyVersion}</bundle>
+        <!-- needed by jsr223 support -->
+        <bundle>mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/1.2</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-macro/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-nio/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-servlet/${groovyVersion}</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-sql/${groovyVersion}</bundle>
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-swing/${groovyVersion}</bundle> -->
+        <bundle>mvn:org.codehaus.groovy/groovy-templates/${groovyVersion}</bundle>
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-test/${groovyVersion}</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-test-junit5/${groovyVersion}</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-testng/${groovyVersion}</bundle> -->
+        <bundle>mvn:org.codehaus.groovy/groovy-xml/${groovyVersion}</bundle>
+    </feature>
     <feature name="guava" version="${guavaVersion}" description="Google :: Guava">
         <bundle dependency="true">mvn:com.google.guava/guava/${guavaVersion}</bundle>
     </feature>
@@ -999,7 +1028,7 @@
     </feature>
     <feature name="opennms-telemetry-nxos" version="${project.version}" description="OpenNMS :: Telemetry :: NX-OS">
         <feature>opennms-telemetry-collection</feature>
-	<bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.nxos/org.opennms.features.telemetry.protocols.nxos.adapter/${project.version}</bundle>
     </feature>
     <feature name="opennms-karaf-health" description="OpenNMS :: Karaf Health">
@@ -1317,9 +1346,9 @@
     </feature>
     <feature name="opennms-topology-runtime-graphml" version="${project.version}" description="OpenNMS :: Features :: Topology :: Features :: GraphML">
         <details>GraphML runtime and plugins for the OpenNMS topology web app.</details>
+        <feature>groovy</feature>
         <feature>opennms-topology-runtime-base</feature>
         <bundle>mvn:org.opennms.features.topology.plugins.topo/graphml/${project.version}</bundle>
-        <bundle>mvn:org.codehaus.groovy/groovy-all/${groovyVersion}</bundle>
         <bundle>mvn:org.opennms.features/org.opennms.features.osgi-jsr223/${project.version}</bundle>
     </feature>
     <feature name="opennms-topology-runtime-asset" version="${project.version}" description="OpenNMS :: Features :: Topology :: Features :: Runtime :: Asset">
@@ -1512,7 +1541,7 @@
         <bundle>mvn:io.github.resilience4j/resilience4j-core/${resilience4jVersion}</bundle>
         <bundle>mvn:io.github.resilience4j/resilience4j-circuitbreaker/${resilience4jVersion}</bundle>
         <bundle>mvn:io.github.resilience4j/resilience4j-bulkhead/${resilience4jVersion}</bundle>
-        <bundle>mvn:io.github.resilience4j/resilience4j-retry/${resilience4jVersion}</bundle>        
+        <bundle>mvn:io.github.resilience4j/resilience4j-retry/${resilience4jVersion}</bundle>
     </feature>
 
     <feature name="netty4" version="${netty4Version}" description="Netty">

--- a/core/schema/pom.xml
+++ b/core/schema/pom.xml
@@ -98,8 +98,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/test-api/db/pom.xml
+++ b/core/test-api/db/pom.xml
@@ -95,8 +95,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dependencies/groovy/pom.xml
+++ b/dependencies/groovy/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.opennms</groupId>
+    <artifactId>dependencies</artifactId>
+    <version>25.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.opennms.dependencies</groupId>
+  <artifactId>groovy-dependencies</artifactId>
+  <packaging>pom</packaging>
+  <name>OpenNMS :: Dependencies :: Groovy</name>
+  <description>
+    This module is used to provide a single artifact that the opennms project
+    can depend on to use Groovy.
+  </description>
+  <dependencies>
+    <!-- add a subset of `groovy-all` -->
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-ant</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-datetime</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-jmx</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-json</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-jsr223</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-macro</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-nio</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-servlet</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-sql</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-swing</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-templates</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-xml</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+
+    <!--
+    skipped dependencies from `groovy-all`:
+
+    * org.codehaus.groovy/groovy-cli-commons
+    * org.codehaus.groovy/groovy-cli-picocli
+    * org.codehaus.groovy/groovy-console
+    * org.codehaus.groovy/groovy-docgenerator
+    * org.codehaus.groovy/groovy-groovydoc
+    * org.codehaus.groovy/groovy-groovysh
+    * org.codehaus.groovy/groovy-test
+    * org.codehaus.groovy/groovy-test-junit5
+    * org.codehaus.groovy/groovy-testng
+
+    -->
+
+    <!-- additional dependencies that are new in 2.5 or no longer in `groovy-all` -->
+
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-bsf</artifactId>
+      <version>${groovyVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-dateutil</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-jaxb</artifactId>
+      <version>${groovyVersion}</version>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -21,6 +21,7 @@
     <module>dnsjava</module>
     <module>drools</module>
     <module>felix</module>
+    <module>groovy</module>
     <module>hibernate</module>
     <module>jasper</module>
     <module>jasypt</module>

--- a/features/remote-poller/pom.xml
+++ b/features/remote-poller/pom.xml
@@ -73,6 +73,19 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
@@ -80,7 +93,6 @@
             <id>add-groovy-source</id>
             <phase>generate-sources</phase>
             <goals>
-            
               <goal>add-source</goal>
             </goals>
             <configuration>
@@ -113,13 +125,20 @@ groovy.compiler.output.path=target/classes
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.13.1</version>
         <executions>
           <execution>
             <goals>
+              <goal>addSources</goal>
+              <goal>addTestSources</goal>
+              <goal>generateStubs</goal>
               <goal>compile</goal>
-              <goal>testCompile</goal>
+              <goal>generateTestStubs</goal>
+              <goal>compileTests</goal>
+              <goal>removeStubs</goal>
+              <goal>removeTestStubs</goal>
             </goals>
           </execution>
         </executions>
@@ -212,8 +231,9 @@ groovy.compiler.output.path=target/classes
       <artifactId>opennms-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
     <dependency>
       <groupId>org.opennms.core</groupId>

--- a/features/remote-poller/src/main/groovy/org/opennms/groovy/poller/remote/ScanGui.groovy
+++ b/features/remote-poller/src/main/groovy/org/opennms/groovy/poller/remote/ScanGui.groovy
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/features/remote-poller/src/main/groovy/org/opennms/groovy/poller/remote/ScanGui.groovy
+++ b/features/remote-poller/src/main/groovy/org/opennms/groovy/poller/remote/ScanGui.groovy
@@ -57,7 +57,7 @@ import org.springframework.util.Assert
 class ScanGui extends AbstractGui implements ScanReportHandler, PropertyChangeListener, InitializingBean {
     def m_metadataFieldTypes = new TreeSet<MetadataField>()
     def m_locations = new ArrayList<String>()
-    def m_applications = new HashMap<Set<String>>()
+    def m_applications = new HashMap<String, Set<String>>()
     def m_theme
     def m_geoMetadata
     def m_scanReport

--- a/features/telemetry/protocols/collection/pom.xml
+++ b/features/telemetry/protocols/collection/pom.xml
@@ -37,8 +37,9 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.collection</groupId>

--- a/features/telemetry/protocols/flows/pom.xml
+++ b/features/telemetry/protocols/flows/pom.xml
@@ -47,8 +47,9 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.collection</groupId>

--- a/features/topology-map/features/runtime-graphml/pom.xml
+++ b/features/topology-map/features/runtime-graphml/pom.xml
@@ -17,16 +17,10 @@
       <artifactId>graphml</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- At the moment this is provided by the system bundle -->
-    <!--<dependency>-->
-      <!--<groupId>org.opennms.features</groupId>-->
-      <!--<artifactId>org.opennms.features.graphml</artifactId>-->
-      <!--<version>${project.version}</version>-->
-    <!--</dependency>-->
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <version>${groovyVersion}</version>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
     <dependency>
       <groupId>org.opennms.features</groupId>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/pom.xml
@@ -158,8 +158,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/opennms-provision/opennms-detector-bsf/pom.xml
+++ b/opennms-provision/opennms-detector-bsf/pom.xml
@@ -53,8 +53,9 @@
       <artifactId>org.opennms.core.test-api.lib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/opennms-provision/opennms-provision-persistence/pom.xml
+++ b/opennms-provision/opennms-provision-persistence/pom.xml
@@ -140,8 +140,9 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
     <!-- test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -789,27 +789,6 @@
           </archive>
         </configuration>
       </plugin>
-      <!-- Make sure that this version of gmaven roughly matches the version of groovy that we depend on -->
-      <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <version>1.4</version>
-        <configuration>
-          <providerSelection>1.8</providerSelection>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.gmaven.runtime</groupId>
-            <artifactId>gmaven-runtime-1.8</artifactId>
-            <version>1.4</version>
-          </dependency>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>${groovyVersion}</version>
-          </dependency>
-        </dependencies>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>native-maven-plugin</artifactId>
@@ -1331,7 +1310,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <goals>
@@ -1741,7 +1720,7 @@
     <freemarkerVersion>2.3.23</freemarkerVersion>
     <fstVersion>2.47</fstVersion>
     <geronimoVersion>1.1.1</geronimoVersion>
-    <groovyVersion>2.4.5</groovyVersion>
+    <groovyVersion>2.5.16</groovyVersion>
     <gsonVersion>2.8.5</gsonVersion>
     <guavaVersion>18.0</guavaVersion>
     <guavaOldVersion>17.0</guavaOldVersion>
@@ -1822,7 +1801,7 @@
     <snmp4jVersion>2.5.5</snmp4jVersion>
     <snmp4jagentVersion>2.5.3</snmp4jagentVersion>
     <sonarVersion>3.7.0.1746</sonarVersion>
-    <spockVersion>1.1-groovy-2.4</spockVersion>
+    <spockVersion>1.3-groovy-2.5</spockVersion>
     <trackerVersion>0.7</trackerVersion>
     <twitter4jVersion>3.0.6</twitter4jVersion>
     <xalanVersion>2.7.2</xalanVersion>
@@ -4690,9 +4669,10 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-all</artifactId>
-        <version>${groovyVersion}</version>
+        <groupId>org.opennms.dependencies</groupId>
+        <artifactId>groovy-dependencies</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>com.zaxxer</groupId>

--- a/protocols/selenium-monitor/pom.xml
+++ b/protocols/selenium-monitor/pom.xml
@@ -172,30 +172,9 @@
     </dependency>
 
     <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-all</artifactId>
-        <exclusions>
-          <exclusion>
-            <groupId>asm</groupId>
-            <artifactId>asm</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>asm</groupId>
-            <artifactId>asm-analysis</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>asm</groupId>
-            <artifactId>asm-commons</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>asm</groupId>
-            <artifactId>asm-tree</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>asm</groupId>
-            <artifactId>asm-util</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>org.opennms.dependencies</groupId>
+        <artifactId>groovy-dependencies</artifactId>
+        <type>pom</type>
     </dependency>
     <dependency>
         <groupId>org.ow2.asm</groupId>

--- a/protocols/selenium-monitor/src/assembly/lib.xml
+++ b/protocols/selenium-monitor/src/assembly/lib.xml
@@ -16,7 +16,7 @@
       <includes>
         <include>com.google.guava:guava</include>
         <include>org.seleniumhq.selenium:selenium*</include>
-        <include>org.codehaus.groovy:groovy-all</include>
+        <include>org.codehaus.groovy:*</include>
         <include>com.codeborne:phantomjsdriver</include>
         <include>com.google.code.gson:gson</include>
         <include>junit:junit</include>

--- a/protocols/selenium-monitor/src/main/java/org/opennms/netmgt/poller/monitors/SeleniumMonitor.java
+++ b/protocols/selenium-monitor/src/main/java/org/opennms/netmgt/poller/monitors/SeleniumMonitor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -51,6 +51,8 @@ import org.slf4j.LoggerFactory;
 
 public class SeleniumMonitor extends AbstractServiceMonitor {
     private static final Logger LOG = LoggerFactory.getLogger(SeleniumMonitor.class);
+
+    private final GroovyClassLoader m_gcl = new GroovyClassLoader();
 
     public static class BaseUrlUtils{
         private static Pattern s_ipAddrPattern = Pattern.compile("\\$\\{ipAddr\\}");
@@ -181,11 +183,9 @@ public class SeleniumMonitor extends AbstractServiceMonitor {
 
     private Class<?> createGroovyClass(String filename) throws CompilationFailedException, IOException 
     {
-        GroovyClassLoader gcl = new GroovyClassLoader();
-        
         String file = System.getProperty("opennms.home") + "/etc/selenium/" + filename;
         System.err.println("File name: " + file);
-        return gcl.parseClass( new File( file ) );
+        return m_gcl.parseClass( new File( file ) );
     }
 
 }

--- a/protocols/selenium-monitor/src/main/java/org/opennms/netmgt/poller/monitors/SeleniumMonitor.java
+++ b/protocols/selenium-monitor/src/main/java/org/opennms/netmgt/poller/monitors/SeleniumMonitor.java
@@ -101,17 +101,17 @@ public class SeleniumMonitor extends AbstractServiceMonitor {
             } catch (CompilationFailedException e) {
                 serviceStatus = PollStatus.unavailable("Selenium page sequence attempt on:" + svc.getIpAddr() + " failed : selenium-test compilation error " + e.getMessage());
                 String reason = "Selenium sequence failed: CompilationFailedException" + e.getMessage();
-                SeleniumMonitor.LOG.debug(reason);
+                SeleniumMonitor.LOG.debug(reason, e);
                 PollStatus.unavailable(reason);
             } catch (IOException e) {
                 serviceStatus = PollStatus.unavailable("Selenium page sequence attempt on " + svc.getIpAddr() + " failed: IOException occurred, failed to find selenium-test: " + seleniumTestFilename);
                 String reason = "Selenium sequence failed: IOException: " + e.getMessage();
-                SeleniumMonitor.LOG.debug(reason);
+                SeleniumMonitor.LOG.debug(reason, e);
                 PollStatus.unavailable(reason);
             } catch (Exception e) {
                 serviceStatus = PollStatus.unavailable("Selenium page sequence attempt on " + svc.getIpAddr() + " failed:\n" + e.getMessage());
                 String reason = "Selenium sequence failed: Exception: " + e.getMessage();
-                SeleniumMonitor.LOG.debug(reason);
+                SeleniumMonitor.LOG.debug(reason, e);
                 PollStatus.unavailable(reason);
             }
 		}

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -457,10 +457,24 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- 4.2.0 is the last version that used groovy 2.x,
+         force it to match ours since it's a transient dependency -->
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.3</version>
+      <version>4.2.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>groovy-dependencies</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
This PR upgrades our embedded Groovy to the latest 2.x -- 2.5.16 -- which was recently updated in March.

2.5, in general, should be almost entirely source-compatible with the version we'd been using/embedding in OpenNMS.
The biggest changes have been structural (how the Maven project is published, some things being pulled out into "optional" dependencies, etc.)

This patch _should_ provide a version that's functionally equivalent to what we already were using.
At least, smoke tests pass... ¯\\\_(ツ)\_/¯

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14208
