### PR TITLE
NMS-14148: Still listen for traps without a subscribtion

### DIFF
--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
@@ -102,13 +102,30 @@ public class TrapListener implements TrapNotificationListener {
     }
 
     public void start() {
-        m_twinSubscription = m_twinSubscriber.subscribe(TrapListenerConfig.TWIN_KEY, TrapListenerConfig.class, (config) ->  {
+        if (m_twinSubscriber != null) {
+            subscribe();
+        } else {
+            open(new TrapListenerConfig());
+        }
+    }
+
+    public void subscribe() {
+        m_twinSubscription = m_twinSubscriber.subscribe(TrapListenerConfig.TWIN_KEY, TrapListenerConfig.class, (config) -> {
             try (Logging.MDCCloseable mdc = Logging.withPrefixCloseable(Trapd.LOG4J_CATEGORY)) {
                 LOG.info("Got listener config update - reloading");
                 this.close();
                 this.open(config);
             }
         });
+    }
+
+    public void bind(TwinSubscriber twinSubscriber) {
+        m_twinSubscriber = twinSubscriber;
+        subscribe();
+    }
+
+    public void unbind(TwinSubscriber twinSubscriber) {
+        m_twinSubscriber = null;
     }
 
     private void open(final TrapListenerConfig config) {
@@ -186,14 +203,6 @@ public class TrapListener implements TrapNotificationListener {
 
     public void setDistPollerDao(DistPollerDao distPollerDao) {
         m_distPollerDao = Objects.requireNonNull(distPollerDao);
-    }
-
-    public TwinSubscriber getTwinSubscriber() {
-        return this.m_twinSubscriber;
-    }
-
-    public void setTwinSubscriber(final TwinSubscriber twinSubscriber) {
-        this.m_twinSubscriber = Objects.requireNonNull(twinSubscriber);
     }
 
     private void restartWithNewConfig(final TrapdConfigBean newConfig) {

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
@@ -63,7 +63,7 @@ public class TrapListener implements TrapNotificationListener {
     private boolean m_configured = false;
     private Object configuredLock = new Object();
 
-    public static long SUBSCRIBER_TIMEOUT_MS = 60 * 1000;
+    private long subscriberTimeoutMs = 60 * 1000;
 
     @Autowired
     private MessageDispatcherFactory m_messageDispatcherFactory;
@@ -119,7 +119,7 @@ public class TrapListener implements TrapNotificationListener {
                 public void run() {
                     delayedConfigurationCheck();
                 }
-            }, SUBSCRIBER_TIMEOUT_MS); // wait 60 seconds for connection from core
+            }, subscriberTimeoutMs); // wait 60 seconds for connection from core
         }
     }
 
@@ -292,5 +292,13 @@ public class TrapListener implements TrapNotificationListener {
             return false;
         }
         return !newConfig.getSnmpV3Users().equals(m_config.getSnmpV3Users());
+    }
+
+    void setSubscriberTimeoutMs(long ms) {
+        subscriberTimeoutMs = ms;
+    }
+
+    long getSubscriberTimeoutMs() {
+        return subscriberTimeoutMs;
     }
 }

--- a/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
+++ b/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
@@ -20,7 +20,6 @@
 
 	<reference id="messageDispatcherFactory" interface="org.opennms.core.ipc.sink.api.MessageDispatcherFactory"/>
 	<reference id="distPollerDao" interface="org.opennms.netmgt.dao.api.DistPollerDao"/>
-	<reference id="twinSubscriber" interface="org.opennms.core.ipc.twin.api.TwinSubscriber"/>
 
 	<!-- Config Bean -->
 	<bean id="trapdConfig" class="org.opennms.netmgt.trapd.TrapdConfigBean">
@@ -42,6 +41,9 @@
 		<argument ref="trapdConfig"/>
 		<property name="messageDispatcherFactory" ref="messageDispatcherFactory"/>
 		<property name="distPollerDao" ref="distPollerDao"/>
-		<property name="twinSubscriber" ref="twinSubscriber"/>
 	</bean>
+
+	<reference-list id="twinSubscriberRef" interface="org.opennms.core.ipc.twin.api.TwinSubscriber" availability="optional">
+		<reference-listener bind-method="bind" unbind-method="unbind" ref="trapListener"/>
+	</reference-list>
 </blueprint>

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapListenerTest.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapListenerTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -126,5 +126,17 @@ public class TrapListenerTest {
         user.setPrivacyProtocol(privatcyProtocol);
         user.setSecurityName(securityName);
         return user;
+    }
+
+    @Test
+    public void noSubscriberTest() throws Exception {
+        TrapListener listener = new TrapListener(initialConfig);
+        listener.start();
+        Assert.assertEquals(Boolean.FALSE, listener.isRegisteredForTraps());
+        try {
+            Thread.currentThread().sleep(61 * 1000);
+        }
+        catch (Exception e) {}
+        Assert.assertEquals(Boolean.TRUE, listener.isRegisteredForTraps());
     }
 }

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapListenerTest.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapListenerTest.java
@@ -133,10 +133,11 @@ public class TrapListenerTest {
     @Test
     public void noSubscriberTest() throws Exception {
         TrapListener listener = new TrapListener(initialConfig);
+        listener.setSubscriberTimeoutMs(2 * 1000);
         listener.start();
         Assert.assertEquals(Boolean.FALSE, listener.isRegisteredForTraps());
         
-        Awaitility.await().atMost(TrapListener.SUBSCRIBER_TIMEOUT_MS + 1000, TimeUnit.MILLISECONDS).with()
+        Awaitility.await().atMost(10 * 1000, TimeUnit.MILLISECONDS).with()
             .pollInterval(1, TimeUnit.SECONDS)
             .until(() -> listener.isRegisteredForTraps());
     }

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapListenerTest.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapListenerTest.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.trapd;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import com.jayway.awaitility.Awaitility;
+import java.util.concurrent.TimeUnit;
 import org.opennms.netmgt.config.trapd.Snmpv3User;
 import org.opennms.netmgt.config.trapd.TrapdConfiguration;
 
@@ -133,10 +135,9 @@ public class TrapListenerTest {
         TrapListener listener = new TrapListener(initialConfig);
         listener.start();
         Assert.assertEquals(Boolean.FALSE, listener.isRegisteredForTraps());
-        try {
-            Thread.currentThread().sleep(61 * 1000);
-        }
-        catch (Exception e) {}
-        Assert.assertEquals(Boolean.TRUE, listener.isRegisteredForTraps());
+        
+        Awaitility.await().atMost(TrapListener.SUBSCRIBER_TIMEOUT_MS + 1000, TimeUnit.MILLISECONDS).with()
+            .pollInterval(1, TimeUnit.SECONDS)
+            .until(() -> listener.isRegisteredForTraps());
     }
 }


### PR DESCRIPTION
If the broker is not available :  The `opennms-trapd-listener` feature would hang indefinitely while waiting for a `TwinSubscriber` to initialize, which couldn't complete until a connection to the core was made. This prevented the feature from ever attempting to listen for traps.

These updates make this dependency optional. The TrapListener will now wait 60 seconds for trapd configuration to come from the core instance. If that is not received, it uses default settings and listens anyways.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14148

