### PR TITLE
auto-assign bonnie as a reviewer if docs are changed

### DIFF
--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -1,0 +1,9 @@
+---
+"**/*.adoc":
+  - Bonrob2
+
+"opennms-doc/**/*":
+  - Bonrob2
+
+"docs/**/*":
+  - Bonrob2

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,12 @@
+name: "Auto Assign"
+on:
+  - pull_request
+
+jobs:
+  assign_reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shufo/auto-assign-reviewer-by-files@v1.1.3
+        with:
+          config: ".github/assign-by-files.yml"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

Cherry picking the commit from `release-30.x` to also be in `foundation-2022` for auto-approving documentation PRs. (per @Bonrob2's request)