### PR TITLE
NMS-14252: use the Atlassian updates to jackson1

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -522,6 +522,13 @@
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>jackson1-dependencies</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <!-- Required for com.eclipsesource.jaxrs/* -->

--- a/dependencies/activemq/pom.xml
+++ b/dependencies/activemq/pom.xml
@@ -223,6 +223,11 @@
     -->
     <dependency>
       <groupId>org.opennms.dependencies</groupId>
+      <artifactId>jackson1-dependencies</artifactId>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
       <artifactId>spring-dependencies</artifactId>
       <type>pom</type>
       <version>${project.version}</version>

--- a/dependencies/cxf/pom.xml
+++ b/dependencies/cxf/pom.xml
@@ -46,12 +46,9 @@
 
     <!-- Jackson JSON -->
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>jackson1-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
 
     <!-- Abdera Atom -->

--- a/dependencies/jackson1/pom.xml
+++ b/dependencies/jackson1/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>dependencies</artifactId>
+    <groupId>org.opennms</groupId>
+    <version>25.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.opennms.dependencies</groupId>
+  <artifactId>jackson1-dependencies</artifactId>
+  <packaging>pom</packaging>
+  <name>OpenNMS :: Dependencies :: Jackson 1</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-xc</artifactId>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>atlassian-public</id>
+      <name>Atlassian public repo</name>
+      <url>https://maven.opennms.org/content/repositories/atlassian-public/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+</project>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -23,6 +23,7 @@
     <module>felix</module>
     <module>groovy</module>
     <module>hibernate</module>
+    <module>jackson1</module>
     <module>jasper</module>
     <module>jasypt</module>
     <module>javamail</module>

--- a/dependencies/spring/pom.xml
+++ b/dependencies/spring/pom.xml
@@ -138,20 +138,9 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>jackson1-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
     <!-- Get the JMS spec (javax.jms.*) so that spring-jms can load in OSGi -->
     <dependency>

--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -68,12 +68,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>jackson1-dependencies</artifactId>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>

--- a/features/rest/common/pom.xml
+++ b/features/rest/common/pom.xml
@@ -27,8 +27,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>jackson1-dependencies</artifactId>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/features/rest/model/pom.xml
+++ b/features/rest/model/pom.xml
@@ -36,8 +36,9 @@
       <artifactId>org.opennms.core.api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>jackson1-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1733,7 +1733,7 @@
     <httpcoreVersion>4.4.4</httpcoreVersion>
     <httpclientVersion>4.5.13</httpclientVersion>
     <httpasyncclientVersion>4.1.3</httpasyncclientVersion>
-    <jacksonVersion>1.9.13</jacksonVersion>
+    <jacksonVersion>1.9.13-atlassian-6</jacksonVersion>
     <jackson2Version>2.9.10</jackson2Version>
     <jacocoVersion>0.8.5</jacocoVersion>
     <jasperreportsVersion>6.3.0</jasperreportsVersion>
@@ -2823,6 +2823,12 @@
       <dependency>
         <groupId>org.opennms.dependencies</groupId>
         <artifactId>gwt-maps-dependencies</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.opennms.dependencies</groupId>
+        <artifactId>jackson1-dependencies</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
This PR updates our version of the (old) Jackson dependencies to an Atlassian fork that includes security fixes.

As far as I can tell it's a simple drop-in replacement, all I did was add a "dependency" pom to make it easier to pull it from Atlassian's repo since their fork isn't in Maven Central.

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14252
