### PR TITLE
NMS-14250: Performance of time series integration layer: free samples as soon as possible for garbage collection

### DIFF
--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/samplewrite/TimeseriesWriter.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/samplewrite/TimeseriesWriter.java
@@ -196,6 +196,8 @@ public class TimeseriesWriter implements WorkHandler<SampleBatchEvent>, Disposab
             this.stats.record(event.getSamples());
         } catch (Throwable t) {
             RATE_LIMITED_LOGGER.error("An error occurred while inserting samples. Some sample may be lost.", t);
+        } finally {
+            event.setSamples(null); // free sample reference for garbage collection
         }
     }
 


### PR DESCRIPTION
This PR helps to free some memory but doesn't solve the problem completely.


* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14250
