### PR TITLE
NMS-14260: Use ip-regex for validation, fix VMware case

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -45,6 +45,7 @@
     "d3": "^7.4.4",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.3.4",
+    "ip-regex": "^5.0.0",
     "leaflet": "^1.8.0",
     "leaflet.markercluster": "^1.5.3",
     "lodash": "^4.17.21",

--- a/ui/src/components/Configuration/ConfigurationHelper.ts
+++ b/ui/src/components/Configuration/ConfigurationHelper.ts
@@ -23,6 +23,7 @@ import {
 } from './copy/requisitionTypes'
 import { scheduleTypes, weekTypes, dayTypes } from './copy/scheduleTypes'
 import cronstrue from 'cronstrue'
+import ipRegex from 'ip-regex'
 
 const cronTabLength = (cronTab: string) => cronTab.replace(/\s$/, '').split(' ').length
 
@@ -673,15 +674,9 @@ const validateCronTab = (item: LocalConfiguration, oldErrors: LocalErrors) => {
  */
 const validateHost = (host: string) => {
   let hostError = ''
-  /**
-   * Character separators: hyphen, point, space or % (%20: encoded space).
-   * Expression only valid if:
-   *  - only one separator betwwen word
-   *  - no separator at begin, end or between uri and port
-   *  - expression names (uri, port) can be used, with expression.match(), to target specific part of the host string
-   * */
-  const ipv4 = new RegExp(/^[^\s.\-%](?<uri>[\w]*[\s.\-%]?[\w]*[^\s.\-%20:])*(?<port>:\d{4})?$/, 'gmi')
-  const isHostValid = ipv4.test(host)
+
+  // Tests against a regex for matching both IPv4 and IPv6.
+  const isHostValid = ipRegex({exact: true}).test(host)
 
   if (!isHostValid) {
     hostError = ErrorStrings.InvalidHostname

--- a/ui/src/components/Configuration/copy/requisitionTypes.ts
+++ b/ui/src/components/Configuration/copy/requisitionTypes.ts
@@ -2,7 +2,7 @@ export const RequisitionFields = {
   Name: 'Name'
 }
 export const RequisitionTypes = {
-  VMWare: 'VMWare',
+  VMWare: 'VMware',
   RequisitionPlugin: 'Requisition Plugin',
   DNS: 'DNS',
   File: 'File',

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2201,6 +2201,11 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
+ip-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-5.0.0.tgz#cd313b2ae9c80c07bd3851e12bf4fa4dc5480632"
+  integrity sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"


### PR DESCRIPTION
- Add the predominant lib/regex for validating IP addresses, fix validation issue.
- Fix spelling: VMWare -> VMware


### External References
* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14260

