### PR TITLE
NMS-14271: Display error when VMware username or password missing

### DIFF
--- a/ui/src/components/Configuration/ConfigurationHelpPanel.vue
+++ b/ui/src/components/Configuration/ConfigurationHelpPanel.vue
@@ -150,7 +150,7 @@ const helpText = computed(() => {
   } else if (typeName === RequisitionTypes.VMWare) {
     helpVals = {
       title: RequisitionTypes.VMWare,
-      subTitle: 'The VMware adapter pulls hosts and/or virtual machines from a vCenter server into OpenNMS. With this adapter, you can automatically add, update, or remove nodes from your inventory based on the status of the VMware entity. Requires the host, username, and password parameters to construct the URL OpenNMS uses to locate this external source.',
+      subTitle: 'The VMware adapter pulls hosts and/or virtual machines from a vCenter server into OpenNMS. With this adapter, you can automatically add, update, or remove nodes from your inventory based on the status of the VMware entity. Uses the host, optional username, and optional password parameters to construct the URL OpenNMS uses to locate this external source. If username and password are left blank, the system will rely on credentials configured in vmware-config.xml.',
       help: 'See the online documentation for detailed information on supported options:',
       linkCopy: 'READ FULL ARTICLE',
       link: 'https://docs.opennms.com/horizon/latest/reference/provisioning/handlers/vmware.html'

--- a/ui/src/components/Configuration/ConfigurationHelper.ts
+++ b/ui/src/components/Configuration/ConfigurationHelper.ts
@@ -767,6 +767,14 @@ const validateLocalItem = (
     if (localItem.type.name === RequisitionTypes.File) {
       errors.path = validatePath(localItem.path)
     }
+    if (localItem.type.name === RequisitionTypes.VMWare) {
+      if (localItem.username && !localItem.password) {
+        errors.password = ErrorStrings.Password
+      }
+      if (localItem.password && !localItem.username) {
+        errors.username = ErrorStrings.Username
+      }
+    }
     if (!localItem.advancedCrontab) {
       errors = validateCronTab(localItem, errors)
     } else {

--- a/ui/src/components/Configuration/ProvisionDForm.vue
+++ b/ui/src/components/Configuration/ProvisionDForm.vue
@@ -91,7 +91,7 @@
           :error="errors.username"
           :modelValue="config.username"
           @update:modelValue="(val) => updateFormValue('username', val)"
-          hint="vSphere username"
+          hint="vSphere username (optional)"
         />
         <FeatherInput
           type="password"
@@ -100,7 +100,7 @@
           :error="errors.password"
           :modelValue="config.password"
           @update:modelValue="(val) => updateFormValue('password', val)"
-          hint="vSphere password"
+          hint="vSphere password (optional)"
         />
       </div>
     </div>

--- a/ui/src/components/Configuration/copy/requisitionTypes.ts
+++ b/ui/src/components/Configuration/copy/requisitionTypes.ts
@@ -63,7 +63,9 @@ export const ErrorStrings = {
   FilePathStart: 'Path must start with a /',
   MustHave: (nameType: string) => `Must have a ${nameType.toLocaleLowerCase()}`,
   NameShort: (nameType: string) => `${nameType} must have at least two chars`,
-  NameLong: (nameType: string, length = 255) => `${nameType} must be shorter than ${length}`
+  NameLong: (nameType: string, length = 255) => `${nameType} must be shorter than ${length}`,
+  Password: 'Must include a password',
+  Username: 'Must include a username'
 }
 
 export const requisitionTypeList = [

--- a/ui/tests/configuration.test.ts
+++ b/ui/tests/configuration.test.ts
@@ -176,4 +176,13 @@ test('Display appropriate form errors', async () => {
   errors = ConfigurationHelper.validateLocalItem(mockLocalConfig, [], 1, false)
   expect(errors.username).toBe(ErrorStrings.Username)
   expect(errors.password).toBe('')
+
+  // update form props
+  mockLocalConfig.username = ''
+  mockLocalConfig.password = ''
+
+  // expect no errors if fields left blank
+  errors = ConfigurationHelper.validateLocalItem(mockLocalConfig, [], 1, false)
+  expect(errors.username).toBe('')
+  expect(errors.password).toBe('')
 })

--- a/ui/tests/configuration.test.ts
+++ b/ui/tests/configuration.test.ts
@@ -1,10 +1,9 @@
 import { mount } from '@vue/test-utils'
 import store from '@/store'
 import { ConfigurationHelper } from '../src/components/Configuration/ConfigurationHelper'
-import { RequisitionTypes, RequisitionData } from '../src/components/Configuration/copy/requisitionTypes'
+import { RequisitionTypes, RequisitionData, ErrorStrings } from '../src/components/Configuration/copy/requisitionTypes'
 import { test, expect } from 'vitest'
 import { LocalConfiguration, ProvisionDServerConfiguration } from '@/components/Configuration/configuration.types'
-import { ErrorStrings } from '@/components/Configuration/copy/requisitionTypes'
 import ConfigurationTable from '@/components/Configuration/ConfigurationTable.vue'
 
 const mockRequisitionProvisionDServiceConfig = {
@@ -149,9 +148,32 @@ test('The edit btn disables if the record starts with "requisition://"', async (
   expect(editBtn.attributes('aria-disabled')).toBeUndefined()
 
   // update props with requisition type url
-  const newProps = {...mockProps, itemList: [mockRequisitionProvisionDServiceConfig]}
+  const newProps = { ...mockProps, itemList: [mockRequisitionProvisionDServiceConfig] }
   await wrapper.setProps(newProps)
 
   // expect edit btn to be disabled
   expect(editBtn.attributes('aria-disabled')).toBe('true')
+})
+
+test('Display appropriate form errors', async () => {
+  const mockLocalConfig = {
+    username: 'test',
+    password: '',
+    type: { name: 'VMware', id: 1 },
+    occurance: { name: ''}
+  } as LocalConfiguration
+
+  let errors = ConfigurationHelper.validateLocalItem(mockLocalConfig, [], 1, false)
+  // expect password input error
+  expect(errors.password).toBe(ErrorStrings.Password)
+  expect(errors.username).toBe('')
+
+  // update form props
+  mockLocalConfig.username = ''
+  mockLocalConfig.password = 'pass'
+
+  // expect username input error
+  errors = ConfigurationHelper.validateLocalItem(mockLocalConfig, [], 1, false)
+  expect(errors.username).toBe(ErrorStrings.Username)
+  expect(errors.password).toBe('')
 })


### PR DESCRIPTION
- Puts VMware form state invalid with error msgs, if username but no password or password but no username.
- Marks username and password fields as optional.
- Updates VMware help text to convey that those fields are optional and what happens if left blank.

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14271

