### PR TITLE
NMS-14725: Don't error out early when script file is missing

### DIFF
--- a/features/device-config/monitor/src/main/java/org/opennms/features/deviceconfig/monitors/DeviceConfigMonitor.java
+++ b/features/device-config/monitor/src/main/java/org/opennms/features/deviceconfig/monitors/DeviceConfigMonitor.java
@@ -42,7 +42,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.utils.ConfigFileConstants;
 import org.opennms.features.deviceconfig.persistence.api.ConfigType;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
@@ -74,6 +73,7 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
     public static final String HOST_KEY = "host-key";
     public static final String LAST_RETRIEVAL = "lastRetrieval";
     public static final String SCRIPT_FILE = "script-file";
+    private static final String SCRIPT_ERROR = "script-error";
 
     private static final Duration DEFAULT_DURATION = Duration.ofMinutes(1); // 60sec
     private static final int DEFAULT_SSH_PORT = 22;
@@ -86,17 +86,6 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
 
     @Override
     public Map<String, Object> getRuntimeAttributes(final MonitoredService svc, final Map<String, Object> parameters) {
-        if (ipInterfaceDao == null) {
-            ipInterfaceDao = BeanUtils.getBean("daoContext", "ipInterfaceDao", IpInterfaceDao.class);
-        }
-
-        if (deviceConfigDao == null) {
-            deviceConfigDao = BeanUtils.getBean("daoContext", "deviceConfigDao", DeviceConfigDao.class);
-        }
-
-        if (sessionUtils == null) {
-            sessionUtils = BeanUtils.getBean("daoContext", "sessionUtils", SessionUtils.class);
-        }
 
         return sessionUtils.withReadOnlyTransaction(() -> {
             final Map<String, Object> params = new HashMap<>();
@@ -117,7 +106,8 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
                 }
             } catch (Exception e) {
                 LOG.error("Error while parsing script file {}", scriptFile, e);
-                throw new RuntimeException(e);
+                // Don't fail fast here, we want to create empty backup entry in DB, just cache the error.
+                params.put(SCRIPT_ERROR, e.getMessage());
             }
 
             return params;
@@ -136,9 +126,6 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
 
     @Override
     public PollStatus poll(MonitoredService svc, Map<String, Object> parameters) {
-        if (retriever == null) {
-            retriever = BeanUtils.getBean("daoContext", "deviceConfigRetriever", Retriever.class);
-        }
 
         boolean triggeredPoll = Boolean.parseBoolean(getKeyedString(parameters, DeviceConfigConstants.TRIGGERED_POLL, "false"));
 
@@ -157,6 +144,12 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
             }
         }
 
+        if (parameters.containsKey(SCRIPT_ERROR)) {
+            String reason = getObjectAsStringFromParams(parameters, SCRIPT_ERROR);
+            var status = PollStatus.unavailable(reason);
+            status.setDeviceConfig(new DeviceConfig());
+            return status;
+        }
         String script = getObjectAsStringFromParams(parameters, SCRIPT);
         String user = getObjectAsStringFromParams(parameters, USERNAME);
         String password = getObjectAsStringFromParams(parameters, PASSWORD);
@@ -233,6 +226,9 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
 
     private String getObjectAsStringFromParams(Map<String, Object> params, String key) {
         Object obj = params.get(key);
+        if (obj == null) {
+            throw new IllegalArgumentException(key + " doesn't exist");
+        }
         if (obj instanceof String) {
             return (String) obj;
         }

--- a/features/device-config/monitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/device-config/monitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,9 +4,15 @@
 		https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <reference id="retriever" interface="org.opennms.features.deviceconfig.retrieval.api.Retriever" availability="mandatory" />
+    <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils" availability="mandatory" />
+    <reference id="ipInterfaceDao" interface="org.opennms.netmgt.dao.api.IpInterfaceDao" availability="mandatory" />
+    <reference id="deviceConfigDao" interface="org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao" availability="mandatory"/>
 
     <bean id="deviceConfigMonitor" class="org.opennms.features.deviceconfig.monitors.DeviceConfigMonitor" >
         <property name="retriever" ref="retriever"/>
+        <property name="ipInterfaceDao" ref="ipInterfaceDao"/>
+        <property name="deviceConfigDao" ref="deviceConfigDao"/>
+        <property name="sessionUtils" ref="sessionUtils"/>
     </bean>
 
     <service ref="deviceConfigMonitor" interface="org.opennms.netmgt.poller.ServiceMonitor">

--- a/features/device-config/monitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/device-config/monitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,9 +4,11 @@
 		https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <reference id="retriever" interface="org.opennms.features.deviceconfig.retrieval.api.Retriever" availability="mandatory" />
-    <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils" availability="mandatory" />
-    <reference id="ipInterfaceDao" interface="org.opennms.netmgt.dao.api.IpInterfaceDao" availability="mandatory" />
-    <reference id="deviceConfigDao" interface="org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao" availability="mandatory"/>
+      <!--Minion doesn't have any of these references, but only DeviceConfigMonitor#getRuntimeAttributes
+      will use these references which only runs on OpenNMS, so these are optional on Minion -->
+    <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils" availability="optional" />
+    <reference id="ipInterfaceDao" interface="org.opennms.netmgt.dao.api.IpInterfaceDao" availability="optional" />
+    <reference id="deviceConfigDao" interface="org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao" availability="optional"/>
 
     <bean id="deviceConfigMonitor" class="org.opennms.features.deviceconfig.monitors.DeviceConfigMonitor" >
         <property name="retriever" ref="retriever"/>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
@@ -558,7 +558,8 @@
         <uei>uei.opennms.org/deviceconfig/configRetrievalFailed</uei>
         <event-label>OpenNMS-defined node event: configRetrievalFailed</event-label>
         <descr>&lt;p>Failed to retrieve config associated with %service%
-            during the last poll on interface %interface%.&lt;/p></descr>
+            during the last poll on interface %interface% because of
+            the following condition: %parm[eventReason]%.&lt;/p></descr>
         <logmsg dest="logndisplay">
             %service% config retrieval failed on interface %interface%.
         </logmsg>


### PR DESCRIPTION
We want to create empty entries for all devices if they have DeviceConfig
service running.
If we throw exception in run time attributes, that will prevent us
from creating these entries. So send this error to poll and throw error there



### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14275

