### PR TITLE
NMS-14291: make sure snapshot OIA is always updated when building

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -491,9 +491,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.opennms.integration.api.sample</groupId>
-      <artifactId>sample-project</artifactId>
-      <version>${opennmsApiVersion}</version>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>oia-dependencies</artifactId>
+      <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/dependencies/oia/pom.xml
+++ b/dependencies/oia/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>dependencies</artifactId>
+    <groupId>org.opennms</groupId>
+    <version>25.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.opennms.dependencies</groupId>
+  <artifactId>oia-dependencies</artifactId>
+  <packaging>pom</packaging>
+  <name>OpenNMS :: Dependencies :: OpenNMS Integration API</name>
+  <description>
+    Include the OpenNMS integration API, and be sure that other OIA
+    dependencies are downloaded.
+
+    Note that everything here except the actual API is set to
+    scope=provided, so if you need the others as a build dependency,
+    you will still need to depend on those items directly.
+  </description>
+  <dependencies>
+    <dependency>
+      <groupId>org.opennms.integration.api</groupId>
+      <artifactId>api</artifactId>
+      <version>${opennmsApiVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.integration.api</groupId>
+      <artifactId>common</artifactId>
+      <version>${opennmsApiVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.integration.api</groupId>
+      <artifactId>karaf-features</artifactId>
+      <version>${opennmsApiVersion}</version>
+      <type>xml</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <snapshots><enabled>false</enabled></snapshots>
+      <releases><enabled>true</enabled></releases>
+      <id>opennms-repo</id>
+      <name>OpenNMS Maven Repository</name>
+      <url>https://maven.opennms.org/content/groups/opennms.org-release</url>
+    </repository>
+    <repository>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+      <releases><enabled>false</enabled></releases>
+      <id>opennms-snapshots</id>
+      <name>OpenNMS Maven Repository</name>
+      <url>https://maven.opennms.org/content/groups/opennms.org-snapshot/</url>
+    </repository>
+  </repositories>
+</project>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -44,6 +44,7 @@
     <module>mina</module>
     <module>netty</module>
     <module>newts</module>
+    <module>oia</module>
     <module>owasp</module>
     <module>pax-exam</module>
     <module>quartz</module>

--- a/features/api-layer/pom.xml
+++ b/features/api-layer/pom.xml
@@ -61,9 +61,10 @@
             <artifactId>opennms-config-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opennms.integration.api</groupId>
-            <artifactId>api</artifactId>
-            <version>${opennmsApiVersion}</version>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>oia-dependencies</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.opennms.integration.api</groupId>

--- a/features/distributed/coordination/common/pom.xml
+++ b/features/distributed/coordination/common/pom.xml
@@ -35,9 +35,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.opennms.integration.api</groupId>
-            <artifactId>api</artifactId>
-            <version>${opennmsApiVersion}</version>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>oia-dependencies</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/features/distributed/coordination/zookeeper/pom.xml
+++ b/features/distributed/coordination/zookeeper/pom.xml
@@ -36,6 +36,12 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>oia-dependencies</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.features.distributed</groupId>
             <artifactId>coordination-api</artifactId>
             <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -2209,9 +2209,25 @@
       <!--  opennms dependencies that are outside of the opennms/trunk project -->
       <!--  PLEASE KEEP THESE IN ALPHABETICAL ORDER -->
       <dependency>
-        <groupId>org.opennms.api.integration</groupId>
-        <artifactId>opennms-provisioning</artifactId>
-        <version>1.0.0</version>
+        <groupId>org.opennms.integration.api</groupId>
+        <artifactId>api</artifactId>
+        <version>${opennmsApiVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.opennms.integration.api</groupId>
+        <artifactId>common</artifactId>
+        <version>${opennmsApiVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.opennms.integration.api</groupId>
+        <artifactId>config</artifactId>
+        <version>${opennmsApiVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.opennms.integration.api</groupId>
+        <artifactId>karaf-features</artifactId>
+        <version>${opennmsApiVersion}</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>com.sun</groupId>
@@ -2928,6 +2944,12 @@
       <dependency>
         <groupId>org.opennms.dependencies</groupId>
         <artifactId>jstl-dependencies</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.opennms.dependencies</groupId>
+        <artifactId>oia-dependencies</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
This PR changes our OIA dependencies to be routed through an `oia-dependencies` package that sets the snapshot repository to always update.  This _should_ 🤞 make sure OIA is up-to-date when doing development builds.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14291

