### PR TITLE
NMS-14297: Use sink as config type for push based configs 

### DIFF
--- a/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/ConfigType.java
+++ b/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/ConfigType.java
@@ -33,4 +33,5 @@ public abstract class ConfigType {
     }
 
     public static final String Default = "default";
+    public static final String Sink = "sink";
 }

--- a/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
+++ b/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
@@ -29,6 +29,8 @@
 package org.opennms.features.deviceconfig.persistence.impl;
 
 import com.google.common.base.Strings;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -105,12 +107,19 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
 
     @Override
     public Optional<DeviceConfig> getLatestConfigForInterface(OnmsIpInterface ipInterface, String serviceName) {
-        List<DeviceConfig> deviceConfigs =
-                findObjects(DeviceConfig.class,
-                        "from DeviceConfig dc WHERE dc.ipInterface.id = ? AND serviceName = ? " +
-                                "ORDER BY lastUpdated DESC LIMIT 1", ipInterface.getId(), serviceName);
+        List<DeviceConfig> deviceConfigs = new ArrayList<>();
+        if (!Strings.isNullOrEmpty(serviceName)) {
+            deviceConfigs =
+                    findObjects(DeviceConfig.class,
+                            "from DeviceConfig dc WHERE dc.ipInterface.id = ? AND serviceName = ? " +
+                                    "ORDER BY lastUpdated DESC LIMIT 1", ipInterface.getId(), serviceName);
+        } else {
+            deviceConfigs = findObjects(DeviceConfig.class,
+                    "from DeviceConfig dc WHERE dc.ipInterface.id = ? AND serviceName is NULL " +
+                            "ORDER BY lastUpdated DESC LIMIT 1", ipInterface.getId());
+        }
 
-        if (deviceConfigs != null && !deviceConfigs.isEmpty()) {
+        if (!deviceConfigs.isEmpty()) {
             return Optional.of(deviceConfigs.get(0));
         }
         return Optional.empty();

--- a/features/device-config/persistence/impl/src/test/java/org/opennms/features/deviceconfig/persistence/DeviceConfigDaoIT.java
+++ b/features/device-config/persistence/impl/src/test/java/org/opennms/features/deviceconfig/persistence/DeviceConfigDaoIT.java
@@ -214,8 +214,12 @@ public class DeviceConfigDaoIT {
             deviceConfig.setConfig((ipInterface.getInterfaceId() + ":" + i).getBytes(Charset.defaultCharset()));
             deviceConfig.setEncoding(Charset.defaultCharset().name());
             deviceConfig.setCreatedTime(Date.from(Instant.now().plusSeconds(i * 60)));
-            String configType = serviceName.substring(serviceName.lastIndexOf("-") +1);
-            deviceConfig.setConfigType(configType);
+            if (serviceName != null) {
+                String configType = serviceName.substring(serviceName.lastIndexOf("-") + 1);
+                deviceConfig.setConfigType(configType);
+            } else {
+                deviceConfig.setConfigType(ConfigType.Default);
+            }
             deviceConfig.setLastUpdated(Date.from(Instant.now().plusSeconds(i * 60)));
             deviceConfig.setLastSucceeded(deviceConfig.getLastUpdated());
             deviceConfig.setStatus(DeviceConfig.determineBackupStatus(deviceConfig));

--- a/features/device-config/sink/consumer/src/main/java/org/opennms/features/deviceconfig/sink/consumer/DeviceConfigConsumer.java
+++ b/features/device-config/sink/consumer/src/main/java/org/opennms/features/deviceconfig/sink/consumer/DeviceConfigConsumer.java
@@ -93,9 +93,8 @@ public class DeviceConfigConsumer implements MessageConsumer<DeviceConfigSinkDTO
                 deviceConfigDao.updateDeviceConfigContent(
                         ipInterface,
                         null,
-                        // use default ConfigType for now
-                        // -> later on the config type may be derived from the filename somehow...
-                        ConfigType.Default,
+                        // use config type sink for configs that are pushed from Device.
+                        ConfigType.Sink,
                         null,
                         content,
                         message.fileName


### PR DESCRIPTION
Any config that is uploaded from device will use config type sink instead of default.
Service name for these will be null

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14297

