### PR TITLE
NMS-14309: Rename ROLE_CONFIG_EDITOR to ROLE_FILESYSTEM_EDITOR

### DIFF
--- a/docs/modules/operation/pages/user-management/security-roles.adoc
+++ b/docs/modules/operation/pages/user-management/security-roles.adoc
@@ -15,15 +15,15 @@ endif::opennms-prime[]
 | Description
 
 | ROLE_ADMIN*
-| Permissions to create, read, update, and delete in the web UI and the ReST API (except see ROLE_CONFIG_EDITOR below).
+| Permissions to create, read, update, and delete in the web UI and the ReST API (except see ROLE_FILESYSTEM_EDITOR below).
 
 | ROLE_ASSET_EDITOR
 | Permissions only to update the asset records from nodes.
 
-| ROLE_CONFIG_EDITOR
-| Permissions only to view and update configuration data via the REST API (and consequently, from the UI Preview).
-Note that even ROLE_ADMIN cannot view or edit configurations unless they also have the ROLE_CONFIG_EDITOR role.
-Also, for a user with ROLE_CONFIG_EDITOR to use the UI, they will also need the ROLE_USER or similar role.
+| ROLE_FILESYSTEM_EDITOR
+| Permissions only to view and update file configuration data via the REST API (and consequently, from the UI Preview).
+Note that even ROLE_ADMIN cannot view or edit configurations unless they also have the ROLE_FILESYSTEM_EDITOR role.
+Also, for a user with ROLE_FILESYSTEM_EDITOR to use the UI, they will also need the ROLE_USER or similar role.
 
 | ROLE_DASHBOARD
 | Allow user access only to the dashboard.

--- a/docs/modules/operation/pages/user-management/security-roles.adoc
+++ b/docs/modules/operation/pages/user-management/security-roles.adoc
@@ -15,7 +15,7 @@ endif::opennms-prime[]
 | Description
 
 | ROLE_ADMIN*
-| Permissions to create, read, update, and delete in the web UI and the ReST API (except see ROLE_FILESYSTEM_EDITOR below).
+| Permissions to create, read, update, and delete in the web UI and the REST API (except see ROLE_FILESYSTEM_EDITOR below).
 
 | ROLE_ASSET_EDITOR
 | Permissions only to update the asset records from nodes.

--- a/opennms-web-api/src/main/java/org/opennms/web/api/Authentication.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/Authentication.java
@@ -77,7 +77,7 @@ public final class Authentication extends Object {
     public static final String ROLE_PROVISION = "ROLE_PROVISION";
     public static final String ROLE_REST = "ROLE_REST";
     public static final String ROLE_ASSET_EDITOR = "ROLE_ASSET_EDITOR";
-    public static final String ROLE_CONFIG_EDITOR = "ROLE_CONFIG_EDITOR";
+    public static final String ROLE_FILESYSTEM_EDITOR = "ROLE_FILESYSTEM_EDITOR";
     public static final String ROLE_MOBILE = "ROLE_MOBILE";
     public static final String ROLE_JMX = "ROLE_JMX";
     public static final String ROLE_MINION = "ROLE_MINION";
@@ -98,7 +98,7 @@ public final class Authentication extends Object {
         s_availableRoles.add(ROLE_PROVISION);
         s_availableRoles.add(ROLE_REST);
         s_availableRoles.add(ROLE_ASSET_EDITOR);
-        s_availableRoles.add(ROLE_CONFIG_EDITOR);
+        s_availableRoles.add(ROLE_FILESYSTEM_EDITOR);
         s_availableRoles.add(ROLE_MOBILE);
         s_availableRoles.add(ROLE_JMX);
         s_availableRoles.add(ROLE_MINION);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
@@ -94,8 +94,8 @@ public class FilesystemRestService {
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
     public List<String> getFiles(@QueryParam("changedFilesOnly") boolean changedFilesOnly, @Context SecurityContext securityContext) {
-        if (!securityContext.isUserInRole(Authentication.ROLE_CONFIG_EDITOR)) {
-            throw new ForbiddenException("CONFIG EDITOR role is required for enumerating files.");
+        if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
+            throw new ForbiddenException("FILESYSTEM EDITOR role is required for enumerating files.");
         }
 
         try {
@@ -128,8 +128,8 @@ public class FilesystemRestService {
     @Path("/help")
     @Produces("text/markdown")
     public InputStream getFileHelp(@QueryParam("f") String fileName, @Context SecurityContext securityContext) {
-        if (!securityContext.isUserInRole(Authentication.ROLE_CONFIG_EDITOR)) {
-            throw new ForbiddenException("CONFIG EDITOR role is required for retrieving help.");
+        if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
+            throw new ForbiddenException("FILESYSTEM EDITOR role is required for retrieving help.");
         }
         ensureFileIsAllowed(fileName);
         return this.getClass().getResourceAsStream("/help/" + fileName + ".md");
@@ -139,8 +139,8 @@ public class FilesystemRestService {
     @Path("/extensions")
     @Produces(MediaType.APPLICATION_JSON)
     public List<String> getSupportedExtensions(@Context SecurityContext securityContext) {
-        if (!securityContext.isUserInRole(Authentication.ROLE_CONFIG_EDITOR)) {
-            throw new ForbiddenException("CONFIG EDITOR role is required for retrieving supported extensions.");
+        if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
+            throw new ForbiddenException("FILESYSTEM EDITOR role is required for retrieving supported extensions.");
         }
         return SUPPORTED_FILE_EXTENSIONS.stream()
                 .sorted()
@@ -150,8 +150,8 @@ public class FilesystemRestService {
     @GET
     @Path("/contents")
     public Response getFileContents(@QueryParam("f") String fileName, @Context SecurityContext securityContext) {
-        if (!securityContext.isUserInRole(Authentication.ROLE_CONFIG_EDITOR)) {
-            throw new ForbiddenException("CONFIG EDITOR role is required for reading files.");
+        if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
+            throw new ForbiddenException("FILESYSTEM EDITOR role is required for reading files.");
         }
         return fileContents(ensureFileIsAllowed(fileName));
     }
@@ -163,8 +163,8 @@ public class FilesystemRestService {
     public String uploadFile(@QueryParam("f") String fileName,
                              @Multipart("upload") Attachment attachment,
                              @Context SecurityContext securityContext) throws IOException {
-        if (!securityContext.isUserInRole(Authentication.ROLE_CONFIG_EDITOR)) {
-            throw new ForbiddenException("CONFIG EDITOR role is required for uploading file contents.");
+        if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
+            throw new ForbiddenException("FILESYSTEM EDITOR role is required for uploading file contents.");
         }
         final java.nio.file.Path targetPath = ensureFileIsAllowed(fileName);
 
@@ -195,8 +195,8 @@ public class FilesystemRestService {
     @Produces(MediaType.TEXT_HTML)
     public String deleteFile(@QueryParam("f") String fileName,
                              @Context SecurityContext securityContext) throws IOException {
-        if (!securityContext.isUserInRole(Authentication.ROLE_CONFIG_EDITOR)) {
-            throw new ForbiddenException("CONFIG EDITOR role is required for deleting file contents.");
+        if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
+            throw new ForbiddenException("FILESYSTEM EDITOR role is required for deleting file contents.");
         }
         final java.nio.file.Path targetPath = ensureFileIsAllowed(fileName);
         Files.delete(targetPath);

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -10,7 +10,7 @@
   <!-- Only use BASIC auth for the RESTful APIs -->
   <http pattern="/rest/**" realm="OpenNMS Realm" create-session="never">
     <!-- OPTIONS pre-flight requests should always be accepted -->
-    <intercept-url pattern="/rest/**" method="OPTIONS" access="ROLE_ANONYMOUS,ROLE_REST,ROLE_ADMIN,ROLE_USER,ROLE_MOBILE,ROLE_CONFIG_EDITOR"/>
+    <intercept-url pattern="/rest/**" method="OPTIONS" access="ROLE_ANONYMOUS,ROLE_REST,ROLE_ADMIN,ROLE_USER,ROLE_MOBILE,ROLE_FILESYSTEM_EDITOR"/>
 
     <!-- Calls to health/overview are always accepted -->
     <intercept-url pattern="/rest/health/probe" method="GET" access="ROLE_ANONYMOUS,ROLE_REST,ROLE_ADMIN,ROLE_USER,ROLE_MOBILE"/>
@@ -57,13 +57,13 @@
     <intercept-url pattern="/rest/device-config/**" method="PUT" access="ROLE_REST,ROLE_ADMIN,ROLE_DEVICE_CONFIG_BACKUP" />
 
     <!--
-      Must have ROLE_CONFIG_EDITOR to view or edit files. Added here, but additional checks are done in code
+      Must have ROLE_FILESYSTEM_EDITOR to view or edit files. Added here, but additional checks are done in code
       to disallow any other role.
     -->
-    <intercept-url pattern="/rest/filesystem/**" method="GET" access="ROLE_CONFIG_EDITOR"/>
-    <intercept-url pattern="/rest/filesystem/**" method="DELETE" access="ROLE_CONFIG_EDITOR"/>
-    <intercept-url pattern="/rest/filesystem/**" method="POST" access="ROLE_CONFIG_EDITOR"/>
-    <intercept-url pattern="/rest/filesystem/**" method="PUT" access="ROLE_CONFIG_EDITOR"/>
+    <intercept-url pattern="/rest/filesystem/**" method="GET" access="ROLE_FILESYSTEM_EDITOR"/>
+    <intercept-url pattern="/rest/filesystem/**" method="DELETE" access="ROLE_FILESYSTEM_EDITOR"/>
+    <intercept-url pattern="/rest/filesystem/**" method="POST" access="ROLE_FILESYSTEM_EDITOR"/>
+    <intercept-url pattern="/rest/filesystem/**" method="PUT" access="ROLE_FILESYSTEM_EDITOR"/>
 
     <!-- Allow certain actions for the ROLE_USER role -->
     <intercept-url pattern="/rest/resources/generateId" method="POST" access="ROLE_REST,ROLE_ADMIN,ROLE_USER" />

--- a/ui/src/components/Layout/NavigationRail.vue
+++ b/ui/src/components/Layout/NavigationRail.vue
@@ -24,7 +24,7 @@
       />
       <FeatherRailItem
         :class="{ selected: isSelected('/file-editor') }"
-        v-if="configEditorRole"
+        v-if="filesystemEditorRole"
         href="#/file-editor"
         :icon="FileEditor"
         title="File Editor"
@@ -96,7 +96,7 @@ import { Plugin } from '@/types'
 
 const store = useStore()
 const route = useRoute()
-const { adminRole, configEditorRole, dcbRole } = useRole()
+const { adminRole, filesystemEditorRole, dcbRole } = useRole()
 const plugins = computed<Plugin[]>(() => store.state.pluginModule.plugins)
 const navRailOpen = computed(() => store.state.appModule.navRailOpen)
 const onNavRailClick = () => store.dispatch('appModule/setNavRailOpen', !navRailOpen.value)

--- a/ui/src/composables/useRole.ts
+++ b/ui/src/composables/useRole.ts
@@ -4,7 +4,7 @@ const enum Roles {
   ROLE_ADMIN = 'ROLE_ADMIN',
   ROLE_USER = 'ROLE_USER',
   ROLE_REST = 'ROLE_REST',
-  ROLE_CONFIG_EDITOR = 'ROLE_CONFIG_EDITOR',
+  ROLE_FILESYSTEM_EDITOR = 'ROLE_FILESYSTEM_EDITOR',
   ROLE_DEVICE_CONFIG_BACKUP = 'ROLE_DEVICE_CONFIG_BACKUP'
 }
 
@@ -24,10 +24,10 @@ const hasOneOf = (...rolesToCheck: Role[]) => {
 
 const useRole = () => {
   const adminRole = computed<boolean>(() => hasOneOf(Roles.ROLE_ADMIN))
-  const configEditorRole = computed<boolean>(() => hasOneOf(Roles.ROLE_CONFIG_EDITOR))
+  const filesystemEditorRole = computed<boolean>(() => hasOneOf(Roles.ROLE_FILESYSTEM_EDITOR))
   const dcbRole = computed<boolean>(() => hasOneOf(Roles.ROLE_ADMIN, Roles.ROLE_REST, Roles.ROLE_DEVICE_CONFIG_BACKUP))
 
-  return { adminRole, configEditorRole, dcbRole, rolesAreLoaded }
+  return { adminRole, filesystemEditorRole, dcbRole, rolesAreLoaded }
 }
 
 export default useRole

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -8,7 +8,7 @@ import useRole from '@/composables/useRole'
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
 
-const { adminRole, configEditorRole, dcbRole, rolesAreLoaded } = useRole()
+const { adminRole, filesystemEditorRole, dcbRole, rolesAreLoaded } = useRole()
 const { showSnackBar } = useSnackbar()
 const { startSpinner, stopSpinner } = useSpinner()
 
@@ -37,7 +37,7 @@ const router = createRouter({
       component: FileEditor,
       beforeEnter: (to, from) => {
         const checkRoles = () => {
-          if (!configEditorRole.value) {
+          if (!filesystemEditorRole.value) {
             showSnackBar({ msg: 'No role access to file editor.' })
             router.push(from.path)
           }


### PR DESCRIPTION
This is a follow up to NMS-14242 (PR: https://github.com/OpenNMS/opennms/pull/4682).

We determined that `ROLE_FILESYSTEM_EDITOR` is a bit clearer than `ROLE_CONFIG_EDITOR`. This role allows user to view and edit configuration files on the OpenNMS filesystem (i.e., under `/etc`) via UI and Rest API.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14309

