### PR TITLE
NMS-14317: DCB Rest API, filter history by configType

### DIFF
--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/api/DeviceConfigRestService.java
@@ -116,12 +116,14 @@ public interface DeviceConfigRestService {
     /**
      * Get a list of device configs for a given IP interface id.
      * This is a history of configs for a particular device.
-     * Returns all config types.
+     * Returns all config types by default, use 'configType' to filter.
      */
     @GET
     @Path("/interface/{id : \\d+}")
     @Produces(MediaType.APPLICATION_JSON)
-    Response getDeviceConfigsByInterface(@PathParam("id") Integer ipInterfaceId);
+    Response getDeviceConfigsByInterface(
+        @PathParam("id") Integer ipInterfaceId,
+        @QueryParam("configType") @DefaultValue("") String configType);
 
     /**
      * Delete a single device config.

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -205,7 +205,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
 
     /** {@inheritDoc} */
     @Override
-    public Response getDeviceConfigsByInterface(Integer ipInterfaceId) {
+    public Response getDeviceConfigsByInterface(Integer ipInterfaceId, String configType) {
         var criteria = getCriteria(
             null,
             null,
@@ -214,7 +214,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
             null,
             null,
             ipInterfaceId,
-            null,
+            configType,
             null,
             null,
             null);

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceScheduleIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceScheduleIT.java
@@ -239,7 +239,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
             });
 
             // Now do a 'history' search which should return 2 items for index 1 "dcb-2", having 2 different backup dates
-            final var historyResponse = deviceConfigRestService.getDeviceConfigsByInterface(ipInterfaceIds.get(1));
+            final var historyResponse = deviceConfigRestService.getDeviceConfigsByInterface(ipInterfaceIds.get(1), null);
             assertThat(historyResponse, notNullValue());
             assertThat(historyResponse.hasEntity(), is(true));
 
@@ -529,7 +529,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
 
             final int nonExistingIpInterfaceId = ipInterfaces.stream().mapToInt(OnmsIpInterface::getId).max().orElse(9999) + 1;
 
-            final var response = deviceConfigRestService.getDeviceConfigsByInterface(nonExistingIpInterfaceId);
+            final var response = deviceConfigRestService.getDeviceConfigsByInterface(nonExistingIpInterfaceId, null);
             assertThat(response, notNullValue());
             assertThat(response.hasEntity(), is(false));
             assertThat(response.getStatus(), is(Response.Status.NO_CONTENT.getStatusCode()));
@@ -665,7 +665,7 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
             final var expectedDeviceConfigs = List.of(List.of(dc0), List.of(dc1a, dc1b), List.of(dc2), List.of(dc3), List.of(dc4));
 
             IntStream.range(0, RECORD_COUNT).forEach(i -> {
-                final var response = deviceConfigRestService.getDeviceConfigsByInterface(ipInterfaces.get(i).getId());
+                final var response = deviceConfigRestService.getDeviceConfigsByInterface(ipInterfaces.get(i).getId(), null);
                 assertThat(response, notNullValue());
                 assertThat(response.hasEntity(), is(true));
 
@@ -690,6 +690,21 @@ public class DefaultDeviceConfigRestServiceScheduleIT {
                     assertThat(dto.getIpInterfaceId(), equalTo(expectedDc.getIpInterface().getId()));
                     assertThat(dto.getDeviceName(), equalTo(expectedDc.getIpInterface().getNode().getLabel()));
                 });
+            });
+
+            // Test filtering by config type
+            IntStream.range(0, 2).forEach(i -> {
+                final var response = deviceConfigRestService.getDeviceConfigsByInterface(ipInterfaces.get(1).getId(), CONFIG_TYPES.get(i));
+
+                assertThat(response, notNullValue());
+                assertThat(response.hasEntity(), is(true));
+
+                final List<DeviceConfigDTO> responseList = (List<DeviceConfigDTO>) response.getEntity();
+                assertThat(responseList.size(), equalTo(1));
+
+                DeviceConfigDTO dto = responseList.get(0);
+                assertThat(dto.getIpInterfaceId(), equalTo(ipInterfaces.get(1).getId()));
+                assertThat(dto.getConfigType(), equalTo(CONFIG_TYPES.get(i)));
             });
         });
     }


### PR DESCRIPTION
Device Config Backup Rest API, add ability to filter history by configType. UI will use this for History and Compare screens.

Get all configs for this device: `/rest/device-config/interface/{id}`
Get default configs for this device: `/rest/device-config/interface/{id}?configType=default`
Get running configs for this device: `/rest/device-config/interface/{id}?configType=running`

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}

