### PR TITLE
NMS-12991: Better error message when missing datacollection

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -415,49 +415,53 @@ class CollectableService implements ReadyRunnable {
     /**
      * Perform data collection.
      */
-	private void doCollection() throws CollectionException {
-		LOG.info("run: starting new collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
-		CollectionSet result = null;
-		try {
-		    result = m_spec.collect(m_agent);
-		    if (result != null) {
-                        Collectd.instrumentation().beginPersistingServiceData(m_spec.getPackageName(), m_nodeId, getHostAddress(), m_spec.getServiceName());
-                        try {
-                            CollectionSetVisitor persister = m_persisterFactory.createPersister(m_params, m_repository, result.ignorePersist(), false, false);
-                            if (Boolean.getBoolean(USE_COLLECTION_START_TIME_SYS_PROP)) {
-                                final ConstantTimeKeeper timeKeeper = new ConstantTimeKeeper(new Date(m_lastScheduledCollectionTime));
-                                // Wrap the persister visitor such that calls to CollectionResource.getTimeKeeper() return the given timeKeeper
-                                persister = wrapResourcesWithTimekeeper(persister, timeKeeper);
-                            }
-                            result.visit(persister);
-                        } finally {
-                            Collectd.instrumentation().endPersistingServiceData(m_spec.getPackageName(), m_nodeId, getHostAddress(), m_spec.getServiceName());
-                        }
-
-                        // Do thresholding
-                        if (m_thresholdingSession != null) {
-                            try {
-                                m_thresholdingSession.accept(result);
-                            } catch (ThresholdInitializationException e) {
-                                LOG.warn("ThresholdInitializationException for {}. Thresholding skipped.", this, e);
-                            }
-                        } else {
-                            LOG.warn("No thresholding session for {}. Thresholding skipped.", this);
-                        }
-
-                        if (!CollectionStatus.SUCCEEDED.equals(result.getStatus())) {
-                            throw new CollectionFailed(result.getStatus());
-                        }
+    private void doCollection() throws CollectionException {
+        LOG.info("run: starting new collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
+        CollectionSet result = null;
+        try {
+            result = m_spec.collect(m_agent);
+            if (result != null) {
+                Collectd.instrumentation().beginPersistingServiceData(m_spec.getPackageName(), m_nodeId, getHostAddress(), m_spec.getServiceName());
+                try {
+                    CollectionSetVisitor persister = m_persisterFactory.createPersister(m_params, m_repository, result.ignorePersist(), false, false);
+                    if (Boolean.getBoolean(USE_COLLECTION_START_TIME_SYS_PROP)) {
+                        final ConstantTimeKeeper timeKeeper = new ConstantTimeKeeper(new Date(m_lastScheduledCollectionTime));
+                        // Wrap the persister visitor such that calls to CollectionResource.getTimeKeeper() return the given timeKeeper
+                        persister = wrapResourcesWithTimekeeper(persister, timeKeeper);
                     }
-                } catch (CollectionException e) {
-                    LOG.warn("run: failed collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
-                    throw e;
-		} catch (Throwable t) {
-                    LOG.warn("run: failed collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
-                    throw new CollectionException("An undeclared throwable was caught during data collection for interface " + m_nodeId + "/" + getHostAddress() + "/" + m_spec.getServiceName(), t);
-		}
-		LOG.info("run: finished collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
-	}
+                    result.visit(persister);
+                } finally {
+                    Collectd.instrumentation().endPersistingServiceData(m_spec.getPackageName(), m_nodeId, getHostAddress(), m_spec.getServiceName());
+                }
+
+                // Do thresholding
+                if (m_thresholdingSession != null) {
+                    try {
+                        m_thresholdingSession.accept(result);
+                    } catch (ThresholdInitializationException e) {
+                        LOG.warn("ThresholdInitializationException for {}. Thresholding skipped.", this, e);
+                    }
+                } else {
+                    LOG.warn("No thresholding session for {}. Thresholding skipped.", this);
+                }
+
+                if (!CollectionStatus.SUCCEEDED.equals(result.getStatus())) {
+                    throw new CollectionFailed(result.getStatus());
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            LOG.warn("run: failed collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
+            throw new CollectionException("Illegal Argument Exception was caught during data collection for interface " + m_nodeId + "/" + getHostAddress() + "/" + m_spec.getServiceName()
+                    + " with message: " + e.getMessage(), e);
+        } catch (CollectionException e) {
+            LOG.warn("run: failed collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
+            throw e;
+        } catch (Throwable t) {
+            LOG.warn("run: failed collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
+            throw new CollectionException("An undeclared throwable was caught during data collection for interface " + m_nodeId + "/" + getHostAddress() + "/" + m_spec.getServiceName(), t);
+        }
+        LOG.info("run: finished collection for {}/{}/{}/{}", m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getPackageName());
+    }
 
 	/**
      * Process any outstanding updates.


### PR DESCRIPTION
Apologies, but I had to reformat the method below, as parts used tabs, and other parts just used spaces, with the result that things weren't properly aligned in my IDE. Hopefully things are now consistent for everybody.

The actual part of the code that has changed is the part marked in green between lines 452 and 455.

On the events page, the error the user sees in the Description box has changed from:

JMX-Kafka data collection on interface 127.0.0.1 failed because of the following condition: 'An undeclared throwable was caught during data collection for interface 1/127.0.0.1/JMX-Kafka'.

to:

JMX-Kafka data collection on interface 127.0.0.1 failed because of the following condition: 'Illegal Argument Exception was caught during data collection for interface 1/127.0.0.1/JMX-Kafka with message: JMXCollector: No collection found with name 'jmx-kafka'.'.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12991

