### PR TITLE
NMS-14328: Update scripts to use tftp binary mode

### DIFF
--- a/docs/modules/operation/pages/device-config-backup/dcb-requisition.adoc
+++ b/docs/modules/operation/pages/device-config-backup/dcb-requisition.adoc
@@ -6,7 +6,11 @@ After you have xref:operation:device-config-backup/ssh.adoc#backup-script[create
 To activate the device configuration backup, you must add metadata that defines the device configuration backup script you created for the node's device type, and the device's username and password.
 
 We recommend you also add metadata to overwrite the default device configuration backup schedule.
-By default, {page-component-title} never schedules the device confib backup (see xref:reference:service-assurance/monitors/DeviceConfigMonitor.adoc[Device Config Monitor] for details). It is still possible to retrieve backups on demand by using the Web UI or the REST services. Default behavior can be overwritten by specifying backup schedule in the form of cron expression. In order to prevent all devices fetching the config at the same time, it is better to space out schedule.  For ex: `0 0 0 * * ?` runs every 24 hrs at 12.00am. `0 0 1 * * ?` runs every 24 hrs at 1.00am.
+By default, {page-component-title} never schedules the device config backup (see xref:reference:service-assurance/monitors/DeviceConfigMonitor.adoc[Device Config Monitor] for details). 
+It is still possible to retrieve backups on demand by using the Web UI or the REST services. 
+Specify a backup schedule in the form of a cron expression to overwrite default behavior. 
+To prevent all devices fetching the configuration at the same time, it is better to space out the schedule.  
+For example, `0 0 0 * * ?` runs every 24 hrs at 12:00 a.m. `0 0 1 * * ?` runs every 24 hrs at 1:00 a.m.
 
 . Log in to OpenNMS and click the gears icon.
 . Choose *Provisioning>Manage Provisioning Requisitions*.

--- a/docs/modules/operation/pages/device-config-backup/dcb-requisition.adoc
+++ b/docs/modules/operation/pages/device-config-backup/dcb-requisition.adoc
@@ -16,10 +16,10 @@ If you want to enable device config backup on existing nodes in a requisition, s
 . Click on the edit icon and click *Add Node*.
 . Set up your requisition as described in xref:operation:provisioning/getting-started.adoc#requisition-create[Create a requisition].
 . Click *Add Meta-Data*, and define the following key-value pairs:
-.. `username`: username for the device
-.. `password`: password for the device
-.. `script-file`: name of the device configuration script for this type of device
-.. `schedule`: a cron expression to specify the time to fetch the device backup configuration (default is `0 0 0 * * ?`, every 24 hrs at 12:00 a.m.)
+.. `dcb:username`: username for the device
+.. `dcb:password`: password for the device
+.. `dcb:script-file`: name of the device configuration script for this type of device without .dcb extension
+.. `dcb:schedule`: a cron expression to specify the time to fetch the device backup configuration (default is `0 0 0 * * ?`, every 24 hrs at 12:00 a.m.)
 .. `retention-period`: an optional Java `Period` expression to specify the length of time before "stale" configuration data is deleted from the database (default is `P1Y`, one year)
 . Click *Save* to save the metadata and then *Save* to save the requisition.
 . Click *Return* and click *Synchronize*.

--- a/docs/modules/operation/pages/device-config-backup/dcb-requisition.adoc
+++ b/docs/modules/operation/pages/device-config-backup/dcb-requisition.adoc
@@ -6,8 +6,7 @@ After you have xref:operation:device-config-backup/ssh.adoc#backup-script[create
 To activate the device configuration backup, you must add metadata that defines the device configuration backup script you created for the node's device type, and the device's username and password.
 
 We recommend you also add metadata to overwrite the default device configuration backup schedule.
-By default, {page-component-title} fetches device configuration backups every 24 hours at 12:00 a.m. (see xref:reference:service-assurance/monitors/DeviceConfigMonitor.adoc[Device Config Monitor] for details).
-Changing the default schedule spaces out the backup for each group of nodes, rather than them all running at the same time.
+By default, {page-component-title} never schedules the device confib backup (see xref:reference:service-assurance/monitors/DeviceConfigMonitor.adoc[Device Config Monitor] for details). It is still possible to retrieve backups on demand by using the Web UI or the REST services. Default behavior can be overwritten by specifying backup schedule in the form of cron expression. In order to prevent all devices fetching the config at the same time, it is better to space out schedule.  For ex: `0 0 0 * * ?` runs every 24 hrs at 12.00am. `0 0 1 * * ?` runs every 24 hrs at 1.00am.
 
 . Log in to OpenNMS and click the gears icon.
 . Choose *Provisioning>Manage Provisioning Requisitions*.
@@ -19,10 +18,9 @@ If you want to enable device config backup on existing nodes in a requisition, s
 .. `dcb:username`: username for the device
 .. `dcb:password`: password for the device
 .. `dcb:script-file`: name of the device configuration script for this type of device without .dcb extension
-.. `dcb:schedule`: a cron expression to specify the time to fetch the device backup configuration (default is `0 0 0 * * ?`, every 24 hrs at 12:00 a.m.)
+.. `dcb:schedule`: a cron expression to specify the time to fetch the device backup configuration (default is `never`)
 .. `retention-period`: an optional Java `Period` expression to specify the length of time before "stale" configuration data is deleted from the database (default is `P1Y`, one year)
 . Click *Save* to save the metadata and then *Save* to save the requisition.
 . Click *Return* and click *Synchronize*.
 . Choose a scan option and click *Synchronize*.
 
-NOTE: By specifying the value `never` for the key `schedule`, device configuration backups will not be triggered automatically. It is still possible to retrieve backups on demand by using the Web UI or the REST services.

--- a/docs/modules/reference/pages/service-assurance/monitors/DeviceConfigMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/DeviceConfigMonitor.adoc
@@ -32,12 +32,12 @@ Don't include `.dcb` extension when specifying the file name in metadata.
 | default.dcb
 
 | username
-| Username for ssh login. 
+| Username for SSH login. 
 Overwrite in metadata as `dcb:username`.
 | admin
 
 | password
-| Password for ssh login. 
+| Password for SSH login. 
 Overwrite in metadata as `dcb:password`.
 | admin
 
@@ -45,7 +45,7 @@ Overwrite in metadata as `dcb:password`.
 
 | config-type
 | If device has multiple configurations, specify the config-type with each service.
-Overwrite in metadata as `dcb:config-type`
+Overwrite in metadata as `dcb:config-type`.
 | default
 
 | ssh-port

--- a/docs/modules/reference/pages/service-assurance/monitors/DeviceConfigMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/DeviceConfigMonitor.adoc
@@ -24,19 +24,43 @@ This monitor tries to retrieve configuration from the network device and shows t
 3+| *Required*
 
 | script-file
-| Script file to use to retrieve configuration.
-| -
+| Script file to use to retrieve configuration. Script files should be placed in `etc/device-config` folder.
+Example script files can be found in `etc/examples/device-config` folder with `.dcb` extension. Script file name can be
+overwritten in metadata as `dcb:script-file`. Don't include `.dcb` extension when specifying the file name in metadata.
+| default.dcb
+
+| username
+| username for ssh login. This can be overwritten in metadata as `dcb:username`.
+| admin
+
+| password
+| password for ssh login. This can be overwritten in metadata as `dcb:password`.
+| admin
 
 3+| *Optional*
 
 | config-type
 | If device has multiple configurations, specify the config-type with each service.
+This can be overwritten in metadata as `dcb:config-type`
 | default
 
+| ssh-port
+| ssh port for the target device. This can be overwritten in meatadata as `dcb:ssh-port`
+| 22
+
+| ssh-timeout
+| ssh max timeout after which ssh session will be closed, can be overwritten in metadata as dcb:ssh-timeout
+| 60000
+
 | schedule
-| Schedule to fetch configuration, in the form of cron expression.
-| `0 0 0 * * ?`
-The default cron expression runs every 24 hrs at 12:00 a.m.
+| Schedule to fetch configuration, in the form of cron expression,
+  Defaults to never run, overwrite this in metadata with proper cron expression.
+| never
+
+| retention-period
+| Max retention period after which configs without any updates will be deleted from database. Specified in ISO-8601 period format `PnYnMnD` and `PnW`.
+Defaults to `P1Y` (1 Year). Examples : `P20Y2M25D` means 20 years, 2 months, and 25 days.
+| P1Y
 
 | host-key
 | SSH fingerprint of the remote host key.
@@ -48,20 +72,10 @@ The default cron expression runs every 24 hrs at 12:00 a.m.
 |===
 
 
-== Examples
-
-Example for how to configure the DeviceConfigMonitor in the `poller-configuration.xml`.
-
-[source, xml]
-----
-<parameter key="schedule" value="${requisition:dcb:schedule|0 0 0 * * ?}"/>
-<parameter key="script-file" value="${requisition:dcb:script-file|juniper-vsrx-default}.dcb"/>
-----
 
 == Schedule and interval
 
 The service uses an interval of 300 seconds and a cron expression for the schedule.
-The default cron expression runs every 24 hrs at 12:00 a.m. (`0 0 0 * * ?`).
 The monitor checks every 300 seconds (interval) for the next trigger time in the cron schedule.
 It retrieves the configuration only when the next trigger time matches the current time (current time must be greater than the trigger time).
 For example, if the monitor checks at 11:59 p.m., but the trigger time is 12:00 a.m., the monitor will retrieve the configuration at the next check interval at 12:04 a.m.

--- a/docs/modules/reference/pages/service-assurance/monitors/DeviceConfigMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/DeviceConfigMonitor.adoc
@@ -24,42 +24,50 @@ This monitor tries to retrieve configuration from the network device and shows t
 3+| *Required*
 
 | script-file
-| Script file to use to retrieve configuration. Script files should be placed in `etc/device-config` folder.
-Example script files can be found in `etc/examples/device-config` folder with `.dcb` extension. Script file name can be
-overwritten in metadata as `dcb:script-file`. Don't include `.dcb` extension when specifying the file name in metadata.
+| Script file to use to retrieve configuration. 
+Place script files in the `etc/device-config` folder.
+Find example script files in `etc/examples/device-config` folder with `.dcb` extension. 
+Overwrite script file name in metadata as `dcb:script-file`. 
+Don't include `.dcb` extension when specifying the file name in metadata.
 | default.dcb
 
 | username
-| username for ssh login. This can be overwritten in metadata as `dcb:username`.
+| Username for ssh login. 
+Overwrite in metadata as `dcb:username`.
 | admin
 
 | password
-| password for ssh login. This can be overwritten in metadata as `dcb:password`.
+| Password for ssh login. 
+Overwrite in metadata as `dcb:password`.
 | admin
 
 3+| *Optional*
 
 | config-type
 | If device has multiple configurations, specify the config-type with each service.
-This can be overwritten in metadata as `dcb:config-type`
+Overwrite in metadata as `dcb:config-type`
 | default
 
 | ssh-port
-| ssh port for the target device. This can be overwritten in meatadata as `dcb:ssh-port`
+| SSH port for the target device. 
+Overwrite in meatadata as `dcb:ssh-port`.
 | 22
 
 | ssh-timeout
-| ssh max timeout after which ssh session will be closed, can be overwritten in metadata as dcb:ssh-timeout
+| SSH maximum timeout after which SSH session will be closed.
+Overwrite in metadata as `dcb:ssh-timeout`.
 | 60000
 
 | schedule
-| Schedule to fetch configuration, in the form of cron expression,
-  Defaults to never run, overwrite this in metadata with proper cron expression.
+| Schedule to fetch configuration, in the form of cron expression.
+  Defaults to never run; overwrite this in metadata with proper cron expression.
 | never
 
 | retention-period
-| Max retention period after which configs without any updates will be deleted from database. Specified in ISO-8601 period format `PnYnMnD` and `PnW`.
-Defaults to `P1Y` (1 Year). Examples : `P20Y2M25D` means 20 years, 2 months, and 25 days.
+| Maximum retention period after which configs without any updates will be deleted from database. 
+Specified in ISO-8601 period format `PnYnMnD` and `PnW`.
+Defaults to `P1Y` (1 Year). 
+Example: `P20Y2M25D` means 20 years, 2 months, and 25 days.
 | P1Y
 
 | host-key

--- a/opennms-base-assembly/src/main/filtered/etc/examples/device-config/juniper-junos-config-gz.dcb
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/device-config/juniper-junos-config-gz.dcb
@@ -5,6 +5,8 @@ send: cd /config
 await: %
 send: tftp ${tftpServerIp}
 await: tftp>
+send: binary
+await: tftp>
 send: put juniper.conf.gz juniper.conf.gz${filenameSuffix}
 await: tftp>
 send: exit

--- a/opennms-base-assembly/src/main/filtered/etc/examples/device-config/juniper-junos-config-set.dcb
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/device-config/juniper-junos-config-set.dcb
@@ -7,6 +7,8 @@ send: cd /var/tmp
 await: %
 send: tftp ${tftpServerIp}
 await: tftp>
+send: binary
+await: tftp>
 send: put juniper.conf-set juniper.conf-set${filenameSuffix}
 await: tftp>
 send: exit

--- a/opennms-base-assembly/src/main/filtered/etc/examples/device-config/juniper-junos-config-txt.dcb
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/device-config/juniper-junos-config-txt.dcb
@@ -7,6 +7,8 @@ send: cd /var/tmp
 await: %
 send: tftp ${tftpServerIp}
 await: tftp>
+send: binary
+await: tftp>
 send: put juniper.conf juniper.conf${filenameSuffix}
 await: tftp>
 send: exit

--- a/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
@@ -358,8 +358,8 @@
          <parameter key="password" value="${requisition:dcb:password|admin}"/>
          <parameter key="ssh-port" value="${requisition:dcb:ssh-port|22}"/>
          <parameter key="ssh-timeout" value="${requisition:dcb:ssh-timeout|60000}"/>
-         <!-- schedule is a cron expression -->
-         <parameter key="schedule" value="${requisition:dcb:schedule|0 0 0 * * ?}"/>
+         <!-- schedule is a cron expression like 0 0 0 * * ?, defaults to never -->
+         <parameter key="schedule" value="${requisition:dcb:schedule|never}"/>
          <!-- retention-period is a Java Period expression -->
          <parameter key="retention-period" value="${requisition:dcb:retention-period|P1Y}"/>
          <parameter key="script-file" value="${requisition:dcb:script-file|assets:operating-system|node:os|default}.dcb"/>


### PR DESCRIPTION
For now, this is only updated for juniper devices.
Also updated default schedule to be never ( should still able to backup configs manually)
update docs.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14328

