### PR TITLE
NMS-14336 CircleCI : Intermittent failures in horizon-deb-build

### DIFF
--- a/opennms-container/launch_apt_server.sh
+++ b/opennms-container/launch_apt_server.sh
@@ -83,12 +83,11 @@ while [ "$COUNT" -lt 120 ]; do
   sleep 1
 done
 
+echo "docker logs:"
 docker logs "${APT_CONTAINER_NAME}"
 
-if [ "$COUNT" -eq 30 ]; then
-  echo "gave up waiting for server"
-  echo "docker logs:"
+if [ "$COUNT" -eq 120 ]; then
   echo ""
-  docker logs "${APT_CONTAINER_NAME}"
+  echo "Giving up after waiting $COUNT seconds for the server to come up"
   exit 1
 fi

--- a/opennms-container/launch_apt_server.sh
+++ b/opennms-container/launch_apt_server.sh
@@ -14,6 +14,7 @@ PORT="$1"; shift || :
 APT_VOLUME="$1"; shift || :
 OCI="ubuntu:focal"
 MOUNT_PATH="/repo"
+TIMEOUT=120
 
 [ -n "${APT_CONTAINER_NAME}" ] || APT_CONTAINER_NAME="apt-repo"
 [ -n "${BUILD_NETWORK}"      ] || BUILD_NETWORK="opennms-build-network"
@@ -74,7 +75,7 @@ docker run --rm --detach --name "${APT_CONTAINER_NAME}" --volume ${APT_VOLUME}:$
 
 echo "=== waiting for server to be available ==="
 COUNT=0
-while [ "$COUNT" -lt 120 ]; do
+while [ "$COUNT" -lt $TIMEOUT ]; do
   COUNT="$((COUNT+1))"
   if [ "$( (docker logs "${APT_CONTAINER_NAME}" 2>&1 || :) | grep -c 'Start apt server' )" -gt 0 ]; then
     echo "READY"
@@ -86,7 +87,7 @@ done
 echo "docker logs:"
 docker logs "${APT_CONTAINER_NAME}"
 
-if [ "$COUNT" -eq 120 ]; then
+if [ "$COUNT" -eq $TIMEOUT ]; then
   echo ""
   echo "Giving up after waiting $COUNT seconds for the server to come up"
   exit 1


### PR DESCRIPTION
This intermittent failure can occur when the machine executing this script is slow. As a result, I'm increasing the timeout value we compare the count variable against. 

In addition, I'm making slight modifications to how the output for this script looks.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14336

