### PR TITLE
NMS-14324: DCB Order by Location and Backup Status

### DIFF
--- a/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfig.java
+++ b/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfig.java
@@ -202,6 +202,10 @@ public class DeviceConfig implements Serializable {
 
     public void setStatus(DeviceConfigStatus status) { this.status = status; }
 
+    public DeviceConfigStatus getStatusOrDefault() {
+        return this.status != null ? this.status : DeviceConfigStatus.NONE;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -226,26 +230,5 @@ public class DeviceConfig implements Serializable {
         int result = Objects.hash(ipInterface, serviceName, encoding, configType, fileName, failureReason, createdTime, lastUpdated, lastFailed, lastSucceeded, status);
         result = 31 * result + Arrays.hashCode(config);
         return result;
-    }
-
-    public static DeviceConfigStatus determineBackupStatus(DeviceConfig dc) {
-        return determineBackupStatus(dc.getLastUpdated(), dc.getLastSucceeded());
-    }
-
-    public static DeviceConfigStatus determineBackupStatus(Date lastUpdated, Date lastSucceeded) {
-        // backup never attempted
-        if (lastUpdated == null) {
-            return DeviceConfigStatus.NONE;
-        }
-
-        // most recent backup attempt was successful
-        if (lastSucceeded != null &&
-            lastSucceeded.getTime() >= lastUpdated.getTime()) {
-            return DeviceConfigStatus.SUCCESS;
-        }
-
-        // backup attempted but either never succeeded or else latest attempt failed
-        // NOTE: DeviceConfig.lastFailed should be non-null and >= lastUpdated if we get here
-        return DeviceConfigStatus.FAILED;
     }
 }

--- a/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfigQueryResult.java
+++ b/features/device-config/persistence/api/src/main/java/org/opennms/features/deviceconfig/persistence/api/DeviceConfigQueryResult.java
@@ -52,6 +52,7 @@ public class DeviceConfigQueryResult {
     private String nodeLabel;
     private String operatingSystem;
     private String location;
+    private DeviceConfigStatus status;
 
     public Long getId() { return this.id; }
     public Integer getIpInterfaceId() { return this.ipInterfaceId; }
@@ -70,6 +71,8 @@ public class DeviceConfigQueryResult {
     public String getNodeLabel() { return this.nodeLabel; }
     public String getOperatingSystem() { return this.operatingSystem; }
     public String getLocation() { return this.location; }
+    public DeviceConfigStatus getStatus() { return this.status; }
+    public DeviceConfigStatus getStatusOrDefault() { return this.status != null ? this.status : DeviceConfigStatus.NONE; }
 
     public void setId(Long n) { this.id = n; }
     public void setIpInterfaceId(Integer n) { this.ipInterfaceId = n; }
@@ -88,6 +91,7 @@ public class DeviceConfigQueryResult {
     public void setNodeLabel(String s) { this.nodeLabel = s; }
     public void setOperatingSystem(String s) { this.operatingSystem = s; }
     public void setLocation(String s) { this.location = s; }
+    public void setStatus(DeviceConfigStatus status) { this.status = status; }
 
     public DeviceConfigQueryResult() {
     }
@@ -110,5 +114,6 @@ public class DeviceConfigQueryResult {
         this.nodeLabel = node.getLabel();
         this.operatingSystem = node.getOperatingSystem();
         this.location = node.getLocation().getLocationName();
+        this.status = dc.getStatus();
     }
 }

--- a/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
+++ b/features/device-config/persistence/impl/src/main/java/org/opennms/features/deviceconfig/persistence/impl/DeviceConfigDaoImpl.java
@@ -57,7 +57,9 @@ public class DeviceConfigDaoImpl extends AbstractDaoHibernate<DeviceConfig, Long
         "lastupdated", "last_updated",
         "devicename", "nodelabel",
         "lastbackup", "created_time",
-        "ipaddress", "ipaddr"
+        "ipaddress", "ipaddr",
+        "location", "location",
+        "status", "status"
     );
 
     private static final Logger LOG = LoggerFactory.getLogger(DeviceConfigDaoImpl.class);

--- a/features/device-config/persistence/impl/src/test/java/org/opennms/features/deviceconfig/persistence/DeviceConfigDaoIT.java
+++ b/features/device-config/persistence/impl/src/test/java/org/opennms/features/deviceconfig/persistence/DeviceConfigDaoIT.java
@@ -222,7 +222,7 @@ public class DeviceConfigDaoIT {
             }
             deviceConfig.setLastUpdated(Date.from(Instant.now().plusSeconds(i * 60)));
             deviceConfig.setLastSucceeded(deviceConfig.getLastUpdated());
-            deviceConfig.setStatus(DeviceConfig.determineBackupStatus(deviceConfig));
+            deviceConfig.setStatus(DeviceConfigStatus.SUCCESS);
             deviceConfigDao.saveOrUpdate(deviceConfig);
         }
     }
@@ -236,7 +236,7 @@ public class DeviceConfigDaoIT {
         deviceConfig.setLastUpdated(Date.from(Instant.now().plus(2, HOURS)));
         deviceConfig.setLastFailed(Date.from(Instant.now().plus(2, HOURS)));
         deviceConfig.setFailureReason("Not able to connect to SSHServer");
-        deviceConfig.setStatus(DeviceConfig.determineBackupStatus(deviceConfig));
+        deviceConfig.setStatus(DeviceConfigStatus.FAILED);
         deviceConfigDao.saveOrUpdate(deviceConfig);
     }
 

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -28,6 +28,7 @@
 
 package org.opennms.features.deviceconfig.rest.impl;
 
+import org.apache.commons.lang3.NotImplementedException;
 import static org.opennms.features.deviceconfig.service.DeviceConfigService.DEVICE_CONFIG_PREFIX;
 
 import java.io.ByteArrayOutputStream;
@@ -94,7 +95,9 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         "lastupdated", "lastUpdated",
         "devicename", "ipInterface.node.label",
         "lastbackup", "createdTime",
-        "ipaddress", "ipInterface.ipAddr"
+        "ipaddress", "ipInterface.ipAddr",
+        "location", "ipInterface.node.location.locationName",
+        "status", "status"
     );
 
     private final DeviceConfigDao deviceConfigDao;
@@ -493,7 +496,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         dto.setConfig(config);
         dto.setFailureReason(queryResult.getFailureReason());
 
-        DeviceConfigStatus backupStatus = DeviceConfig.determineBackupStatus(queryResult.getLastUpdated(), queryResult.getLastSucceeded());
+        DeviceConfigStatus backupStatus = queryResult.getStatusOrDefault();
         dto.setIsSuccessfulBackup(backupStatus.equals(DeviceConfigStatus.SUCCESS));
         dto.setBackupStatus(backupStatus.name().toLowerCase(Locale.ROOT));
 
@@ -529,7 +532,7 @@ public class DefaultDeviceConfigRestService implements DeviceConfigRestService {
         dto.setConfig(config);
         dto.setFailureReason(deviceConfig.getFailureReason());
 
-        DeviceConfigStatus backupStatus = DeviceConfig.determineBackupStatus(deviceConfig);
+        DeviceConfigStatus backupStatus = deviceConfig.getStatusOrDefault();
         dto.setIsSuccessfulBackup(backupStatus.equals(DeviceConfigStatus.SUCCESS));
         dto.setBackupStatus(backupStatus.name().toLowerCase(Locale.ROOT));
 

--- a/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
+++ b/features/device-config/rest/src/main/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestService.java
@@ -28,7 +28,6 @@
 
 package org.opennms.features.deviceconfig.rest.impl;
 
-import org.apache.commons.lang3.NotImplementedException;
 import static org.opennms.features.deviceconfig.service.DeviceConfigService.DEVICE_CONFIG_PREFIX;
 
 import java.io.ByteArrayOutputStream;

--- a/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
+++ b/features/device-config/rest/src/test/java/org/opennms/features/deviceconfig/rest/impl/DefaultDeviceConfigRestServiceIT.java
@@ -319,7 +319,7 @@ public class DefaultDeviceConfigRestServiceIT {
         dc.setIpInterface(ipInterface1);
         dc.setServiceName("DeviceConfig-default");
         dc.setLastUpdated(new Date(createdTime(version)));
-        dc.setStatus(DeviceConfig.determineBackupStatus(dc));
+        dc.setStatus(DeviceConfigStatus.SUCCESS);
 
         return dc;
     }

--- a/ui/src/components/Device/DCBTableStatusDropdown.vue
+++ b/ui/src/components/Device/DCBTableStatusDropdown.vue
@@ -11,8 +11,8 @@
       :key="option"
       @click="filterByStatus(option)"
     >
-      <div class="option" :class="option">
-      {{ option === 'none' ? 'No Backup' : option }}
+      <div class="option" :class="option.toLowerCase()">
+      {{ option === 'NONE' ? 'No Backup' : option.toLowerCase() }}
       </div>
     </FeatherDropdownItem>
   </FeatherDropdown>

--- a/ui/src/store/device/actions.ts
+++ b/ui/src/store/device/actions.ts
@@ -33,7 +33,9 @@ const getHistoryByIpInterface = async (context: ContextWithState) => {
 
 const getAndMergeDeviceConfigBackups = async (context: ContextWithState) => {
   const deviceConfigBackups = await API.getDeviceConfigBackups(context.state.deviceConfigBackupQueryParams)
-  context.commit('MERGE_DEVICE_CONFIG_BACKUPS', deviceConfigBackups)
+  if (deviceConfigBackups && deviceConfigBackups.data) {
+    context.commit('MERGE_DEVICE_CONFIG_BACKUPS', deviceConfigBackups.data)
+  }
 }
 
 const downloadByConfig = async (context: VuexContext, config: DeviceConfigBackup | DeviceConfigBackup[]) => {

--- a/ui/src/store/device/state.ts
+++ b/ui/src/store/device/state.ts
@@ -18,7 +18,7 @@ const state: State = {
   modalDeviceConfigBackup: {} as DeviceConfigBackup,
   selectedIds: [],
   vendorOptions: [],
-  backupStatusOptions: ['success', 'failed', 'none'],
+  backupStatusOptions: ['SUCCESS', 'FAILED', 'NONE'],
   osImageOptions: [],
   deviceConfigTotal: 'N/A',
   historyModalBackups: []

--- a/ui/src/types/deviceConfig.d.ts
+++ b/ui/src/types/deviceConfig.d.ts
@@ -34,7 +34,8 @@ export interface DeviceConfigQueryParams extends QueryParameters {
   configType?: string
   createdAfter?: number
   createdBefore?: number
+  location?: string
   status?: status
 }
 
-export type status = 'none' | 'success' | 'failed'
+export type status = 'NONE' | 'SUCCESS' | 'FAILED'


### PR DESCRIPTION
NMS-14324: Device Config Backup, Rest API and UI, order by Location and Backup Status.

- Update Rest API `latest` to allow `orderBy` on location and status
- Remove code to determine backup status by device config dates. Backup status is now stored in the DB and status is determine by `DeviceConfigMonitorAdaptor` during polling
- Update integration tests
- Minimal changes in UI to enable sort by location
- UI sort by status is not implemented, would need changes to `DCBTableStatusDropdown`. However, filter by status works correctly
- UI updated 'status' query params for filtering by status to be uppercase, otherwise Java server code doesn't recognize parameters and returns a 404
- FIxed small bug in `getAndMergeDeviceConfigBackups` where responses with `204 - No Content` contained just empty string data, instead of expected array data


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14324

