### PR TITLE
Mem/jira/nms 14124 disable smoke tests and rpm generation on normal builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,22 +547,28 @@ workflows:
             - build
           filters:
             branches:
-              ignore:
-                - /^merge-foundation.*/
+              only:
+                - /^foundation.*/
+                - /^release-.*/
+                - develop
       - minion-rpm-build:
           requires:
             - build
           filters:
             branches:
-              ignore:
-                - /^merge-foundation.*/
+              only:
+                - /^foundation.*/
+                - /^release-.*/
+                - develop
       - sentinel-rpm-build:
           requires:
             - build
           filters:
             branches:
-              ignore:
-                - /^merge-foundation.*/
+              only:
+                - /^foundation.*/
+                - /^release-.*/
+                - develop
       - integration-test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,7 +653,7 @@ workflows:
       #          - /^master-.*/
       #          - /^release-.*/
       #          - /^foundation.*/
-      3          - /^merge-foundation.*/
+      #          - /^merge-foundation.*/
       #          - /^features.*/
       #          - /.*smoke.*/
       #          - /^dependabot.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,7 +653,7 @@ workflows:
       #          - /^master-.*/
       #          - /^release-.*/
       #          - /^foundation.*/
-      #          - /^merge-foundation.*/
+      3          - /^merge-foundation.*/
       #          - /^features.*/
       #          - /.*smoke.*/
       #          - /^dependabot.*/
@@ -666,7 +666,6 @@ workflows:
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
-            - smoke-test-minimal
             - smoke-test-sentinel
           filters:
             branches:
@@ -683,7 +682,6 @@ workflows:
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
-            - smoke-test-minimal
             - smoke-test-sentinel
           filters:
             branches:
@@ -700,7 +698,6 @@ workflows:
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
-            - smoke-test-minimal
             - smoke-test-sentinel
           filters:
             branches:
@@ -760,7 +757,6 @@ workflows:
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
-            - smoke-test-minimal
             - smoke-test-sentinel
           filters:
             branches:
@@ -784,7 +780,6 @@ workflows:
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
-            - smoke-test-minimal
             - smoke-test-sentinel
           filters:
             branches:
@@ -798,7 +793,6 @@ workflows:
             - smoke-test-flaky
             - smoke-test-minion
             - smoke-test-sentinel
-            - smoke-test-minimal
             - integration-test
           filters:
             branches:
@@ -815,7 +809,6 @@ workflows:
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
-            - smoke-test-minimal
             - smoke-test-sentinel
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,23 +640,23 @@ workflows:
                 - /^features.*/
                 - /.*smoke.*/
                 - /^dependabot.*/
-      - smoke-test-minimal:
-          requires:
-            - tarball-assembly
-            - horizon-rpm-build
-            - minion-rpm-build
-            - sentinel-rpm-build
-          filters:
-            branches:
-              ignore:
-                - develop
-                - /^master-.*/
-                - /^release-.*/
-                - /^foundation.*/
-                - /^merge-foundation.*/
-                - /^features.*/
-                - /.*smoke.*/
-                - /^dependabot.*/
+      #- smoke-test-minimal:
+      #    requires:
+      #      - tarball-assembly
+      #      - horizon-rpm-build
+      #      - minion-rpm-build
+      #      - sentinel-rpm-build
+      #    filters:
+      #      branches:
+      #        only:
+      #          - develop
+      #          - /^master-.*/
+      #          - /^release-.*/
+      #          - /^foundation.*/
+      #          - /^merge-foundation.*/
+      #          - /^features.*/
+      #          - /.*smoke.*/
+      #          - /^dependabot.*/
       - horizon-publish-oci:
           requires:
             - horizon-deb-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,6 +551,7 @@ workflows:
                 - /^foundation.*/
                 - /^release-.*/
                 - develop
+                - /.*smoke.*/
       - minion-rpm-build:
           requires:
             - build
@@ -560,6 +561,7 @@ workflows:
                 - /^foundation.*/
                 - /^release-.*/
                 - develop
+                - /.*smoke.*/
       - sentinel-rpm-build:
           requires:
             - build
@@ -569,6 +571,7 @@ workflows:
                 - /^foundation.*/
                 - /^release-.*/
                 - develop
+                - /.*smoke.*/
       - integration-test:
           requires:
             - build


### PR DESCRIPTION
Disable smoke tests and rpm generation during normal builds. 

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?


### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14124

