### PR TITLE
NMS-14003: Telemetryd does not shut down gracefully

### DIFF
--- a/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/receiver/GracefulShutdownListener.java
+++ b/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/receiver/GracefulShutdownListener.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.api.receiver;
+
+import java.util.concurrent.Future;
+
+/**
+ * It extends standard listener with extra future for monitor shutdown status. In order to prevent deadlock of shutdown process.
+ */
+public interface GracefulShutdownListener extends Listener {
+    Future getShutdownFuture();
+}

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
@@ -170,7 +170,11 @@ public class Telemetryd implements SpringServiceDaemon {
                 listener.stop();
                 if (listener instanceof GracefulShutdownListener) {
                     Future<?> future = ((GracefulShutdownListener) listener).getShutdownFuture();
-                    stopFutures.add(future);
+                    if (future == null) {
+                        LOG.warn("Shutdown future is missing for {}.", listener.getName());
+                    } else {
+                        stopFutures.add(future);
+                    }
                 }
             } catch (InterruptedException e) {
                 LOG.warn("Error while stopping listener.", e);

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -30,11 +30,15 @@ package org.opennms.netmgt.telemetry.daemon;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.core.ipc.sink.api.MessageConsumerManager;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.netmgt.telemetry.api.receiver.GracefulShutdownListener;
 import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.daemon.DaemonTools;
 import org.opennms.netmgt.daemon.SpringServiceDaemon;
@@ -157,16 +161,29 @@ public class Telemetryd implements SpringServiceDaemon {
     public synchronized void destroy() {
         LOG.info("{} is stopping.", NAME);
 
+        List<Future<?>> stopFutures = new ArrayList<>();
+
         // Stop the listeners
         for (Listener listener : listeners) {
             try {
                 LOG.info("Stopping {} listener.", listener.getName());
                 listener.stop();
+                if (listener instanceof GracefulShutdownListener) {
+                    Future<?> future = ((GracefulShutdownListener) listener).getShutdownFuture();
+                    stopFutures.add(future);
+                }
             } catch (InterruptedException e) {
                 LOG.warn("Error while stopping listener.", e);
             }
         }
         listeners.clear();
+
+        // wait for 60s
+        try {
+            this.waitForStop(stopFutures, 60);
+        } catch (ExecutionException | InterruptedException e) {
+            LOG.warn("Error while waiting stop future.", e);
+        }
 
         // Stop the dispatchers
         for (AsyncDispatcher<?> dispatcher : telemetryRegistry.getDispatchers()) {
@@ -193,6 +210,42 @@ public class Telemetryd implements SpringServiceDaemon {
         consumers.clear();
 
         LOG.info("{} is stopped.", NAME);
+    }
+
+    /**
+     * It will wait for the futures by maxTime (second)
+     * @param futures shutdown future
+     * @param maxTime
+     */
+    private void waitForStop(List<Future<?>> futures, int maxTime) throws ExecutionException, InterruptedException {
+        Objects.requireNonNull(futures);
+        Object lock = new Object();
+        synchronized (lock) {
+            int i = 0;
+            while (i < maxTime) {
+                boolean allDone = true;
+                for (Future<?> future : futures) {
+                    if (!future.isDone()) {
+                        allDone = false;
+                        break;
+                    }
+                }
+                if (allDone) {
+                    if (LOG.isInfoEnabled()) {
+                        StringBuilder builder = new StringBuilder();
+                        for (Future<?> future : futures) {
+                            builder.append(future.get());
+                            builder.append(" ");
+                        }
+                        LOG.info("Future done time: {}s output: {}", i, builder);
+                    }
+                    return;
+                }
+                lock.wait(1000L);
+                i++;
+            }
+            LOG.warn("Fail to wait for stop future. Futures: {} maxTime: {}", futures, maxTime);
+        }
     }
 
     @Override

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
@@ -32,8 +32,14 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import org.opennms.netmgt.telemetry.api.receiver.GracefulShutdownListener;
 import org.opennms.netmgt.telemetry.api.receiver.Listener;
+import org.opennms.netmgt.telemetry.listeners.utils.NettyEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +61,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.util.internal.SocketUtils;
 
-public class TcpListener implements Listener {
+public class TcpListener implements GracefulShutdownListener {
     private static final Logger LOG = LoggerFactory.getLogger(TcpListener.class);
 
     private final String name;
@@ -70,6 +76,8 @@ public class TcpListener implements Listener {
     private EventLoopGroup workerGroup;
 
     private ChannelFuture socketFuture;
+
+    private Future<String> stopFuture;
 
     public TcpListener(final String name,
                        final TcpParser parser,
@@ -144,20 +152,55 @@ public class TcpListener implements Listener {
     }
 
     public void stop() throws InterruptedException {
-        LOG.info("Closing channel...");
-        this.socketFuture.channel().close();
-        if (this.socketFuture.channel().parent() != null) {
-            this.socketFuture.channel().parent().close();
-        }
-        var future = this.socketFuture.channel().closeFuture();
-        if (future != null) {
-            future.sync();
-        }
+        NettyEventListener workerListener = new NettyEventListener("worker");
+        NettyEventListener bossListener = new NettyEventListener("boss");
 
-        this.parser.stop();
+        LOG.info("Closing worker group...");
+        this.workerGroup.shutdownGracefully().addListener(workerListener);
 
         LOG.info("Closing boss group...");
-        this.bossGroup.shutdownGracefully().sync();
+        this.bossGroup.shutdownGracefully().addListener(bossListener);
+
+        if (this.socketFuture != null) {
+            LOG.info("Closing channel...");
+            this.socketFuture.channel().close().sync();
+            if (this.socketFuture.channel().parent() != null) {
+                this.socketFuture.channel().parent().close().sync();
+            }
+        }
+
+        LOG.info("Stopping parser...");
+        if (this.parser != null) {
+            this.parser.stop();
+        }
+
+        stopFuture = new Future<String>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return false;
+            }
+
+            @Override
+            public boolean isDone() {
+                return workerListener.isDone() && bossListener.isDone();
+            }
+
+            @Override
+            public String get() {
+                return name + "[" + workerListener.getName() + ":" + workerListener.isDone() + ","
+                        + bossListener.getName() + ":" + bossListener.isDone() + "]";
+            }
+
+            @Override
+            public String get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+                return get();
+            }
+        };
     }
 
     @Override
@@ -179,5 +222,10 @@ public class TcpListener implements Listener {
 
     public void setPort(final int port) {
         this.port = port;
+    }
+
+    @Override
+    public Future getShutdownFuture() {
+        return stopFuture;
     }
 }

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -103,7 +103,7 @@ public class TcpListener implements Listener {
                         ch.pipeline()
                                 .addFirst(new ChannelInboundHandlerAdapter() {
                                     @Override
-                                    public  void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                                         packetsReceived.mark();
                                         super.channelRead(ctx, msg);
                                     }
@@ -113,8 +113,7 @@ public class TcpListener implements Listener {
                                     protected void decode(final ChannelHandlerContext ctx,
                                                           final ByteBuf in,
                                                           final List<Object> out) throws Exception {
-                                        session.parse(in)
-                                               .ifPresent(out::add);
+                                        session.parse(in).ifPresent(out::add);
                                     }
                                 })
                                 .addLast(new SimpleChannelInboundHandler<CompletableFuture<?>>() {
@@ -146,7 +145,9 @@ public class TcpListener implements Listener {
 
     public void stop() throws InterruptedException {
         LOG.info("Closing channel...");
-        this.socketFuture.channel().close().sync();
+        this.socketFuture.channel().close();
+        this.socketFuture.channel().parent().close();
+        this.socketFuture.channel().closeFuture().sync();
 
         this.parser.stop();
 

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
@@ -156,6 +156,7 @@ public class TcpListener implements GracefulShutdownListener {
         NettyEventListener bossListener = new NettyEventListener("boss");
 
         LOG.info("Closing worker group...");
+        // switch to use even listener rather than sync to prevent shutdown deadlock hang
         this.workerGroup.shutdownGracefully().addListener(workerListener);
 
         LOG.info("Closing boss group...");

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
@@ -146,8 +146,13 @@ public class TcpListener implements Listener {
     public void stop() throws InterruptedException {
         LOG.info("Closing channel...");
         this.socketFuture.channel().close();
-        this.socketFuture.channel().parent().close();
-        this.socketFuture.channel().closeFuture().sync();
+        if (this.socketFuture.channel().parent() != null) {
+            this.socketFuture.channel().parent().close();
+        }
+        var future = this.socketFuture.channel().closeFuture();
+        if (future != null) {
+            future.sync();
+        }
 
         this.parser.stop();
 

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
@@ -115,7 +115,9 @@ public class UdpListener implements Listener {
 
     public void stop() throws InterruptedException {
         LOG.info("Closing channel...");
-        this.socketFuture.channel().close().sync();
+        this.socketFuture.channel().close();
+        this.socketFuture.channel().parent().close();
+        this.socketFuture.channel().closeFuture().sync();
 
         this.parsers.forEach(Parser::stop);
 

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
@@ -123,8 +123,10 @@ public class UdpListener implements GracefulShutdownListener {
 
     public void stop() throws InterruptedException {
         NettyEventListener bossListener = new NettyEventListener("boss");
+
         LOG.info("Closing boss group...");
         if (this.bossGroup != null) {
+            // switch to use even listener rather than sync to prevent shutdown deadlock hang
             this.bossGroup.shutdownGracefully().addListener(bossListener);
         }
 

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -116,8 +116,13 @@ public class UdpListener implements Listener {
     public void stop() throws InterruptedException {
         LOG.info("Closing channel...");
         this.socketFuture.channel().close();
-        this.socketFuture.channel().parent().close();
-        this.socketFuture.channel().closeFuture().sync();
+        if (this.socketFuture.channel().parent() != null) {
+            this.socketFuture.channel().parent().close();
+        }
+        var future = this.socketFuture.channel().closeFuture();
+        if(future != null){
+            future.sync();
+        }
 
         this.parsers.forEach(Parser::stop);
 

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/utils/NettyEventListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/utils/NettyEventListener.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.listeners.utils;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+
+public class NettyEventListener implements GenericFutureListener {
+    private String name;
+    private boolean isDone = false;
+    public NettyEventListener(String name){
+        this.name = name;
+    }
+
+    @Override
+    public void operationComplete(Future future) {
+        isDone = future.isDone();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isDone() {
+        return isDone;
+    }
+}


### PR DESCRIPTION
The major problem of the shutdown is due to deadlock inside sync() call of NioEventLoopGroup.shutdownGracefully(). This PR change the sync by using using an event listener.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14003
