### PR TITLE
NMS-14282: Enable multiline text entry for requisition metadata values

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/MetaData.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/MetaData.js
@@ -51,6 +51,17 @@ const _ = require('lodash');
       $uibModalInstance.dismiss('cancel');
     };
 
+    $scope.getValueRowCount = function (entry) {
+      // Expand size of value textarea to up to 3 rows if user enters 3+ lines
+      if (!entry.value || entry.value.indexOf('\n') < 0) {
+        return 1;
+      }
+
+      const lineBreaks = (entry.value.match(/\n/g) || []).length;
+
+      return Math.min(lineBreaks + 1, 3);
+    }
+
     // Initialization
     $scope.interfacesWithServices = [];
     $scope.availableScopes = {};

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/metadata.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/metadata.html
@@ -43,7 +43,8 @@
       </div>
       <div class="form-group" ng-class="{ 'has-error' : metaDataForm.value.$invalid }">
         <label class="control-label" for="metadata-value">Value</label>
-        <input class="form-control" type="text" id="metadata-value" name="value" placeholder="Value" ng-model="entry.value" required>
+        <textarea class="form-control" cols="60" rows="{{ getValueRowCount(entry) }}" id="metadata-value" name="value" placeholder="Value" ng-model="entry.value">
+        </textarea>
         <p ng-show="metaDataForm.value.$invalid" class="help-block">A non empty value is required.</p>
       </div>
     </div>


### PR DESCRIPTION
NMS-14282. Enable multiline text entry for requisition Metadata values.

In Requisition UI, replaces the text input control for entering the Metadata value with a textarea. Initial it displays 1 row, but expands to up to 3 rows if user enters 3+ lines of text (then it scrolls).

For now, always has this new multiline textarea input. It's possible this is only desired for certain types of metadata, e.g. SSH keys or DCB scripts. Can add that if needed due to following issue.

One issue is that hitting 'Enter' key inside the 'value' textarea no longer saves the Metadata item, but would add another line. User would need to tab out or else click 'Save' button.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14282

