### PR TITLE
NMS-13785: fix casting error when flow persistence gives errors

### DIFF
--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
@@ -425,7 +425,7 @@ public class ElasticFlowRepository implements FlowRepository {
                 bulkRequest.execute();
             } catch (BulkException ex) {
                 if (ex.getBulkResult() != null) {
-                    throw new PersistenceException(ex.getMessage(), ex.getBulkResult().getFailedDocuments());
+                    throw new PersistenceException(ex.getMessage(), ex.getBulkResult().getFailedItems());
                 } else {
                     throw new PersistenceException(ex.getMessage(), Collections.emptyList());
                 }


### PR DESCRIPTION
* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13785

Interestingly, the constructor for PersistenceException expects a List<FailedItem<FlowDocument>>, but the defect was caused because a List<FlowDocument> was passed through instead. The compiler didn't catch this, and at run time the constructor succeeds and the wrong type of list is assigned into the PersistenceException's member variable failedItems. ElasticFlowRepository.persistBulk is called in two different ways. One of which attempts to handle PersistenceExceptions by iterating through the list. This then gives the casting error as the list doesn't contain FailedItems as expected. I suspect the other method for calling persistBulk is how it is more commonly called, which won't give the casting error as the exception handling doesn't iterate through the failed items.

