### PR TITLE
Bridge Topology Discovery Mismatch

### DIFF
--- a/features/enlinkd/service/api/src/main/java/org/opennms/netmgt/enlinkd/service/api/BridgeSimpleConnection.java
+++ b/features/enlinkd/service/api/src/main/java/org/opennms/netmgt/enlinkd/service/api/BridgeSimpleConnection.java
@@ -398,12 +398,6 @@ public class BridgeSimpleConnection implements Topology {
             }
 
         }
-        // all macs on the same port
-        if (mac2 == null) {
-        	bbports.add(0, xp1);
-        	bbports.add(1, yp1);
-        	return bbports;
-        }
         LOG.warn("condition3: no simple connection found [{}] -> [{}]", bridgexFt.getNodeId(), bridgeyFt.getNodeId());
         return bbports;
    }

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/BroadcastDomainTest.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/BroadcastDomainTest.java
@@ -1748,7 +1748,7 @@ public class BroadcastDomainTest extends EnLinkdTestHelper {
         
         ndbtB.calculate();
         
-        assertEquals(0, ndbtB.getFailed().size());
+        assertEquals(1, ndbtB.getFailed().size());
 
     }
 
@@ -1971,7 +1971,7 @@ public class BroadcastDomainTest extends EnLinkdTestHelper {
 
         ndbtB.calculate();
         
-        assertEquals(0, ndbtB.getFailed().size());
+        assertEquals(1, ndbtB.getFailed().size());
 
     }
 
@@ -1993,7 +1993,7 @@ public class BroadcastDomainTest extends EnLinkdTestHelper {
 
         ndbtB.calculate();
         
-        assertEquals(0, ndbtB.getFailed().size());
+        assertEquals(1, ndbtB.getFailed().size());
 
     }
 
@@ -2018,7 +2018,7 @@ public class BroadcastDomainTest extends EnLinkdTestHelper {
 
         ndbtB.calculate();
         
-        assertEquals(0, ndbtB.getFailed().size());
+        assertEquals(1, ndbtB.getFailed().size());
 
     }
 
@@ -2046,7 +2046,7 @@ public class BroadcastDomainTest extends EnLinkdTestHelper {
 
         ndbtB.calculate();
         
-        assertEquals(0, ndbtB.getFailed().size());
+        assertEquals(1, ndbtB.getFailed().size());
 
     }
     @Test


### PR DESCRIPTION

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14322

Cleaning up a wrong condition that lead to wrong bridge topology discovery.
The Tests has been fixed accordingly.

