### PR TITLE
NMS-13834: Modified opennms.spec and debian/rules to also create web-inf-pristine

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -64,6 +64,11 @@ install: build
 	rsync -avr --exclude=examples debian/temp/etc/ debian/opennms-common/var/lib/opennms/etc-pristine/
 	chmod -R go-w debian/opennms-common/var/lib/opennms/etc-pristine/
 
+	mkdir -p debian/opennms-common/var/lib/opennms/spring-security-pristine/spring-security.d/
+	rsync -avr --exclude=examples debian/temp/jetty-webapps/opennms/WEB-INF/spring-security.d/ debian/opennms-common/var/lib/opennms/spring-security-pristine/
+	cp debian/temp/jetty-webapps/opennms/WEB-INF/applicationContext-spring-security.xml debian/opennms-common/var/lib/opennms/spring-security-pristine/applicationContext-spring-security.xml
+	chmod -R go-w debian/opennms-common/var/lib/opennms/spring-security-pristine/
+	
 	##
 	## Setup the alarm northbounders
 	##

--- a/debian/rules
+++ b/debian/rules
@@ -64,10 +64,12 @@ install: build
 	rsync -avr --exclude=examples debian/temp/etc/ debian/opennms-common/var/lib/opennms/etc-pristine/
 	chmod -R go-w debian/opennms-common/var/lib/opennms/etc-pristine/
 
-	mkdir -p debian/opennms-common/var/lib/opennms/spring-security-pristine/spring-security.d/
-	rsync -avr --exclude=examples debian/temp/jetty-webapps/opennms/WEB-INF/spring-security.d/ debian/opennms-common/var/lib/opennms/spring-security-pristine/
-	cp debian/temp/jetty-webapps/opennms/WEB-INF/applicationContext-spring-security.xml debian/opennms-common/var/lib/opennms/spring-security-pristine/applicationContext-spring-security.xml
-	chmod -R go-w debian/opennms-common/var/lib/opennms/spring-security-pristine/
+	mkdir -p debian/opennms-common/var/lib/opennms/web-inf-pristine/spring-security.d/
+	rsync -avr --exclude=examples debian/temp/jetty-webapps/opennms/WEB-INF/spring-security.d/ debian/opennms-common/var/lib/opennms/web-inf-pristine/
+	cp debian/temp/jetty-webapps/opennms/WEB-INF/applicationContext-spring-security.xml debian/opennms-common/var/lib/opennms/web-inf-pristine/applicationContext-spring-security.xml
+	cp debian/temp/jetty-webapps/opennms/WEB-INF/web.xml debian/opennms-common/var/lib/opennms/web-inf-pristine/web.xml
+	cp debian/temp/etc/examples/jetty.xml debian/opennms-common/var/lib/opennms/web-inf-pristine/jetty.xml
+	chmod -R go-w debian/opennms-common/var/lib/opennms/web-inf-pristine/
 	
 	##
 	## Setup the alarm northbounders

--- a/debian/rules
+++ b/debian/rules
@@ -65,7 +65,7 @@ install: build
 	chmod -R go-w debian/opennms-common/var/lib/opennms/etc-pristine/
 
 	mkdir -p debian/opennms-common/var/lib/opennms/web-inf-pristine/spring-security.d/
-	rsync -avr --exclude=examples debian/temp/jetty-webapps/opennms/WEB-INF/spring-security.d/ debian/opennms-common/var/lib/opennms/web-inf-pristine/
+	rsync -avr --exclude=examples debian/temp/jetty-webapps/opennms/WEB-INF/spring-security.d/ debian/opennms-common/var/lib/opennms/web-inf-pristine/spring-security.d/
 	cp debian/temp/jetty-webapps/opennms/WEB-INF/applicationContext-spring-security.xml debian/opennms-common/var/lib/opennms/web-inf-pristine/applicationContext-spring-security.xml
 	cp debian/temp/jetty-webapps/opennms/WEB-INF/web.xml debian/opennms-common/var/lib/opennms/web-inf-pristine/web.xml
 	cp debian/temp/etc/examples/jetty.xml debian/opennms-common/var/lib/opennms/web-inf-pristine/jetty.xml

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -611,11 +611,13 @@ rm -rf %{buildroot}%{instprefix}/share
 rsync -avr --exclude=examples %{buildroot}%{instprefix}/etc/ %{buildroot}%{sharedir}/etc-pristine/
 chmod -R go-w %{buildroot}%{sharedir}/etc-pristine/
 
-# Copy the /jetty-webapps/opennms/WEB-INF spring-security files into /spring-security-pristine
-mkdir -p %{buildroot}%{sharedir}/spring-security-pristine/spring-security.d/
-rsync -avr %{buildroot}%{instprefix}/jetty-webapps/opennms/WEB-INF/spring-security.d/ %{buildroot}%{sharedir}/spring-security-pristine/spring-security.d/
-cp %{buildroot}%{instprefix}/jetty-webapps/opennms/WEB-INF/applicationContext-spring-security.xml %{buildroot}%{sharedir}/spring-security-pristine/applicationContext-spring-security.xml
-chmod -R go-w %{buildroot}%{sharedir}/spring-security-pristine/
+# Copy the /jetty-webapps/opennms/WEB-INF spring-security files into /web-inf-pristine
+mkdir -p %{buildroot}%{sharedir}/web-inf-pristine/spring-security.d/
+rsync -avr %{buildroot}%{instprefix}/jetty-webapps/opennms/WEB-INF/spring-security.d/ %{buildroot}%{sharedir}/web-inf-pristine/spring-security.d/
+cp %{buildroot}%{instprefix}/jetty-webapps/opennms/WEB-INF/applicationContext-spring-security.xml %{buildroot}%{sharedir}/web-inf-pristine/applicationContext-spring-security.xml
+cp %{buildroot}%{instprefix}/jetty-webapps/opennms/WEB-INF/web.xml %{buildroot}%{sharedir}/web-inf-pristine/web.xml
+cp %{buildroot}%{instprefix}/etc/examples/jetty.xml %{buildroot}%{sharedir}/web-inf-pristine/jetty.xml
+chmod -R go-w %{buildroot}%{sharedir}/web-inf-pristine/
 
 install -d -m 755 "%{buildroot}%{_initrddir}" "%{buildroot}%{_sysconfdir}/sysconfig" "%{buildroot}%{_unitdir}"
 install -m 644 %{buildroot}%{instprefix}/etc/opennms.service %{buildroot}%{_unitdir}
@@ -723,7 +725,7 @@ find %{buildroot}%{instprefix}/bin \
 # Put various shared directories in the package
 find %{buildroot}%{instprefix}/bin \
 	%{buildroot}%{sharedir}/etc-pristine \
-	%{buildroot}%{sharedir}/spring-security-pristine \
+	%{buildroot}%{sharedir}/web-inf-pristine \
 	%{buildroot}%{sharedir}/mibs \
 	%{buildroot}%{sharedir}/reports \
 	%{buildroot}%{sharedir}/rrd \

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -611,6 +611,12 @@ rm -rf %{buildroot}%{instprefix}/share
 rsync -avr --exclude=examples %{buildroot}%{instprefix}/etc/ %{buildroot}%{sharedir}/etc-pristine/
 chmod -R go-w %{buildroot}%{sharedir}/etc-pristine/
 
+# Copy the /jetty-webapps/opennms/WEB-INF spring-security files into /spring-security-pristine
+mkdir -p %{buildroot}%{sharedir}/spring-security-pristine/spring-security.d/
+rsync -avr %{buildroot}%{instprefix}/jetty-webapps/opennms/WEB-INF/spring-security.d/ %{buildroot}%{sharedir}/spring-security-pristine/spring-security.d/
+cp %{buildroot}%{instprefix}/jetty-webapps/opennms/WEB-INF/applicationContext-spring-security.xml %{buildroot}%{sharedir}/spring-security-pristine/applicationContext-spring-security.xml
+chmod -R go-w %{buildroot}%{sharedir}/spring-security-pristine/
+
 install -d -m 755 "%{buildroot}%{_initrddir}" "%{buildroot}%{_sysconfdir}/sysconfig" "%{buildroot}%{_unitdir}"
 install -m 644 %{buildroot}%{instprefix}/etc/opennms.service %{buildroot}%{_unitdir}
 
@@ -717,6 +723,7 @@ find %{buildroot}%{instprefix}/bin \
 # Put various shared directories in the package
 find %{buildroot}%{instprefix}/bin \
 	%{buildroot}%{sharedir}/etc-pristine \
+	%{buildroot}%{sharedir}/spring-security-pristine \
 	%{buildroot}%{sharedir}/mibs \
 	%{buildroot}%{sharedir}/reports \
 	%{buildroot}%{sharedir}/rrd \


### PR DESCRIPTION
This creates a new directory `web-inf-pristine` at the same level as `etc-pristine` that contains  

- `jetty-webapps/opennms/WEB-INF/applicationContext-spring-security.xml`
- `jetty-webapps/opennms/WEB-INF/web.xml`
- `jetty-webapps/opennms/WEB-INF/spring-security.d/`
- `etc/examples/jetty.xml`

This is installed at `/var/lib/opennms/web-inf-pristine` on debian systems and at `/var/opennms/web-inf-pristine` on centos.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13834

