### PR TITLE
NMS-14300: Disable backup for single selected config w/o service name

### DIFF
--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -17,7 +17,7 @@
           <FeatherButton
             data-test="view-history-btn"
             @click="onViewHistory"
-            :disabled="(!all && selectedDeviceConfigIds.length !== 1) || (all && deviceConfigBackups.length !== 1)"
+            :disabled="!singleConfigSelected"
             text
           >
             <template v-slot:icon>
@@ -29,7 +29,7 @@
           <FeatherButton
             data-test="download-btn"
             @click="onDownload"
-            :disabled="(selectedDeviceConfigIds.length === 0 && !all) || (all && !deviceConfigBackups.length)"
+            :disabled="noConfigsSelected"
             text
           >
             <template v-slot:icon>
@@ -41,7 +41,7 @@
           <FeatherButton
             data-test="backup-now-btn"
             @click="onBackupNow"
-            :disabled="(selectedDeviceConfigIds.length === 0 && !all) || (all && !deviceConfigBackups.length)"
+            :disabled="noConfigsSelected || singleConfigSelectedHasNoServiceName"
             text
           >
             <template v-slot:icon>
@@ -53,7 +53,7 @@
           <FeatherButton
             data-test="compare-btn"
             @click="onCompare"
-            :disabled="(!all && selectedDeviceConfigIds.length !== 1) || (all && deviceConfigBackups.length !== 1)"
+            :disabled="!singleConfigSelected"
             text
           >
             <template v-slot:icon>
@@ -272,13 +272,19 @@ const selectedDeviceConfigIds = computed<number[]>(() => {
     .map((id) => parseInt(id))
 })
 
-const numberOfSelectedDevices = computed(() => {
+const numberOfSelectedDevices = computed<number>(() => {
   if (all.value) {
     return totalCountOfDeviceConfigBackups.value
   }
 
   return selectedDeviceConfigIds.value.length
 })
+
+// for enabling / disabling table buttons (history, backup, d/l, compare...)
+const noConfigsSelected = computed<boolean>(() => (selectedDeviceConfigIds.value.length === 0 && !all.value) || (all.value && !deviceConfigBackups.value.length))
+const singleConfigSelected = computed<boolean>(() => (!all.value && selectedDeviceConfigIds.value.length === 1) || (all.value && deviceConfigBackups.value.length === 1))
+const singleConfigSelectedHasNoServiceName = computed<boolean>(() => singleConfigSelected.value && !getDeviceConfigBackupById(selectedDeviceConfigIds.value[0]).serviceName)
+const getDeviceConfigBackupById = (id: number) => deviceConfigBackups.value.filter((backup) => backup.id === id)[0]
 
 const sortByColumnHandler = (sortObj: FeatherSortObject) => {
   for (const key in sortStates) {

--- a/ui/tests/deviceConfigBackup.test.ts
+++ b/ui/tests/deviceConfigBackup.test.ts
@@ -56,7 +56,7 @@ const mockDeviceConfigBackups: DeviceConfigBackup[] = [
     operatingSystem: '',
     isSuccessfulBackup: true,
     monitoredServiceId: 1,
-    serviceName: 'DeviceConfig-default'
+    serviceName: ''
   }
 ]
 
@@ -80,6 +80,7 @@ test('action btns enable and disable correctly', async () => {
   const backupNowBtn = wrapper.get('[data-test="backup-now-btn"]')
   const checkboxes = wrapper.findAll('.dcb-config-checkbox')
   const firstDeviceConfig = wrapper.find('.dcb-config-checkbox > .feather-checkbox')
+  const checkboxArray = wrapper.findAll('.dcb-config-checkbox > .feather-checkbox')
   const allCheckbox = wrapper.find('[data-test="all-checkbox"] > .feather-checkbox')
 
   // two DCB mock records
@@ -113,4 +114,13 @@ test('action btns enable and disable correctly', async () => {
   expect(downloadBtn.attributes('aria-disabled')).toBe('true')
   expect(backupNowBtn.attributes('aria-disabled')).toBe('true')
   expect(allCheckbox.attributes('aria-checked')).toBe('false')
+
+  // select second config checkbox
+  await checkboxArray[1]?.trigger('click')
+  // expect backup btn to be disabled because the only one selected has no service name
+  expect(backupNowBtn.attributes('aria-disabled')).toBe('true')
+  // select first checkbox again
+  await firstDeviceConfig.trigger('click')
+  // expect backup btn enabled because at least one selected has a service name
+  expect(backupNowBtn.attributes('aria-disabled')).toBeUndefined()
 })


### PR DESCRIPTION
- If only one config is selected, and that config does not have a service name, the backup btn should be disabled.
- Make btn disable logic computed vars to avoid repetition

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14300

