### PR TITLE
NMS-14043: Negate search terms in alarms advanced search

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeAlarmTextFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeAlarmTextFilter.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -28,43 +28,38 @@
 
 package org.opennms.web.alarm.filter;
 
-import org.opennms.netmgt.model.OnmsSeverity;
-import org.opennms.web.filter.NotEqualsFilter;
-import org.opennms.web.filter.SQLType;
+import org.opennms.web.filter.AndFilter;
 
-/**
- * Encapsulates negative severity filtering functionality, that is filtering OUT
- * this value instead of only filtering IN this value.
- */
-public class NegativeSeverityFilter extends NotEqualsFilter<OnmsSeverity> {
-    /** Constant <code>TYPE="severitynot"</code> */
-    public static final String TYPE = "severitynot";
+public class NegativeAlarmTextFilter extends AndFilter {
+    /** Constant <code>TYPE="alarmtextNot"</code> */
+    public static final String TYPE = "alarmtextNot";
 
-    /** Constant <code>NESTED_TYPE="nestedSeverityNot"</code> */
-    public static final String NESTED_TYPE = "nestedSeverityNot";
+    private final String value;
 
-    public NegativeSeverityFilter(final OnmsSeverity severity) {
-        super(TYPE, SQLType.SEVERITY, "ALARMS.SEVERITY", "severity", severity);
+    public NegativeAlarmTextFilter(String substring) {
+        super(new NegativeLogMessageSubstringFilter(substring), new NegativeDescriptionSubstringFilter(substring));
+        this.value = substring;
     }
 
     @Override
     public String getTextDescription() {
-        return (TYPE + " is not " + getValue().getLabel());
+        return ("alarm text not containing \"" + value + "\"");
     }
 
     @Override
     public String toString() {
-        return ("<AlarmFactory.NegativeSeverityFilter: " + this.getDescription() + ">");
-    }
-
-    public int getSeverity() {
-        return getValue().getId();
+        return ("<NegativeAlarmTextFilter: " + this.getDescription() + ">");
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public String getDescription() {
+        return TYPE + "!=" + value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof NegativeSeverityFilter)) return false;
-        return (this.toString().equals(obj.toString()));
+        if (!(obj instanceof NegativeAlarmTextFilter)) return false;
+        return this.toString().equals(obj.toString());
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeCategoryFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeCategoryFilter.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.alarm.filter;
+
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.type.StringType;
+import org.hibernate.type.Type;
+import org.opennms.web.filter.OneArgFilter;
+import org.opennms.web.filter.SQLType;
+
+public class NegativeCategoryFilter extends OneArgFilter<String> {
+    /** Constant <code>TYPE="categoryNot"</code> */
+    public static final String TYPE = "categoryNot";
+    /** Constant <code>NESTED_TYPE="nestedCategoryNot"</code> */
+    public static final String NESTED_TYPE = "nestedCategoryNot";
+
+    public NegativeCategoryFilter(final String category) {
+        super(TYPE, SQLType.STRING, "NODEID", "nodeid", category);
+    }
+
+    public String getSQLTemplate() {
+        return " " + getSQLFieldName() + " NOT IN (SELECT CN.NODEID FROM CATEGORY_NODE CN, CATEGORIES C WHERE CN.CATEGORYID = C.CATEGORYID AND C.CATEGORYNAME = %s) ";
+    }
+
+    @Override
+    public Criterion getCriterion() {
+        return Restrictions.sqlRestriction(" {alias}." + this.getSQLFieldName() + " NOT IN (SELECT CN.NODEID FROM CATEGORY_NODE CN, CATEGORIES C WHERE CN.CATEGORYID = C.CATEGORYID AND C.CATEGORYNAME = ?)",
+                new Object[]{this.getValue()},
+                new Type[]{StringType.INSTANCE});
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("category is not \"" + getValue() + "\"");
+    }
+
+    @Override
+    public String toString() {
+        return ("<AlarmFactory.NegativeCategoryFilter: " + this.getDescription() + ">");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeCategoryFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeDescriptionSubstringFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeDescriptionSubstringFilter.java
@@ -28,66 +28,54 @@
 
 package org.opennms.web.alarm.filter;
 
-import javax.servlet.ServletContext;
-
-import org.opennms.web.element.NetworkElementFactory;
-import org.opennms.web.filter.NotEqualOrNullFilter;
-import org.opennms.web.filter.SQLType;
+import org.opennms.web.filter.NoSubstringFilter;
 
 /**
- * Encapsulates all service filtering functionality.
+ * <p>DescriptionSubstringFilter class.</p>
  *
  * @author ranger
  * @version $Id: $
  * @since 1.8.1
  */
-public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
-    /** Constant <code>TYPE="servicenot"</code> */
-    public static final String TYPE = "servicenot";
-
-    /** Constant <code>NESTED_TYPE="nestedServiceNot"</code> */
-    public static final String NESTED_TYPE = "nestedServiceNot";
-
-    private ServletContext m_servletContext;
+public class NegativeDescriptionSubstringFilter extends NoSubstringFilter {
+    /** Constant <code>TYPE="descsub"</code> */
+    public static final String TYPE = "descsubNot";
 
     /**
-     * <p>Constructor for NegativeServiceFilter.</p>
+     * <p>Constructor for DescriptionSubstringFilter.</p>
      *
-     * @param serviceId a int.
+     * @param substring a {@link String} object.
      */
-    public NegativeServiceFilter(int serviceId, ServletContext servletContext) {
-        super(TYPE, SQLType.INT, "SERVICEID", "serviceType.id", serviceId);
-        m_servletContext = servletContext;
+    public NegativeDescriptionSubstringFilter(String substring) {
+        super(TYPE, "DESCRIPTION", "description", substring);
     }
 
     /**
      * <p>getTextDescription</p>
      *
-     * @return a {@link java.lang.String} object.
+     * @return a {@link String} object.
      */
+    @Override
     public String getTextDescription() {
-        String serviceName = Integer.toString(getValue());
-        serviceName = NetworkElementFactory.getInstance(m_servletContext).getServiceNameFromId(getValue());
-
-        return ("service is not " + serviceName);
+        return ("description not containing \"" + getValue() + "\"");
     }
 
     /**
      * <p>toString</p>
      *
-     * @return a {@link java.lang.String} object.
+     * @return a {@link String} object.
      */
     @Override
     public String toString() {
-        return ("<AlarmFactory.NegativeServiceFilter: " + this.getDescription() + ">");
+        return ("<NegativeDescriptionSubstringFilter: " + this.getDescription() + ">");
     }
 
     /**
-     * <p>getServiceId</p>
+     * <p>getSubstring</p>
      *
-     * @return a int.
+     * @return a {@link String} object.
      */
-    public int getServiceId() {
+    public String getSubstring() {
         return getValue();
     }
 
@@ -95,7 +83,7 @@ public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof NegativeServiceFilter)) return false;
+        if (!(obj instanceof NegativeDescriptionSubstringFilter)) return false;
         return (this.toString().equals(obj.toString()));
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeIPAddrLikeFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeIPAddrLikeFilter.java
@@ -28,66 +28,54 @@
 
 package org.opennms.web.alarm.filter;
 
-import javax.servlet.ServletContext;
-
-import org.opennms.web.element.NetworkElementFactory;
-import org.opennms.web.filter.NotEqualOrNullFilter;
-import org.opennms.web.filter.SQLType;
+import org.opennms.web.filter.NegativeIPLikeFilter;
 
 /**
- * Encapsulates all service filtering functionality.
+ * Encapsulates all interface filtering functionality.
  *
  * @author ranger
  * @version $Id: $
  * @since 1.8.1
  */
-public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
-    /** Constant <code>TYPE="servicenot"</code> */
-    public static final String TYPE = "servicenot";
-
-    /** Constant <code>NESTED_TYPE="nestedServiceNot"</code> */
-    public static final String NESTED_TYPE = "nestedServiceNot";
-
-    private ServletContext m_servletContext;
+public class NegativeIPAddrLikeFilter extends NegativeIPLikeFilter {
+    /** Constant <code>TYPE="iplikeNot"</code> */
+    public static final String TYPE = "iplikeNot";
 
     /**
-     * <p>Constructor for NegativeServiceFilter.</p>
+     * <p>Constructor for NegativeIPAddrLikeFilter.</p>
      *
-     * @param serviceId a int.
+     * @param ipLikePattern a {@link String} object.
      */
-    public NegativeServiceFilter(int serviceId, ServletContext servletContext) {
-        super(TYPE, SQLType.INT, "SERVICEID", "serviceType.id", serviceId);
-        m_servletContext = servletContext;
+    public NegativeIPAddrLikeFilter(String ipLikePattern) {
+        super(TYPE, "IPADDR", "ipAddr", ipLikePattern);
     }
 
     /**
      * <p>getTextDescription</p>
      *
-     * @return a {@link java.lang.String} object.
+     * @return a {@link String} object.
      */
+    @Override
     public String getTextDescription() {
-        String serviceName = Integer.toString(getValue());
-        serviceName = NetworkElementFactory.getInstance(m_servletContext).getServiceNameFromId(getValue());
-
-        return ("service is not " + serviceName);
+        return ("IP Address not like \"" + getValue() + "\"");
     }
 
     /**
      * <p>toString</p>
      *
-     * @return a {@link java.lang.String} object.
+     * @return a {@link String} object.
      */
     @Override
     public String toString() {
-        return ("<AlarmFactory.NegativeServiceFilter: " + this.getDescription() + ">");
+        return ("<NegativeIPLikeFilter: " + this.getDescription() + ">");
     }
 
     /**
-     * <p>getServiceId</p>
+     * <p>getIpLikePattern</p>
      *
-     * @return a int.
+     * @return a {@link String} object.
      */
-    public int getServiceId() {
+    public String getIpLikePattern() {
         return getValue();
     }
 
@@ -95,7 +83,7 @@ public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof NegativeServiceFilter)) return false;
+        if (!(obj instanceof NegativeIPAddrLikeFilter)) return false;
         return (this.toString().equals(obj.toString()));
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeLogMessageSubstringFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeLogMessageSubstringFilter.java
@@ -28,66 +28,47 @@
 
 package org.opennms.web.alarm.filter;
 
-import javax.servlet.ServletContext;
+import org.opennms.web.filter.NoSubstringFilter;
 
-import org.opennms.web.element.NetworkElementFactory;
-import org.opennms.web.filter.NotEqualOrNullFilter;
-import org.opennms.web.filter.SQLType;
-
-/**
- * Encapsulates all service filtering functionality.
- *
- * @author ranger
- * @version $Id: $
- * @since 1.8.1
- */
-public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
-    /** Constant <code>TYPE="servicenot"</code> */
-    public static final String TYPE = "servicenot";
-
-    /** Constant <code>NESTED_TYPE="nestedServiceNot"</code> */
-    public static final String NESTED_TYPE = "nestedServiceNot";
-
-    private ServletContext m_servletContext;
+public class NegativeLogMessageSubstringFilter extends NoSubstringFilter {
+    /** Constant <code>TYPE="msgsub"</code> */
+    public static final String TYPE = "msgsubNot";
 
     /**
-     * <p>Constructor for NegativeServiceFilter.</p>
+     * <p>Constructor for NegativeLogMessageSubstringFilter.</p>
      *
-     * @param serviceId a int.
+     * @param substring a {@link String} object.
      */
-    public NegativeServiceFilter(int serviceId, ServletContext servletContext) {
-        super(TYPE, SQLType.INT, "SERVICEID", "serviceType.id", serviceId);
-        m_servletContext = servletContext;
+    public NegativeLogMessageSubstringFilter(String substring) {
+        super(TYPE, "logMsg", "logMsg", substring);
     }
 
     /**
      * <p>getTextDescription</p>
      *
-     * @return a {@link java.lang.String} object.
+     * @return a {@link String} object.
      */
+    @Override
     public String getTextDescription() {
-        String serviceName = Integer.toString(getValue());
-        serviceName = NetworkElementFactory.getInstance(m_servletContext).getServiceNameFromId(getValue());
-
-        return ("service is not " + serviceName);
+        return ("description not containing \"" + getValue() + "\"");
     }
 
     /**
      * <p>toString</p>
      *
-     * @return a {@link java.lang.String} object.
+     * @return a {@link String} object.
      */
     @Override
     public String toString() {
-        return ("<AlarmFactory.NegativeServiceFilter: " + this.getDescription() + ">");
+        return ("<NegativeLogMessageSubstringFilter: " + this.getDescription() + ">");
     }
 
     /**
-     * <p>getServiceId</p>
+     * <p>getSubstring</p>
      *
-     * @return a int.
+     * @return a {@link String} object.
      */
-    public int getServiceId() {
+    public String getSubstring() {
         return getValue();
     }
 
@@ -95,7 +76,7 @@ public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof NegativeServiceFilter)) return false;
+        if (!(obj instanceof NegativeLogMessageSubstringFilter)) return false;
         return (this.toString().equals(obj.toString()));
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeNodeNameLikeFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeNodeNameLikeFilter.java
@@ -50,14 +50,14 @@ public class NegativeNodeNameLikeFilter extends NoSubstringFilter {
     /** {@inheritDoc} */
     @Override
     public String getSQLTemplate() {
-        return " alarmid NOT IN (SELECT alarmid FROM alarms JOIN node ON alarms.nodeid=node.nodeid WHERE node.nodelabel ILIKE '%s') ";
+        return " ALARMID NOT IN (SELECT ALARMID FROM ALARMS JOIN NODE ON ALARMS.NODEID=NODE.NODEID WHERE NODE.NODELABEL ILIKE %s) ";
     }
 
     /** {@inheritDoc} */
     @Override
     public Criterion getCriterion() {
         return Restrictions.sqlRestriction(" {alias}.alarmid NOT IN (SELECT alarmid FROM alarms JOIN node ON alarms.nodeid=node.nodeid WHERE node.nodelabel ILIKE ?)",
-                new Object[]{this.getValue()}, new Type[]{StringType.INSTANCE});
+                new Object[]{getBoundValue(this.getValue())}, new Type[]{StringType.INSTANCE});
     }
 
     /**

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeNodeNameLikeFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeNodeNameLikeFilter.java
@@ -28,66 +28,64 @@
 
 package org.opennms.web.alarm.filter;
 
-import javax.servlet.ServletContext;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.type.StringType;
+import org.hibernate.type.Type;
+import org.opennms.web.filter.NoSubstringFilter;
 
-import org.opennms.web.element.NetworkElementFactory;
-import org.opennms.web.filter.NotEqualOrNullFilter;
-import org.opennms.web.filter.SQLType;
-
-/**
- * Encapsulates all service filtering functionality.
- *
- * @author ranger
- * @version $Id: $
- * @since 1.8.1
- */
-public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
-    /** Constant <code>TYPE="servicenot"</code> */
-    public static final String TYPE = "servicenot";
-
-    /** Constant <code>NESTED_TYPE="nestedServiceNot"</code> */
-    public static final String NESTED_TYPE = "nestedServiceNot";
-
-    private ServletContext m_servletContext;
+public class NegativeNodeNameLikeFilter extends NoSubstringFilter {
+    /** Constant <code>TYPE="nodenamelikeNOT"</code> */
+    public static final String TYPE = "nodenamelikeNOT";
 
     /**
-     * <p>Constructor for NegativeServiceFilter.</p>
+     * <p>Constructor for NodeNameLikeFilter.</p>
      *
-     * @param serviceId a int.
+     * @param substring a {@link String} object.
      */
-    public NegativeServiceFilter(int serviceId, ServletContext servletContext) {
-        super(TYPE, SQLType.INT, "SERVICEID", "serviceType.id", serviceId);
-        m_servletContext = servletContext;
+    public NegativeNodeNameLikeFilter(String substring) {
+        super(TYPE, "NODELABEL", "node.label", substring);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public String getSQLTemplate() {
+        return " alarmid NOT IN (SELECT alarmid FROM alarms JOIN node ON alarms.nodeid=node.nodeid WHERE node.nodelabel ILIKE '%s') ";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Criterion getCriterion() {
+        return Restrictions.sqlRestriction(" {alias}.alarmid NOT IN (SELECT alarmid FROM alarms JOIN node ON alarms.nodeid=node.nodeid WHERE node.nodelabel ILIKE ?)",
+                new Object[]{this.getValue()}, new Type[]{StringType.INSTANCE});
     }
 
     /**
      * <p>getTextDescription</p>
      *
-     * @return a {@link java.lang.String} object.
+     * @return a {@link String} object.
      */
+    @Override
     public String getTextDescription() {
-        String serviceName = Integer.toString(getValue());
-        serviceName = NetworkElementFactory.getInstance(m_servletContext).getServiceNameFromId(getValue());
-
-        return ("service is not " + serviceName);
+        return ("Node name not containing \"" + getValue() + "\"");
     }
 
     /**
      * <p>toString</p>
      *
-     * @return a {@link java.lang.String} object.
+     * @return a {@link String} object.
      */
     @Override
     public String toString() {
-        return ("<AlarmFactory.NegativeServiceFilter: " + this.getDescription() + ">");
+        return ("<NegativeNodeNameLikeFilter: " + this.getDescription() + ">");
     }
 
     /**
-     * <p>getServiceId</p>
+     * <p>getSubstring</p>
      *
-     * @return a int.
+     * @return a {@link String} object.
      */
-    public int getServiceId() {
+    public String getSubstring() {
         return getValue();
     }
 
@@ -95,7 +93,8 @@ public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof NegativeServiceFilter)) return false;
+        if (!(obj instanceof NegativeNodeNameLikeFilter)) return false;
         return (this.toString().equals(obj.toString()));
     }
+    
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeServiceFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeServiceFilter.java
@@ -45,9 +45,6 @@ public class NegativeServiceFilter extends NotEqualOrNullFilter<Integer> {
     /** Constant <code>TYPE="servicenot"</code> */
     public static final String TYPE = "servicenot";
 
-    /** Constant <code>NESTED_TYPE="nestedServiceNot"</code> */
-    public static final String NESTED_TYPE = "nestedServiceNot";
-
     private ServletContext m_servletContext;
 
     /**

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/ServiceOrFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/ServiceOrFilter.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.alarm.filter;
+
+import org.opennms.web.element.NetworkElementFactory;
+import org.opennms.web.filter.Filter;
+import org.opennms.web.filter.OrFilter;
+import org.springframework.util.CollectionUtils;
+
+import javax.servlet.ServletContext;
+import java.util.Arrays;
+import java.util.Map;
+
+public class ServiceOrFilter extends OrFilter {
+
+    private final Integer[] serviceIds;
+    private final  Map<String, Integer> serviceNameToIdMap;
+
+    public ServiceOrFilter(Integer[] serviceIds, ServletContext servletContext) {
+        super(Arrays.stream(serviceIds)
+                .map(serviceId -> new ServiceFilter(serviceId, servletContext))
+                .toArray(Filter[]::new));
+        this.serviceIds = serviceIds;
+        this.serviceNameToIdMap = NetworkElementFactory
+                .getInstance(servletContext).getServiceNameToIdMap();
+    }
+
+    @Override
+    public String getTextDescription() {
+        String[] serviceNames = new String[serviceIds.length];
+        for (int index = 0; index < serviceIds.length; index++) {
+            Integer serviceId = serviceIds[index];
+            serviceNames[index] = findServiceName(serviceId);
+        }
+        return ("Service OR Filter: \"" + Arrays.toString(serviceNames) + "\"");
+    }
+
+    private String findServiceName(Integer serviceId) {
+        if (!CollectionUtils.isEmpty(serviceNameToIdMap)) {
+            for (Map.Entry<String, Integer> stringIntegerEntry : serviceNameToIdMap.entrySet()) {
+                if (stringIntegerEntry.getValue().equals(serviceId)) {
+                    return stringIntegerEntry.getKey();
+                }
+            }
+        }
+        return String.format("Service ID: %d",  serviceId);
+    }
+
+    @Override
+    public String toString() {
+        return ("<ServiceOrFilter: " + this.getDescription() + ">");
+    }
+
+    @Override
+    public String getDescription() {
+        return TYPE + "=" + Arrays.toString(serviceIds);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof ServiceOrFilter)) return false;
+        return this.toString().equals(obj.toString());
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/SeverityOrFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/SeverityOrFilter.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -29,39 +29,41 @@
 package org.opennms.web.alarm.filter;
 
 import org.opennms.netmgt.model.OnmsSeverity;
-import org.opennms.web.filter.NotEqualsFilter;
-import org.opennms.web.filter.SQLType;
+import org.opennms.web.filter.Filter;
+import org.opennms.web.filter.OrFilter;
 
-/**
- * Encapsulates negative severity filtering functionality, that is filtering OUT
- * this value instead of only filtering IN this value.
- */
-public class NegativeSeverityFilter extends NotEqualsFilter<OnmsSeverity> {
-    /** Constant <code>TYPE="severitynot"</code> */
-    public static final String TYPE = "severitynot";
+import java.util.Arrays;
 
-    public NegativeSeverityFilter(final OnmsSeverity severity) {
-        super(TYPE, SQLType.SEVERITY, "ALARMS.SEVERITY", "severity", severity);
+public class SeverityOrFilter extends OrFilter {
+
+    private final OnmsSeverity[] severities;
+
+    public SeverityOrFilter(OnmsSeverity[] severities) {
+        super(Arrays.stream(severities)
+                .map(SeverityFilter::new)
+                .toArray(Filter[]::new));
+        this.severities = severities;
     }
 
     @Override
     public String getTextDescription() {
-        return (TYPE + " is not " + getValue().getLabel());
+        return ("Severity OR Filter: \"" + Arrays.toString(severities) + "\"");
     }
 
     @Override
     public String toString() {
-        return ("<AlarmFactory.NegativeSeverityFilter: " + this.getDescription() + ">");
-    }
-
-    public int getSeverity() {
-        return getValue().getId();
+        return ("<SeverityOrFilter: " + this.getDescription() + ">");
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public String getDescription() {
+        return TYPE + "=" + Arrays.toString(severities);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof NegativeSeverityFilter)) return false;
-        return (this.toString().equals(obj.toString()));
+        if (!(obj instanceof SeverityOrFilter)) return false;
+        return this.toString().equals(obj.toString());
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AcknowledgeAlarmByFilterController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AcknowledgeAlarmByFilterController.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -119,7 +119,7 @@ public class AcknowledgeAlarmByFilterController extends AbstractController imple
         // handle the filter parameters
         ArrayList<Filter> filterArray = new ArrayList<>();
         for (String filterString : filterStrings) {
-            Filter filter = AlarmUtil.getFilter(filterString, getServletContext());
+            Filter filter = AlarmUtil.getFilter(filterStrings, filterString, getServletContext());
             if (filter != null) {
                 filterArray.add(filter);
             }

--- a/opennms-webapp/src/main/java/org/opennms/web/filter/NegativeIPLikeFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/filter/NegativeIPLikeFilter.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.filter;
+
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.type.StringType;
+
+
+/**
+ * Encapsulates all interface filtering functionality.
+ */
+public abstract class NegativeIPLikeFilter extends OneArgFilter<String> {
+
+    /**
+     * <p>Constructor for IPLikeFilter.</p>
+     *
+     * @param filterType a {@link String} object.
+     * @param fieldName a {@link String} object.
+     * @param propertyName a {@link String} object.
+     * @param ipLikePattern a {@link String} object.
+     */
+    public NegativeIPLikeFilter(final String filterType, final String fieldName, final String propertyName, final String ipLikePattern) {
+        super(filterType, SQLType.STRING, fieldName, propertyName, ipLikePattern);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getSQLTemplate() {
+        return " `NOT IPLIKE`(" + getSQLFieldName() + ", %s) ";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Criterion getCriterion() {
+        return Restrictions.not(Restrictions.sqlRestriction("iplike( {alias}." + getPropertyName() + ", ?)", getValue(), StringType.INSTANCE));
+    }
+}

--- a/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
@@ -86,36 +86,28 @@
 		<input class="form-control" type="text" name="nodenamelike" />
 	</div>
 
-	<div class="form-group col-sm-6">
-		<label for="severity">Severity</label>
-		<select class="form-control custom-select" name="severity">
-			<option selected="selected"><%=AlarmUtil.ANY_SEVERITIES_OPTION%></option>
+    <div class="form-group col-sm-6">
+        <label for="severity">Severity</label>
+        <% for (OnmsSeverity severity : OnmsSeverity.values()) { %>
+            <div>
+                <label>
+                    <input type="checkbox" name="severity-<%=severity.getId()%>" value="1" /> <%=severity.getLabel()%>
+                </label>
+            </div>
+        <% } %>
+    </div>
 
-			<% for (OnmsSeverity severity : OnmsSeverity.values()) { %>
-			<option value="<%=severity.getId()%>">
-				<%=severity.getLabel()%>
-			</option>
-			<% } %>
-		</select>
-
-        <label for="nestedSeverityNot">Negate Severity:</label>
-        <input type="checkbox" name="nestedSeverityNot" />
-	</div>
-
-	<!-- Use clear:left to make sure that this column breaks onto a new row -->
-	<div class="form-group col-sm-6" style="clear: left;">
-		<label for="service">Service</label>
-		<select class="form-control custom-select" name="service">
-			<option selected><%=AlarmUtil.ANY_SERVICES_OPTION%></option>
-
-			<% for (String name : serviceNameSet) { %>
-			<option value="<%=serviceNameMap.get(name)%>"><%=name%></option>
-			<% } %>
-		</select>
-
-        <label for="nestedServiceNot">Negate Service:</label>
-        <input type="checkbox" name="nestedServiceNot" />
-	</div>
+    <!-- Use clear:left to make sure that this column breaks onto a new row -->
+    <div class="form-group col-sm-6">
+        <label for="service">Service</label>
+        <% for (String name : serviceNameSet) { %>
+            <div>
+                <label>
+                    <input type="checkbox" name="service-<%=serviceNameMap.get(name)%>" value="1" /> <%=name%>
+                </label>
+            </div>
+        <% } %>
+    </div>
 
 	<div class="form-group col-sm-6">
 		<label for="sortby">Sort By</label>
@@ -165,15 +157,15 @@
 			<% } %>
 		</select>
 
-        <label for="nestedCategoryNot">Negate Category:</label>
+        <label for="nestedCategoryNot">Exclude:</label>
         <input type="checkbox" name="nestedCategoryNot" />
 	</div>
 
 	<div class="col-sm-6 my-2">
 		<label data-toggle="collapse" data-target="#collapseAlarmsFirstAfter" aria-expanded="false" aria-controls="collapseAlarmsFirstAfter">
-			<input type="checkbox" name="useafterfirsteventtime" value="1" /> Filter for Alarm's First Event After:
+			<input type="checkbox" name="useafterfirsteventtime" value="1" /> Filter for Alarms after First Event:
 		</label>
-		<!-- 
+		<!--
 		<input type="date" name="beforedate"/>
 		<input type="time" name="beforetime"/>
 		-->
@@ -218,9 +210,9 @@
 
 	<div class="col-sm-6 my-2">
 		<label data-toggle="collapse" data-target="#collapseAlarmsFirstBefore" aria-expanded="false" aria-controls="collapseAlarmsFirstBefore">
-			<input type="checkbox" name="usebeforefirsteventtime" value="1" /> Filter for Alarm's First Event Before:
+			<input type="checkbox" name="usebeforefirsteventtime" value="1" /> Filter for Alarms before First Event:
 		</label>
-		<!-- 
+		<!--
 		<input type="date" name="beforedate"/>
 		<input type="time" name="beforetime"/>
 		-->
@@ -265,9 +257,9 @@
 
 	<div class="col-sm-6 my-2">
 		<label data-toggle="collapse" data-target="#collapseAlarmsLastAfter" aria-expanded="false" aria-controls="collapseAlarmsLastAfter">
-			<input type="checkbox" name="useafterlasteventtime"	value="1" /> Filter for Alarm's Last Event After:
+			<input type="checkbox" name="useafterlasteventtime"	value="1" /> Filter for Alarms after Last Event:
 		</label>
-		<!-- 
+		<!--
 		<input type="date" name="beforedate"/>
 		<input type="time" name="beforetime"/>
 		-->
@@ -312,7 +304,7 @@
 
 	<div class="col-sm-6 my-2">
 		<label data-toggle="collapse" data-target="#collapseAlarmsLasttBefore" aria-expanded="false" aria-controls="collapseAlarmsLasttBefore">
-			<input type="checkbox" name="usebeforelasteventtime" value="1" /> Filter for Alarm Last Event Before:
+			<input type="checkbox" name="usebeforelasteventtime" value="1" /> Filter for Alarms before Last Event:
 		</label>
 		<!-- 
 		<input type="date" name="beforedate"/>

--- a/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -97,6 +97,9 @@
 			</option>
 			<% } %>
 		</select>
+
+        <label for="nestedSeverityNot">Negate Severity:</label>
+        <input type="checkbox" name="nestedSeverityNot" />
 	</div>
 
 	<!-- Use clear:left to make sure that this column breaks onto a new row -->
@@ -109,6 +112,9 @@
 			<option value="<%=serviceNameMap.get(name)%>"><%=name%></option>
 			<% } %>
 		</select>
+
+        <label for="nestedServiceNot">Negate Service:</label>
+        <input type="checkbox" name="nestedServiceNot" />
 	</div>
 
 	<div class="form-group col-sm-6">
@@ -158,6 +164,9 @@
 			<option value="<%=category%>"><%=category%></option>
 			<% } %>
 		</select>
+
+        <label for="nestedCategoryNot">Negate Category:</label>
+        <input type="checkbox" name="nestedCategoryNot" />
 	</div>
 
 	<div class="col-sm-6 my-2">


### PR DESCRIPTION
Within Alarm advanced search, it is now possible to search for the negative values of Alarm Text contains, TCP/IP address like, and NodeLabel contains.

To do this the first character in the field should be a -

If you negate the nodeLabel field, currently you only get alarms that have a different node to the negated one. You don't get alarms that aren't associated to a node. I thought I would create a pull request as I was told I was moving onto Streams after today. If required I can create another jira and explain my work to somebody else, or alternatively ask them to continue working on this branch.

Example. Alarm 1 is associated with Node 1. Alarm 2 is associated with Node 2. Alarm 3 has no node associated.
You type '-2' into the node label field. Only alarm 1 is returned in the list. I would have expected alarms 1 and 3.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14043

