### PR TITLE
NMS-14425: Let plugins use routing

### DIFF
--- a/ui/src/components/Layout/NavigationRail.vue
+++ b/ui/src/components/Layout/NavigationRail.vue
@@ -67,7 +67,7 @@
       <FeatherRailItem
         v-for="plugin of plugins"
         :key="plugin.extensionId"
-        :class="{ selected: isSelected(`/plugins/${plugin.extensionId}/${plugin.resourceRootPath}/${plugin.moduleFileName}`) }"
+        :class="{ selected: isSelected(`/plugins/${plugin.extensionId}/${plugin.resourceRootPath}/${plugin.moduleFileName}`, true) }"
         :href="`#/plugins/${plugin.extensionId}/${plugin.resourceRootPath}/${plugin.moduleFileName}`"
         :title="plugin.menuEntry"
         :icon="UpdateUtilities"
@@ -103,7 +103,10 @@ const { adminRole, filesystemEditorRole, dcbRole } = useRole()
 const plugins = computed<Plugin[]>(() => store.state.pluginModule.plugins)
 const navRailOpen = computed(() => store.state.appModule.navRailOpen)
 const onNavRailClick = () => store.dispatch('appModule/setNavRailOpen', !navRailOpen.value)
-const isSelected = (path: string) => path === route.fullPath
+const isSelected = (path: string, useInclude?: boolean): boolean => {
+  if (useInclude) return route.fullPath.includes(path)
+  return path === route.fullPath
+}
 </script>
 
 <style lang="scss">

--- a/ui/src/components/Plugin/utils.ts
+++ b/ui/src/components/Plugin/utils.ts
@@ -51,4 +51,12 @@ const addStylesheet = (url: string) => {
   head.prepend(link)
 }
 
-export { externalComponent, addStylesheet }
+const getJSPath = (baseUrl: string, extensionId: string, rootPath: string, fileName: string) => {
+  return `${baseUrl}/plugins/ui-extension/module/${extensionId}?path=${rootPath}/${fileName}`
+}
+
+const getCSSPath = (baseUrl: string, extensionId: string) => {
+  return `${baseUrl}/plugins/ui-extension/css/${extensionId}`
+}
+
+export { externalComponent, addStylesheet, getJSPath, getCSSPath }

--- a/ui/src/containers/Plugin.vue
+++ b/ui/src/containers/Plugin.vue
@@ -3,18 +3,8 @@
 </template>
 
 <script setup lang="ts">
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import * as Vue from 'vue/dist/vue.esm-bundler'
-import * as Pinia from 'pinia'
-import * as Vuex from 'vuex'
-import { addStylesheet } from '@/components/Plugin/utils'
+import { addStylesheet, getCSSPath, getJSPath } from '@/components/Plugin/utils'
 import Container from '@/components/Plugin/Container.vue'
-
-// lets plugins access vue & stores
-(window as any).Vue = Vue;
-(window as any).Pinia = Pinia;
-(window as any).Vuex = Vuex
 
 const baseUrl = import.meta.env.VITE_BASE_REST_URL
 const externalJsUrl = ref<string>('')
@@ -35,8 +25,8 @@ const props = defineProps({
 })
 
 const addResources = () => {
-  externalJsUrl.value = `${baseUrl}/plugins/ui-extension/module/${props.extensionId}?path=${props.resourceRootPath}/${props.moduleFileName}`
-  const externalCssUrl = `${baseUrl}/plugins/ui-extension/css/${props.extensionId}`
+  externalJsUrl.value = getJSPath(baseUrl, props.extensionId, props.resourceRootPath, props.moduleFileName)
+  const externalCssUrl = getCSSPath(baseUrl, props.extensionId)
   addStylesheet(externalCssUrl)
 }
 

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -11,6 +11,7 @@ import API from '@/services'
 import * as Vue from 'vue/dist/vue.esm-bundler'
 import * as Pinia from 'pinia'
 import * as Vuex from 'vuex'
+import * as VueRouter from 'vue-router'
 
 import '@featherds/styles'
 import '@featherds/styles/themes/open-light.css'
@@ -24,7 +25,8 @@ import { externalComponent, getJSPath } from './components/Plugin/utils'
 (window as any).Vue = Vue;
 (window as any).Pinia = Pinia;
 (window as any).Vuex = Vuex;
-(window as any)['VRouter'] = router
+(window as any).VueRouter = VueRouter;
+(window as any)['VRouter'] = router;
 
 // plugin scripts must be loaded before app to use their routes
 const baseUrl = import.meta.env.VITE_BASE_REST_URL

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -4,6 +4,13 @@ import router from './router'
 import store from './store'
 import VueDiff from 'vue-diff'
 import { createPinia } from 'pinia'
+import API from '@/services'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import * as Vue from 'vue/dist/vue.esm-bundler'
+import * as Pinia from 'pinia'
+import * as Vuex from 'vuex'
 
 import '@featherds/styles'
 import '@featherds/styles/themes/open-light.css'
@@ -11,6 +18,22 @@ import '@featherds/styles/themes/open-light.css'
 import 'vue-diff/dist/index.css'
 
 import dateFormatDirective from './directives/v-date'
+import { externalComponent, getJSPath } from './components/Plugin/utils'
+
+// let plugins use state mngmnt / router
+(window as any).Vue = Vue;
+(window as any).Pinia = Pinia;
+(window as any).Vuex = Vuex;
+(window as any)['VRouter'] = router
+
+// plugin scripts must be loaded before app to use their routes
+const baseUrl = import.meta.env.VITE_BASE_REST_URL
+const plugins = await API.getPlugins()
+
+for (const plugin of plugins) {
+  const js = getJSPath(baseUrl, plugin.extensionId, plugin.resourceRootPath, plugin.moduleFileName)
+  await externalComponent(js)
+}
 
 createApp({
   render: () => h(App)

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -36,5 +36,8 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom'
+  },
+  build: {
+    target: 'esnext'
   }
 })


### PR DESCRIPTION
 - Gives plugin access to router
 - Loads plugin js files before rendering app - this is required to be able to hit a plugin route directly from the url / refresh

### External References
* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14425

