### PR TITLE
NMS-12981: Update Alarm Not Found Error message to include that it co…

### DIFF
--- a/opennms-webapp/src/main/webapp/errors/alarmidnotfound.jsp
+++ b/opennms-webapp/src/main/webapp/errors/alarmidnotfound.jsp
@@ -48,13 +48,15 @@
   <jsp:param name="breadcrumb" value="Error" />
 </jsp:include>
 
-<h1>Alarm ID Not Found</h1>
+<h1>Alarm Cleared or Not Found</h1>
 
 <p>
-  The alarm ID <%=einfe.getBadID()%> is invalid. <%=einfe.getMessage()%>
+  <%=einfe.getMessage()%>. The alarm has been cleared or has an invalid alarm ID.
   <br/>
-  You can re-enter it here or <a href="alarm/list.htm?acktyp=unack">browse all
-  of the alarms</a> to find the alarm you are looking for.
+  Re-enter the alarm ID here or <a href="alarm/list.htm?acktyp=unack">browse all
+   alarms</a> to find the alarm you are looking for.
+   <br /> If you get the same error message,
+   you can assume that the alarm has been cleared.
 </p>
 
 <form role="form" method="get" action="alarm/detail.htm" class="form mb-4">


### PR DESCRIPTION
…uld have been cleared

Updating the error message to include the case that it could have also been cleared. 
When an Alarm gets cleared it will get deleted automatically by drools after 5 minutes.
Refreshing the detail page after 5 minutes will result in the Alarm Not Found error page showing stating that it is an invalid alarm but really it was valid, just time has passed and is now automatically deleted.

![image](https://user-images.githubusercontent.com/8379423/175505497-2648c17c-8d47-4e26-b7d1-5e80568d980f.png)


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12981
