### PR TITLE
NMS-14120: DCB: Add full script output option to karaf shell command

### DIFF
--- a/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigService.java
+++ b/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigService.java
@@ -38,16 +38,16 @@ public interface DeviceConfigService {
     public static final String DEVICE_CONFIG_PREFIX = "DeviceConfig";
 
     /**
-     *   Trigger device config backup for the given ipAddress at given location.
+     * Trigger device config backup for the given ipAddress at given location.
      *
-     * @param ipAddress  specific IpAddress for which we need to fetch device config.
-     * @param location   specific minion location at which we need to fetch device config.
-     * @param service    name of the bound service.
+     * @param ipAddress specific IpAddress for which we need to fetch device config.
+     * @param location  specific minion location at which we need to fetch device config.
+     * @param service   name of the bound service.
      * @param persist
-     * @throws IOException
      * @return
+     * @throws IOException
      */
-    CompletableFuture<Boolean> triggerConfigBackup(String ipAddress, String location, String service, boolean persist) throws IOException;
+    CompletableFuture<DeviceConfigBackupResponse> triggerConfigBackup(String ipAddress, String location, String service, boolean persist) throws IOException;
 
     /**
      * Get device config for the given ipAddress at given location.
@@ -78,5 +78,23 @@ public interface DeviceConfigService {
         String getServiceName();
         String getConfigType();
         String getSchedule();
+    }
+
+    public class DeviceConfigBackupResponse {
+        private String errorStr;
+        private String scriptOutput;
+
+        public DeviceConfigBackupResponse(String error, String scriptOutput) {
+            this.errorStr = error;
+            this.scriptOutput = scriptOutput;
+        }
+
+        public String getErrorMessage() {
+            return errorStr;
+        }
+
+        public String getScriptOutput() {
+            return scriptOutput;
+        }
     }
 }

--- a/features/device-config/monitor/src/main/java/org/opennms/features/deviceconfig/monitors/DeviceConfigMonitor.java
+++ b/features/device-config/monitor/src/main/java/org/opennms/features/deviceconfig/monitors/DeviceConfigMonitor.java
@@ -197,12 +197,14 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
                             LOG.error("Device config retrieval could not be triggered - target: {}; script: {};  message: {} \nstdout: {}\nstderr: {}", target, script, failure.message, failure.stdout, failure.stderr);
                             final var pollStatus = PollStatus.unavailable(failure.message);
                             pollStatus.setDeviceConfig(new DeviceConfig());
+                            pollStatus.setDcbScriptDebugOutput(failure.scriptOutput);
                             return pollStatus;
                         },
                         success -> {
                             LOG.debug("Retrieved device configuration - target: " + target);
                             var pollStatus = PollStatus.up();
                             pollStatus.setDeviceConfig(new DeviceConfig(success.config, success.filename));
+                            pollStatus.setDcbScriptDebugOutput(success.scriptOutput);
                             return pollStatus;
                         }
                 )

--- a/features/device-config/monitor/src/main/java/org/opennms/features/deviceconfig/monitors/DeviceConfigMonitor.java
+++ b/features/device-config/monitor/src/main/java/org/opennms/features/deviceconfig/monitors/DeviceConfigMonitor.java
@@ -196,15 +196,13 @@ public class DeviceConfigMonitor extends AbstractServiceMonitor {
                         failure -> {
                             LOG.error("Device config retrieval could not be triggered - target: {}; script: {};  message: {} \nstdout: {}\nstderr: {}", target, script, failure.message, failure.stdout, failure.stderr);
                             final var pollStatus = PollStatus.unavailable(failure.message);
-                            pollStatus.setDeviceConfig(new DeviceConfig());
-                            pollStatus.setDcbScriptDebugOutput(failure.scriptOutput);
+                            pollStatus.setDeviceConfig(new DeviceConfig(failure.scriptOutput));
                             return pollStatus;
                         },
                         success -> {
                             LOG.debug("Retrieved device configuration - target: " + target);
                             var pollStatus = PollStatus.up();
-                            pollStatus.setDeviceConfig(new DeviceConfig(success.config, success.filename));
-                            pollStatus.setDcbScriptDebugOutput(success.scriptOutput);
+                            pollStatus.setDeviceConfig(new DeviceConfig(success.config, success.filename, success.scriptOutput));
                             return pollStatus;
                         }
                 )

--- a/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/api/Retriever.java
+++ b/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/api/Retriever.java
@@ -67,10 +67,16 @@ public interface Retriever {
 
         public final byte[] config;
         public final String filename;
+        public final String scriptOutput;
 
         public Success(byte[] config, String filename) {
+            this(config, filename, "");
+        }
+
+        public Success(byte[] config, String fileName, String scriptOutput) {
             this.config = config;
-            this.filename = filename;
+            this.filename = fileName;
+            this.scriptOutput = scriptOutput;
         }
     }
 
@@ -80,16 +86,24 @@ public interface Retriever {
         public final Optional<String> stdout;
         public final Optional<String> stderr;
 
+        public final String scriptOutput;
+
         public Failure(String message, Optional<String> stdout, Optional<String> stderr) {
+            this(message, stdout, stderr, "");
+        }
+
+        public Failure(String message, Optional<String> stdout, Optional<String> stderr, String scriptOutput) {
             this.message = message;
             this.stdout = stdout;
             this.stderr = stderr;
+            this.scriptOutput = scriptOutput;
         }
 
         public Failure(String message) {
             this.message = message;
             this.stdout = Optional.empty();
             this.stderr = Optional.empty();
+            this.scriptOutput = "";
         }
     }
 

--- a/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
+++ b/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
@@ -175,10 +175,10 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
             this.uploadTrigger = uploadTrigger;
         }
 
-        private void fail(String msg, Optional<String> stdout, Optional<String> stderr) {
+        private void fail(String msg, Optional<String> stdout, Optional<String> stderr, String debug) {
             if (!future.isDone()) {
                 LOG.error(msg);
-                future.complete(Either.left(new Failure(msg, stdout, stderr)));
+                future.complete(Either.left(new Failure(msg, stdout, stderr, debug)));
             }
             else {
                 LOG.debug("TftpFileReceiverImpl attempting to fail an already completed future, msg \"{}\"- ignoring...", msg);
@@ -194,18 +194,18 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
             try {
                 SshScriptingService.Result result = uploadTrigger.get();
                 if (result.isFailed()) {
-                    fail(scriptingFailureMsg(this.target, result.message), result.stdout, result.stderr);
+                    fail(scriptingFailureMsg(this.target, result.message), result.stdout, result.stderr, result.scriptOutput);
                 }
             } catch (Throwable e) {
                 var msg = scriptingFailureMsg(this.target, e.getMessage());
                 LOG.error(msg, e);
-                fail(msg, Optional.empty(), Optional.empty());
+                fail(msg, Optional.empty(), Optional.empty(), null);
             }
         }
 
         public void onTimeout(CompletableFuture<Either<Failure, Success>> future) {
             this.future = future;
-            fail(timeoutFailureMsg(this.target), Optional.empty(), Optional.empty());
+            fail(timeoutFailureMsg(this.target), Optional.empty(), Optional.empty(), null);
         }
 
         @Override

--- a/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
+++ b/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
@@ -217,7 +217,8 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
                 if (future != null) {
                     LOG.debug("received config - target: " + this.target + "; address: " + address.getHostAddress());
                     // strip the '.' and filenameSuffix from the filename
-                    future.complete(Either.right(new Success(content, fileName.substring(0, fileName.length() - fileNameSuffix.length()))));
+                    uploadTrigger.get();
+                    future.complete(Either.right(new Success(content, fileName.substring(0, fileName.length() - fileNameSuffix.length()), sshScriptingService.getScriptOutput())));
                 }
             }
         }

--- a/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
+++ b/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
@@ -72,7 +72,7 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
     private static String SCRIPT_VAR_TFTP_SERVER_PORT = "tftpServerPort";
     private static String SCRIPT_VAR_CONFIG_TYPE = "configType";
 
-    private final SshScriptingService sshScriptingService;
+    final SshScriptingService sshScriptingService;
     private final TftpServer tftpServer;
     private final ExecutorService executor;
 
@@ -157,7 +157,7 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
         executor.shutdown();
     }
 
-    private static class TftpFileReceiverImpl implements TftpFileReceiver, FutureUtils.Completer<Either<Failure, Success>> {
+    private class TftpFileReceiverImpl implements TftpFileReceiver, FutureUtils.Completer<Either<Failure, Success>> {
 
         private final SocketAddress target;
         private final String fileNameSuffix;
@@ -199,13 +199,13 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
             } catch (Throwable e) {
                 var msg = scriptingFailureMsg(this.target, e.getMessage());
                 LOG.error(msg, e);
-                fail(msg, Optional.empty(), Optional.empty(), null);
+                fail(msg, Optional.empty(), Optional.empty(), sshScriptingService.getScriptOutput());
             }
         }
 
         public void onTimeout(CompletableFuture<Either<Failure, Success>> future) {
             this.future = future;
-            fail(timeoutFailureMsg(this.target), Optional.empty(), Optional.empty(), null);
+            fail(timeoutFailureMsg(this.target), Optional.empty(), Optional.empty(), sshScriptingService.getScriptOutput());
         }
 
         @Override

--- a/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
+++ b/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
@@ -136,7 +136,10 @@ public class RetrieverImplTest {
 
         var failure = either.getLeft();
 
-        assertThat(failure.message, containsString(RetrieverImpl.scriptingFailureMsg(new InetSocketAddress("host", 80), scriptingException.getMessage())));
+        // The script is wrapped in a future, so any exceptions will be wrapped in an ExecutionException.
+        // ExecutionExceptions preface the exception's msg with the original exception's full class name.
+        assertThat(failure.message, containsString(RetrieverImpl.scriptingFailureMsg(new InetSocketAddress("host", 80),
+                String.format("%s: %s", RuntimeException.class.getName(), scriptingException.getMessage()))));
 
         verify(tftpServer, times(1)).unregister(receiver);
     }

--- a/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
+++ b/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
@@ -29,7 +29,6 @@
 package org.opennms.features.deviceconfig.service.impl;
 
 import static org.opennms.netmgt.poller.support.AbstractServiceMonitor.getKeyedString;
-import static org.opennms.features.deviceconfig.service.DeviceConfigService.DEVICE_CONFIG_PREFIX;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -38,6 +37,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -87,7 +87,7 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
     private PollerConfig pollerConfig;
 
     @Override
-    public CompletableFuture<Boolean> triggerConfigBackup(String ipAddress, String location, String service, boolean persist) throws IOException {
+    public CompletableFuture<DeviceConfigBackupResponse> triggerConfigBackup(String ipAddress, String location, String service, boolean persist) throws IOException {
         try {
             InetAddress.getByName(ipAddress);
         } catch (UnknownHostException e) {
@@ -97,12 +97,8 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
 
         return pollDeviceConfig(ipAddress, location, service, persist)
                 .thenApply(response -> {
-                    if (response.getPollStatus().isAvailable()) {
-                        return true;
-                    } else {
-                        throw new RuntimeException("Requesting backup failed: " + response.getPollStatus().getReason());
-                    }
-                }).whenComplete((Boolean, throwable) -> {
+                    return new DeviceConfigBackupResponse(response.getPollStatus().getReason(), response.getPollStatus().getDcbScriptDebugOutput());
+                }).whenComplete((response, throwable) -> {
                     if (throwable != null) {
                         LOG.error("Error while getting device config for IpAddress {} at location {}", ipAddress, location, throwable);
                     }

--- a/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
+++ b/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
@@ -97,7 +97,7 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
 
         return pollDeviceConfig(ipAddress, location, service, persist)
                 .thenApply(response -> {
-                    return new DeviceConfigBackupResponse(response.getPollStatus().getReason(), response.getPollStatus().getDcbScriptDebugOutput());
+                    return new DeviceConfigBackupResponse(response.getPollStatus().getReason(), response.getPollStatus().getDeviceConfig().getScriptOutput());
                 }).whenComplete((response, throwable) -> {
                     if (throwable != null) {
                         LOG.error("Error while getting device config for IpAddress {} at location {}", ipAddress, location, throwable);

--- a/features/device-config/shell/src/main/java/org/opennms/features/deviceconfig/shell/DcbTriggerCommand.java
+++ b/features/device-config/shell/src/main/java/org/opennms/features/deviceconfig/shell/DcbTriggerCommand.java
@@ -62,6 +62,9 @@ public class DcbTriggerCommand implements Action {
     @Option(name = "-p", aliases = "--persist", description = "Whether to persist config or not")
     boolean persist = false;
 
+    @Option(name = "-v", aliases = "--verbose", description = "Watch script run line-by-line", required = false, multiValued = false)
+    boolean verbose = false;
+
     @Override
     public Object execute() throws Exception {
         try {

--- a/features/device-config/shell/src/main/java/org/opennms/features/deviceconfig/shell/DcbTriggerCommand.java
+++ b/features/device-config/shell/src/main/java/org/opennms/features/deviceconfig/shell/DcbTriggerCommand.java
@@ -86,7 +86,7 @@ public class DcbTriggerCommand implements Action {
                             System.out.println(" and persisted");
                         }
                     } else {
-                        System.out.println("\nFailed to trigger device config backup: " + response.getErrorMessage());
+                        System.err.println("Failed to trigger device config backup: " + response.getErrorMessage());
                     }
                     if (verbose && !Strings.isNullOrEmpty(response.getScriptOutput())) {
                         System.out.println(String.format("---SSH script output---\n%s\n----------end----------", response.getScriptOutput()));

--- a/features/device-config/shell/src/main/java/org/opennms/features/deviceconfig/shell/DcbTriggerCommand.java
+++ b/features/device-config/shell/src/main/java/org/opennms/features/deviceconfig/shell/DcbTriggerCommand.java
@@ -85,11 +85,14 @@ public class DcbTriggerCommand implements Action {
                         if (persist) {
                             System.out.println(" and persisted");
                         }
+                        else {
+                            System.out.println();
+                        }
                     } else {
                         System.err.println("Failed to trigger device config backup: " + response.getErrorMessage());
                     }
                     if (verbose && !Strings.isNullOrEmpty(response.getScriptOutput())) {
-                        System.out.println(String.format("---SSH script output---\n%s\n----------end----------", response.getScriptOutput()));
+                        System.out.printf("---SSH script output---\n%s\n----------end----------\n", response.getScriptOutput());
                     }
                     break;
                 } catch (InterruptedException e) {

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/SshScriptingService.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/SshScriptingService.java
@@ -61,6 +61,8 @@ public interface SshScriptingService {
             Duration timeout
     );
 
+    String getScriptOutput();
+
     class Result {
         public final String message;
         public final Optional<String> stdout;

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/SshScriptingService.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/SshScriptingService.java
@@ -67,27 +67,38 @@ public interface SshScriptingService {
         public final Optional<String> stderr;
         public final boolean success;
 
-        private Result(final boolean success, final String message, final Optional<String> stdout, final Optional<String> stderr) {
+        public final String scriptOutput;
+
+        private Result(final boolean success, final String message, final Optional<String> stdout, final Optional<String> stderr, String scriptOutput) {
             this.success = success;
             this.message = message;
             this.stdout = stdout;
             this.stderr = stderr;
+            this.scriptOutput = scriptOutput;
+        }
+
+        public static Result success(final String message, final String stdout, final String stderr, String scriptOutput) {
+            return new Result(true, message, Optional.of(stdout), Optional.of(stderr), scriptOutput);
         }
 
         public static Result success(final String message, final String stdout, final String stderr) {
-            return new Result(true, message, Optional.of(stdout), Optional.of(stderr));
+            return new Result(true, message, Optional.of(stdout), Optional.of(stderr), "");
         }
 
         public static Result success(final String message) {
-            return new Result(true, message, Optional.empty(), Optional.empty());
+            return new Result(true, message, Optional.empty(), Optional.empty(), "");
+        }
+
+        public static Result failure(final String message, final String stdout, final String stderr, String scriptOutput) {
+            return new Result(false, message, Optional.of(stdout), Optional.of(stderr), scriptOutput);
         }
 
         public static Result failure(final String message, final String stdout, final String stderr) {
-            return new Result(false, message, Optional.of(stdout), Optional.of(stderr));
+            return new Result(false, message, Optional.of(stdout), Optional.of(stderr), "");
         }
 
         public static Result failure(final String message) {
-            return new Result(false, message, Optional.empty(), Optional.empty());
+            return new Result(false, message, Optional.empty(), Optional.empty(), "");
         }
 
         public boolean isSuccess() {

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
@@ -74,6 +74,8 @@ public class SshScriptingServiceImpl implements SshScriptingService {
     private InetAddress tftpServerIPv4Address;
     private InetAddress tftpServerIPv6Address;
 
+    private String scriptDebugOutput;
+
     public void setTftpServerIPv4Address(final String tftpServerIPv4Address) throws UnknownHostException {
         if (!Strings.isNullOrEmpty(tftpServerIPv4Address)) {
             this.tftpServerIPv4Address = InetAddress.getByName(tftpServerIPv4Address);
@@ -119,13 +121,14 @@ public class SshScriptingServiceImpl implements SshScriptingService {
 
                                     var stdout = sshInteraction.stdout.toString(StandardCharsets.UTF_8);
                                     var stderr = sshInteraction.stderr.toString(StandardCharsets.UTF_8);
-                                    var debugOutput = sshInteraction.debugOutput.toString(StandardCharsets.UTF_8);
+                                    var debugOutput = sshInteraction.getDebugOutput();
                                     LOG.error("ssh scripting exception - {} \n### script ###\n {} \n### stdout ###\n {} \n### stderr ###\n {}", errorDescription, script, stdout, stderr, e);
                                     return Result.failure("ssh scripting exception - " + errorDescription, stdout, stderr, debugOutput);
                                 }
+                                scriptDebugOutput = sshInteraction.getDebugOutput();
                                 prevStatement = statement;
                             }
-                            return Result.success("Script execution succeeded",  sshInteraction.stdout.toString(StandardCharsets.UTF_8),  sshInteraction.stderr.toString(StandardCharsets.UTF_8), sshInteraction.debugOutput.toString(StandardCharsets.UTF_8));
+                            return Result.success("Script execution succeeded",  sshInteraction.stdout.toString(StandardCharsets.UTF_8),  sshInteraction.stderr.toString(StandardCharsets.UTF_8), sshInteraction.getDebugOutput());
                         }
                     } catch (Exception e) {
                         LOG.error("error with ssh interactions", e);
@@ -157,6 +160,11 @@ public class SshScriptingServiceImpl implements SshScriptingService {
         } else {
             return errorDesc + " - encountered when sending input \"" + statementWithVars + "\" following successful \"" + prevStatementWithVars + "\"";
         }
+    }
+
+    @Override
+    public String getScriptOutput() {
+        return scriptDebugOutput;
     }
 
     private static class SshInteractionImpl implements SshInteraction, AutoCloseable {
@@ -348,6 +356,10 @@ public class SshScriptingServiceImpl implements SshScriptingService {
         @Override
         public String replaceVars(String string) {
             return StrSubstitutor.replace(string, vars);
+        }
+
+        String getDebugOutput() {
+            return debugOutput.toString(StandardCharsets.UTF_8);
         }
     }
 

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
@@ -143,22 +143,20 @@ public class SshScriptingServiceImpl implements SshScriptingService {
      */
     private String getErrorDescription(Throwable t, SshInteraction sshInteraction, Statement prevStatement, Statement currentStatement) {
 
-        String errorDesc = t.getClass().getName() + ": " + t.getMessage();
-
         if (currentStatement == null) {
-            return errorDesc;
+            return t.getMessage();
         }
 
         String statementWithVars = sshInteraction.replaceVars(currentStatement.toString());
         if (prevStatement == null) {
-            return errorDesc + " - encountered during initial " + statementWithVars + "\"";
+            return t.getMessage() + " - encountered during initial " + statementWithVars + "\"";
         }
 
         String prevStatementWithVars = sshInteraction.replaceVars(prevStatement.toString());
         if (currentStatement.statementType == Statement.StatementType.await) {
-            return errorDesc + " - encountered while waiting for \"" + statementWithVars + "\" following execution of \"" + prevStatementWithVars + "\"";
+            return t.getMessage() + " - encountered while waiting for \"" + statementWithVars + "\" following execution of \"" + prevStatementWithVars + "\"";
         } else {
-            return errorDesc + " - encountered when sending input \"" + statementWithVars + "\" following successful \"" + prevStatementWithVars + "\"";
+            return t.getMessage() + " - encountered when sending input \"" + statementWithVars + "\" following successful \"" + prevStatementWithVars + "\"";
         }
     }
 

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/DeviceConfig.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/DeviceConfig.java
@@ -43,9 +43,21 @@ public class DeviceConfig {
     @XmlAttribute(name="filename")
     private String filename;
 
+    @XmlAttribute(name="scriptOutput")
+    private String scriptOutput;
+
+    public DeviceConfig(String scriptOutput) {
+        this(null, null, scriptOutput);
+    }
+
     public DeviceConfig(byte[] content, String fileName) {
+        this(content, fileName, null);
+    }
+
+    public DeviceConfig(byte[] content, String fileName, String scriptOutput) {
         this.content = content;
         this.filename = fileName;
+        this.scriptOutput = scriptOutput;
     }
 
     // for JAXB
@@ -66,5 +78,13 @@ public class DeviceConfig {
 
     public void setFilename(String filename) {
         this.filename = filename;
+    }
+
+    public String getScriptOutput() {
+        return scriptOutput;
+    }
+
+    public void setScriptOutput(String scriptOutput) {
+        this.scriptOutput = scriptOutput;
     }
 }

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollStatus.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollStatus.java
@@ -69,6 +69,8 @@ public class PollStatus implements Serializable {
     private final Map<String, Number> m_properties = Collections.synchronizedMap(new LinkedHashMap<String, Number>());
 
     private DeviceConfig deviceConfig;
+
+    private String dcbScriptDebugOutput;
     
     /**
      * <P>
@@ -558,5 +560,12 @@ public class PollStatus implements Serializable {
 
     public void setDeviceConfig(DeviceConfig deviceConfig) {
         this.deviceConfig = deviceConfig;
+    }
+
+    @XmlElement(name = "dcbScriptDebugOutput")
+    public String getDcbScriptDebugOutput() {return dcbScriptDebugOutput; }
+
+    public void setDcbScriptDebugOutput(String output) {
+        this.dcbScriptDebugOutput = output;
     }
 }

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollStatus.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollStatus.java
@@ -69,8 +69,6 @@ public class PollStatus implements Serializable {
     private final Map<String, Number> m_properties = Collections.synchronizedMap(new LinkedHashMap<String, Number>());
 
     private DeviceConfig deviceConfig;
-
-    private String dcbScriptDebugOutput;
     
     /**
      * <P>
@@ -560,12 +558,5 @@ public class PollStatus implements Serializable {
 
     public void setDeviceConfig(DeviceConfig deviceConfig) {
         this.deviceConfig = deviceConfig;
-    }
-
-    @XmlElement(name = "dcbScriptDebugOutput")
-    public String getDcbScriptDebugOutput() {return dcbScriptDebugOutput; }
-
-    public void setDcbScriptDebugOutput(String output) {
-        this.dcbScriptDebugOutput = output;
     }
 }


### PR DESCRIPTION
This adds a new option (-v, --verbose) to the `dcb-trigger` karaf shell command. If the script starts executing at all during the retrieval, this captures the ssh session I/O and sends it to stdout. 

The dummy script below:

![image](https://user-images.githubusercontent.com/93448083/175648515-221a52ff-aace-422b-b015-b6d44b3f35b2.png)

Results in something like this being seen from the karaf shell:

![image](https://user-images.githubusercontent.com/93448083/175648328-c2026230-619d-44d0-b547-725b9dd453cc.png)


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14120

