### PR TITLE
NMS-14396: Stop appending RUNAS=root multiple times in container start script

### DIFF
--- a/opennms-container/horizon/container-fs/entrypoint.sh
+++ b/opennms-container/horizon/container-fs/entrypoint.sh
@@ -29,8 +29,10 @@ MYUSER="$(getent passwd "${MYID}" | cut -d: -f1)"
 export RUNAS="${MYUSER}"
 
 if [ "$MYID" -eq 0 ]; then
-  echo "RUNAS=${MYUSER}" >> /opt/opennms/etc/opennms.conf
-  chown "$MYUSER" /opt/opennms/etc/opennms.conf
+  if ! grep -Fxq "RUNAS=${MYUSER}" "${OPENNMS_HOME}/etc/opennms.conf"; then
+      echo "RUNAS=${MYUSER}" >> "${OPENNMS_HOME}/etc/opennms.conf"
+  fi
+  chown "$MYUSER" "${OPENNMS_HOME}/etc/opennms.conf"
 fi
 
 # Help function used in error messages and -h option


### PR DESCRIPTION
This only affects installations running as root.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14396

