### PR TITLE
HELM-272: Fixes for Helm API properties call for affectedNodeCount and situationAlarmCount

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -80,7 +80,13 @@ public abstract class SearchProperties {
 
 	static final SortedSet<SearchProperty> ALARM_PROPERTIES = new TreeSet<>(Arrays.asList(
 		new SearchProperty(OnmsAlarm.class, "id", "ID", INTEGER),
-		new SearchProperty(OnmsAlarm.class, null, "affectedNodeCount", null, "affectedNodeCount", INTEGER, false, false, null),
+		new SearchProperty(OnmsAlarm.class, null, "affectedNodeCount", null, "Affected Node Count", INTEGER,
+			false, false,
+			ImmutableMap.<String, String> builder()
+				.put("0", "0")
+				.put("1", "1")
+				.build()
+			),
 		new SearchProperty(OnmsAlarm.class, "alarmAckTime", "Acknowledged Time", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "alarmAckUser", "Acknowledging User", STRING),
 		new SearchProperty(OnmsAlarm.class, "alarmType", "Alarm Type", INTEGER, ImmutableMap.<String,String>builder()
@@ -111,7 +117,12 @@ public abstract class SearchProperties {
 		new SearchProperty(OnmsAlarm.class, "qosAlarmState", "QoS Alarm State", STRING),
 		new SearchProperty(OnmsAlarm.class, "reductionKey", "Reduction Key", STRING),
 		new SearchProperty(OnmsAlarm.class, "severity", "Severity", INTEGER, ONMS_SEVERITIES),
-		new SearchProperty(OnmsAlarm.class, null, "situationAlarmCount", null, "situationAlarmCount", INTEGER, false, false, null),
+		new SearchProperty(OnmsAlarm.class, null, "situationAlarmCount", null, "Situation Alarm Count", INTEGER, false, false,
+			ImmutableMap.<String, String> builder()
+				.put("0", "0")
+				.put("1", "1")
+				.build()
+		),
 		new SearchProperty(OnmsAlarm.class, "suppressedTime", "Suppressed Time", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "suppressedUntil", "Suppressed Until", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "suppressedUser", "Suppressed User", STRING),


### PR DESCRIPTION
HELM-272: Hard-code values for Helm Rest API properties call for affectedNodeCount and situationAlarmCount to prevent invalid HQL query. Also fix labels to be "Affected Node Count", etc.

This needs to be done in conjunction with OpenNMS/opennms-helm HELM-272, see [PR](https://github.com/OpenNMS/opennms-helm/pull/453).

These values (cf. `OnmsAlarm.java`) are derived inside the entity Java code, not from the database directly.  This was causing HQL parsing issues in `AlarmRestService.java` and `AbstractDaoRestServiceWithDTO.getPropertyValues()`, responding to the "properties" call from Grafana/Helm when user added one of these Filter fields in a Filter Panel. Also, these SearchProperties are set to orderBy = false, which also wasn't being handled in HQL query construction (cf. `AbstractDaoRestServiceWithDTO.doInHibernate`).

Having hard-coded values means the code path will return directly without attempting a Hibernate query. User should be using text boxes for these filter values anyway.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-272
