### PR TITLE
NMS-14331: Grafana Panel Internal Server Error when lasteventid is Null for an Alarm when Using HELM

### DIFF
--- a/features/rest/mapper/src/main/java/org/opennms/web/rest/mapper/v2/AlarmMapper.java
+++ b/features/rest/mapper/src/main/java/org/opennms/web/rest/mapper/v2/AlarmMapper.java
@@ -144,7 +144,10 @@ public abstract class AlarmMapper {
 
     @AfterMapping
     protected void mapEventLabel(@MappingTarget AlarmSummaryDTO summaryDTO) {
-        summaryDTO.setLabel(eventConfDao.getEventLabel(summaryDTO.getUei()));
+        //there are cases when lasteventid in alarms is null, making api/v2/alarms throw a null pointer exception
+        if(summaryDTO.getUei() != null) {
+            summaryDTO.setLabel(eventConfDao.getEventLabel(summaryDTO.getUei()));
+        }
     }
 
     public void setEventConfDao(EventConfDao eventConfDao) {


### PR DESCRIPTION
Fix null pointer exception in api/v2/alarms rest point when lasteventid in alarms are null

See: AlarmMapperImpl.alarmLastEventEventUei

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14331

