### PR TITLE
NMS-14403: Fixed conversion of query string

### DIFF
--- a/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
@@ -471,7 +471,7 @@ public abstract class Util extends Object {
             buffer.deleteCharAt(0);
         }
 
-        return WebSecurityUtils.sanitizeString(buffer.toString());
+        return buffer.toString();
     }
 
     public static enum IgnoreType {


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-14403

Reverted the change in the Util class, since this made the query-string get double-quoted. I also went through the code and the logic handling parameters looks fine to me. So, in my opinion this revert will not introduce any security issues.