### PR TITLE
NMS-14478: External Requisition UI, add Requisition Name input for VMware

### DIFF
--- a/ui/src/components/Configuration/ConfigurationHelpPanel.vue
+++ b/ui/src/components/Configuration/ConfigurationHelpPanel.vue
@@ -153,7 +153,7 @@ const helpText = computed(() => {
   } else if (typeName === RequisitionTypes.VMWare) {
     helpVals = {
       title: RequisitionTypes.VMWare,
-      subTitle: 'The VMware adapter pulls hosts and/or virtual machines from a vCenter server into OpenNMS. With this adapter, you can automatically add, update, or remove nodes from your inventory based on the status of the VMware entity. Uses the host, optional username, and optional password parameters to construct the URL OpenNMS uses to locate this external source. If username and password are left blank, the system will rely on credentials configured in vmware-config.xml.',
+      subTitle: 'The VMware adapter pulls hosts and/or virtual machines from a vCenter server into OpenNMS. With this adapter, you can automatically add, update, or remove nodes from your inventory based on the status of the VMware entity. Uses the host, requisition name, optional username, and optional password parameters to construct the URL OpenNMS uses to locate this external source. If username and password are left blank, the system will rely on credentials configured in vmware-config.xml.',
       help: 'See the online documentation for detailed information on supported options:',
       linkCopy: 'READ FULL ARTICLE',
       link: 'https://docs.opennms.com/horizon/latest/reference/provisioning/handlers/vmware.html'

--- a/ui/src/components/Configuration/ProvisionDForm.vue
+++ b/ui/src/components/Configuration/ProvisionDForm.vue
@@ -71,6 +71,8 @@
         @update:modelValue="(val) => updateFormValue('zone', val)"
         hint="DNS zone to use as basis for this definition"
       />
+    </div>
+    <div v-if="[RequisitionTypes.DNS].includes(config.type.name) || [RequisitionTypes.VMWare].includes(config.type.name)">
       <FeatherInput
         label="Requisition Name"
         class="side-input mb-m"

--- a/ui/src/components/Configuration/copy/requisitionTypes.ts
+++ b/ui/src/components/Configuration/copy/requisitionTypes.ts
@@ -48,12 +48,14 @@ export const VMWareFields = {
   Username: 'username',
   Password: 'password',
   UpperUsername: 'Username',
-  UpperPassword: 'Password'
+  UpperPassword: 'Password',
+  RequisitionName: 'Requisition Name'
 }
 
 export const SplitTypes = {
   dns: 'dns://',
-  file: 'file://'
+  file: 'file://',
+  vmware: 'vmware://'
 }
 
 export const ErrorStrings = {

--- a/ui/tests/configuration.test.ts
+++ b/ui/tests/configuration.test.ts
@@ -152,8 +152,9 @@ describe('Zone field - validateZoneField()', () => {
   })
 })
 
-describe('Requisition namd field - validateRequisitionNameField()', () => {
+describe('Requisition name field - validateRequisitionNameField()', () => {
   it('should be valid', () => {
+    expect(ConfigurationHelper.validateRequisitionNameField('')).toEqual('')
     expect(ConfigurationHelper.validateRequisitionNameField('Requisition-name_field .123')).toEqual('')
   })
   it('should be invalid', () => {
@@ -200,7 +201,7 @@ test('The edit btn disables if the record starts with "requisition://"', async (
   expect(editBtn.attributes('aria-disabled')).toBe('true')
 })
 
-test('Display appropriate form errors', async () => {
+test('Display appropriate form errors for VMware requisition', async () => {
   const mockLocalConfig = {
     username: 'test',
     password: '',
@@ -209,6 +210,17 @@ test('Display appropriate form errors', async () => {
   } as LocalConfiguration
 
   let errors = ConfigurationHelper.validateLocalItem(mockLocalConfig, [], 1, false)
+
+  // expect host required error
+  expect(errors.host).toBe(ErrorStrings.Required('Host'))
+
+  // expect invalid requisition name error
+  expect(errors.foreignSource).toBe(ErrorStrings.Required(VMWareFields.RequisitionName))
+
+  mockLocalConfig.foreignSource = ' . '
+  errors = ConfigurationHelper.validateLocalItem(mockLocalConfig, [], 1, false)
+  expect(errors.foreignSource).toBe(ErrorStrings.InvalidRequisitionName)
+
   // expect password input error
   expect(errors.password).toBe(ErrorStrings.Required(VMWareFields.UpperPassword))
   expect(errors.username).toBe('')
@@ -230,4 +242,9 @@ test('Display appropriate form errors', async () => {
   errors = ConfigurationHelper.validateLocalItem(mockLocalConfig, [], 1, false)
   expect(errors.username).toBe('')
   expect(errors.password).toBe('')
+
+  // if host is invalid, expect error
+  mockLocalConfig.host = '  '
+  errors = ConfigurationHelper.validateLocalItem(mockLocalConfig, [], 1, false)
+  expect(errors.host).toBe(ErrorStrings.InvalidHostname)
 })


### PR DESCRIPTION
In the UI Preview, External Requisitions, the Requisition Name / Foreign Source Name was not being added to the URL for the "import-url-resource" being saved in the DB via via Configuration Manager Rest API. Added a new text box input field when VMware is selected as an External Source.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14478

