### PR TITLE
NMS-14524: Improved pollerd startup time

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfig.java
@@ -315,10 +315,7 @@ public interface PollerConfig extends PathOutageConfig {
             }
 
             if (!this.isInterfaceInPackage(ipAddr, pkg)) {
-                this.rebuildPackageIpListMap();
-                if (!this.isInterfaceInPackage(ipAddr, pkg)) {
-                    continue;
-                }
+                continue;
             }
 
             lastPkg = pkg;

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
@@ -486,7 +486,6 @@ abstract public class PollerConfigManager implements PollerConfig {
             getReadLock().lock();
             final String filterRules = pkg.getFilter().getContent();
             LOG.debug("createPackageIpMap: package is {}. filter rules are {}", pkg.getName(), filterRules);
-            FilterDaoFactory.getInstance().flushActiveIpAddressListCache();
             return FilterDaoFactory.getInstance().getActiveIPAddressList(filterRules);
         } finally {
             getReadLock().unlock();
@@ -502,6 +501,7 @@ abstract public class PollerConfigManager implements PollerConfig {
      */
     @Override
     public void rebuildPackageIpListMap() {
+        FilterDaoFactory.getInstance().flushActiveIpAddressListCache();
         createPackageIpListMap();
     }
 

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
@@ -40,10 +40,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -162,7 +162,7 @@ abstract public class PollerConfigManager implements PollerConfig {
      * A mapping of the configured package to a list of IPs selected via filter
      * rules, so as to avoid repetitive database access.
      */
-    private AtomicReference<Map<Package, List<InetAddress>>> m_pkgIpMap = new AtomicReference<>();
+    private AtomicReference<Map<Package, Set<InetAddress>>> m_pkgIpMap = new AtomicReference<>();
     /**
      * A mapp of service names to service monitors. Constructed based on data in
      * the configuration file.
@@ -450,7 +450,7 @@ abstract public class PollerConfigManager implements PollerConfig {
         getReadLock().lock();
         
         try {
-            Map<Package, List<InetAddress>> pkgIpMap = new HashMap<>();
+            Map<Package, Set<InetAddress>> pkgIpMap = new HashMap<>();
             
             for(final Package pkg : packages()) {
         
@@ -458,7 +458,7 @@ abstract public class PollerConfigManager implements PollerConfig {
                 // database and populate the package, IP list map.
                 //
                 try {
-                    List<InetAddress> ipList = getIpList(pkg);
+                    Set<InetAddress> ipList = new HashSet<>(getIpList(pkg));
                     LOG.debug("createPackageIpMap: package {}: ipList size = {}", pkg.getName(), ipList.size());
         
                     if (ipList.size() > 0) {
@@ -522,7 +522,7 @@ abstract public class PollerConfigManager implements PollerConfig {
         final InetAddress ifaceAddr = addr(iface);
     
         // get list of IPs in this package
-        final List<InetAddress> ipList = m_pkgIpMap.get().get(pkg);
+        final Set<InetAddress> ipList = m_pkgIpMap.get().get(pkg);
         if (ipList != null && ipList.size() > 0) {
 			filterPassed = ipList.contains(ifaceAddr);
         }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/OutageDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/OutageDao.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.dao.api;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.opennms.netmgt.model.HeatMapElement;
 import org.opennms.netmgt.model.OnmsMonitoredService;
@@ -59,6 +61,11 @@ public interface OutageDao extends LegacyOnmsDao<OnmsOutage, Integer> {
      * @return a {@link java.util.Collection} object.
      */
     Collection<OnmsOutage> currentOutages();
+
+    /**
+     * Open outages grouped by {@link OnmsMonitoredService} id.
+     */
+    Map<Integer, Set<OnmsOutage>> currentOutagesByServiceId();
 
     /**
      * Return the current open outage for the service or if the service

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockOutageDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockOutageDao.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.dao.mock;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.opennms.netmgt.dao.api.OutageDao;
@@ -75,6 +77,11 @@ public class MockOutageDao extends AbstractMockDao<OnmsOutage, Integer> implemen
 
     @Override
     public Collection<OnmsOutage> currentOutages() {
+        throw new UnsupportedOperationException("Not yet implemented!");
+    }
+
+    @Override
+    public Map<Integer, Set<OnmsOutage>> currentOutagesByServiceId() {
         throw new UnsupportedOperationException("Not yet implemented!");
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java
@@ -556,7 +556,10 @@ public class Poller extends AbstractServiceDaemon {
     }
 
     private Package findPackageForService(String ipAddr, String serviceName) {
-        this.m_pollerConfig.rebuildPackageIpListMap();
+        if (m_initialized) {
+            // Only rebuild the map when services are scheduled after the initial initialization
+            m_pollerConfig.rebuildPackageIpListMap();
+        }
         return this.m_pollerConfig.findPackageForService(ipAddr, serviceName);
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java
@@ -31,9 +31,10 @@ package org.opennms.netmgt.poller;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetAddress;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
-import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -456,7 +457,7 @@ public class Poller extends AbstractServiceDaemon {
                         @Override
                         protected void doInTransactionWithoutResult(TransactionStatus arg0) {
                             final OnmsMonitoredService service = m_monitoredServiceDao.get(nodeId, InetAddressUtils.addr(ipAddr), svcName);
-                            if (scheduleService(service)) {
+                            if (scheduleService(service, service.getCurrentOutages())) {
                                 svcNode.recalculateStatus();
                                 svcNode.processStatusChange(new Date());
                             } else {
@@ -481,17 +482,17 @@ public class Poller extends AbstractServiceDaemon {
             @Override
             public Integer doInTransaction(TransactionStatus arg0) {
                 final List<OnmsMonitoredService> services =  m_monitoredServiceDao.findMatching(criteria);
+                final Map<Integer, Set<OnmsOutage>> outagesByServiceId = m_outageDao.currentOutagesByServiceId();
                 for (OnmsMonitoredService service : services) {
-                    scheduleService(service);
+                    scheduleService(service, outagesByServiceId.getOrDefault(service.getId(), Collections.emptySet()));
                 }
                 return services.size();
             }
         });
     }
 
-    private boolean scheduleService(OnmsMonitoredService service) {
+    private boolean scheduleService(OnmsMonitoredService service, Set<OnmsOutage> outages) {
         final OnmsIpInterface iface = service.getIpInterface();
-        final Set<OnmsOutage> outages = service.getCurrentOutages();
         final OnmsOutage outage = (outages == null || outages.size() < 1 ? null : outages.iterator().next());
         final OnmsEvent event = (outage == null ? null : outage.getServiceLostEvent());
         final String ipAddr = InetAddressUtils.str(iface.getIpAddress());

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.poller;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -42,12 +41,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.db.DataSourceFactory;
@@ -57,8 +53,8 @@ import org.opennms.core.test.db.MockDatabase;
 import org.opennms.core.test.db.TemporaryDatabaseAware;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.utils.Querier;
-import org.opennms.netmgt.config.poller.Package;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.eventd.AbstractEventUtil;
 import org.opennms.netmgt.events.api.EventConstants;
@@ -140,6 +136,9 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
 	private LocationAwarePollerClient m_locationAwarePollerClient;
 
 	private LocationAwarePingClient m_locationAwarePingClient;
+
+	@Autowired
+	private OutageDao m_outageDao;
 
 	@Override
 	public void setTemporaryDatabase(MockDatabase database) {
@@ -231,6 +230,7 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
 		m_poller.setLocationAwarePollerClient(m_locationAwarePollerClient);
 		m_poller.setServiceMonitorAdaptor((svc, parameters, status) -> status);
 		m_poller.setPersisterFactory(new MockPersisterFactory());
+		m_poller.setOutageDao(m_outageDao);
 	}
 
 	@After


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-14524

A few tweaks to make pollerd startup faster for on systems with large amounts of nodes and services.

This patch avoids caches being reset for every service that is being scheduled and reduces the amount of round-trips to the DB required. For a deployment in ~100k nodes and ~300k monitored services, this takes pollerd startup time from several hours to < 10 minutes.