### PR TITLE
Minion test revert to smoke tests

### DIFF
--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageIT.java
@@ -63,8 +63,8 @@ import org.opennms.smoketest.utils.TestContainerUtils;
  * 
  * @author Seth
  */
-@Category(org.opennms.smoketest.junit.FlakyTests.class)
-//@Category(org.opennms.smoketest.junit.MinionTests.class)
+//@Category(org.opennms.smoketest.junit.FlakyTests.class)
+@Category(org.opennms.smoketest.junit.MinionTests.class)
 public class MinionHeartbeatOutageIT {
 
     @Rule

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageKafkaIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageKafkaIT.java
@@ -38,8 +38,8 @@ import org.opennms.smoketest.stacks.IpcStrategy;
  * 
  * @author Seth
  */
-// @Category(MinionTests.class)
-@org.junit.experimental.categories.Category(org.opennms.smoketest.junit.FlakyTests.class)
+@Category(MinionTests.class)
+//@org.junit.experimental.categories.Category(org.opennms.smoketest.junit.FlakyTests.class)
 public class MinionHeartbeatOutageKafkaIT extends MinionHeartbeatOutageIT {
 
     @Override


### PR DESCRIPTION
Adding back Minion tests to the Smoke-test as they not flaky for the last 2 weeks

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14365

