### PR TITLE
NMS-14488: Add KPIs for notification entities to datachoices telemetry

### DIFF
--- a/docs/modules/operation/pages/user-management/introduction.adoc
+++ b/docs/modules/operation/pages/user-management/introduction.adoc
@@ -51,6 +51,9 @@ When enabled, the `Data Choices` module collects the following anonymous statist
 * Provisiond thread pool sizes
 * List of enabled/disabled services
 * List of installed features in Karaf
+* Global notification enablement status
+* Destination path count
+* On-call role count
 
 [[ga-admin-user-setup]]
 === Admin User Setup

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTO.java
@@ -59,6 +59,9 @@ public class UsageStatisticsReportDTO {
     private int m_events;
     private int m_alarms;
     private long m_situations;
+    private int m_destinationPathCount;
+    private Boolean m_notificationEnablementStatus;
+    private int m_roleCount;
 
     private Map<String, Long> m_nodesBySysOid = Collections.emptyMap();
 
@@ -264,6 +267,30 @@ public class UsageStatisticsReportDTO {
 
     public void setServices(Map<String, Boolean> services) {
         m_services = services;
+    }
+
+    public int getDestinationPathCount() {
+        return m_destinationPathCount;
+    }
+
+    public void setDestinationPathCount(int m_destinationPathCount) {
+        this.m_destinationPathCount = m_destinationPathCount;
+    }
+
+    public Boolean isNotificationEnablementStatus() {
+        return m_notificationEnablementStatus;
+    }
+
+    public void setNotificationEnablementStatus(Boolean m_notificationEnablementStatus) {
+        this.m_notificationEnablementStatus = m_notificationEnablementStatus;
+    }
+
+    public int getRoleCount() {
+        return m_roleCount;
+    }
+
+    public void setRoleCount(int m_roleCount) {
+        this.m_roleCount = m_roleCount;
     }
 
     public String toJson() {

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReporter.java
@@ -43,7 +43,10 @@ import org.apache.karaf.features.FeaturesService;
 import org.opennms.core.utils.SystemInfoUtils;
 import org.opennms.core.web.HttpClientWrapper;
 import org.opennms.features.datachoices.internal.StateManager.StateChangeHandler;
+import org.opennms.netmgt.config.GroupFactory;
+import org.opennms.netmgt.config.NotifdConfigFactory;
 import org.opennms.netmgt.config.ServiceConfigFactory;
+import org.opennms.netmgt.config.DestinationPathFactory;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.EventDao;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
@@ -91,6 +94,12 @@ public class UsageStatisticsReporter implements StateChangeHandler {
     private ProvisiondConfigurationDao m_provisiondConfigurationDao;
 
     private ServiceConfigFactory m_serviceConfigurationFactory;
+
+    private DestinationPathFactory m_destinationPathFactory;
+
+    private NotifdConfigFactory m_notifdConfigFactory;
+
+    private GroupFactory m_groupFactory;
 
     private boolean m_useSystemProxy = true; // true == legacy behaviour
 
@@ -216,6 +225,10 @@ public class UsageStatisticsReporter implements StateChangeHandler {
         gatherProvisiondData(usageStatisticsReport);
         usageStatisticsReport.setServices(m_serviceConfigurationFactory.getServiceNameMap());
 
+        usageStatisticsReport.setDestinationPathCount(getDestinationPathCount());
+        usageStatisticsReport.setNotificationEnablementStatus(getNotificationEnablementStatus());
+        usageStatisticsReport.setRoleCount(m_groupFactory.getRoles().size());
+
         return usageStatisticsReport;
     }
 
@@ -297,5 +310,42 @@ public class UsageStatisticsReporter implements StateChangeHandler {
 
     public void setServiceConfigurationFactory(ServiceConfigFactory serviceConfigurationFactory) {
         m_serviceConfigurationFactory = serviceConfigurationFactory;
+    }
+
+    public void setDestinationPathFactory(DestinationPathFactory destinationPathFactory){
+        m_destinationPathFactory = destinationPathFactory;
+    }
+
+    public void setNotifdConfigFactory(NotifdConfigFactory notifdConfigFactory) {
+        this.m_notifdConfigFactory = notifdConfigFactory;
+    }
+
+    public void setGroupFactory(GroupFactory groupFactory) {
+        this.m_groupFactory = groupFactory;
+    }
+
+    private int getDestinationPathCount(){
+        try {
+            return m_destinationPathFactory.getPaths().size();
+
+        } catch (IOException e) {
+            return -1;
+        }
+    }
+
+    private Boolean getNotificationEnablementStatus(){
+        try {
+            final String bool = m_notifdConfigFactory.getNotificationStatus();
+            switch (bool){
+                case "on":
+                    return true;
+                case "off":
+                    return false;
+                default:
+                    return null;
+            }
+        } catch (IOException e) {
+            return null;
+        }
     }
 }

--- a/features/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -35,6 +35,24 @@
 
     <bean id="serviceConfigurationFactory" class="org.opennms.netmgt.config.ServiceConfigFactory" />
 
+    <bean id="destinationPathFactory-init" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod"><value>org.opennms.netmgt.config.DestinationPathFactory.init</value></property>
+    </bean>
+
+    <bean id="destinationPathFactory" class="org.opennms.netmgt.config.DestinationPathFactory" depends-on="destinationPathFactory-init" factory-method="getInstance"/>
+
+    <bean id="notifdConfigFactory-init" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod"><value>org.opennms.netmgt.config.NotifdConfigFactory.init</value></property>
+    </bean>
+
+    <bean id="notifdConfigFactory" class="org.opennms.netmgt.config.NotifdConfigFactory" depends-on="notifdConfigFactory-init" factory-method="getInstance"/>
+
+    <bean id="groupFactory-init" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod"><value>org.opennms.netmgt.config.GroupFactory.init</value></property>
+    </bean>
+
+    <bean id="groupFactory" class="org.opennms.netmgt.config.GroupFactory" depends-on="groupFactory-init" factory-method="getInstance"/>
+
     <!-- The state manager will manually pull properties from the configuration file -->
     <bean id="stateManager" class="org.opennms.features.datachoices.internal.StateManager">
         <argument ref="configurationManagerService" />
@@ -56,6 +74,9 @@
         <property name="featuresService" ref="featuresService"/>
         <property name="provisiondConfigurationDao" ref="provisiondConfigDao"/>
         <property name="serviceConfigurationFactory" ref="serviceConfigurationFactory"/>
+        <property name="destinationPathFactory" ref="destinationPathFactory"/>
+        <property name="notifdConfigFactory" ref="notifdConfigFactory"/>
+        <property name="groupFactory" ref="groupFactory"/>
     </bean>
 
     <bean id="dataChoiceRestService" class="org.opennms.features.datachoices.web.internal.DataChoiceRestServiceImpl">

--- a/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTOTest.java
+++ b/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTOTest.java
@@ -61,9 +61,13 @@ public class UsageStatisticsReportDTOTest {
         services.put("Telemetryd", false);
         usageStatisticsReport.setServices(services);
 
+        usageStatisticsReport.setRoleCount(1);
+        usageStatisticsReport.setNotificationEnablementStatus(null);
+        usageStatisticsReport.setDestinationPathCount(-1);
+
         String actualJson = usageStatisticsReport.toJson();
         System.err.println(actualJson);
-        String expectedJson = "{\"alarms\":0,\"events\":0,\"installedFeatures\":null,\"ipInterfaces\":0,\"minions\":0,\"monitoredServices\":0,\"monitoringLocations\":0,\"nodes\":0,\"nodesBySysOid\":{\".1.2.3.4\":2,\".1.2.3.5\":6},\"osArch\":null,\"osName\":null,\"osVersion\":null,\"packageName\":\"opennms\",\"provisiondImportThreadPoolSize\":0,\"provisiondRequisitionSchemeCount\":{\"file\":4,\"vmware\":3},\"provisiondRescanThreadPoolSize\":0,\"provisiondScanThreadPoolSize\":0,\"provisiondWriteThreadPoolSize\":0,\"services\":{\"Provisiond\":true,\"Telemetryd\":false},\"situations\":0,\"snmpInterfaces\":0,\"snmpInterfacesWithFlows\":0,\"systemId\":\"aae3fdeb-3014-47b4-bb13-c8aa503fccb7\",\"version\":\"10.5.7\"}";
+        String expectedJson = "{\"alarms\":0,\"destinationPathCount\":-1,\"events\":0,\"installedFeatures\":null,\"ipInterfaces\":0,\"minions\":0,\"monitoredServices\":0,\"monitoringLocations\":0,\"nodes\":0,\"nodesBySysOid\":{\".1.2.3.4\":2,\".1.2.3.5\":6},\"notificationEnablementStatus\":null,\"osArch\":null,\"osName\":null,\"osVersion\":null,\"packageName\":\"opennms\",\"provisiondImportThreadPoolSize\":0,\"provisiondRequisitionSchemeCount\":{\"file\":4,\"vmware\":3},\"provisiondRescanThreadPoolSize\":0,\"provisiondScanThreadPoolSize\":0,\"provisiondWriteThreadPoolSize\":0,\"roleCount\":1,\"services\":{\"Provisiond\":true,\"Telemetryd\":false},\"situations\":0,\"snmpInterfaces\":0,\"snmpInterfacesWithFlows\":0,\"systemId\":\"aae3fdeb-3014-47b4-bb13-c8aa503fccb7\",\"version\":\"10.5.7\"}";
         assertEquals(expectedJson, actualJson);
     }
 }


### PR DESCRIPTION
Global notification enablement status (Boolean)
Destination path count (integer gauge)
On-call role count (integer gauge)

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14488

