### PR TITLE
Revert "NMS-14482: Add KPIs for CPU count and memory size to datachoices telemetry"

### DIFF
--- a/docs/modules/operation/pages/user-management/introduction.adoc
+++ b/docs/modules/operation/pages/user-management/introduction.adoc
@@ -34,14 +34,11 @@ NOTE: Admin users can enable or disable usage statistics collection at any time 
 When enabled, the `Data Choices` module collects the following anonymous statistics and publishes them on system startup and every 24 hours after:
 
 * System ID (a randomly generated universally unique identifier (UUID))
-* {page-component-title} release
-* {page-component-title} version
-* OS architecture
-* OS name
-* OS version
-* Number of available processors (CPU)
-* Amount of free physical memory
-* Amount of total physical memory
+* {page-component-title} Release
+* {page-component-title} Version
+* OS Architecture
+* OS Name
+* OS Version
 * Number of alarms in the `alarms` table
 * Number of situations in the `alarms` table
 * Number of events in the `events` table

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTO.java
@@ -67,10 +67,6 @@ public class UsageStatisticsReportDTO {
 
     private String m_installedFeatures;
 
-    private Integer m_availableProcessors;
-    private Long m_freePhysicalMemorySize;
-    private Long m_totalPhysicalMemorySize;
-
     public void setSystemId(String systemId) {
         m_systemId = systemId;
     }
@@ -213,30 +209,6 @@ public class UsageStatisticsReportDTO {
 
     public void setInstalledFeatures(String installedFeatures) {
         m_installedFeatures = installedFeatures;
-    }
-
-    public void setAvailableProcessors(Integer availableProcessors) {
-        this.m_availableProcessors = availableProcessors;
-    }
-
-    public Integer getAvailableProcessors() {
-        return this.m_availableProcessors;
-    }
-
-    public Long getFreePhysicalMemorySize() {
-        return this.m_freePhysicalMemorySize;
-    }
-
-    public void setFreePhysicalMemorySize(Long freePhysicalMemorySize) {
-        this.m_freePhysicalMemorySize = freePhysicalMemorySize;
-    }
-
-    public Long getTotalPhysicalMemorySize() {
-        return this.m_totalPhysicalMemorySize;
-    }
-
-    public void setTotalPhysicalMemorySize(long totalPhysicalMemorySize) {
-        this.m_totalPhysicalMemorySize = totalPhysicalMemorySize;
     }
 
     public String toJson() {

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReporter.java
@@ -29,7 +29,6 @@
 package org.opennms.features.datachoices.internal;
 
 import java.io.IOException;
-import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Timer;
@@ -56,23 +55,10 @@ import org.opennms.netmgt.model.OnmsMonitoringSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanException;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-import javax.management.ReflectionException;
-
 public class UsageStatisticsReporter implements StateChangeHandler {
     private static final Logger LOG = LoggerFactory.getLogger(UsageStatisticsReporter.class);
 
     public static final String USAGE_REPORT = "usage-report";
-    private static final String JMX_OBJ_OS = "java.lang:type=OperatingSystem";
-    private static final String JMX_ATTR_FREE_PHYSICAL_MEMORY_SIZE = "FreePhysicalMemorySize";
-    private static final String JMX_ATTR_TOTAL_PHYSICAL_MEMORY_SIZE = "TotalPhysicalMemorySize";
-    private static final String JMX_ATTR_AVAILABLE_PROCESSORS = "AvailableProcessors";
-    private static final MBeanServer M_BEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
 
     private String m_url;
 
@@ -221,40 +207,7 @@ public class UsageStatisticsReporter implements StateChangeHandler {
             installedFeatures = "ERROR: Failed to enumerate the installed features: " + e.getMessage();
         }
         usageStatisticsReport.setInstalledFeatures(installedFeatures);
-        setJmxAttributes(usageStatisticsReport);
-
         return usageStatisticsReport;
-    }
-    private void setJmxAttributes(UsageStatisticsReportDTO usageStatisticsReport) {
-        Object freePhysicalMemSizeObj = getJmxAttribute(JMX_OBJ_OS, JMX_ATTR_FREE_PHYSICAL_MEMORY_SIZE);
-        if (freePhysicalMemSizeObj != null) {
-            usageStatisticsReport.setFreePhysicalMemorySize((long) freePhysicalMemSizeObj);
-        }
-        Object totalPhysicalMemSizeObj = getJmxAttribute(JMX_OBJ_OS, JMX_ATTR_TOTAL_PHYSICAL_MEMORY_SIZE);
-        if (totalPhysicalMemSizeObj != null) {
-            usageStatisticsReport.setTotalPhysicalMemorySize((long) totalPhysicalMemSizeObj);
-        }
-        Object availableProcessorsObj = getJmxAttribute(JMX_OBJ_OS, JMX_ATTR_AVAILABLE_PROCESSORS);
-        if (availableProcessorsObj != null) {
-            usageStatisticsReport.setAvailableProcessors((int) availableProcessorsObj);
-        }
-    }
-
-    private Object getJmxAttribute(String objectName, String attributeName) {
-        ObjectName objNameActual;
-        try {
-            objNameActual = new ObjectName(objectName);
-        } catch (MalformedObjectNameException e) {
-            LOG.warn("Failed to query from object name " + objectName, e);
-            return null;
-        }
-        try {
-            return M_BEAN_SERVER.getAttribute(objNameActual, attributeName);
-        } catch (InstanceNotFoundException | AttributeNotFoundException
-                 | ReflectionException | MBeanException e) {
-            LOG.warn("Failed to query from attribute name " + attributeName + " on object " + objectName, e);
-            return null;
-        }
     }
 
     public void setUrl(String url) {

--- a/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTOTest.java
+++ b/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTOTest.java
@@ -51,7 +51,7 @@ public class UsageStatisticsReportDTOTest {
         usageStatisticsReport.setNodesBySysOid(numberOfNodesBySysOid);
 
         String actualJson = usageStatisticsReport.toJson();
-        String expectedJson = "{\"alarms\":0,\"availableProcessors\":null,\"events\":0,\"freePhysicalMemorySize\":null,\"installedFeatures\":null,\"ipInterfaces\":0,\"minions\":0,\"monitoredServices\":0,\"monitoringLocations\":0,\"nodes\":0,\"nodesBySysOid\":{\".1.2.3.4\":2,\".1.2.3.5\":6},\"osArch\":null,\"osName\":null,\"osVersion\":null,\"packageName\":\"opennms\",\"situations\":0,\"snmpInterfaces\":0,\"snmpInterfacesWithFlows\":0,\"systemId\":\"aae3fdeb-3014-47b4-bb13-c8aa503fccb7\",\"totalPhysicalMemorySize\":null,\"version\":\"10.5.7\"}";
+        String expectedJson = "{\"alarms\":0,\"events\":0,\"installedFeatures\":null,\"ipInterfaces\":0,\"minions\":0,\"monitoredServices\":0,\"monitoringLocations\":0,\"nodes\":0,\"nodesBySysOid\":{\".1.2.3.4\":2,\".1.2.3.5\":6},\"osArch\":null,\"osName\":null,\"osVersion\":null,\"packageName\":\"opennms\",\"situations\":0,\"snmpInterfaces\":0,\"snmpInterfacesWithFlows\":0,\"systemId\":\"aae3fdeb-3014-47b4-bb13-c8aa503fccb7\",\"version\":\"10.5.7\"}";
         assertEquals(expectedJson, actualJson);
     }
 }


### PR DESCRIPTION
Reverts OpenNMS/opennms#5020

This should only target `release-30.x` and beyond.