### PR TITLE
NMS-14476: Negate search terms in event advanced search

### DIFF
--- a/docs/modules/operation/nav.adoc
+++ b/docs/modules/operation/nav.adoc
@@ -83,6 +83,7 @@
 ** xref:events/event-configuration.adoc[]
 ** xref:events/event-translator.adoc[]
 ** xref:events/perf-data.adoc[]
+** xref:events/event-advanced-search.adoc[]
 
 * xref:alarms/introduction.adoc[]
 ** xref:alarms/alarmd.adoc[]

--- a/docs/modules/operation/pages/events/event-advanced-search.adoc
+++ b/docs/modules/operation/pages/events/event-advanced-search.adoc
@@ -1,0 +1,66 @@
+
+[[ga-advanced-event-search]]
+= Advanced Event Search
+
+Often users wish to query the event list with more customizations to narrow down the search.
+The {page-component-title} event detail page has a button to filter your searches based on different criteria.
+
+Choose from the following search criteria:
+
+* Event ID
+** Performs an equals filter on the event ID.
+
+* Node Label Contains
+** Performs a substring filter on the node label.
+** To negate this search, prefix the input text with `!`.
+This returns results that do not contain the provided input text.
+
+* Event Text Contains
+** Performs a substring filter on both the log message and the description.
+** To negate this search, prefix the input text with `!`.
+This returns results that do not contain the provided input text.
+
+* TCP/IP Address Like
+** Performs an `IPLIKE` on the provided IP Address to filter the results.
+** To negate this search, prefix the input text with `!`.
+This returns results that do not satisfy the `IPLIKE` function.
+
+* Node Location
+** Select from the dropdown to filter results to only this Node Location.
+** Choose `Any` to return all results.
+
+* System ID
+** Select from the dropdown to filter results to only this System ID.
+** Choose `Any` to return all results.
+
+* Severity
+** Filter the event list based on the event severity.
+** This is a multi-select checkbox.
+Select the severities you wish to filter by.
+By default they are unselected, which returns all events.
+Selecting one or multiple severities restricts your search results to those selected.
+
+* Service
+** Filter the event list based on the alarm service.
+** This is a multi-select checkbox.
+Select the services you wish to filter by.
+By default they are unselected, which returns all events.
+Selecting one or multiple services restricts your search results to those selected.
+
+* Exact Event UEI
+** Performs an equals filter on the event UEI.
+
+* Relative Time
+** Filter the results based on a relative time from now.
+
+* Sort By
+** Sort the results ascending or descending for the selected field name.
+
+* Number of Events per page
+** The number of events per page shown on the list page.
+
+* Events after
+** Select the timestamp to filter for events after this timestamp.
+
+* Events before
+** Select the timestamp to filter for events before this timestamp.

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/AlarmUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/AlarmUtil.java
@@ -29,22 +29,14 @@
 package org.opennms.web.alarm;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.servlet.ServletContext;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
 import org.opennms.core.utils.InetAddressUtils;
-import org.opennms.core.utils.StringUtils;
 import org.opennms.core.utils.WebSecurityUtils;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsCriteria;
@@ -88,6 +80,10 @@ import org.opennms.web.alarm.filter.SeverityFilter;
 import org.opennms.web.alarm.filter.SeverityOrFilter;
 import org.opennms.web.alarm.filter.SituationFilter;
 import org.opennms.web.filter.Filter;
+import org.opennms.web.utils.filter.CheckboxFilterUtils;
+import org.opennms.web.utils.filter.FilterTokenizeUtils;
+
+import static org.opennms.web.utils.filter.CheckboxFilterUtils.ARRAY_DELIMITER;
 
 /**
  * <p>Abstract AlarmUtil class.</p>
@@ -106,20 +102,8 @@ public abstract class AlarmUtil extends Object {
     /** Constant <code>ANY_RELATIVE_TIMES_OPTION="Any"</code> */
     public static final String ANY_RELATIVE_TIMES_OPTION = "Any";
 
-    /** Constant <code>POSITIVE_CHECKBOX_VALUE="ON"</code> */
-    public static final String POSITIVE_CHECKBOX_VALUE = "on";
-
     /** Constant <code>NEGATION_PREFIX_SYMBOL="!"</code> */
     public static final String NEGATION_PREFIX_SYMBOL = "!";
-
-    /** Constant <code>ARRAY_DELIMITER=","</code> */
-    public static final String ARRAY_DELIMITER = ",";
-
-    /**
-     * Constant <code>MULTI_CHECKBOX_PATTERN="[a-zA-Z]+-\d+=1"</code>
-     * Matches filter strings such as the format "severity-4=1" or "service-1=1" or similar
-     */
-    private static final Pattern MULTI_CHECKBOX_PATTERN = Pattern.compile("[a-zA-Z]+-\\d+=1");
 
     public static OnmsCriteria getOnmsCriteria(final AlarmCriteria alarmCriteria) {
         final OnmsCriteria criteria = new OnmsCriteria(OnmsAlarm.class);
@@ -242,7 +226,7 @@ public abstract class AlarmUtil extends Object {
 
         Filter filter = null;
 
-        String[] tokenizedFilterString = tokenizeFilterString(filterString);
+        String[] tokenizedFilterString = FilterTokenizeUtils.tokenizeFilterString(filterString);
         String type = tokenizedFilterString[0];
         String value = tokenizedFilterString[1];
 
@@ -328,7 +312,7 @@ public abstract class AlarmUtil extends Object {
             filter = new SituationFilter(Boolean.valueOf(value));
         } else if (type.equals(CategoryFilter.TYPE)) {
             String[] nestedFilterString = findFilterString(allFilters, NegativeCategoryFilter.NESTED_TYPE);
-            if (isCheckboxToggled(nestedFilterString)) {
+            if (CheckboxFilterUtils.isCheckboxToggled(nestedFilterString)) {
                 filter = new NegativeCategoryFilter(value);
             } else {
                 filter = new CategoryFilter(value);
@@ -351,39 +335,10 @@ public abstract class AlarmUtil extends Object {
         }
         for (String thisFilter : allFilters) {
             if (thisFilter.startsWith(filterString)) {
-                return tokenizeFilterString(thisFilter);
+                return FilterTokenizeUtils.tokenizeFilterString(thisFilter);
             }
         }
         return null;
-    }
-
-    /**
-     * <p>tokenizeFilterString</p>
-     *
-     * @param filterString a {@link java.lang.String} object.
-     * @return a {@link java.lang.String}[] object representing the type and value tokenized.
-     */
-    private static String[] tokenizeFilterString(String filterString) {
-        String[] tempTokens = filterString.split("=");
-        try {
-            String type = tempTokens[0];
-            String[] values = (String[]) ArrayUtils.remove(tempTokens, 0);
-            String value = org.apache.commons.lang.StringUtils.join(values, "=");
-            return new String[]{type, value};
-        } catch (NoSuchElementException e) {
-            throw new IllegalArgumentException("Could not tokenize filter string: " + filterString);
-        }
-    }
-
-    /**
-     * <p>isCheckboxToggled</p>
-     *
-     * @param tokenizedFilterString a {@link java.lang.String}[] object representing the type and value tokenized.
-     * @return a {@link java.lang.Boolean}[] representing if the option is toggled.
-     */
-    private static boolean isCheckboxToggled(String[] tokenizedFilterString) {
-        return tokenizedFilterString != null &&
-                StringUtils.equalsTrimmed(tokenizedFilterString[1], POSITIVE_CHECKBOX_VALUE);
     }
 
     /**
@@ -470,7 +425,7 @@ public abstract class AlarmUtil extends Object {
     }
 
     public static List<Filter> getFilterList(String[] filterStrings, ServletContext servletContext) {
-        filterStrings = handleCheckboxDuplication(filterStrings);
+        filterStrings = CheckboxFilterUtils.handleCheckboxDuplication(filterStrings);
 
         List<Filter> filterList = new ArrayList<>();
         if (filterStrings != null) {
@@ -482,82 +437,5 @@ public abstract class AlarmUtil extends Object {
             }
         }
         return filterList;
-    }
-
-    /**
-     * <p>handleCheckboxDuplication</p>
-     *
-     * @param filterStrings array of filter strings
-     * @return an array of filter strings which have checkbox deduplication handled. With multi-select there could be
-     * multiple IDs selected so we try to consolidate it into a single filter string
-     */
-    private static String[] handleCheckboxDuplication(String[] filterStrings) {
-        if (filterStrings == null) {
-            return filterStrings;
-        }
-        Map<String, List<String>> selectedCheckboxes = dedupCheckboxSelections(filterStrings);
-
-        if (selectedCheckboxes.isEmpty()) {
-            return filterStrings;
-        }
-        return replaceCheckboxValues(filterStrings, selectedCheckboxes);
-    }
-
-    /**
-     * <p>dedupCheckboxSelections</p>
-     *
-     * @param filterStrings array of filter strings
-     * @return a Map of Filter type to List of IDs associated with the filter.
-     */
-    private static Map<String, List<String>> dedupCheckboxSelections(String[] filterStrings) {
-        Map<String, List<String>> selectedCheckboxes = new HashMap<>();
-
-        for (String filterString : filterStrings) {
-
-            if (MULTI_CHECKBOX_PATTERN.matcher(filterString).matches()) {
-
-                String[] filterStringHyphenSplit = filterString.split("-");
-                String type = filterStringHyphenSplit[0];
-                String remainder = filterStringHyphenSplit[1];
-                String idStr = remainder.split("=")[0];
-
-                if (selectedCheckboxes.containsKey(type)) {
-                    selectedCheckboxes.get(type).add(idStr);
-                } else {
-                    List<String> checkedIds = new ArrayList<>();
-                    checkedIds.add(idStr);
-                    selectedCheckboxes.put(type, checkedIds);
-                }
-            }
-        }
-        return selectedCheckboxes;
-    }
-
-    /**
-     * <p>replaceCheckboxValues</p>
-     *
-     * @param filterStrings array of filter strings
-     * @param selectedCheckboxes map of multiselect filter to IDs
-     * @return the new filter string array with consolidated multi-select checkbox values
-     */
-    private static String[] replaceCheckboxValues(String[] filterStrings, Map<String, List<String>> selectedCheckboxes) {
-        List<String> collectedFilterList = Arrays.stream(filterStrings).filter(thisFilterString -> {
-            for (String selectedKey : selectedCheckboxes.keySet()) {
-                if (thisFilterString.startsWith(selectedKey + "-")) {
-                    return false;
-                }
-            }
-            return true;
-        }).collect(Collectors.toList());
-
-        for (String selectedKey : selectedCheckboxes.keySet()) {
-            List<String> selectedIds = selectedCheckboxes.get(selectedKey);
-            String joinedIds = String.join(ARRAY_DELIMITER, selectedIds);
-            String checkboxFormattedFilter = String.format("%s=%s", selectedKey, joinedIds);
-
-            collectedFilterList.add(checkboxFormattedFilter);
-        }
-
-        return collectedFilterList.toArray(new String[0]);
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/event/EventController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/event/EventController.java
@@ -135,7 +135,7 @@ public class EventController extends MultiActionController implements Initializi
         modelAndView.setViewName("event/list");
         return modelAndView;
     }
-    
+
     public ModelAndView detail(HttpServletRequest request, HttpServletResponse response) throws Exception {
     	String idString = request.getParameter("id");
     	// asking for a specific ID; only filter should be event ID
@@ -151,7 +151,7 @@ public class EventController extends MultiActionController implements Initializi
 
         return modelAndView;
     }
-    
+
     // index view
     public ModelAndView index(HttpServletRequest request, HttpServletResponse response) throws Exception {
     	List<OnmsFilterFavorite> userFilterList = favoriteService.getFavorites(request.getRemoteUser(), OnmsFilterFavorite.Page.EVENT);
@@ -291,12 +291,12 @@ public class EventController extends MultiActionController implements Initializi
     }
 
     private String getDisplay(HttpServletRequest request) {
-    	return request.getParameter("display");
+    	return getQueryParameter(request, "display");
     }
-    
+
     private int getLimit(HttpServletRequest request) {
     	final String display = getDisplay(request);
-        final String limitString = request.getParameter("limit");
+        String limitString = getQueryParameter(request, "limit");
     	int limit = "long".equals(display) ? DEFAULT_LONG_LIMIT : DEFAULT_SHORT_LIMIT;
         if (limitString != null) {
             try {
@@ -310,21 +310,22 @@ public class EventController extends MultiActionController implements Initializi
         }
         return limit;
     }
-    
+
     private int getMultiple(HttpServletRequest request) {
-    	final String multipleString = request.getParameter("multiple");
+    	final String multipleString = getQueryParameter(request, "multiple");
     	int multiple = DEFAULT_MULTIPLE;
         if (multipleString != null) {
             try {
                 multiple = Math.max(0, WebSecurityUtils.safeParseInt(multipleString));
             } catch (NumberFormatException e) {
+                // ignoring invalid string as integer, default is set
             }
         }
         return multiple;
     }
-    
+
     private SortStyle getSortStyle(HttpServletRequest request) {
-    	final String sortStyleString = request.getParameter("sortby");
+    	final String sortStyleString = getQueryParameter(request, "sortby");
     	SortStyle sortStyle = DEFAULT_SORT_STYLE;
         if (sortStyleString != null) {
             SortStyle temp = SortStyle.getSortStyle(sortStyleString);
@@ -334,9 +335,9 @@ public class EventController extends MultiActionController implements Initializi
         }
         return sortStyle;
     }
-    
+
     private AcknowledgeType getAcknowledgeType(HttpServletRequest request) {
-    	 String ackTypeString = request.getParameter("acktype");
+    	 String ackTypeString = getQueryParameter(request, "acktype");
     	 AcknowledgeType ackType = DEFAULT_ACKNOWLEDGE_TYPE;
     	 // otherwise, apply filters/acktype/etc.
          if (ackTypeString != null) {
@@ -347,7 +348,33 @@ public class EventController extends MultiActionController implements Initializi
          }
          return ackType;
     }
-    
+
+    /**
+     * This is required as when the advanced search gets called there is a difference in the query parameters.
+     * Sometimes they are delimited with '&amp;' and sometimes its delimited with '&' This method handles both cases.
+     *
+     * @param request the HttpServletRequest
+     * @param key     the string key of the parameter
+     * @return the value for corresponding key
+     */
+    private String getQueryParameter(HttpServletRequest request, String key) {
+        String queryParams = request.getQueryString();
+        if (StringUtils.isNotEmpty(queryParams)) {
+            if (queryParams.contains("&amp;")) {
+                String[] querySplit = queryParams.split("&amp;");
+                for (String queryParam : querySplit) {
+                    String[] queryParamSplit = queryParam.split("=");
+                    if (queryParamSplit[0].equalsIgnoreCase(key)) {
+                        return queryParamSplit[1];
+                    }
+                }
+            } else {
+                return request.getParameter(key);
+            }
+        }
+        return null;
+    }
+
     private EventQueryParms createEventQueryParms(HttpServletRequest request, List<Filter> filterList, AcknowledgeType ackType) {
     	EventQueryParms parms = new EventQueryParms();
         parms.ackType = ackType;
@@ -355,7 +382,7 @@ public class EventController extends MultiActionController implements Initializi
         parms.filters = filterList;
         parms.limit = getLimit(request);
         parms.multiple =  getMultiple(request);
-        parms.sortStyle = getSortStyle(request);	
+        parms.sortStyle = getSortStyle(request);
         return parms;
     }
 
@@ -369,7 +396,7 @@ public class EventController extends MultiActionController implements Initializi
     	final EventQueryParms parms = createEventQueryParms(request, filterList, ackType);
         final EventCriteria queryCriteria = new EventCriteria(parms);
         final Event[] events = m_webEventRepository.getMatchingEvents(queryCriteria);
-        
+
         final ModelAndView modelAndView = new ModelAndView();
         modelAndView.addObject("events", events);
         modelAndView.addObject("parms", new NormalizedQueryParameters(parms));

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeDescriptionSubstringFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeDescriptionSubstringFilter.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.event.filter;
+
+import org.opennms.web.filter.NoSubstringFilter;
+
+/**
+ * <p>DescriptionSubstringFilter class.</p>
+ *
+ * @author ranger
+ * @version $Id: $
+ * @since 1.8.1
+ */
+public class NegativeDescriptionSubstringFilter extends NoSubstringFilter {
+    /** Constant <code>TYPE="descsub"</code> */
+    public static final String TYPE = "descsubNot";
+
+    /**
+     * <p>Constructor for DescriptionSubstringFilter.</p>
+     *
+     * @param substring a {@link String} object.
+     */
+    public NegativeDescriptionSubstringFilter(String substring) {
+        super(TYPE, "EVENTDESCR", "eventDescr", substring);
+    }
+
+    /**
+     * <p>getTextDescription</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String getTextDescription() {
+        return ("description not containing \"" + getValue() + "\"");
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String toString() {
+        return ("<NegativeDescriptionSubstringFilter: " + this.getDescription() + ">");
+    }
+
+    /**
+     * <p>getSubstring</p>
+     *
+     * @return a {@link String} object.
+     */
+    public String getSubstring() {
+        return getValue();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeDescriptionSubstringFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeEventTextFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeEventTextFilter.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.event.filter;
+
+import org.opennms.web.filter.AndFilter;
+
+public class NegativeEventTextFilter extends AndFilter {
+    /** Constant <code>TYPE="eventtextNot"</code> */
+    public static final String TYPE = "eventtextNot";
+
+    private final String value;
+
+    public NegativeEventTextFilter(String substring) {
+        super(new NegativeLogMessageSubstringFilter(substring), new NegativeDescriptionSubstringFilter(substring));
+        this.value = substring;
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("event text not containing \"" + value + "\"");
+    }
+
+    @Override
+    public String toString() {
+        return ("<NegativeEventTextFilter: " + this.getDescription() + ">");
+    }
+
+    @Override
+    public String getDescription() {
+        return TYPE + "!=" + value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeEventTextFilter)) return false;
+        return this.toString().equals(obj.toString());
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeIPAddrLikeFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeIPAddrLikeFilter.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.event.filter;
+
+import org.opennms.web.filter.NegativeIPLikeFilter;
+
+/**
+ * Encapsulates all interface filtering functionality.
+ *
+ * @author ranger
+ * @version $Id: $
+ * @since 1.8.1
+ */
+public class NegativeIPAddrLikeFilter extends NegativeIPLikeFilter {
+    /** Constant <code>TYPE="iplikeNot"</code> */
+    public static final String TYPE = "iplikeNot";
+
+    /**
+     * <p>Constructor for NegativeIPAddrLikeFilter.</p>
+     *
+     * @param ipLikePattern a {@link String} object.
+     */
+    public NegativeIPAddrLikeFilter(String ipLikePattern) {
+        super(TYPE, "IPADDR", "ipAddr", ipLikePattern);
+    }
+
+    /**
+     * <p>getTextDescription</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String getTextDescription() {
+        return ("IP Address not like \"" + getValue() + "\"");
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String toString() {
+        return ("<NegativeIPAddrLikeFilter: " + this.getDescription() + ">");
+    }
+
+    /**
+     * <p>getIpLikePattern</p>
+     *
+     * @return a {@link String} object.
+     */
+    public String getIpLikePattern() {
+        return getValue();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeIPAddrLikeFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeLogMessageSubstringFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeLogMessageSubstringFilter.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.event.filter;
+
+import org.opennms.web.filter.NoSubstringFilter;
+
+public class NegativeLogMessageSubstringFilter extends NoSubstringFilter {
+    /** Constant <code>TYPE="msgsub"</code> */
+    public static final String TYPE = "msgsubNot";
+
+    /**
+     * <p>Constructor for NegativeLogMessageSubstringFilter.</p>
+     *
+     * @param substring a {@link String} object.
+     */
+    public NegativeLogMessageSubstringFilter(String substring) {
+        super(TYPE, "EVENTLOGMSG", "eventLogMsg", substring);
+    }
+
+    /**
+     * <p>getTextDescription</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String getTextDescription() {
+        return ("description not containing \"" + getValue() + "\"");
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String toString() {
+        return ("<NegativeLogMessageSubstringFilter: " + this.getDescription() + ">");
+    }
+
+    /**
+     * <p>getSubstring</p>
+     *
+     * @return a {@link String} object.
+     */
+    public String getSubstring() {
+        return getValue();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeLogMessageSubstringFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeNodeNameLikeFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeNodeNameLikeFilter.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.event.filter;
+
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.type.StringType;
+import org.hibernate.type.Type;
+import org.opennms.web.filter.NoSubstringFilter;
+
+public class NegativeNodeNameLikeFilter extends NoSubstringFilter {
+    /** Constant <code>TYPE="nodenamelikeNOT"</code> */
+    public static final String TYPE = "nodenamelikeNOT";
+
+    /**
+     * <p>Constructor for NodeNameLikeFilter.</p>
+     *
+     * @param substring a {@link String} object.
+     */
+    public NegativeNodeNameLikeFilter(String substring) {
+        super(TYPE, "NODE.NODELABEL", "node.label", substring);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public String getSQLTemplate() {
+        return (" EVENTID NOT IN (SELECT EVENTID FROM EVENTS JOIN NODE ON EVENTS.NODEID=NODE.NODEID WHERE NODE.NODELABEL ILIKE %s) ");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Criterion getCriterion() {
+        return Restrictions.sqlRestriction(" {alias}.eventid NOT IN (SELECT eventid FROM events JOIN node ON events.nodeid=node.nodeid WHERE node.nodelabel ILIKE ?)",
+                new Object[]{getBoundValue(this.getValue())}, new Type[]{StringType.INSTANCE});
+    }
+
+    /**
+     * <p>getTextDescription</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String getTextDescription() {
+        return ("Node name not containing \"" + getValue() + "\"");
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String toString() {
+        return ("<NegativeNodeNameLikeFilter: " + this.getDescription() + ">");
+    }
+
+    /**
+     * <p>getSubstring</p>
+     *
+     * @return a {@link String} object.
+     */
+    public String getSubstring() {
+        return getValue();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeNodeNameLikeFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+    
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/ServiceOrFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/ServiceOrFilter.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.event.filter;
+
+import org.opennms.web.element.NetworkElementFactory;
+import org.opennms.web.filter.Filter;
+import org.opennms.web.filter.OrFilter;
+import org.springframework.util.CollectionUtils;
+
+import javax.servlet.ServletContext;
+import java.util.Arrays;
+import java.util.Map;
+
+public class ServiceOrFilter extends OrFilter {
+
+    private final Integer[] serviceIds;
+    private final Map<String, Integer> serviceNameToIdMap;
+
+    public ServiceOrFilter(Integer[] serviceIds, ServletContext servletContext) {
+        super(Arrays.stream(serviceIds)
+                .map(serviceId -> new ServiceFilter(serviceId, servletContext))
+                .toArray(Filter[]::new));
+        this.serviceIds = serviceIds;
+        this.serviceNameToIdMap = NetworkElementFactory
+                .getInstance(servletContext).getServiceNameToIdMap();
+    }
+
+    @Override
+    public String getTextDescription() {
+        String[] serviceNames = new String[serviceIds.length];
+        for (int index = 0; index < serviceIds.length; index++) {
+            Integer serviceId = serviceIds[index];
+            serviceNames[index] = findServiceName(serviceId);
+        }
+        return ("Service OR Filter: \"" + Arrays.toString(serviceNames) + "\"");
+    }
+
+    private String findServiceName(Integer serviceId) {
+        if (!CollectionUtils.isEmpty(serviceNameToIdMap)) {
+            for (Map.Entry<String, Integer> stringIntegerEntry : serviceNameToIdMap.entrySet()) {
+                if (stringIntegerEntry.getValue().equals(serviceId)) {
+                    return stringIntegerEntry.getKey();
+                }
+            }
+        }
+        return String.format("Service ID: %d", serviceId);
+    }
+
+    @Override
+    public String toString() {
+        return ("<ServiceOrFilter: " + this.getDescription() + ">");
+    }
+
+    @Override
+    public String getDescription() {
+        return TYPE + "=" + Arrays.toString(serviceIds);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof ServiceOrFilter)) return false;
+        return this.toString().equals(obj.toString());
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/SeverityOrFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/SeverityOrFilter.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.event.filter;
+
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.web.filter.Filter;
+import org.opennms.web.filter.OrFilter;
+
+import java.util.Arrays;
+
+public class SeverityOrFilter extends OrFilter {
+
+    private final OnmsSeverity[] severities;
+
+    public SeverityOrFilter(OnmsSeverity[] severities) {
+        super(Arrays.stream(severities)
+                .map(SeverityFilter::new)
+                .toArray(Filter[]::new));
+        this.severities = severities;
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("Severity OR Filter: \"" + Arrays.toString(severities) + "\"");
+    }
+
+    @Override
+    public String toString() {
+        return ("<SeverityOrFilter: " + this.getDescription() + ">");
+    }
+
+    @Override
+    public String getDescription() {
+        return TYPE + "=" + Arrays.toString(severities);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof SeverityOrFilter)) return false;
+        return this.toString().equals(obj.toString());
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/filter/FilterUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/filter/FilterUtil.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2013-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -27,6 +27,8 @@
  *******************************************************************************/
 
 package org.opennms.web.filter;
+
+import org.opennms.core.utils.StringUtils;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -55,10 +57,11 @@ public abstract class FilterUtil {
 
     public static String[] parse(String filterString) {
         String decodedString = URLDecoder.decode(filterString, StandardCharsets.UTF_8);
-        String[] filterParameter = (decodedString == null) ? null : Arrays.stream(decodedString.split("&amp;"))
-                .filter(fp -> fp.startsWith("filter="))
+        if (StringUtils.isEmpty(decodedString)) {
+            return null;
+        }
+        return Arrays.stream(decodedString.split("&amp;"))
                 .map(fp -> fp.replace("filter=", ""))
-                .toArray(String[]::new);
-        return filterParameter;
+                .distinct().toArray(String[]::new);
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
@@ -29,6 +29,7 @@
 package org.opennms.web.tags.filters;
 
 
+import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.model.OnmsFilterFavorite;
 import org.opennms.web.filter.Filter;
 import org.opennms.web.filter.FilterUtil;
@@ -71,7 +72,8 @@ public abstract class AbstractFilterCallback implements FilterCallback {
      */
     @Override
     public List<Filter> parse(String filterString) {
-        String[] filterParameter = filterString.split("&amp;");
+        String[] filterParameter = (StringUtils.isEmpty(filterString))
+                ? new String[0] : filterString.split("&amp;");
         for (int i=0; i< filterParameter.length; i++) {
             if (filterParameter[i].startsWith("filter=")) {
                 filterParameter[i] = filterParameter[i].replaceFirst("filter=", "");

--- a/opennms-webapp/src/main/java/org/opennms/web/utils/filter/CheckboxFilterUtils.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/utils/filter/CheckboxFilterUtils.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.utils.filter;
+
+import org.opennms.core.utils.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class CheckboxFilterUtils {
+
+    /**  Constant <code>ARRAY_DELIMITER=","</code> */
+    public static final String ARRAY_DELIMITER = ",";
+
+    /** Constant <code>POSITIVE_CHECKBOX_VALUE="ON"</code> */
+    public static final String POSITIVE_CHECKBOX_VALUE = "on";
+
+    /**
+     * Constant <code>MULTI_CHECKBOX_PATTERN="[a-zA-Z]+-\d+=1"</code>
+     * Matches filter strings such as the format "severity-4=1" or "service-1=1" or similar
+     */
+    private static final Pattern MULTI_CHECKBOX_PATTERN = Pattern.compile("[a-zA-Z]+-\\d+=1");
+
+    /**
+     * <p>isCheckboxToggled</p>
+     *
+     * @param tokenizedFilterString a {@link java.lang.String}[] object representing the type and value tokenized.
+     * @return a {@link java.lang.Boolean}[] representing if the option is toggled.
+     */
+    public static boolean isCheckboxToggled(String[] tokenizedFilterString) {
+        return tokenizedFilterString != null &&
+                StringUtils.equalsTrimmed(tokenizedFilterString[1], POSITIVE_CHECKBOX_VALUE);
+    }
+
+    /**
+     * <p>handleCheckboxDuplication</p>
+     *
+     * @param filterStrings array of filter strings
+     * @return an array of filter strings which have checkbox deduplication handled. With multi-select there could be
+     * multiple IDs selected so we try to consolidate it into a single filter string
+     */
+    public static String[] handleCheckboxDuplication(String[] filterStrings) {
+        if (filterStrings == null) {
+            return filterStrings;
+        }
+        Map<String, List<String>> selectedCheckboxes = dedupCheckboxSelections(filterStrings);
+
+        if (selectedCheckboxes.isEmpty()) {
+            return filterStrings;
+        }
+        return replaceCheckboxValues(filterStrings, selectedCheckboxes);
+    }
+
+    /**
+     * <p>dedupCheckboxSelections</p>
+     *
+     * @param filterStrings array of filter strings
+     * @return a Map of Filter type to List of IDs associated with the filter.
+     */
+    private static Map<String, List<String>> dedupCheckboxSelections(String[] filterStrings) {
+        Map<String, List<String>> selectedCheckboxes = new HashMap<>();
+
+        for (String filterString : filterStrings) {
+
+            if (MULTI_CHECKBOX_PATTERN.matcher(filterString).matches()) {
+
+                String[] filterStringHyphenSplit = filterString.split("-");
+                String type = filterStringHyphenSplit[0];
+                String remainder = filterStringHyphenSplit[1];
+                String idStr = remainder.split("=")[0];
+
+                if (selectedCheckboxes.containsKey(type)) {
+                    selectedCheckboxes.get(type).add(idStr);
+                } else {
+                    List<String> checkedIds = new ArrayList<>();
+                    checkedIds.add(idStr);
+                    selectedCheckboxes.put(type, checkedIds);
+                }
+            }
+        }
+        return selectedCheckboxes;
+    }
+
+    /**
+     * <p>replaceCheckboxValues</p>
+     *
+     * @param filterStrings      array of filter strings
+     * @param selectedCheckboxes map of multiselect filter to IDs
+     * @return the new filter string array with consolidated multi-select checkbox values
+     */
+    private static String[] replaceCheckboxValues(String[] filterStrings, Map<String, List<String>> selectedCheckboxes) {
+        List<String> collectedFilterList = Arrays.stream(filterStrings).filter(thisFilterString -> {
+            for (String selectedKey : selectedCheckboxes.keySet()) {
+                if (thisFilterString.startsWith(selectedKey + "-")) {
+                    return false;
+                }
+            }
+            return true;
+        }).collect(Collectors.toList());
+
+        for (String selectedKey : selectedCheckboxes.keySet()) {
+            List<String> selectedIds = selectedCheckboxes.get(selectedKey);
+            String joinedIds = String.join(ARRAY_DELIMITER, selectedIds);
+            String checkboxFormattedFilter = String.format("%s=%s", selectedKey, joinedIds);
+
+            collectedFilterList.add(checkboxFormattedFilter);
+        }
+
+        return collectedFilterList.toArray(new String[0]);
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/utils/filter/FilterTokenizeUtils.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/utils/filter/FilterTokenizeUtils.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.utils.filter;
+
+import org.apache.commons.lang.ArrayUtils;
+
+import java.util.NoSuchElementException;
+
+public class FilterTokenizeUtils {
+
+    private static final String QUERY_PARAM_DELIMITER = "=";
+
+    /**
+     * <p>tokenizeFilterString</p>
+     *
+     * @param filterString a {@link java.lang.String} object.
+     * @return a {@link java.lang.String}[] object representing the type and value tokenized.
+     */
+    public static String[] tokenizeFilterString(String filterString) {
+        String[] tempTokens = filterString.split(QUERY_PARAM_DELIMITER);
+        try {
+            String type = tempTokens[0];
+            String[] values = (String[]) ArrayUtils.remove(tempTokens, 0);
+            String value = org.apache.commons.lang.StringUtils.join(values, QUERY_PARAM_DELIMITER);
+            return new String[]{type, value};
+        } catch (NoSuchElementException e) {
+            throw new IllegalArgumentException("Could not tokenize filter string: " + filterString);
+        }
+    }
+}

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/event/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/event/list.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -104,6 +104,7 @@
 				<% } %>
 			</select>
 		</div>
+
 		<div class="form-group col-sm-6">
 			<label for="systemId">System-ID</label>
 			<select class="form-control custom-select" name="systemId">
@@ -118,26 +119,27 @@
 	</div>
 
 	<div class="row">
-	<div class="form-group col-sm-6">
-		<label for="severity">Severity</label>
-		<select class="form-control custom-select" name="severity">
-			<option selected="selected">Any</option>
-			<% for (OnmsSeverity severity : OnmsSeverity.values() ) { %>
-			<option value="<%= severity.getId() %>">
-				<%= severity.getLabel() %>
-			</option>
-			<% } %>
-		</select>
-	</div>
-	<div class="form-group col-sm-6">
-		<label for="service">Service</label>
-		<select class="form-control custom-select" name="service">
-			<option selected>Any</option>
-			<% for (String name : serviceNameSet) { %>
-				<option value="<%=serviceNameMap.get(name)%>"><%=name%></option>
-			<% } %>
-		</select>
-	</div>
+        <div class="form-group col-sm-6">
+            <label for="severity">Severity</label>
+            <% for (OnmsSeverity severity : OnmsSeverity.values()) { %>
+                <div>
+                    <label>
+                        <input type="checkbox" name="severity-<%=severity.getId()%>" value="1" /> <%=severity.getLabel()%>
+                    </label>
+                </div>
+            <% } %>
+        </div>
+
+        <div class="form-group col-sm-6">
+            <label for="service">Service</label>
+            <% for (String name : serviceNameSet) { %>
+                <div>
+                    <label>
+                        <input type="checkbox" name="service-<%=serviceNameMap.get(name)%>" value="1" /> <%=name%>
+                    </label>
+                </div>
+            <% } %>
+        </div>
 	</div>
 
 	<div class="row">


### PR DESCRIPTION
Negating the following terms:

Node Label Contains - negated with a `!`.
Event Text Contains - negated with a `!`.
TCP/IP Address Like - negated with a `!`.
Severity - added checkboxes to choose what to filter by.
Service - added checkboxes to choose what to filter by.

Also had to fix a bug with the Node Location and System ID, where the "Any" string was being passed as a filter instead of showing all.

I did notice there is another bug when doing an Advanced Search, that the sort and pagination doesnt work consistently. It looks like this is due to an inconsistency with how the query parameters are delimited. However this does not happen when listing all events from "All Events". I will document this in another ticket.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14476

