### PR TITLE
NMS-14523: Update OpenAPI license link to point to AGPL

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
@@ -46,8 +46,8 @@
         <property name="title" value="OpenNMS V2 RESTful API" />
         <property name="version" value="0.1.0" />
         <property name="description" value="OpenNMS V2 RESTful API" />
-        <property name="license" value="OpenNMS(R) Licensing" />
-        <property name="licenseUrl" value="http://www.gnu.org/licenses/" />
+        <property name="license" value="OpenNMS(R) Licensing (GNU Affero General Public License)" />
+        <property name="licenseUrl" value="http://www.gnu.org/licenses/agpl.html" />
         <property name="contactName" value="OpenNMS" />
         <property name="contactUrl" value="http://www.opennms.com/" />
         <property name="securityDefinitions" ref="securityDefinitionsMap" />


### PR DESCRIPTION
Update licensing link and text in OpenAPI (see new UI, Endpoints) to point to AGPL license specifically. Text and link:

[OpenNMS(R) Licensing (GNU Affero General Public License)](http://www.gnu.org/licenses/agpl.html)


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14523

