### PR TITLE
Adding collectd restart to the test after we have added a node. 

### DIFF
--- a/smoke-test/src/test/java/org/opennms/smoketest/flow/BmpIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/flow/BmpIT.java
@@ -45,6 +45,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.resource.ResourceDTO;
 import org.opennms.smoketest.stacks.NetworkProtocol;
 import org.opennms.smoketest.stacks.OpenNMSStack;
@@ -61,7 +63,6 @@ import com.google.common.collect.Sets;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
-@org.junit.experimental.categories.Category(org.opennms.smoketest.junit.FlakyTests.class)
 public class BmpIT {
     private static final Logger LOG = LoggerFactory.getLogger(BmpIT.class);
 
@@ -166,6 +167,11 @@ public class BmpIT {
                 .contentType(ContentType.XML).post()
                 .then().assertThat()
                 .statusCode(201);
+
+        // Restarting collectd after we have added a node to the db
+        final EventBuilder builder = new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_UEI, getClass().getSimpleName());
+        builder.setParam(EventConstants.PARM_DAEMON_NAME, "collectd");
+        stack.opennms().getRestClient().sendEvent(builder.getEvent());
 
         await().atMost(1, MINUTES).pollDelay(0, SECONDS).pollInterval(5, SECONDS)
                 .until(() -> {

--- a/smoke-test/src/test/java/org/opennms/smoketest/flow/BmpIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/flow/BmpIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2020 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2020-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *


### PR DESCRIPTION
Added restart of CollectD after the node has been added to the db. This was the main issue for the test to be flaky. 

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-14360

