### PR TITLE
NMS-14482: Capitalization fix in docs

### DIFF
--- a/docs/modules/operation/pages/user-management/introduction.adoc
+++ b/docs/modules/operation/pages/user-management/introduction.adoc
@@ -34,11 +34,11 @@ NOTE: Admin users can enable or disable usage statistics collection at any time 
 When enabled, the `Data Choices` module collects the following anonymous statistics and publishes them on system startup and every 24 hours after:
 
 * System ID (a randomly generated universally unique identifier (UUID))
-* {page-component-title} Release
-* {page-component-title} Version
-* OS Architecture
-* OS Name
-* OS Version
+* {page-component-title} release
+* {page-component-title} version
+* OS architecture
+* OS name
+* OS version
 * Number of alarms in the `alarms` table
 * Number of situations in the `alarms` table
 * Number of events in the `events` table


### PR DESCRIPTION
This restores minor doc updates that were reverted along with the KPI work in #5062 .

There have been a few updates to usage statistics merged into `release-30.x` that need accompanying doc updates as well.

