### PR TITLE
NMS-14476: Fixing query param issue with advanced search

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/filter/FilterUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/filter/FilterUtil.java
@@ -57,11 +57,19 @@ public abstract class FilterUtil {
 
     public static String[] parse(String filterString) {
         String decodedString = URLDecoder.decode(filterString, StandardCharsets.UTF_8);
-        if (StringUtils.isEmpty(decodedString)) {
-            return null;
-        }
-        return Arrays.stream(decodedString.split("&amp;"))
+
+        return Arrays.stream(getFilterParameters(decodedString))
                 .map(fp -> fp.replace("filter=", ""))
                 .distinct().toArray(String[]::new);
+    }
+
+    public static String[] getFilterParameters(String filterString) {
+        if (StringUtils.isEmpty(filterString)) {
+            return new String[0];
+        }
+        if (filterString.contains("&amp;")) {
+            return filterString.split("&amp;");
+        }
+        return filterString.split("&");
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
@@ -29,7 +29,6 @@
 package org.opennms.web.tags.filters;
 
 
-import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.model.OnmsFilterFavorite;
 import org.opennms.web.filter.Filter;
 import org.opennms.web.filter.FilterUtil;
@@ -38,6 +37,8 @@ import org.opennms.web.filter.QueryParameters;
 import javax.servlet.ServletContext;
 import java.net.URLDecoder;
 import java.util.List;
+
+import static org.opennms.web.filter.FilterUtil.getFilterParameters;
 
 public abstract class AbstractFilterCallback implements FilterCallback {
     private final ServletContext servletContext;
@@ -72,8 +73,7 @@ public abstract class AbstractFilterCallback implements FilterCallback {
      */
     @Override
     public List<Filter> parse(String filterString) {
-        String[] filterParameter = (StringUtils.isEmpty(filterString))
-                ? new String[0] : filterString.split("&amp;");
+        String[] filterParameter = getFilterParameters(filterString);
         for (int i=0; i< filterParameter.length; i++) {
             if (filterParameter[i].startsWith("filter=")) {
                 filterParameter[i] = filterParameter[i].replaceFirst("filter=", "");


### PR DESCRIPTION
Fixing query param issue with advanced search. 

Unsure as to how the query parameters suddenly change from `&` or `&amp;`, have seen them come through as both.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14476

