### PR TITLE
NMS-14544: fix reading panels from Grafana 8 API

### DIFF
--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImpl.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImpl.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019-2021 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -44,6 +44,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import com.google.gson.GsonBuilder;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.opennms.netmgt.endpoints.grafana.api.Dashboard;
@@ -65,7 +66,7 @@ import okhttp3.ResponseBody;
 public class GrafanaClientImpl implements GrafanaClient {
     private final GrafanaServerConfiguration config;
 
-    private final Gson gson = new Gson();
+    private final Gson gson;
     private final OkHttpClient client;
     private final HttpUrl baseUrl;
 
@@ -78,6 +79,11 @@ public class GrafanaClientImpl implements GrafanaClient {
                 .readTimeout(config.getReadTimeoutSeconds(), TimeUnit.SECONDS);
         builder = configureToIgnoreCertificate(builder);
         client = builder.build();
+
+        // The schema changed between Grafana 7 and 8 for the `datasource` property on panels.
+        this.gson = new GsonBuilder()
+                .registerTypeAdapter(Panel.class, new PanelDeserializer())
+                .create();
     }
 
     @Override

--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/PanelDeserializer.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/PanelDeserializer.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.endpoints.grafana.client;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import org.opennms.netmgt.endpoints.grafana.api.Panel;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The PanelDeserializer is a custom JSON deserializer that handles the difference between
+ * Grafana 7 and Grafana 8.  In 7, the dashboard panel's <code>datasource</code> property
+ * is a JSON primitive string containing just the UID, but in Grafana 8 it is now an object
+ * with <code>uid</code> and <code>type</code> properties.
+ *
+ * This deserializer should behave identical to the default deserializer in Gson
+ * <i>except</i> for the special-case handling of <code>datasource</code>.
+ */
+public class PanelDeserializer implements JsonDeserializer<Panel> {
+    private Gson gson;
+
+    @Override
+    public Panel deserialize(final JsonElement jsonElement, final Type type, final JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        final Panel p = new Panel();
+
+        final JsonObject obj = jsonElement.getAsJsonObject();
+
+        JsonElement prop;
+
+        if (obj.has("id")) {
+            prop = obj.get("id");
+            p.setId(prop.getAsJsonPrimitive().getAsInt());
+        }
+
+        if (obj.has("title")) {
+            prop = obj.get("title");
+            p.setTitle(prop.getAsJsonPrimitive().getAsString());
+        }
+
+        if (obj.has("type")) {
+            prop = obj.get("type");
+            p.setType(prop.getAsJsonPrimitive().getAsString());
+        }
+
+        if (obj.has("datasource")) {
+            prop = obj.get("datasource");
+            if (prop.isJsonPrimitive()) {
+                // older Grafana versions just had the datasource be a JSON string of the UID
+                p.setDatasource(prop.getAsJsonPrimitive().getAsString());
+            } else if (prop.isJsonObject()) {
+                // newer contain an object with { uid: ..., type: ... }
+                p.setDatasource(prop.getAsJsonObject().get("uid").getAsJsonPrimitive().getAsString());
+            } else {
+                throw new JsonParseException("JSON element 'datasource' was expected to be either a uid string, or an object containing a uid string and optional type string, but instead was: " + jsonElement);
+            }
+        }
+
+        if (obj.has("description")) {
+            prop = obj.get("description");
+            p.setDescription(prop.getAsJsonPrimitive().getAsString());
+        }
+
+        if (obj.has("panels")) {
+            final List<Panel> panels = new ArrayList<>();
+            final JsonArray arr = obj.get("panels").getAsJsonArray();
+            for (int i=0; i < arr.size(); i++) {
+                panels.add(this.getGson().fromJson(arr.get(i), Panel.class));
+            }
+            p.setPanels(panels);
+        }
+        return p;
+    }
+
+    private Gson getGson() {
+        if (this.gson == null) {
+            this.gson = new GsonBuilder().registerTypeAdapter(Panel.class, this).create();
+        }
+        return this.gson;
+    }
+}

--- a/features/endpoints/grafana/client/src/test/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImplIT.java
+++ b/features/endpoints/grafana/client/src/test/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImplIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019-2020 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -55,6 +55,21 @@ public class GrafanaClientImplIT {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort());
+
+    @Test
+    public void grafana8DashboardResponse() throws Exception {
+        stubFor(get(urlEqualTo("/api/dashboards/uid/T2Ra73RVk"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("dashboard8.json")));
+
+        GrafanaServerConfiguration config = new GrafanaServerConfiguration(wireMockRule.baseUrl(), "xxxx", 5, 5);
+        GrafanaClientImpl client = new GrafanaClientImpl(config);
+        Dashboard dashboard = client.getDashboardByUid("T2Ra73RVk");
+
+        assertThat(dashboard.getMeta().getSlug(), equalTo("test"));
+        assertThat(dashboard.getPanels().get(0).getDatasource(), equalTo("ecy5MqR4z"));
+    }
 
     @Test
     public void canGetDashboardAndRenderPng() throws IOException, ExecutionException, InterruptedException {

--- a/features/endpoints/grafana/client/src/test/resources/__files/dashboard8.json
+++ b/features/endpoints/grafana/client/src/test/resources/__files/dashboard8.json
@@ -1,0 +1,166 @@
+{
+  "meta": {
+    "type": "db",
+    "canSave": false,
+    "canEdit": false,
+    "canAdmin": false,
+    "canStar": true,
+    "canDelete": false,
+    "slug": "test",
+    "url": "/d/T2Ra73RVk/test",
+    "expires": "0001-01-01T00:00:00Z",
+    "created": "2022-07-25T15:28:49-04:00",
+    "updated": "2022-07-25T15:28:49-04:00",
+    "updatedBy": "admin",
+    "createdBy": "admin",
+    "version": 1,
+    "hasAcl": false,
+    "isFolder": false,
+    "folderId": 0,
+    "folderUid": "",
+    "folderTitle": "General",
+    "folderUrl": "",
+    "provisioned": false,
+    "provisionedExternalId": "",
+    "annotationsPermissions": {
+      "dashboard": {
+        "canAdd": false,
+        "canEdit": false,
+        "canDelete": false
+      },
+      "organization": {
+        "canAdd": false,
+        "canEdit": false,
+        "canDelete": false
+      }
+    }
+  },
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 1,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "postgres",
+          "uid": "ecy5MqR4z"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true
+        },
+        "pluginVersion": "8.5.6",
+        "targets": [
+          {
+            "datasource": {
+              "type": "postgres",
+              "uid": "ecy5MqR4z"
+            },
+            "format": "table",
+            "group": [],
+            "metricColumn": "none",
+            "rawQuery": true,
+            "rawSql": "SELECT\n  count(*)\nFROM events",
+            "refId": "A",
+            "select": [
+              [
+                {
+                  "params": [
+                    "count(*)"
+                  ],
+                  "type": "column"
+                }
+              ]
+            ],
+            "table": "alarms",
+            "timeColumn": "counter",
+            "timeColumnType": "int4",
+            "where": []
+          }
+        ],
+        "title": "Number of Events",
+        "type": "gauge"
+      }
+    ],
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Test",
+    "uid": "T2Ra73RVk",
+    "version": 1,
+    "weekStart": ""
+  }
+}


### PR DESCRIPTION
This PR fixes the handling of the differences between the `"panels"` response when querying dashboards in different Grafana versions.  It implements a custom Gson deserializer for the `Panel` class that handles both the single `datasource` string entry, or the `datasource` object that contains a `uri` and `type`.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14544

