### PR TITLE
NMS-14643: generate SSH keypair on launch

### DIFF
--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -30,11 +30,6 @@ RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
 RUN groupadd -g 10001 minion && \
     adduser -u 10001 -g 10001 -d /opt/minion -s /usr/bin/bash minion
 
-# Create SSH Key-Pair to use with the Karaf Shell
-RUN mkdir /opt/minion/.ssh && \
-    chmod 700 /opt/minion/.ssh && \
-    ssh-keygen -t rsa -f /opt/minion/.ssh/id_rsa -q -N ""
-
 ##
 # Install and setup OpenNMS Minion RPMS
 ##
@@ -77,12 +72,9 @@ RUN echo "installing packages for build ${REVISION} (${BUILD_DATE})"; \
     dnf clean all && \
     rm -rf /var/cache/yum && \
     sed -r -i '/RUNAS/s/.*/export RUNAS=${USER}/' /etc/sysconfig/minion && \
-    echo minion=$(cat /opt/minion/.ssh/id_rsa.pub | awk '{print $2}'),viewer > /opt/minion/etc/keys.properties && \
-    echo "_g_\\:admingroup = group,admin,manager,viewer,systembundles,ssh" >> /opt/minion/etc/keys.properties && \
     chown 10001:10001 -R /opt/minion && \
     chgrp -R 0 /opt/minion && \
-    chmod -R g=u /opt/minion && \
-    chmod 600 /opt/minion/.ssh/id_rsa
+    chmod -R g=u /opt/minion
 
 COPY ./assets/* /
 

--- a/opennms-container/minion/assets/entrypoint.sh
+++ b/opennms-container/minion/assets/entrypoint.sh
@@ -117,6 +117,13 @@ initConfig() {
     fi
 
     if [ ! -f ${MINION_HOME}/etc/configured ]; then
+        # Create SSH Key-Pair to use with the Karaf Shell
+        RUN mkdir -p "${MINION_HOME}/.ssh" && \
+            chmod 700 "${MINION_HOME}/.ssh" && \
+            ssh-keygen -t rsa -f "${MINION_HOME}/.ssh/id_rsa" -q -N "" && \
+            echo "minion=$(cat "${MINION_HOME}/.ssh/id_rsa.pub" | awk '{print $2}'),viewer" > "${MINION_HOME}/etc/keys.properties" && \
+            echo "_g_\\:admingroup = group,admin,manager,viewer,systembundles,ssh" >> ${MINION_HOME}/etc/keys.properties && \
+            chmod 600 "${MINION_HOME}/.ssh/id_rsa"
 
         # Expose Karaf Shell
         sed -i "/^sshHost/s/=.*/= 0.0.0.0/" ${MINION_HOME}/etc/org.apache.karaf.shell.cfg

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -30,11 +30,6 @@ RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
 RUN groupadd -g 10001 sentinel && \
     adduser -u 10001 -g 10001 -d /opt/sentinel -s /usr/bin/bash sentinel
 
-# Create SSH Key-Pair to use with the Karaf Shell
-RUN mkdir /opt/sentinel/.ssh && \
-    chmod 700 /opt/sentinel/.ssh && \
-    ssh-keygen -t rsa -f /opt/sentinel/.ssh/id_rsa -q -N ""
-
 ##
 # Install and setup OpenNMS Sentinel RPMS
 ##
@@ -75,12 +70,9 @@ RUN echo "installing packages for build ${REVISION} (${BUILD_DATE})"; \
     dnf clean all && \
     rm -rf /var/cache/yum && \
     mkdir -p /opt/sentinel/data/{log,tmp} && \
-    echo sentinel=$(cat /opt/sentinel/.ssh/id_rsa.pub | awk '{print $2}'),viewer > /opt/sentinel/etc/keys.properties && \
-    echo "_g_\\:admingroup = group,admin,manager,viewer,systembundles,ssh" >> /opt/sentinel/etc/keys.properties && \
     chown 10001:10001 -R /opt/sentinel && \
     chgrp -R 0 /opt/sentinel && \
-    chmod -R g=u /opt/sentinel && \
-    chmod 600 /opt/sentinel/.ssh/id_rsa
+    chmod -R g=u /opt/sentinel
 
 COPY ./assets/* /
 

--- a/opennms-container/sentinel/assets/entrypoint.sh
+++ b/opennms-container/sentinel/assets/entrypoint.sh
@@ -69,6 +69,14 @@ initConfig() {
     fi
 
     if [ ! -f ${SENTINEL_HOME}/etc/configured ]; then
+        # Create SSH Key-Pair to use with the Karaf Shell
+        RUN mkdir -p "${SENTINEL_HOME}/.ssh" && \
+            chmod 700 "${SENTINEL_HOME}/.ssh" && \
+            ssh-keygen -t rsa -f "${SENTINEL_HOME}/.ssh/id_rsa" -q -N "" && \
+            echo "sentinel=$(cat "${SENTINEL_HOME}/.ssh/id_rsa.pub" | awk '{print $2}'),viewer" > "${SENTINEL_HOME}/etc/keys.properties" && \
+            echo "_g_\\:admingroup = group,admin,manager,viewer,systembundles,ssh" >> "${SENTINEL_HOME}/etc/keys.properties" && \
+            chmod 600 "${SENTINEL_HOME}/.ssh/id_rsa"
+
         # Expose Karaf Shell
         sed -i "/^sshHost/s/=.*/= 0.0.0.0/" ${SENTINEL_HOME}/etc/org.apache.karaf.shell.cfg
 


### PR DESCRIPTION
Change the SSH key generation used for Karaf console access to be executed on first launch.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14643
