### PR TITLE
NMS-14645: Avoid locking thresholding during changes

### DIFF
--- a/features/collection/thresholding/api/src/main/java/org/opennms/netmgt/threshd/api/ThresholdInitializationException.java
+++ b/features/collection/thresholding/api/src/main/java/org/opennms/netmgt/threshd/api/ThresholdInitializationException.java
@@ -51,4 +51,15 @@ public class ThresholdInitializationException extends Exception {
         super(message, cause, enableSuppression, writableStackTrace);
     }
 
+    public class Unchecked extends RuntimeException {
+        private Unchecked() {}
+
+        public ThresholdInitializationException getChecked() {
+            return ThresholdInitializationException.this;
+        }
+    }
+
+    public Unchecked wrapUnchecked() {
+        throw new Unchecked();
+    }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/DefaultThresholdingSetPersister.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/DefaultThresholdingSetPersister.java
@@ -28,9 +28,9 @@
 
 package org.opennms.netmgt.threshd;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.opennms.core.mate.api.EntityScopeProvider;
 import org.opennms.netmgt.config.dao.outages.api.ReadablePollOutagesDao;
@@ -51,7 +51,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class DefaultThresholdingSetPersister implements ThresholdingSetPersister
 {
 
-    private Map<ThresholdingSessionKey, ThresholdingSet> thresholdingSets = new HashMap<>();
+    private ConcurrentMap<ThresholdingSessionKey, ThresholdingSet> thresholdingSets = new ConcurrentHashMap<>();
     
     @Autowired
     private ReadableThreshdDao threshdDao;
@@ -69,31 +69,38 @@ public class DefaultThresholdingSetPersister implements ThresholdingSetPersister
     private EntityScopeProvider entityScopeProvider;
 
     @Override
-    public synchronized void persistSet(ThresholdingSession session, ThresholdingSet set) {
+    public void persistSet(ThresholdingSession session, ThresholdingSet set) {
         thresholdingSets.put(session.getKey(), set);
     }
 
     @Override
-    public synchronized ThresholdingSet getThresholdingSet(ThresholdingSession session, ThresholdingEventProxy eventProxy) throws ThresholdInitializationException {
-        ThresholdingSessionKey key = session.getKey();
-        ThresholdingSet tSet = thresholdingSets.get(key);
-        if (tSet == null) {
-            tSet = new ThresholdingSetImpl(key.getNodeId(), key.getLocation(), key.getServiceName(),
-                                           ((ThresholdingSessionImpl) session).getServiceParameters(),
-                                           eventProxy, session, threshdDao,
-                                           thresholdingDao, pollOutagesDao, ifLabelDao, entityScopeProvider);
-            thresholdingSets.put(key, tSet);
+    public ThresholdingSet getThresholdingSet(ThresholdingSession session, ThresholdingEventProxy eventProxy) throws ThresholdInitializationException {
+        // Hacky way to use `computeIfAbsent` with something that throws a checked exception.
+        // This is needed because `computeIfAbsent` is guaranteed to be atomic. In contrast to
+        // an implementation using two calls like `get` and `put`.
+        try {
+            return thresholdingSets.computeIfAbsent(session.getKey(), (key) -> {
+                try {
+                    return new ThresholdingSetImpl(key.getNodeId(), key.getLocation(), key.getServiceName(),
+                                                   ((ThresholdingSessionImpl) session).getServiceParameters(),
+                                                   eventProxy, session, threshdDao,
+                                                   thresholdingDao, pollOutagesDao, ifLabelDao, entityScopeProvider);
+                } catch (final ThresholdInitializationException e) {
+                    throw e.wrapUnchecked();
+                }
+            });
+        } catch (final ThresholdInitializationException.Unchecked e) {
+            throw e.getChecked();
         }
-        return tSet;
     }
 
     @Override
-    public synchronized void reinitializeThresholdingSets() {
+    public void reinitializeThresholdingSets() {
         thresholdingSets.values().forEach(ThresholdingSet::reinitialize);
     }
 
     @Override
-    public synchronized void clear(ThresholdingSession session) {
+    public void clear(ThresholdingSession session) {
         ThresholdingSessionKey key = session.getKey();
         thresholdingSets.remove(key);
     }


### PR DESCRIPTION
The thresholding engine was blocking whenever the config needed to be
reloaded. This is altered to allow reloading the existing thresholding
sets while processing thresholds concurrently.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14645

