### PR TITLE
DC-266: Get Environement and OpenNMS system Id and provide to access service

### DIFF
--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/DistPollerDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/DistPollerDaoHibernate.java
@@ -43,7 +43,7 @@ public class DistPollerDaoHibernate extends AbstractDaoHibernate<OnmsDistPoller,
     @Override
     public OnmsDistPoller whoami() {
         // Return the OnmsDistPoller
-        final String hql = "from OnmsMonitoringSystem where  type='OpenNMS' AND location='Default'";
+        final String hql = "from OnmsMonitoringSystem where type='OpenNMS'";
         return this.findUnique(hql);
     }
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/DistPollerDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/DistPollerDaoHibernate.java
@@ -42,7 +42,8 @@ public class DistPollerDaoHibernate extends AbstractDaoHibernate<OnmsDistPoller,
 
     @Override
     public OnmsDistPoller whoami() {
-        // Return the OnmsDistPoller with the default UUID
-        return get(DEFAULT_DIST_POLLER_ID);
+        // Return the OnmsDistPoller
+        final String hql = "from OnmsMonitoringSystem where  type='OpenNMS' AND location='Default'";
+        return this.findUnique(hql);
     }
 }


### PR DESCRIPTION
This PR allows OpenNMS to have any UUID as system id. So far it was assumed that the system id = "00000000-0000-0000-0000-000000000000" 
Since we are moving towards the cloud we want universally unique system ids.

It is unresolved how to create a UUID when installing a new system. Ideas?


### External References

* JIRA (Issue Tracker): [http://issues.opennms.org/browse/DC-266
](https://issues.opennms.org/browse/DC-266)