### PR TITLE
NMS-14542: Fix event search filtering

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
@@ -80,7 +80,7 @@ public class EventQueryServlet extends HttpServlet {
      * The list of parameters that are extracted by this servlet and not passed
      * on to the servlet.
      */
-    protected static String[] IGNORE_LIST = new String[] { "eventid", "eventtext", "msgsub", "msgmatchany", "nodenamelike", "exactuei", "service", "iplike", "severity", "relativetime", "usebeforetime", "beforehour", "beforeminute", "beforeampm", "beforedate", "beforemonth", "beforeyear", "useaftertime", "afterhour", "afterminute", "afterampm", "afterdate", "aftermonth", "afteryear" };
+    protected static String[] IGNORE_LIST = new String[] { "eventid", "eventtext", "msgsub", "msgmatchany", "nodenamelike", "exactuei", "location", "nodelocation", "systemId", "service", "iplike", "severity", "eventId", "relativetime", "usebeforetime", "beforehour", "beforeminute", "beforeampm", "beforedate", "beforemonth", "beforeyear", "useaftertime", "afterhour", "afterminute", "afterampm", "afterdate", "aftermonth", "afteryear" };
 
     /**
      * The URL for the servlet. The

--- a/opennms-webapp/src/main/java/org/opennms/web/filter/FilterUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/filter/FilterUtil.java
@@ -55,10 +55,18 @@ public abstract class FilterUtil {
 
     public static String[] parse(String filterString) {
         String decodedString = URLDecoder.decode(filterString, StandardCharsets.UTF_8);
-        String[] filterParameter = (decodedString == null) ? null : Arrays.stream(decodedString.split("&amp;"))
-                .filter(fp -> fp.startsWith("filter="))
+        return Arrays.stream(getFilterParameters(decodedString))
                 .map(fp -> fp.replace("filter=", ""))
                 .toArray(String[]::new);
-        return filterParameter;
+    }
+
+    public static String[] getFilterParameters(String filterString) {
+        if (StringUtils.isEmpty(filterString)) {
+            return new String[0];
+        }
+        if (filterString.contains("&amp;")) {
+            return filterString.split("&amp;");
+        }
+        return filterString.split("&");
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/filter/FilterUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/filter/FilterUtil.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.opennms.core.utils.StringUtils;
+
 public abstract class FilterUtil {
 
     public static String toFilterURL(String[] filters) {

--- a/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
@@ -38,6 +38,8 @@ import javax.servlet.ServletContext;
 import java.net.URLDecoder;
 import java.util.List;
 
+import static org.opennms.web.filter.FilterUtil.getFilterParameters;
+
 public abstract class AbstractFilterCallback implements FilterCallback {
     private final ServletContext servletContext;
 
@@ -71,7 +73,7 @@ public abstract class AbstractFilterCallback implements FilterCallback {
      */
     @Override
     public List<Filter> parse(String filterString) {
-        String[] filterParameter = filterString.split("&amp;");
+        String[] filterParameter = getFilterParameters(filterString);
         for (int i=0; i< filterParameter.length; i++) {
             if (filterParameter[i].startsWith("filter=")) {
                 filterParameter[i] = filterParameter[i].replaceFirst("filter=", "");


### PR DESCRIPTION
There seemed to be two primary issues. 

1. We weren't handling both `&` and `&amp;` as parameter delimiters.
2. The EventQueryServlet was handling the `any` filter option correctly, but when redirecting to the EventController, it was passing that directly on to filters.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14542

