### PR TITLE
don't print a giant exception while waiting for OpenNMS to start

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/RestClient.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/RestClient.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -63,10 +63,14 @@ import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.smoketest.containers.OpenNMSContainer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class RestClient {
+    private static final Logger LOG = LoggerFactory.getLogger(RestClient.class);
 
     private static final String DEFAULT_USERNAME = OpenNMSContainer.ADMIN_USER;
 
@@ -120,8 +124,9 @@ public class RestClient {
             JsonNode actualObj = mapper.readTree(json);
             return actualObj.get("displayVersion").asText();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            LOG.debug("Failed to get displayVersion from the info REST service. (OpenNMS is probably not up yet): {}", e.getMessage());
         }
+        return null;
     }
 
     public void addOrReplaceRequisition(Requisition requisition) {


### PR DESCRIPTION
No issue for this, it's just a cosmetic thing, but while debugging smoke tests, it sure is annoying to scroll through a million stack traces just because the OpenNMS REST interface isn't live yet.

The only code referencing this is `OpenNMSContainer::waitUntilReady`, which _already_ considers getting `null` back a failure, so the behavior is exactly the same.