### PR TITLE
NMS-14675: use new ubuntu 22 deploy base

### DIFF
--- a/.circleci/main/executors.yml
+++ b/.circleci/main/executors.yml
@@ -13,10 +13,10 @@ executors:
       - image: opennms/antora:2.3.4-b7274
   integration-test-executor:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:2022.07.1
   smoke-test-executor:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:2022.07.1
   ui-executor:
     docker:
       - image: cimg/node:16.3.0

--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -13,7 +13,8 @@ find_tests()
     # Generate surefire & failsafe test list based on current
     # branch and the list of files changed
     # (The format of the output files contains the canonical class names i.e. org.opennms.core.soa.filter.FilterTest)
-    pyenv local 3.8.5
+    SYSTEM_PYTHON="$(python3 --version | sed -e 's,^Python *,,')"
+    pyenv local "${SYSTEM_PYTHON}"
     python3 .circleci/scripts/find-tests/find-tests.py generate-test-lists \
       --changes-only="${CCI_CHANGES_ONLY:-true}" \
       --output-unit-test-classes=surefire_classnames \

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Use Java base image and setup required RPMS as cacheable image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:jre-1.3.0.b138"
+ARG BASE_IMAGE="opennms/deploy-base:jre-2.0.4.b161"
 
 FROM ${BASE_IMAGE} as horizon-base
 

--- a/opennms-container/horizon/Makefile
+++ b/opennms-container/horizon/Makefile
@@ -8,7 +8,7 @@
 VERSION                 := $(shell ../../.circleci/scripts/pom2version.sh ../../pom.xml)
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:jre-1.2.2.b135
+BASE_IMAGE              := opennms/deploy-base:jre-2.0.4.b161
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKERX_INSTANCE        := env-horizon-oci
 DOCKER_REGISTRY         := docker.io

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -4,7 +4,7 @@
 # To avoid issues, we rearrange the directories in pre-stage to avoid injecting these
 # as additional layers into the final image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:jre-1.3.0.b138"
+ARG BASE_IMAGE="opennms/deploy-base:jre-2.0.4.b161"
 
 FROM ${BASE_IMAGE} as minion-base
 

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -8,7 +8,7 @@
 VERSION                 := $(shell ../../.circleci/scripts/pom2version.sh ../../pom.xml)
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:jre-1.2.0.b105
+BASE_IMAGE              := opennms/deploy-base:jre-2.0.4.b161
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKERX_INSTANCE        := env-minion-oci
 DOCKER_REGISTRY         := docker.io

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Use Java base image and setup required DEBS as cacheable image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:jre-1.3.0.b138"
+ARG BASE_IMAGE="opennms/deploy-base:jre-2.0.4.b161"
 
 FROM ${BASE_IMAGE} as sentinel-base
 

--- a/opennms-container/sentinel/Makefile
+++ b/opennms-container/sentinel/Makefile
@@ -8,7 +8,7 @@
 VERSION                 := $(shell ../../.circleci/scripts/pom2version.sh ../../pom.xml)
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:jre-1.2.0.b105
+BASE_IMAGE              := opennms/deploy-base:jre-2.0.4.b161
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKERX_INSTANCE        := env-sentinel-oci
 DOCKER_REGISTRY         := docker.io


### PR DESCRIPTION
This PR updates our docker containers to use `deploy-base` 2.x, which has been updated to Ubuntu 22 LTS.

It required just bumping the versions pulled in our docker files, as well as a change to the containers parts of the build run in (I had to move the circle machines to ubuntu jammy as a base as well, to avoid pthread mismatches between host and container).

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14675
