### PR TITLE
DC-266: make systemId a UUID, remove DEFAULT_DIST_POLLER_ID.

### DIFF
--- a/core/schema/src/main/liquibase/31.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/31.0.0/changelog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="pschweizer" id="31.0.0-make-systemid-a-uuid">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*) from monitoringsystems
+                WHERE id = '00000000-0000-0000-0000-000000000000'
+                AND type='OpenNMS'
+                AND location='Default'
+            </sqlCheck>
+        </preConditions>
+        <sql>
+            CREATE EXTENSION pgcrypto;
+        </sql>
+        <sql>
+            UPDATE monitoringsystems
+            SET id=gen_random_uuid ()
+            WHERE id = '00000000-0000-0000-0000-000000000000' AND type='OpenNMS' AND location='Default';
+        </sql>
+        <sql>
+            UPDATE events
+            SET systemid = subquery.id
+            FROM (SELECT id FROM monitoringsystems where type='OpenNMS' AND location='Default') AS subquery
+            WHERE systemid = '00000000-0000-0000-0000-000000000000';
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/core/schema/src/main/liquibase/31.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/31.0.0/changelog.xml
@@ -17,6 +17,16 @@
             CREATE EXTENSION pgcrypto;
         </sql>
         <sql>
+            ALTER TABLE alarms
+            DROP CONSTRAINT fk_alarms_systemid;
+        </sql>
+        <sql>
+            ALTER TABLE alarms
+            ADD CONSTRAINT fk_alarms_systemid
+            FOREIGN KEY (systemid)
+            REFERENCES monitoringsystems (id) ON UPDATE CASCADE ON DELETE CASCADE;
+        </sql>
+        <sql>
             UPDATE monitoringsystems
             SET id=gen_random_uuid ()
             WHERE id = '00000000-0000-0000-0000-000000000000' AND type='OpenNMS' AND location='Default';

--- a/core/schema/src/main/liquibase/changelog.xml
+++ b/core/schema/src/main/liquibase/changelog.xml
@@ -97,6 +97,7 @@
 	<include file="29.0.4/changelog.xml"/>
 	<include file="30.0.0/changelog.xml"/>
 	<include file="30.0.2/changelog.xml"/>
+	<include file="31.0.0/changelog.xml"/>
 
 	<include file="stored-procedures/getManagePercentAvailIntfWindow.xml" />
 	<include file="stored-procedures/getManagePercentAvailNodeWindow.xml" />

--- a/features/distributed/dao/distributed/src/test/java/org/opennms/netmgt/dao/BlueprintDistPollerDaoDistributedIT.java
+++ b/features/distributed/dao/distributed/src/test/java/org/opennms/netmgt/dao/BlueprintDistPollerDaoDistributedIT.java
@@ -49,6 +49,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration( locations = { "classpath:/META-INF/opennms/emptyContext.xml" } )
 public class BlueprintDistPollerDaoDistributedIT extends CamelBlueprintTest {
     private static final String LOCATION = "TEST_LOCATION";
+    private static final String DEFAULT_DIST_POLLER_ID = "00000000-0000-0000-0000-000000000000";
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -56,7 +57,7 @@ public class BlueprintDistPollerDaoDistributedIT extends CamelBlueprintTest {
         MinionIdentity identity = new MinionIdentity() {
             @Override
             public String getId() {
-                return DistPollerDao.DEFAULT_DIST_POLLER_ID;
+                return DEFAULT_DIST_POLLER_ID;
             }
             @Override
             public String getLocation() {
@@ -85,18 +86,18 @@ public class BlueprintDistPollerDaoDistributedIT extends CamelBlueprintTest {
         assertEquals(1, dao.countAll());
 
         // Test get()
-        OnmsDistPoller poller = dao.get(DistPollerDao.DEFAULT_DIST_POLLER_ID);
+        OnmsDistPoller poller = dao.get(DEFAULT_DIST_POLLER_ID);
         assertNotNull(poller);
-        assertEquals(DistPollerDao.DEFAULT_DIST_POLLER_ID, poller.getId());
-        assertEquals(DistPollerDao.DEFAULT_DIST_POLLER_ID, poller.getLabel());
+        assertEquals(DEFAULT_DIST_POLLER_ID, poller.getId());
+        assertEquals(DEFAULT_DIST_POLLER_ID, poller.getLabel());
         assertEquals(LOCATION, poller.getLocation());
         assertEquals(OnmsMonitoringSystem.TYPE_MINION, poller.getType());
 
         // Test whoami()
         poller = dao.whoami();
         assertNotNull(poller);
-        assertEquals(DistPollerDao.DEFAULT_DIST_POLLER_ID, poller.getId());
-        assertEquals(DistPollerDao.DEFAULT_DIST_POLLER_ID, poller.getLabel());
+        assertEquals(DEFAULT_DIST_POLLER_ID, poller.getId());
+        assertEquals(DEFAULT_DIST_POLLER_ID, poller.getLabel());
         assertEquals(LOCATION, poller.getLocation());
         assertEquals(OnmsMonitoringSystem.TYPE_MINION, poller.getType());
     }

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/processor/HibernateEventWriterIT.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/processor/HibernateEventWriterIT.java
@@ -41,13 +41,12 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
-import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.mock.MockDistPollerDao;
 import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
@@ -256,7 +255,7 @@ public class HibernateEventWriterIT {
         assertTrue(event.getDbid() > 0);
 
         String minionId = jdbcTemplate.queryForObject("SELECT systemId FROM events LIMIT 1", String.class);
-        assertEquals(DistPollerDao.DEFAULT_DIST_POLLER_ID, minionId);
+        assertEquals(MockDistPollerDao.DEFAULT_DIST_POLLER_ID, minionId);
 
         jdbcTemplate.execute("DELETE FROM events");
         jdbcTemplate.execute(String.format("INSERT INTO monitoringsystems (id, location, type) VALUES ('%s', 'Hello World', '%s')", systemId, OnmsMonitoringSystem.TYPE_MINION));

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/BufferParserTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/BufferParserTest.java
@@ -38,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opennms.core.test.ConfigurationTestUtils;
@@ -47,8 +46,8 @@ import org.opennms.core.time.ZonedDateTimeBuilder;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.SyslogdConfig;
 import org.opennms.netmgt.config.SyslogdConfigFactory;
-import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.mock.MockDistPollerDao;
 import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
 import org.opennms.netmgt.syslogd.ParserStageSequenceBuilder.MatchChar;
 import org.opennms.netmgt.syslogd.ParserStageSequenceBuilder.MatchMonth;
@@ -240,7 +239,7 @@ public class BufferParserTest {
 			long start = System.currentTimeMillis();
 			for (int i = 0; i < iterations; i++) {
 				ConvertToEvent convertToEvent = new ConvertToEvent(
-					DistPollerDao.DEFAULT_DIST_POLLER_ID,
+					MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
 					MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
 					InetAddressUtils.ONE_TWENTY_SEVEN,
 					9999,
@@ -261,7 +260,7 @@ public class BufferParserTest {
 			long start = System.currentTimeMillis();
 			for (int i = 0; i < iterations; i++) {
 				ConvertToEvent convertToEvent = new ConvertToEvent(
-					DistPollerDao.DEFAULT_DIST_POLLER_ID,
+						MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
 					MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
 					InetAddressUtils.ONE_TWENTY_SEVEN,
 					9999,
@@ -461,7 +460,7 @@ public class BufferParserTest {
 		assertNull(message.getMillisecond());
 		assertNull(message.getZoneId());
 
-		Event event = ConvertToEvent.toEventBuilder(message, DistPollerDao.DEFAULT_DIST_POLLER_ID, MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID).getEvent();
+		Event event = ConvertToEvent.toEventBuilder(message, MockDistPollerDao.DEFAULT_DIST_POLLER_ID, MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID).getEvent();
 		assertEquals("main", event.getParm("messageid").getValue().getContent());
 		assertEquals("foo%d", event.getParm("process").getValue().getContent());
 	}
@@ -517,7 +516,7 @@ public class BufferParserTest {
 		assertEquals("localhost", message.getHostName());
 		assertEquals("connect from www.opennms.org[10.1.1.1]", message.getMessage());
 
-		Event event = ConvertToEvent.toEventBuilder(message, DistPollerDao.DEFAULT_DIST_POLLER_ID, MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID).getEvent();
+		Event event = ConvertToEvent.toEventBuilder(message, MockDistPollerDao.DEFAULT_DIST_POLLER_ID, MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID).getEvent();
 		assertEquals("localhost", event.getParm("hostname").getValue().getContent());
 		assertEquals("postfix/smtpd", event.getParm("process").getValue().getContent());
 	}
@@ -540,7 +539,7 @@ public class BufferParserTest {
 		assertNull(message.getHostName());
 		assertEquals("Authentication failed from 7.40.16.188 - sshd[20189]", message.getMessage());
 
-		Event event = ConvertToEvent.toEventBuilder(message, DistPollerDao.DEFAULT_DIST_POLLER_ID, MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID).getEvent();
+		Event event = ConvertToEvent.toEventBuilder(message, MockDistPollerDao.DEFAULT_DIST_POLLER_ID, MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID).getEvent();
 		assertNull(event.getParm("hostname").getValue().getContent());
 		assertEquals("%AUTHPRIV-3-SYSTEM_MSG", event.getParm("process").getValue().getContent());
 	}

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/ConvertToEventTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/ConvertToEventTest.java
@@ -54,7 +54,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -63,10 +62,10 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.SyslogdConfig;
 import org.opennms.netmgt.config.SyslogdConfigFactory;
 import org.opennms.netmgt.dao.api.AbstractInterfaceToNodeCache;
-import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.hibernate.InterfaceToNodeCacheDaoImpl;
+import org.opennms.netmgt.dao.mock.MockDistPollerDao;
 import org.opennms.netmgt.dao.mock.MockInterfaceToNodeCache;
 import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
 import org.opennms.netmgt.xml.event.Event;
@@ -129,7 +128,7 @@ public class ConvertToEventTest {
         // @param len The length of the XML data in the buffer
         try {
             ConvertToEvent convertToEvent = new ConvertToEvent(
-                DistPollerDao.DEFAULT_DIST_POLLER_ID,
+                MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
                 MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
                 pkt.getAddress(),
                 pkt.getPort(),
@@ -152,7 +151,7 @@ public class ConvertToEventTest {
 
         try {
             ConvertToEvent convertToEvent = new ConvertToEvent(
-                DistPollerDao.DEFAULT_DIST_POLLER_ID,
+                MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
                 MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
                 InetAddressUtils.ONE_TWENTY_SEVEN,
                 9999,
@@ -175,7 +174,7 @@ public class ConvertToEventTest {
 
         try {
             ConvertToEvent convertToEvent = new ConvertToEvent(
-                DistPollerDao.DEFAULT_DIST_POLLER_ID,
+                MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
                 MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
                 InetAddressUtils.ONE_TWENTY_SEVEN,
                 9999,
@@ -322,7 +321,7 @@ public class ConvertToEventTest {
         LocationAwareDnsLookupClient locationAwareDnsLookupClient = Mockito.mock(LocationAwareDnsLookupClient.class);
         try {
             ConvertToEvent convert = new ConvertToEvent(
-                    DistPollerDao.DEFAULT_DIST_POLLER_ID,
+                    MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
                     MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
                     InetAddressUtils.ONE_TWENTY_SEVEN,
                     9999,

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/DnsCacheTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/DnsCacheTest.java
@@ -30,18 +30,16 @@ package org.opennms.netmgt.syslogd;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import java.util.Date;
+import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.SyslogdConfig;
-import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.dao.mock.MockDistPollerDao;
 import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
 import org.opennms.netmgt.xml.event.Event;
-
-import java.util.Date;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 public class DnsCacheTest {
 
@@ -81,7 +79,7 @@ public class DnsCacheTest {
     private Event parseSyslog(final String name, final SyslogdConfig config, final String syslog, Date receivedTimestamp, Cache<HostNameWithLocationKey, String> cache) {
         try {
             ConvertToEvent convert = new ConvertToEvent(
-                    DistPollerDao.DEFAULT_DIST_POLLER_ID,
+                MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
                     "MINION",
                     InetAddressUtils.ONE_TWENTY_SEVEN,
                     9999,

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/Nms6730Test.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/Nms6730Test.java
@@ -32,12 +32,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.nio.ByteBuffer;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opennms.core.utils.InetAddressUtils;
-import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.mock.MockDistPollerDao;
 import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
 
 /**
@@ -65,7 +64,7 @@ public class Nms6730Test {
 		for (ByteBuffer incoming : new ByteBuffer[] { example1, example2, example3, example4 }) {
 			try {
 				ConvertToEvent convertToEvent = new ConvertToEvent(
-					DistPollerDao.DEFAULT_DIST_POLLER_ID,
+						MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
 					MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
 					InetAddressUtils.ONE_TWENTY_SEVEN,
 					514,
@@ -83,7 +82,7 @@ public class Nms6730Test {
 		{
 			ByteBuffer colonNoSpace = SyslogdTestUtils.toByteBuffer("<14> 2001-01-01 localhost procname:this is [my] message");
 			ConvertToEvent convertToEvent = new ConvertToEvent(
-				DistPollerDao.DEFAULT_DIST_POLLER_ID,
+					MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
 				MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
 				InetAddressUtils.ONE_TWENTY_SEVEN,
 				514,
@@ -97,7 +96,7 @@ public class Nms6730Test {
 		{
 			ByteBuffer spaceBeforeColon = SyslogdTestUtils.toByteBuffer("<14> 2001-01-01 localhost proc name: this is [my] message");
 			ConvertToEvent convertToEvent = new ConvertToEvent(
-				DistPollerDao.DEFAULT_DIST_POLLER_ID,
+					MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
 				MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
 				InetAddressUtils.ONE_TWENTY_SEVEN,
 				514,
@@ -124,7 +123,7 @@ public class Nms6730Test {
 		for (ByteBuffer incoming : new ByteBuffer[] { example1, example2, example3, example4 }) {
 			try {
 				ConvertToEvent convertToEvent = new ConvertToEvent(
-					DistPollerDao.DEFAULT_DIST_POLLER_ID,
+						MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
 					MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
 					InetAddressUtils.ONE_TWENTY_SEVEN,
 					514,
@@ -141,7 +140,7 @@ public class Nms6730Test {
 		{
 			ByteBuffer colonNoSpace = SyslogdTestUtils.toByteBuffer("<14> Jan 22 12:39:25 localhost procname:this is [my] message");
 			ConvertToEvent convertToEvent = new ConvertToEvent(
-				DistPollerDao.DEFAULT_DIST_POLLER_ID,
+				MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
 				MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
 				InetAddressUtils.ONE_TWENTY_SEVEN,
 				514,
@@ -155,7 +154,7 @@ public class Nms6730Test {
 		{
 			ByteBuffer spaceBeforeColon = SyslogdTestUtils.toByteBuffer("<14> Jan 22 12:39:25 localhost proc name: this is [my] message");
 			ConvertToEvent convertToEvent = new ConvertToEvent(
-				DistPollerDao.DEFAULT_DIST_POLLER_ID,
+				MockDistPollerDao.DEFAULT_DIST_POLLER_ID,
 				MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
 				InetAddressUtils.ONE_TWENTY_SEVEN,
 				514,

--- a/features/opennms-es-rest/src/test/java/org/opennms/plugins/elasticsearch/rest/AlarmEventToIndexIT.java
+++ b/features/opennms-es-rest/src/test/java/org/opennms/plugins/elasticsearch/rest/AlarmEventToIndexIT.java
@@ -54,6 +54,7 @@ import io.searchbox.core.SearchResult;
 
 
 public class AlarmEventToIndexIT extends AbstractEventToIndexITCase {
+	public final static String DEFAULT_DIST_POLLER_ID = "00000000-0000-0000-0000-000000000000";
 	public static final int INDEX_WAIT_SECONDS=10; // time to wait for index to catch up
 
 	// See NMS-9831 for more information
@@ -149,7 +150,7 @@ public class AlarmEventToIndexIT extends AbstractEventToIndexITCase {
 		final Event event = new Event();
 		event.setUei(EventConstants.NODE_DOWN_EVENT_UEI);
 		event.setCreationTime(new Date());
-		event.setDistPoller(DistPollerDao.DEFAULT_DIST_POLLER_ID);
+		event.setDistPoller(DEFAULT_DIST_POLLER_ID);
 		event.setDescr("Dummy Event");
 		event.setSeverity(OnmsSeverity.WARNING.getLabel());
 		event.setDbid(eventId);

--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
@@ -274,7 +274,6 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
     /**
      * Creates the mapping.
      *
-     * @param alarmMappings the alarm mappings
      * @param alarm the northbound alarm
      * @return the mapping object
      */
@@ -333,7 +332,7 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
             mapping.put("foreignId", "");
         }
 
-        String poller = alarm.getPoller() == null ? DistPollerDao.DEFAULT_DIST_POLLER_ID : alarm.getPoller().getId();
+        String poller = alarm.getPoller() == null ? "00000000-0000-0000-0000-000000000000" : alarm.getPoller().getId();
         mapping.put("distPoller", poller);
 
         String service = alarm.getService() == null ? "" : alarm.getService();

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/DistPollerDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/DistPollerDao.java
@@ -35,8 +35,6 @@ import org.opennms.netmgt.model.OnmsDistPoller;
  */
 public interface DistPollerDao extends OnmsDao<OnmsDistPoller, String> {
 
-    public static final String DEFAULT_DIST_POLLER_ID = "00000000-0000-0000-0000-000000000000";
-
     /**
      * This function returns the {@link OnmsDistPoller} identity of the
      * local system so that events and other objects can be associated with

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockDistPollerDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockDistPollerDao.java
@@ -35,6 +35,8 @@ import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.model.OnmsDistPoller;
 
 public class MockDistPollerDao extends AbstractMockDao<OnmsDistPoller,String> implements DistPollerDao {
+
+    public final static String DEFAULT_DIST_POLLER_ID = "00000000-0000-0000-0000-000000000000";
     @Override
     protected void generateId(final OnmsDistPoller dp) {
         dp.setId(UUID.randomUUID().toString());

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/DatabasePopulator.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/DatabasePopulator.java
@@ -353,6 +353,7 @@ public class DatabasePopulator {
         final OnmsEvent event = buildEvent(builder.getDistPoller());
         event.setEventCreateTime(new Date(1436881548292L));
         event.setEventTime(new Date(1436881548292L));
+        event.setDistPoller(m_distPollerDao.whoami());
         getEventDao().save(event);
         getEventDao().flush();
 

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NewSuspectScanIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NewSuspectScanIT.java
@@ -60,6 +60,7 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.ServiceTypeDao;
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
 import org.opennms.netmgt.dao.mock.EventAnticipator;
+import org.opennms.netmgt.dao.mock.MockDistPollerDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.events.api.EventConstants;
@@ -174,7 +175,7 @@ public class NewSuspectScanIT extends ProvisioningITCase implements Initializing
         m_eventSubscriber.getEventAnticipator().reset();
 
         if (m_distPollerDao.findAll().size() == 0) {
-            OnmsDistPoller distPoller = new OnmsDistPoller(DistPollerDao.DEFAULT_DIST_POLLER_ID);
+            OnmsDistPoller distPoller = new OnmsDistPoller(MockDistPollerDao.DEFAULT_DIST_POLLER_ID);
             distPoller.setLabel("localhost");
             distPoller.setLocation(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID);
             distPoller.setType(OnmsMonitoringSystem.TYPE_OPENNMS);

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerIT.java
@@ -79,6 +79,7 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.ServiceTypeDao;
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
 import org.opennms.netmgt.dao.mock.EventAnticipator;
+import org.opennms.netmgt.dao.mock.MockDistPollerDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.events.api.EventConstants;
@@ -234,7 +235,7 @@ public class ProvisionerIT extends ProvisioningITCase implements InitializingBea
     @Before
     public void setUp() throws Exception {
         if (m_distPollerDao.findAll().size() == 0) {
-            OnmsDistPoller distPoller = new OnmsDistPoller(DistPollerDao.DEFAULT_DIST_POLLER_ID);
+            OnmsDistPoller distPoller = new OnmsDistPoller(MockDistPollerDao.DEFAULT_DIST_POLLER_ID);
             distPoller.setLabel("localhost");
             distPoller.setLocation(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID);
             distPoller.setType(OnmsMonitoringSystem.TYPE_OPENNMS);


### PR DESCRIPTION
This PR is a follow up from https://github.com/OpenNMS/opennms/pull/5216

This PR creates a UUID system id via liquibase and removes the default DEFAULT_DIST_POLLER_ID

### External References

* JIRA (Issue Tracker): [http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}](https://issues.opennms.org/browse/DC-266)

