### PR TITLE
NMS-14449: Rest API v2 for obtaining a list of SNMP interfaces doesn't return back node id

### DIFF
--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java
@@ -527,7 +527,6 @@ public class OnmsSnmpInterface extends OnmsEntity implements Serializable {
     @XmlElement(name="nodeId")
     //@XmlIDREF
     @XmlJavaTypeAdapter(NodeIdAdapter.class)
-    @JsonIgnore
     public OnmsNode getNode() {
         return m_node;
     }
@@ -616,7 +615,7 @@ public class OnmsSnmpInterface extends OnmsEntity implements Serializable {
             .add("snmpifalias", getIfAlias())
             .add("snmpCollect", getCollect())
             .add("snmpPoll", getPoll())
-            .add("nodeId", getNode() == null ? null : getNode().getId())
+            .add("nodeId", getNodeId())
             .add("lastCapsdPoll", getLastCapsdPoll())
             .add("lastSnmpPoll", getLastSnmpPoll())
             .add("lastIngressFlow", m_lastIngressFlow)


### PR DESCRIPTION
NMS-14449: added node ID to SnmpInterface json object returned by the api/v2/snmpinterfaces rest

Part of work done for HELM-334

OpenNMS/opennms-js#377
and
OpenNMS/opennms-helm#492

External References
JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14449