### PR TITLE
NMS-14696: use dom4j 2.1.3

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -179,9 +179,12 @@
     <feature name="guava17" version="${guavaOldVersion}" description="Google :: Guava">
         <bundle dependency="true">mvn:com.google.guava/guava/${guavaOldVersion}</bundle>
     </feature>
+    <feature name="dom4j" version="${dom4jVersion}" description="DOM4J">
+        <bundle dependency="true">wrap:mvn:org.dom4j/dom4j/${dom4jVersion}</bundle>
+    </feature>
     <feature name="hibernate36" version="3.6.10.Final" description="Hibernate :: Hibernate ORM">
+        <feature>dom4j</feature>
         <bundle dependency="true">wrap:mvn:antlr/antlr/${antlr.version}$Import-Package=org.hibernate.hql.ast</bundle>
-        <bundle dependency="true">wrap:mvn:dom4j/dom4j/1.6.1</bundle>
         <bundle dependency="true">mvn:commons-collections/commons-collections/${commonsCollectionsVersion}</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${geronimoVersion}</bundle>
         <bundle dependency="true">mvn:org.javassist/javassist/3.18.2-GA</bundle>
@@ -894,6 +897,7 @@
         <feature>commons-cli</feature>
         <feature>commons-io</feature>
         <feature>commons-lang</feature>
+        <feature>dom4j</feature>
         <feature>guava</feature>
         <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcoreVersion}</bundle>
         <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${httpclientVersion}</bundle>

--- a/container/karaf/src/main/filtered-resources/etc/blacklisted.properties
+++ b/container/karaf/src/main/filtered-resources/etc/blacklisted.properties
@@ -4,3 +4,6 @@ spring-security
 # no karaf Spring repos
 mvn:org.apache.karaf.features/spring
 mvn:org.apache.karaf.features/spring-legacy
+
+# we should use org.dom4j:dom4j instead
+dom4j:dom4j

--- a/container/karaf/src/main/filtered-resources/etc/custom.properties
+++ b/container/karaf/src/main/filtered-resources/etc/custom.properties
@@ -296,6 +296,20 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         org.apache.velocity.texen.util,\
         org.apache.velocity.util,\
         org.apache.velocity.util.introspection,\
+        org.dom4j;version=${dom4jVersion},\
+        org.dom4j.bean;version=${dom4jVersion},\
+        org.dom4j.datatype;version=${dom4jVersion},\
+        org.dom4j.dom;version=${dom4jVersion},\
+        org.dom4j.dtd;version=${dom4jVersion},\
+        org.dom4j.io;version=${dom4jVersion},\
+        org.dom4j.jaxb;version=${dom4jVersion},\
+        org.dom4j.rule;version=${dom4jVersion},\
+        org.dom4j.rule.pattern;version=${dom4jVersion},\
+        org.dom4j.swing;version=${dom4jVersion},\
+        org.dom4j.tree;version=${dom4jVersion},\
+        org.dom4j.util;version=${dom4jVersion},\
+        org.dom4j.xpath;version=${dom4jVersion},\
+        org.dom4j.xpp;version=${dom4jVersion},\
         org.graphdrawing.graphml;version=${opennms.osgi.version},\
         org.jfree.chart;version=${jfreechartVersion},\
         org.jfree.chart.axis;version=${jfreechartVersion},\

--- a/dependencies/hibernate/pom.xml
+++ b/dependencies/hibernate/pom.xml
@@ -35,7 +35,15 @@
           <groupId>cglib</groupId>
           <artifactId>cglib</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>dom4j</groupId>
+          <artifactId>dom4j</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.dom4j</groupId>
+      <artifactId>dom4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/integrations/opennms-vmware/pom.xml
+++ b/integrations/opennms-vmware/pom.xml
@@ -88,6 +88,14 @@
             <version>6.0.05</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.directory.studio</groupId>
+                    <artifactId>org.dom4j.dom4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
@@ -101,6 +109,10 @@
                     <artifactId>lombok</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
         </dependency>
 
         <!-- Attention this is EPL license -->

--- a/pom.xml
+++ b/pom.xml
@@ -1168,6 +1168,7 @@
                    <exclude>com.github.detro:*</exclude>             <!-- use: com.codeborne.phantomjsdriver -->
                    <exclude>com.github.detro.ghostdriver:*</exclude> <!-- use: com.codeborne.phantomjsdriver -->
                    <exclude>com.sun.xml.bind:jaxb-impl</exclude>     <!-- use: jaxb-dependencies -->
+                   <exclude>dom4j:dom4j</exclude>                    <!-- use: org.dom4j:dom4j -->
                    <exclude>javax.servlet:jstl</exclude>             <!-- use: jstl-dependencies -->
                    <exclude>javax.servlet.jsp:jsp-api</exclude>      <!-- use: servlet-dependencies -->
                    <exclude>javax.ws.rs:jsr311-api</exclude>         <!-- use: javax.ws.rs-api -->
@@ -1717,6 +1718,7 @@
     <cxfXjcVersion>3.3.0</cxfXjcVersion>
     <dhcp4javaVersion>1.1.0</dhcp4javaVersion>
     <dnsjavaVersion>2.1.9_1</dnsjavaVersion>
+    <dom4jVersion>2.1.3</dom4jVersion>
     <dropwizardMetricsVersion>3.1.2</dropwizardMetricsVersion>
     <ecjVersion>4.4.2</ecjVersion>
     <eclipseGeminiVersion>2.0.0.RELEASE</eclipseGeminiVersion>
@@ -3869,6 +3871,11 @@
         <artifactId>dbunit</artifactId>
         <version>2.4.8</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.dom4j</groupId>
+        <artifactId>dom4j</artifactId>
+        <version>${dom4jVersion}</version>
       </dependency>
       <dependency>
         <groupId>geoGoogle</groupId>


### PR DESCRIPTION
Turns out dom4j 2.x is (almost entirely) API-compatible with the 1.6.1 our Hibernate depends on.
Turns out updating it was pretty simple and everything is green.
Who knew?

(I have a companion branch to this against foundation 2022 and it went green as well.)

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14696
