### PR TITLE
NMS-14690: enable sonar in foundation-2022, release-X, and develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,6 @@ commands:
             ulimit -n 65536 || :
             export OPENNMS_VERSION="$(.circleci/scripts/pom2version.sh pom.xml)"
             .circleci/scripts/configure-signing.sh
-            ./clean.pl
             << parameters.node-memory >>
             export MAVEN_OPTS="$MAVEN_OPTS -Xmx8g -XX:ReservedCodeCacheSize=1g"
             MAVEN_ARGS="install"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,25 +560,6 @@ workflows:
             ((?!docs/).)* trigger-build true
             docs/.*       trigger-docs  true
             .circleci/.*  trigger-docs  true
-#  weekly-coverage:
-#    when:
-#      equal: [ false, << pipeline.parameters.minimal >> ]
-#    triggers:
-#      - schedule:
-#          # Saturday at 12:00 AM
-#          cron: "0 0 * * 6"
-#          filters:
-#            branches:
-#              only:
-#                - develop
-#    jobs:
-#      - build
-#      - integration-test-with-coverage:
-#          requires:
-#            - build
-#      - code-coverage:
-#          requires:
-#            - integration-test-with-coverage
   build-minimal:
     when:
       and:
@@ -717,7 +698,18 @@ workflows:
           filters:
             branches:
               ignore:
+                - /^.*sonar.*/
                 - /^merge-foundation.*/
+      - integration-test-with-coverage:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - /^.*sonar.*/
+      - code-coverage:
+          requires:
+            - integration-test-with-coverage
       - smoke-test-core:
           requires:
             - tarball-assembly
@@ -800,6 +792,7 @@ workflows:
             - minion-deb-build
             - sentinel-deb-build
             - integration-test
+            - code-coverage
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
@@ -816,6 +809,7 @@ workflows:
             - minion-deb-build
             - sentinel-deb-build
             - integration-test
+            - code-coverage
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
@@ -826,11 +820,12 @@ workflows:
                 - develop
                 - /^master-.*/
                 - /^release-.*/
-      # These don't actually require `integration-test` but we shouldn't bother
+      # These don't actually require `integration-test`/`code-coverage` but we shouldn't bother
       # spending cycles unless everything else passed
       - horizon-deb-build:
           requires:
             - integration-test
+            - code-coverage
           filters:
             branches:
               ignore:
@@ -838,6 +833,7 @@ workflows:
       - minion-deb-build:
           requires:
             - integration-test
+            - code-coverage
           filters:
             branches:
               ignore:
@@ -845,6 +841,7 @@ workflows:
       - sentinel-deb-build:
           requires:
             - integration-test
+            - code-coverage
           filters:
             branches:
               ignore:
@@ -857,6 +854,7 @@ workflows:
             - minion-deb-build
             - sentinel-deb-build
             - integration-test
+            - code-coverage
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
@@ -880,6 +878,7 @@ workflows:
             - minion-deb-build
             - sentinel-deb-build
             - integration-test
+            - code-coverage
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion
@@ -897,6 +896,7 @@ workflows:
             - smoke-test-minion
             - smoke-test-sentinel
             - integration-test
+            - code-coverage
           filters:
             branches:
               only:
@@ -909,6 +909,7 @@ workflows:
             - minion-deb-build
             - sentinel-deb-build
             - integration-test
+            - code-coverage
             - smoke-test-core
             - smoke-test-flaky
             - smoke-test-minion

--- a/.circleci/scripts/codecoverage-restore.sh
+++ b/.circleci/scripts/codecoverage-restore.sh
@@ -1,5 +1,13 @@
 #!/bin/sh -e
 cd ~/project
 for file in ~/code-coverage/target-*.zip; do
+    FILENAME="$(basename "$file")"
+    NUMBER="$(echo "$FILENAME" | cut -d. -f1 | cut -d- -f2-)"
+    echo "* unpacking coverage reports $NUMBER:"
     unzip -qo "$file"
+    find . -type d -name failsafe-reports -o -name surefire-reports | while read DIR; do
+      mkdir -p "${DIR}-${NUMBER}"
+      mv "${DIR}"/* "${DIR}-${NUMBER}/"
+      rm -rf "${DIR}"
+    done
 done

--- a/.circleci/scripts/smoke.sh
+++ b/.circleci/scripts/smoke.sh
@@ -54,9 +54,6 @@ export MAVEN_OPTS="-Xmx1g -Xms1g"
 # Set higher open files limit
 ulimit -n 65536
 
-# Clean up the workspace so there's less junk lying around
-./clean.pl
-
 cd ~/project/smoke-test
 if [ $SUITE = "minimal" ]; then
   echo "#### Executing minimal set smoke/system tests"

--- a/.circleci/scripts/sonar.sh
+++ b/.circleci/scripts/sonar.sh
@@ -21,6 +21,12 @@ generate_junit_report_names()
   echo "$(generate_report_names 'target/surefire-reports-'),$(generate_report_names 'target/failsafe-reports-')"
 }
 
+dnf -y remove npm nodejs-full-i18n
+dnf module reset -y nodejs
+dnf module enable -y nodejs:14
+dnf module switch-to -y nodejs:14
+dnf -y install npm nodejs-full-i18n
+
 echo "#### Executing Sonar"
 cd ~/project
 ./compile.pl sonar:sonar \


### PR DESCRIPTION
This PR fixes a few bugs in getting Sonar to process and submit properly. It also enables forcing Sonar builds on for branches with "sonar" in the name.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14690
