### PR TITLE
NMS-14670 Newly created node failes on device backup

### DIFF
--- a/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
+++ b/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
@@ -271,6 +271,10 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
         this.serviceMonitorAdaptor = serviceMonitorAdaptor;
     }
 
+    public void setPollerConfig(PollerConfig pollerConfig) {
+        this.pollerConfig = pollerConfig;
+    }
+
     public PollerConfig getPollerConfig() throws IOException {
         if (this.pollerConfig == null) {
             this.pollerConfig = ReadOnlyPollerConfigManager.create();

--- a/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
+++ b/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
@@ -126,13 +126,7 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
     @Override
     public List<RetrievalDefinition> getRetrievalDefinitions(final String ipAddress, final String location) {
         final var iface = findMatchingInterface(ipAddress, location, null);
-        PollerConfig pollerConfig;
-        try {
-            pollerConfig = this.getPollerConfig();
-        } catch (IOException e) {
-            LOG.error("Exception while retrieving pollerConfig", e);
-            return new ArrayList<>();
-        }
+
         return iface
                 // Get all device config services defined for this interface
                 .getMonitoredServices().stream()
@@ -275,10 +269,7 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
         this.pollerConfig = pollerConfig;
     }
 
-    public PollerConfig getPollerConfig() throws IOException {
-        if (this.pollerConfig == null) {
-            this.pollerConfig = ReadOnlyPollerConfigManager.create();
-        }
-        return this.pollerConfig;
+    public PollerConfig getPollerConfig() {
+        return pollerConfig;
     }
 }

--- a/features/device-config/service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/device-config/service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,12 +10,14 @@
     <reference id="ipInterfaceDao" interface="org.opennms.netmgt.dao.api.IpInterfaceDao" availability="mandatory"/>
     <reference id="deviceConfigMonitorAdaptor" interface="org.opennms.netmgt.poller.ServiceMonitorAdaptor" availability="mandatory"/>
     <reference id="monitoredServiceDao" interface="org.opennms.netmgt.dao.api.MonitoredServiceDao" availability="mandatory"/>
+    <reference id="pollerConfig" interface="org.opennms.netmgt.config.PollerConfig" availability="mandatory"/>
 
     <bean id="deviceConfigService" class="org.opennms.features.deviceconfig.service.impl.DeviceConfigServiceImpl" >
         <property name="locationAwarePollerClient" ref="locationAwarePollerClient"/>
         <property name="sessionUtils" ref="sessionUtils"/>
         <property name="ipInterfaceDao" ref="ipInterfaceDao"/>
         <property name="serviceMonitorAdaptor" ref="deviceConfigMonitorAdaptor"/>
+        <property name="pollerConfig" ref="pollerConfig"/>
     </bean>
 
     <service ref="deviceConfigService" interface="org.opennms.features.deviceconfig.service.DeviceConfigService"/>


### PR DESCRIPTION
Changed DeviceConfig backup to have reference to PollarConfig to avoid created of a new object. 
This resolves issue with newly created node are not able to backup until a reboot. 

### External References

* JIRA (Issue Tracker): (https://issues.opennms.org/browse/NMS-14670)

