### PR TITLE
only run "npm ci" if package-lock.json has changed

### DIFF
--- a/core/web-assets/ci.js
+++ b/core/web-assets/ci.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const child_process = require('child_process');
+const fs    = require('fs');
+const path  = require('path');
+
+var doUpdate = false;
+
+const touchfile = path.join(__dirname, 'target', 'ci.done');
+
+if (fs.existsSync(touchfile)) {
+  const touchstats = fs.statSync(touchfile);
+  const packagestats = fs.statSync(path.join(__dirname, 'package-lock.json'));
+
+  const touchtime = (touchstats && touchstats.mtimeMs) ? touchstats.mtimeMs : 0;
+  const packagetime = (packagestats && packagestats.mtimeMs) ? packagestats.mtimeMs : 0;
+
+  if (touchtime > packagetime) {
+    console.debug('package-lock.json has not changed since the last "npm ci" run');
+  } else {
+    doUpdate = true;
+  }
+} else {
+  doUpdate = true;
+}
+
+if (doUpdate) {
+  console.info('node_modules is out of date compared to package-lock.json');
+  const child = child_process.execFile(path.join(__dirname, 'target', 'node', 'npm'), [ '--prefer-offline', '--no-progress', 'ci' ]);
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+  child.on('error', (err) => {
+    console.error('npm ci failed: ' + err);
+    process.exit(1);
+  });
+  fs.mkdirSync(path.join(__dirname, 'target'), { recursive: true });
+  fs.writeFileSync(touchfile, 'Kilroy Was Here m OvO m\n');
+}

--- a/core/web-assets/package.json
+++ b/core/web-assets/package.json
@@ -177,7 +177,7 @@
         "webpack": "cross-env NODE_OPTIONS=--max-old-space-size=4096 webpack --colors --display-error-details --env=development",
         "webpack-release": "cross-env NODE_OPTIONS=--max-old-space-size=4096 webpack --colors --display-error-details --env=production",
         "check-git": "node check-git.js",
-        "install-deps": "npm --prefer-offline --no-progress install",
+        "install-deps": "node ci.js",
         "build": "npm run check-git && npm run webpack",
         "build-release": "npm run check-git && npm run webpack-release",
         "build-verbose": "npm run check-git && npm run lint && cross-env NODE_OPTIONS=--max-old-space-size=4096 webpack --debug --colors --display-modules --display-chunks --display-error-details --display-origins --display-reasons --env=development",

--- a/core/web-assets/pom.xml
+++ b/core/web-assets/pom.xml
@@ -71,7 +71,7 @@
             <phase>generate-resources</phase>
             <configuration>
               <skip>${skipNodeJSBuild}</skip>
-              <arguments>--prefer-offline --no-progress install</arguments>
+              <arguments>--prefer-offline --no-progress run install-deps</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
After an initial build:

```
[INFO] 
[INFO] --- maven-bundle-plugin:3.5.1:install (default-install) @ org.opennms.core.web-assets ---
[INFO] Local OBR update disabled (enable with -DobrRepository)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.978 s
[INFO] Finished at: 2022-09-20T12:19:48-04:00
[INFO] ------------------------------------------------------------------------
[INFO] finished successfully
```

20 seconds!