### PR TITLE
NMS-14659: GraphiteAdapter, allow groovy script to set the node

### DIFF
--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/dto/CollectionSetDTO.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/dto/CollectionSetDTO.java
@@ -145,6 +145,10 @@ public class CollectionSetDTO implements CollectionSet {
         return timestamp;
     }
 
+    public void setCollectionAgent(CollectionAgentDTO agent) {
+        this.agent = agent;
+    }
+
     private Set<CollectionResource> buildCollectionResources() {
         final Set<CollectionResource> collectionResources = new LinkedHashSet<>();
         for (CollectionResourceDTO entry : this.collectionResources) {

--- a/features/collection/snmp-collector/src/main/java/org/opennms/netmgt/collectd/SnmpCollectionSet.java
+++ b/features/collection/snmp-collector/src/main/java/org/opennms/netmgt/collectd/SnmpCollectionSet.java
@@ -90,7 +90,7 @@ public class SnmpCollectionSet implements Collectable, CollectionSet {
 
     }
 
-    private final SnmpCollectionAgent m_agent;
+    private SnmpCollectionAgent m_agent;
     private final OnmsSnmpCollection m_snmpCollection;
     private final LocationAwareSnmpClient m_client;
     private SnmpIfCollector m_ifCollector;
@@ -255,6 +255,10 @@ public class SnmpCollectionSet implements Collectable, CollectionSet {
      */
     public SnmpCollectionAgent getCollectionAgent() {
        return m_agent;
+    }
+
+    public void setCollectionAgent(SnmpCollectionAgent agent) {
+        m_agent = agent;
     }
 
     Collection<SnmpAttributeType> getAttributeList() {

--- a/features/telemetry/protocols/adapters/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/ScriptedCollectionSetBuilder.java
+++ b/features/telemetry/protocols/adapters/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/ScriptedCollectionSetBuilder.java
@@ -46,6 +46,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Date;
+import java.util.Map;
 
 /**
  * Uses an external script, executed via JSR-223, to generate a
@@ -97,10 +98,12 @@ public class ScriptedCollectionSetBuilder {
      *            the agent associated with the collection set
      * @param message
      *            the messaged passed to script containing the metrics
+     * @param props
+     *            additional global properties to pass into the script
      * @return a collection set
      * @throws ScriptException
      */
-    public CollectionSet build(CollectionAgent agent, Object message, Long timestamp) throws ScriptException {
+    public CollectionSet build(CollectionAgent agent, Object message, Long timestamp, Map<String,Object> props) throws ScriptException {
         final CollectionSetBuilder builder = new CollectionSetBuilder(agent);
         if (timestamp != null && timestamp > 0) {
             builder.withTimestamp(new Date(timestamp));
@@ -109,8 +112,18 @@ public class ScriptedCollectionSetBuilder {
         globals.put("agent", agent);
         globals.put("builder", builder);
         globals.put("msg", message);
+
+        if (props != null && !props.isEmpty()) {
+            for (String key : props.keySet()) {
+                globals.put(key, props.get(key));
+            }
+        }
+
         compiledScript.eval(globals);
         return builder.build();
     }
 
+    public CollectionSet build(CollectionAgent agent, Object message, Long timestamp) throws ScriptException {
+        return build(agent, message, timestamp, null);
+    }
 }

--- a/features/telemetry/protocols/graphite/adapter/pom.xml
+++ b/features/telemetry/protocols/graphite/adapter/pom.xml
@@ -33,6 +33,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.collection</groupId>
+      <artifactId>org.opennms.features.collection.snmp-collector</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
       <scope>provided</scope>

--- a/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapterFactory.java
+++ b/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapterFactory.java
@@ -54,11 +54,11 @@ public class GraphiteAdapterFactory extends AbstractCollectionAdapterFactory {
         adapter.setCollectionAgentFactory(getCollectionAgentFactory());
         adapter.setInterfaceToNodeCache(getInterfaceToNodeCache());
         adapter.setFilterDao(getFilterDao());
+        adapter.setNodeDao(getNodeDao());
         adapter.setPersisterFactory(getPersisterFactory());
         adapter.setThresholdingService(getThresholdingService());
         adapter.setBundleContext(getBundleContext());
 
         return adapter;
     }
-
 }

--- a/features/telemetry/protocols/graphite/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/protocols/graphite/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,6 +13,7 @@
         <reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
         <reference id="interfaceToNodeCache" interface="org.opennms.netmgt.dao.api.InterfaceToNodeCache" />
         <reference id="filterDao" interface="org.opennms.netmgt.filter.api.FilterDao" />
+        <reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao" />
         <reference id="persisterFactory" interface="org.opennms.netmgt.collection.api.PersisterFactory" />
         <reference id="thresholdingService" interface="org.opennms.netmgt.threshd.api.ThresholdingService" />
 
@@ -22,6 +23,7 @@
             <property name="collectionAgentFactory" ref="collectionAgentFactory" />
             <property name="interfaceToNodeCache" ref="interfaceToNodeCache" />
             <property name="filterDao" ref="filterDao" />
+            <property name="nodeDao" ref="nodeDao" />
             <property name="persisterFactory" ref="persisterFactory" />
             <property name="thresholdingService" ref="thresholdingService" />
         </bean>


### PR DESCRIPTION
In `GraphiteAdapter`, allow the Groovy script to set the node for the timeseries data.

Currently, a `CollectionAgent` is created in `GraphiteAdapter` based on the IP address and node of whatever process sent the Graphite message to OpenNMS. This ultimately results in the timeseries record being saved with a resource ID of e.g. `snmp/{nodeId}/...`. This may not actually correlate to a node that the data should be correlated with, which may need additional processing to determine.

This update passes a `List<CollectionAgent>` into the Groovy script which does the processing. If the script adds a `CollectionAgent` to that list, the `GraphiteAdapter` will use that one instead of the one it created. This ultimately results in the resourceId of the saved record having the correct node id.

The update also passes in a `CollectionAgentFactory` and a `NodeDao` to enable the script to determine and create a `CollectionAgent` if needed.

This functionality should be backward compatible with scripts that don't use this functionality.

Unfortunately, `CollectionSet` does not allow modification of the `CollectionAgent` and it looked like adding this could affect a number of files, so the decision was made to check for the underlying type and only update the agent in known cases.

Example script which uses this functionality can be found here: [mos-cdr-graphite-telemetry-interface.groovy](https://github.com/opennms-forge/mos-cdr-processor/blob/main/assets/opennms/etc/telemetryd-adapters/mos-cdr-graphite-telemetry-interface.groovy)

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14659

