### PR TITLE
NMS-9334 added lines to clear default and previous test from the text…

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -579,6 +579,7 @@ public abstract class AbstractOpenNMSSeleniumHelper {
             @Override public Boolean call() throws Exception {
                 waitForElement(textInput).clear();
                 waitForElement(textInput).click();
+                waitForElement(textInput).sendKeys(Keys.chord(Keys.CONTROL, "a"), Keys.BACK_SPACE);
                 waitForValue(textInput, "");
                 waitForElement(textInput).sendKeys(text);
                 // Click on the item that appears

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -816,6 +816,7 @@ public abstract class AbstractOpenNMSSeleniumHelper {
             LOG.debug("enterText({},{}): {}", selector, text, ++count);
             // Clear the element content and then confirm it's really clear
             waitForElement(selector).clear();
+            waitForElement(selector).click();
             waitForValue(selector, "");
 
             // Click the element to make sure it's still got the focus

--- a/smoke-test/src/test/java/org/opennms/smoketest/BSMAdminIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/BSMAdminIT.java
@@ -59,7 +59,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
-@Ignore
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class BSMAdminIT extends OpenNMSSeleniumIT {
 


### PR DESCRIPTION
Added a few lines to reset default text and remove previous text that leads to the test failure. 

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-9334

