### PR TITLE
CircleCI Workspace Optimizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  continuation: circleci/continuation@0.2.0
-  # path-filtering: circleci/path-filtering@0.1.1
+  continuation: circleci/continuation@0.3.1
+  # path-filtering: circleci/path-filtering@0.1.3
 
 parameters:
   trigger-prebuild:

--- a/.circleci/main/@main.yml
+++ b/.circleci/main/@main.yml
@@ -3,14 +3,11 @@ version: 2.1
 aliases:
   #aliases:general#
 
-docker_container_config: &docker_container_config
-  executor: docker-executor
-
 orbs:
-  cloudsmith: cloudsmith/cloudsmith@1.0.3
-  continuation: circleci/continuation@0.2.0
-  # path-filtering: circleci/path-filtering@0.1.1
-  sign-packages: opennms/sign-packages@2.1.3
+  cloudsmith: cloudsmith/cloudsmith@1.0.5
+  continuation: circleci/continuation@0.3.1
+  # path-filtering: circleci/path-filtering@0.1.3
+  sign-packages: opennms/sign-packages@2.3.0
 
 commands:
   #commands:maven/maven.index#

--- a/.circleci/main/commands/cache/cache.yml
+++ b/.circleci/main/commands/cache/cache.yml
@@ -192,6 +192,25 @@ commands:
             fi
             cd -
 
+  persist-project-changes:
+    description: persist project changes to the workspace, skipping files that come from git
+    steps:
+      - fix-workspace-permissions:
+          path: project
+      - run:
+          name: prep the working directory
+          command: |
+            WORKSPACE="/tmp/extracted-workspace"
+            mkdir -p "${WORKSPACE}/project"
+
+            cd ~/project
+            git clean -dx --dry-run | grep -v __pycache__ | sed -e 's,^Would remove ,,' > "${WORKSPACE}.filelist"
+            tar -cf - --files-from "${WORKSPACE}.filelist" | tar -xf - -C "${WORKSPACE}/project"
+      - persist_to_workspace:
+          root: /tmp/extracted-workspace/
+          paths:
+            - project
+
   fix-workspace-permissions:
     description: fix permissions of a path to be compatible with the docker cimg `circleci` user
     parameters:

--- a/.circleci/main/commands/cache/cache.yml
+++ b/.circleci/main/commands/cache/cache.yml
@@ -15,9 +15,9 @@ commands:
       steps:
         - restore_cache:
             keys:
-              - source-v3-{{ .Branch }}-{{ .Revision }}
-              - source-v3-{{ .Branch }}-
-              - source-v3-
+              - source-v4-{{ .Branch }}-{{ .Revision }}
+              - source-v4-{{ .Branch }}-
+              - source-v4-
         - checkout
         - run:
             name: git config merge.renameLimit
@@ -29,7 +29,7 @@ commands:
       description: "Cache a checkout"
       steps:
         - save_cache:
-            key: source-v3-{{ .Branch }}-{{ .Revision }}
+            key: source-v4-{{ .Branch }}-{{ .Revision }}
             paths:
               - ".git"
   cached-checkout-for-pushing:
@@ -52,13 +52,13 @@ commands:
             command: find core/web-assets -name package\*.json -o -name bower.json | grep -v /target/ | sort -u | xargs cat > nodejs-dependency-json-cache.key
         - restore_cache:
             keys:
-              - nodejs-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
-              - nodejs-dependencies-v3-{{ checksum "pom-version-cache.key" }}-
+              - nodejs-dependencies-v4-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
+              - nodejs-dependencies-v4-{{ checksum "pom-version-cache.key" }}-
   save-nodejs-cache:
     description: "NodeJS: Save cache"
     steps:
       - save_cache:
-          key: nodejs-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
+          key: nodejs-dependencies-v4-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
           paths:
             - ~/.npm
   restore-sonar-cache:
@@ -66,12 +66,12 @@ commands:
       steps:
         - restore_cache:
             keys:
-              - sonar-cache-v2-{{ checksum "pom-version-cache.key" }}
+              - sonar-cache-v4-{{ checksum "pom-version-cache.key" }}
   save-sonar-cache:
       description: "Sonar: Save sonar cache"
       steps:
         - save_cache:
-            key: sonar-cache-v2-{{ checksum "pom-version-cache.key" }}
+            key: sonar-cache-v4-{{ checksum "pom-version-cache.key" }}
             paths:
               - ~/.sonar
   cache-workflow-assets:
@@ -92,7 +92,7 @@ commands:
             find "${TARGET_PATH}" -type d -print0 | xargs -0 chmod 775
             find "${TARGET_PATH}" ! -type d -print0 | xargs -0 chmod 664
       - save_cache:
-          key: << parameters.cache_prefix >>-v3-{{ .Branch }}-{{ .Revision }}-{{ .Environment.CIRCLE_SHA1 }}
+          key: << parameters.cache_prefix >>-v4-{{ .Branch }}-{{ .Revision }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - "/tmp/<< parameters.cache_prefix >>"
   restore-workflow-assets:
@@ -107,7 +107,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - << parameters.cache_prefix >>-v3-{{ .Branch }}-{{ .Revision }}-{{ .Environment.CIRCLE_SHA1 }}
+            - << parameters.cache_prefix >>-v4-{{ .Branch }}-{{ .Revision }}-{{ .Environment.CIRCLE_SHA1 }}
       - when:
           condition: << parameters.target_path >>
           steps:

--- a/.circleci/main/commands/executions/run-build.yml
+++ b/.circleci/main/commands/executions/run-build.yml
@@ -48,6 +48,12 @@ commands:
               -Psmoke \
               --batch-mode \
               $MAVEN_ARGS || exit 1
+            ./compile.pl -s .circleci/scripts/structure-settings.xml \
+              --batch-mode \
+              --fail-at-end \
+              -Prun-expensive-tasks \
+              -Pbuild-bamboo \
+              org.opennms.maven.plugins:structure-maven-plugin:1.0:structure || exit 1
       - run:
           name: Check if we have generated apidocs
           command: |
@@ -80,5 +86,6 @@ commands:
           root: ~/
           paths:
             - project
+            - project/target/structure-graph.json
             - .m2
             - .artifacts

--- a/.circleci/main/commands/executions/run-build.yml
+++ b/.circleci/main/commands/executions/run-build.yml
@@ -9,7 +9,7 @@ commands:
         default: echo "NODE_OPTIONS Not Set"
         type: string
       vaadin-javamaxmem:
-        default: 1g
+        default: 2g
         type: string
     steps:
       - cached-checkout
@@ -29,7 +29,7 @@ commands:
             export OPENNMS_VERSION="$(.circleci/scripts/pom2version.sh pom.xml)"
             .circleci/scripts/configure-signing.sh
             << parameters.node-memory >>
-            export MAVEN_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
+            export MAVEN_OPTS="-Xmx12g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
             MAVEN_ARGS="install"
             mkdir -p target/artifacts
             case "${CIRCLE_BRANCH}" in
@@ -62,9 +62,6 @@ commands:
                 tar -czf "../../artifacts/opennms-${OPENNMS_VERSION}-javadoc.tar.gz" *
               popd
             fi
-      # 90% of this is done just by the act of building, I'm not sure it's worth spending 7 minutes
-      # re-running an entire maven reactor build just to fill in a few missing assembly-only bits
-      # - update-maven-cache
       - run:
           name: Remove Extra Maven Repository OpenNMS Files
           command: |
@@ -72,6 +69,7 @@ commands:
             cd ~/.m2/repository/org/opennms
             mkdir /tmp/maven-keep
             mv $(ls -1 | grep -v -E '^(jicmp-api|jicmp6-api|jrrd-api|jrrd2-api|lib|maven)$') /tmp/maven-keep
+      - persist-project-changes
       - save-maven-cache
       - run:
           name: Restore Extra Maven Repository OpenNMS Files
@@ -85,7 +83,7 @@ commands:
       - persist_to_workspace:
           root: ~/
           paths:
-            - project
             - project/target/structure-graph.json
-            - .m2
+            - .m2/repository/org/opennms
+            # is this even necessary anymore?
             - .artifacts

--- a/.circleci/main/commands/executions/run-empty.yml
+++ b/.circleci/main/commands/executions/run-empty.yml
@@ -1,16 +1,6 @@
 commands:
   run-empty:
     description: "Run a simple ls command"
-    parameters:
-      number-vcpu:
-        default: 8
-        type: integer
-      node-memory:
-        default: echo "NODE_OPTIONS Not Set"
-        type: string
-      vaadin-javamaxmem:
-        default: 1g
-        type: string
     steps:
       - run:
           name: ls

--- a/.circleci/main/commands/executions/run-integration-tests.yml
+++ b/.circleci/main/commands/executions/run-integration-tests.yml
@@ -24,6 +24,7 @@ commands:
           background: true
           command: |
             free -m -c 500 -s 30
+      - restore-maven-cache
       - run:
           name: Integration Tests
           no_output_timeout: 15m

--- a/.circleci/main/commands/executions/run-smoke-tests.yml
+++ b/.circleci/main/commands/executions/run-smoke-tests.yml
@@ -27,6 +27,7 @@ commands:
           background: true
           command: |
             free -m -c 500 -s 30
+      - restore-maven-cache
       - run:
           name: Smoke Tests
           no_output_timeout: 30m

--- a/.circleci/main/commands/generic/generic.yml
+++ b/.circleci/main/commands/generic/generic.yml
@@ -5,19 +5,6 @@ commands:
         - run:
             name: Extract Maven POM version
             command: .circleci/scripts/pom2version.sh pom.xml > pom-version-cache.key
-  qemu-user-static:
-    steps:
-      - run:
-          name: multiarch/qemu-user-static
-          command: docker run --privileged multiarch/qemu-user-static --reset -p yes
-  install-buildx:
-    steps:
-      - run:
-          name: Install Docker buildx
-          command: |
-            sudo wget https://github.com/docker/buildx/releases/download/v0.9.1/buildx-v0.9.1.linux-amd64 -O /usr/local/bin/docker-buildx
-            sudo chmod a+x /usr/local/bin/docker-buildx
-            sudo systemctl restart docker
   download-download-artifacts:
     steps:
       - run:

--- a/.circleci/main/commands/maven/restore-maven-cache.yml
+++ b/.circleci/main/commands/maven/restore-maven-cache.yml
@@ -9,6 +9,3 @@ commands:
             keys:
               - maven-dependencies-v4-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
               - maven-dependencies-v4-{{ checksum "pom-version-cache.key" }}-
-        - run:
-            name: Remove old artifacts to keep workspace size down
-            command: .circleci/scripts/clean-m2.sh

--- a/.circleci/main/commands/maven/restore-maven-cache.yml
+++ b/.circleci/main/commands/maven/restore-maven-cache.yml
@@ -7,8 +7,8 @@ commands:
             command: find . -type f -name "pom.xml" | grep -v /target/ | sort -u | xargs cat > maven-dependency-pom-cache.key
         - restore_cache:
             keys:
-              - maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
-              - maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-
+              - maven-dependencies-v4-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
+              - maven-dependencies-v4-{{ checksum "pom-version-cache.key" }}-
         - run:
             name: Remove old artifacts to keep workspace size down
             command: .circleci/scripts/clean-m2.sh

--- a/.circleci/main/commands/maven/save-maven-cache.yml
+++ b/.circleci/main/commands/maven/save-maven-cache.yml
@@ -2,6 +2,9 @@ commands:
   save-maven-cache:
     description: "Maven: Save cache"
     steps:
+      - run:
+          name: Remove old artifacts to keep workspace size down
+          command: .circleci/scripts/clean-m2.sh
       - save_cache:
           key: maven-dependencies-v4-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
           paths:

--- a/.circleci/main/commands/maven/save-maven-cache.yml
+++ b/.circleci/main/commands/maven/save-maven-cache.yml
@@ -3,6 +3,6 @@ commands:
     description: "Maven: Save cache"
     steps:
       - save_cache:
-          key: maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
+          key: maven-dependencies-v4-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
           paths:
             - ~/.m2

--- a/.circleci/main/commands/oci/oci.yml
+++ b/.circleci/main/commands/oci/oci.yml
@@ -39,15 +39,24 @@ commands:
         type: string
       container_name:
         type: string
+      tarball_match:
+        type: string
+      tarball_path:
+        type: string
     steps:
-      - attach_workspace:
-          at: ~/
-      # - dockerhub-login
-      - qemu-user-static
-      - install-buildx
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - cached-checkout
+      - download-download-artifacts
+      - run:
+          name: download tarball dependency to << parameters.tarball_path >>
+          command: download-artifacts.pl --include-failed --workflow="${CIRCLE_WORKFLOW_ID}" --match="<< parameters.tarball_match >>" tar.gz "${CIRCLE_BRANCH}" "$(pwd)/<< parameters.tarball_path >>"
       - run:
           name: build << parameters.container_name >>=<< parameters.architecture >> container image
           command: |
+            # set up multi-arch
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "<< parameters.architecture >>"
+
             export DOCKER_CONTENT_TRUST=1
             cd opennms-container/<< parameters.container_name >>
             export ARCH="$(printf "<< parameters.architecture >>" | tr / -)"

--- a/.circleci/main/executors.yml
+++ b/.circleci/main/executors.yml
@@ -1,22 +1,16 @@
 executors:
-  centos-build-executor:
+  base-executor:
     docker:
-      - image: opennms/build-env:11.0.14_9-3.8.4-b8249
-  debian-build-executor:
+      - image: cimg/base:stable-20.04
+  build-executor:
     docker:
-      - image: opennms/build-env:debian-jdk11-b8243
-  docker-executor:
-    docker:
-      - image: docker:20.10-git
+      - image: opennms/build-env:circleci-ubuntu-jdk11-b8681
   docs-executor:
     docker:
       - image: opennms/antora:2.3.4-b7274
-  integration-test-executor:
-    machine:
-      image: ubuntu-2204:2022.07.1
   smoke-test-executor:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:current
   ui-executor:
     docker:
       - image: cimg/node:16.3.0

--- a/.circleci/main/jobs/build/build.yml
+++ b/.circleci/main/jobs/build/build.yml
@@ -1,11 +1,9 @@
 jobs:
   build:
-    executor: centos-build-executor
+    executor: build-executor
     # Building currently requires the xlarge containers in order for the webpack compilation
     # in the core/web-assets module to complete reliably
     resource_class: xlarge
     steps:
-      - attach_workspace:
-          at: ~/
       - run-build:
           number-vcpu: 8

--- a/.circleci/main/jobs/build/empty.yml
+++ b/.circleci/main/jobs/build/empty.yml
@@ -1,11 +1,8 @@
 jobs:
   empty:
-    executor: centos-build-executor
+    executor: cimg/base:stable
     # Building currently requires the xlarge containers in order for the webpack compilation
     # in the core/web-assets module to complete reliably
     resource_class: small
     steps:
-      - attach_workspace:
-          at: ~/
-      - run-empty:
-          number-vcpu: 8
+      - run-empty

--- a/.circleci/main/jobs/code-coverage.yml
+++ b/.circleci/main/jobs/code-coverage.yml
@@ -1,10 +1,12 @@
  jobs:
   code-coverage:
-    executor: centos-build-executor
+    executor: build-executor
     resource_class: large
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
+      - restore-maven-cache
       - extract-pom-version
       - restore-sonar-cache
       - run:

--- a/.circleci/main/jobs/create-merge-foundation-branch.yml
+++ b/.circleci/main/jobs/create-merge-foundation-branch.yml
@@ -1,6 +1,6 @@
  jobs:
   create-merge-foundation-branch:
-    <<: *docker_container_config
+    executor: base-executor
     steps:
       - run:
           name: "Branch Merge Parameters"

--- a/.circleci/main/jobs/create-merge-meridian-branch.yml
+++ b/.circleci/main/jobs/create-merge-meridian-branch.yml
@@ -7,9 +7,9 @@ jobs:
           steps:
             - restore_cache:
                 keys:
-                  - meridian-v1-{{ .Branch }}-{{ .Revision }}
-                  - meridian-v1-{{ .Branch }}-
-                  - meridian-v1-
+                  - meridian-v2-{{ .Branch }}-{{ .Revision }}
+                  - meridian-v2-{{ .Branch }}-
+                  - meridian-v2-
             - cached-checkout-for-pushing
             - run:
                 name: Add Meridian remote if necessary
@@ -23,7 +23,7 @@ jobs:
                 command: |
                   git fetch meridian
             - save_cache:
-                key: meridian-v1-{{ .Branch }}-{{ .Revision }}
+                key: meridian-v2-{{ .Branch }}-{{ .Revision }}
                 paths:
                   - ".git"
             - run:

--- a/.circleci/main/jobs/create-merge-meridian-branch.yml
+++ b/.circleci/main/jobs/create-merge-meridian-branch.yml
@@ -1,6 +1,6 @@
 jobs: 
   create-merge-meridian-branch:
-    <<: *docker_container_config
+    executor: base-executor
     steps:
       - when:
           condition: << pipeline.parameters.main_branch >>

--- a/.circleci/main/jobs/debian packages/horizon-deb-build.yml
+++ b/.circleci/main/jobs/debian packages/horizon-deb-build.yml
@@ -1,10 +1,12 @@
 jobs:
   horizon-deb-build:
-    executor: debian-build-executor
-    resource_class: xlarge
+    executor: build-executor
+    resource_class: large
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
+      - restore-maven-cache
       - sign-packages/setup-env:
           skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
@@ -18,7 +20,7 @@ jobs:
           command: |
             export NODE_OPTIONS=--max_old_space_size=1024
             export CCI_MAXCPU=2
-            export MAVEN_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
+            export MAVEN_OPTS="-Xmx5g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
             .circleci/scripts/makedeb.sh opennms
       - sign-packages/sign-debs:
           skip_if_forked_pr: true

--- a/.circleci/main/jobs/debian packages/minion-deb-build.yml
+++ b/.circleci/main/jobs/debian packages/minion-deb-build.yml
@@ -1,10 +1,12 @@
 jobs:
   minion-deb-build:
-    executor: debian-build-executor
-    resource_class: xlarge
+    executor: build-executor
+    resource_class: large
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
+      - restore-maven-cache
       - sign-packages/setup-env:
           skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
@@ -12,9 +14,9 @@ jobs:
           name: Build Debian Packages
           command: |
             export NODE_OPTIONS=--max_old_space_size=1024
-            export CCI_MAXCPU=4
+            export CCI_MAXCPU=2
             export CCI_VAADINJAVAMAXMEM=768m
-            export MAVEN_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
+            export MAVEN_OPTS="-Xmx5g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
             .circleci/scripts/makedeb.sh minion
       - sign-packages/sign-debs:
           skip_if_forked_pr: true

--- a/.circleci/main/jobs/debian packages/sentinel-deb-build.yml
+++ b/.circleci/main/jobs/debian packages/sentinel-deb-build.yml
@@ -1,10 +1,12 @@
 jobs:
   sentinel-deb-build:
-    executor: debian-build-executor
-    resource_class: xlarge
+    executor: build-executor
+    resource_class: large
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
+      - restore-maven-cache
       - sign-packages/setup-env:
           skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
@@ -12,9 +14,9 @@ jobs:
           name: Build Debian Packages
           command: |
             export NODE_OPTIONS=--max_old_space_size=1024
-            export CCI_MAXCPU=4
+            export CCI_MAXCPU=2
             export CCI_VAADINJAVAMAXMEM=768m
-            export MAVEN_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
+            export MAVEN_OPTS="-Xmx5g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
             .circleci/scripts/makedeb.sh sentinel
       - sign-packages/sign-debs:
           skip_if_forked_pr: true

--- a/.circleci/main/jobs/merge-foundation-branch.yml
+++ b/.circleci/main/jobs/merge-foundation-branch.yml
@@ -4,7 +4,7 @@ jobs:
   # it will include the contents of the `foundation-2017` branch, thus we need to actually
   # look _backwards_ to the previous_branch and main_branch to merge the correct bits.
   merge-foundation-branch:
-    <<: *docker_container_config
+    executor: base-executor
     steps:
       - run:
           name: "Branch Merge Parameters"

--- a/.circleci/main/jobs/merge-poweredby-branch.yml
+++ b/.circleci/main/jobs/merge-poweredby-branch.yml
@@ -7,14 +7,14 @@ jobs:
           steps:
             - restore_cache:
                 keys:
-                  - poweredby-v1-{{ .Branch }}-{{ .Revision }}
-                  - poweredby-v1-{{ .Branch }}-
-                  - poweredby-v1-
+                  - poweredby-v2-{{ .Branch }}-{{ .Revision }}
+                  - poweredby-v2-{{ .Branch }}-
+                  - poweredby-v2-
             - cached-checkout-for-pushing
             - run:
                 name: Merge Foundation to PoweredBy
                 command: .circleci/scripts/merge-poweredby.sh
             - save_cache:
-                key: poweredby-v1-{{ .Branch }}-{{ .Revision }}
+                key: poweredby-v2-{{ .Branch }}-{{ .Revision }}
                 paths:
                   - ".git"

--- a/.circleci/main/jobs/merge-poweredby-branch.yml
+++ b/.circleci/main/jobs/merge-poweredby-branch.yml
@@ -1,6 +1,6 @@
 jobs:
   merge-poweredby-branch:
-    <<: *docker_container_config
+    executor: base-executor
     steps:
       - when:
           condition: << pipeline.parameters.main_branch >>

--- a/.circleci/main/jobs/oci/horizon-image-single-arch-linux-amd64.yml
+++ b/.circleci/main/jobs/oci/horizon-image-single-arch-linux-amd64.yml
@@ -1,11 +1,12 @@
 jobs:
   horizon-image-single-arch-linux-amd64:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
+    executor: base-executor
+    resource_class: medium
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - build-image-single-arch:
           architecture: linux/amd64
           container_name: horizon
+          tarball_match: -core
+          tarball_path: opennms-full-assembly/target/

--- a/.circleci/main/jobs/oci/horizon-image-single-arch.yml
+++ b/.circleci/main/jobs/oci/horizon-image-single-arch.yml
@@ -1,14 +1,15 @@
 jobs:
   horizon-image-single-arch:
+    executor: base-executor
+    resource_class: medium
     parameters:
       architecture:
         type: string
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - build-image-single-arch:
           architecture: << parameters.architecture >>
           container_name: horizon
+          tarball_match: -core
+          tarball_path: opennms-full-assembly/target/

--- a/.circleci/main/jobs/oci/minion-image-single-arch-linux-amd64.yml
+++ b/.circleci/main/jobs/oci/minion-image-single-arch-linux-amd64.yml
@@ -1,14 +1,15 @@
 jobs:
   minion-image-single-arch-linux-amd64:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
+    executor: base-executor
+    resource_class: medium
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - build-image-single-arch:
           architecture: linux/amd64
           container_name: minion
+          tarball_match: minion
+          tarball_path: /opennms-assemblies/minion/target
       - run:
           name: copy minion config schema for archiving
           command: |

--- a/.circleci/main/jobs/oci/minion-image-single-arch.yml
+++ b/.circleci/main/jobs/oci/minion-image-single-arch.yml
@@ -1,14 +1,15 @@
 jobs:
   minion-image-single-arch:
+    executor: base-executor
+    resource_class: medium
     parameters:
       architecture:
         type: string
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - build-image-single-arch:
           architecture: << parameters.architecture >>
           container_name: minion
+          tarball_match: minion
+          tarball_path: /opennms-assemblies/minion/target

--- a/.circleci/main/jobs/oci/sentinel-image-single-arch-linux-amd64.yml
+++ b/.circleci/main/jobs/oci/sentinel-image-single-arch-linux-amd64.yml
@@ -1,11 +1,12 @@
 jobs:
   sentinel-image-single-arch-linux-amd64:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
+    executor: base-executor
+    resource_class: medium
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - build-image-single-arch:
           architecture: linux/amd64
           container_name: sentinel
+          tarball_match: sentinel
+          tarball_path: /opennms-assemblies/sentinel/target

--- a/.circleci/main/jobs/oci/sentinel-image-single-arch.yml
+++ b/.circleci/main/jobs/oci/sentinel-image-single-arch.yml
@@ -1,14 +1,15 @@
 jobs:  
   sentinel-image-single-arch:
+    executor: base-executor
+    resource_class: medium
     parameters:
       architecture:
         type: string
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - build-image-single-arch:
           architecture: << parameters.architecture >>
           container_name: sentinel
+          tarball_match: sentinel
+          tarball_path: /opennms-assemblies/sentinel/target

--- a/.circleci/main/jobs/publish.yml
+++ b/.circleci/main/jobs/publish.yml
@@ -7,8 +7,7 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - shallow-clone
-      - setup_remote_docker:
-          version: 20.10.11
+      - setup_remote_docker
       - cloudsmith/ensure-api-key
       - cloudsmith/install-cli
       - run:
@@ -20,13 +19,6 @@ jobs:
       - run:
           name: download resources from parent jobs
           command: |
-            sudo apt-get update
-            sudo apt-get -y install \
-              libdatetime-format-iso8601-perl \
-              libjson-pp-perl \
-              libwww-perl \
-              liblwp-protocol-https-perl
-
             for TYPE in oci rpm deb yml; do
               download-artifacts.pl \
                 --vault-layout \

--- a/.circleci/main/jobs/rpms/horizon-rpm-build.yml
+++ b/.circleci/main/jobs/rpms/horizon-rpm-build.yml
@@ -1,11 +1,12 @@
 jobs:
   horizon-rpm-build:
-    executor: centos-build-executor
-    # Larger memory footprint required to speed up builds using Takari smartbuilder
-    resource_class: xlarge
+    executor: build-executor
+    resource_class: large
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
+      - restore-maven-cache
       - sign-packages/setup-env:
           skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
@@ -13,8 +14,8 @@ jobs:
           name: Build RPMs
           command: |
             export NODE_OPTIONS=--max_old_space_size=1024
-            export CCI_MAXCPU=4
-            export MAVEN_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
+            export CCI_MAXCPU=2
+            export MAVEN_OPTS="-Xmx5g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
             .circleci/scripts/makerpm.sh tools/packages/opennms/opennms.spec
       - sign-packages/sign-rpms:
           skip_if_forked_pr: true

--- a/.circleci/main/jobs/rpms/minion-rpm-build.yml
+++ b/.circleci/main/jobs/rpms/minion-rpm-build.yml
@@ -1,12 +1,12 @@
 jobs:
   minion-rpm-build:
-    executor: centos-build-executor
-    # Larger memory footprint required to speed up builds using Takari smartbuilder
-    # Will need to increase resource class if horizon-rpm-build is under 15 min
-    resource_class: xlarge
+    executor: build-executor
+    resource_class: large
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
+      - restore-maven-cache
       - sign-packages/setup-env:
           skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
@@ -14,9 +14,9 @@ jobs:
           name: Build RPMs
           command: |
             export NODE_OPTIONS=--max_old_space_size=1024
-            export CCI_MAXCPU=4
+            export CCI_MAXCPU=2
             export CCI_VAADINJAVAMAXMEM=768m
-            export MAVEN_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
+            export MAVEN_OPTS="-Xmx5g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
             .circleci/scripts/makerpm.sh tools/packages/minion/minion.spec
       - sign-packages/sign-rpms:
           skip_if_forked_pr: true

--- a/.circleci/main/jobs/rpms/sentinel-rpm-build.yml
+++ b/.circleci/main/jobs/rpms/sentinel-rpm-build.yml
@@ -1,12 +1,12 @@
 jobs:
   sentinel-rpm-build:
-    executor: centos-build-executor
-    # Larger memory footprint required to speed up builds using Takari smartbuilder
-    # Will need to increase resource class if horizon-rpm-build is under 19 min
-    resource_class: xlarge
+    executor: build-executor
+    resource_class: large
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
+      - restore-maven-cache
       - sign-packages/setup-env:
           skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
@@ -14,9 +14,9 @@ jobs:
           name: Build RPMs
           command: |
             export NODE_OPTIONS=--max_old_space_size=1024
-            export CCI_MAXCPU=4
+            export CCI_MAXCPU=2
             export CCI_VAADINJAVAMAXMEM=768m
-            export MAVEN_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
+            export MAVEN_OPTS="-Xmx5g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
             .circleci/scripts/makerpm.sh tools/packages/sentinel/sentinel.spec
       - sign-packages/sign-rpms:
           skip_if_forked_pr: true

--- a/.circleci/main/jobs/tarball-assembly-only.yml
+++ b/.circleci/main/jobs/tarball-assembly-only.yml
@@ -1,8 +1,7 @@
 jobs:
   tarball-assembly-only:
-    machine:
-      image: ubuntu-2204:current
-    resource_class: xlarge
+    executor: build-executor
+    resource_class: large
     parameters:
       number-vcpu:
         default: 6
@@ -11,8 +10,10 @@ jobs:
         default: 1g
         type: string
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
+      - restore-maven-cache
       - run:
           name: Assemble tarballs and related artifacts
           command: |
@@ -44,15 +45,11 @@ jobs:
             mkdir -p target/{artifacts,config-schema,tarballs}
             OPENNMS_VERSION="$(.circleci/scripts/pom2version.sh pom.xml)"
             find ./target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/opennms-${OPENNMS_VERSION}.tar.gz" \;
+            find ./opennms-full-assembly/target -name "*-core.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/opennms-${OPENNMS_VERSION}-core.tar.gz" \;
             find ./opennms-assemblies/minion/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/minion-${OPENNMS_VERSION}.tar.gz" \;
             find ./opennms-assemblies/sentinel/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/sentinel-${OPENNMS_VERSION}.tar.gz" \;
             cp ./opennms-assemblies/xsds/target/*-xsds.tar.gz "./target/artifacts/opennms-${OPENNMS_VERSION}-xsds.tar.gz"
             cp target/*-source.tar.gz ./target/artifacts/
-            mkdir -p minion-target
-            tar czf minion-target/minion-target.tar.gz opennms-assemblies/minion/target/
-      - save-artifacts:
-          path: ~/project/minion-target
-          location: miniontarget
       - store_artifacts:
           when: always
           path: ~/project/target/artifacts
@@ -61,10 +58,3 @@ jobs:
           when: always
           path: ~/project/target/tarballs
           destination: tarballs
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - .artifacts
-            - project/opennms-full-assembly/target/opennms-full-assembly-*-core.tar.gz
-            - project/opennms-assemblies/minion/target/org.opennms.assemblies.minion-*-minion.tar.gz
-            - project/opennms-assemblies/sentinel/target/org.opennms.assemblies.sentinel-*-sentinel.tar.gz

--- a/.circleci/main/jobs/tests/integration/integration-test-with-coverage.yml
+++ b/.circleci/main/jobs/tests/integration/integration-test-with-coverage.yml
@@ -1,9 +1,10 @@
 jobs:
   integration-test-with-coverage:
-    executor: integration-test-executor
+    executor: build-executor
     parallelism: 10
     resource_class: xlarge
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
       - run-integration-tests:

--- a/.circleci/main/jobs/tests/integration/integration-test.yml
+++ b/.circleci/main/jobs/tests/integration/integration-test.yml
@@ -1,9 +1,10 @@
 jobs:
   integration-test:
-    executor: integration-test-executor
+    executor: build-executor
     parallelism: 8
     resource_class: xlarge
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
       - run-integration-tests:

--- a/.circleci/main/jobs/tests/smoke/smoke-test-core.yml
+++ b/.circleci/main/jobs/tests/smoke/smoke-test-core.yml
@@ -2,9 +2,6 @@
   smoke-test-core:
     executor: smoke-test-executor
     parallelism: 8
-    # No resource class support for machine executors, we're constrained to use the default
-    # medium class which has 2 vCPUs and 8 GB RAM
-    #resource_class: large
     steps:
       - run:
           name: "skip if flaky tests are enabled"
@@ -16,6 +13,7 @@
                 - << pipeline.parameters.trigger-flaky-smoke >>
                 - matches: { pattern: "^.*flaky.*$", value: << pipeline.git.branch >> }
           steps:
+            - cached-checkout
             - attach_workspace:
                 at: ~/
             - run-smoke-tests:

--- a/.circleci/main/jobs/tests/smoke/smoke-test-flaky.yml
+++ b/.circleci/main/jobs/tests/smoke/smoke-test-flaky.yml
@@ -2,9 +2,6 @@ jobs:
   smoke-test-flaky:
     executor: smoke-test-executor
     parallelism: 5
-    # No resource class support for machine executors, we're constrained to use the default
-    # medium class which has 2 vCPUs and 8 GB RAM
-    #resource_class: large
     steps:
       - run:
           name: "run if flaky tests are enabled"
@@ -15,6 +12,7 @@ jobs:
               - << pipeline.parameters.trigger-flaky-smoke >>
               - matches: { pattern: "^.*flaky.*$", value: << pipeline.git.branch >> }
           steps:
+            - cached-checkout
             - attach_workspace:
                 at: ~/
             - run-smoke-tests:

--- a/.circleci/main/jobs/tests/smoke/smoke-test-minimal.yml
+++ b/.circleci/main/jobs/tests/smoke/smoke-test-minimal.yml
@@ -2,6 +2,7 @@ jobs:
   smoke-test-minimal:
     executor: smoke-test-executor
     steps:
+      - cached-checkout
       - attach_workspace:
           at: ~/
       - run-smoke-tests:

--- a/.circleci/main/jobs/tests/smoke/smoke-test-minion.yml
+++ b/.circleci/main/jobs/tests/smoke/smoke-test-minion.yml
@@ -2,9 +2,6 @@
   smoke-test-minion:
     executor: smoke-test-executor
     parallelism: 4
-    # No resource class support for machine executors, we're constrained to use the default
-    # medium class which has 2 vCPUs and 8 GB RAM
-    #resource_class: large
     steps:
       - run:
           name: "skip if flaky tests are enabled"
@@ -16,6 +13,7 @@
                 - << pipeline.parameters.trigger-flaky-smoke >>
                 - matches: { pattern: "^.*flaky.*$", value: << pipeline.git.branch >> }
           steps:
+            - cached-checkout
             - attach_workspace:
                 at: ~/
             - run-smoke-tests:

--- a/.circleci/main/jobs/tests/smoke/smoke-test-sentinel.yml
+++ b/.circleci/main/jobs/tests/smoke/smoke-test-sentinel.yml
@@ -2,9 +2,6 @@
   smoke-test-sentinel:
     executor: smoke-test-executor
     parallelism: 5
-    # No resource class support for machine executors, we're constrained to use the default
-    # medium class which has 2 vCPUs and 8 GB RAM
-    #resource_class: large
     steps:
       - run:
           name: "skip if flaky tests are enabled"
@@ -16,6 +13,7 @@
                 - << pipeline.parameters.trigger-flaky-smoke >>
                 - matches: { pattern: "^.*flaky.*$", value: << pipeline.git.branch >> }
           steps:
+            - cached-checkout
             - attach_workspace:
                 at: ~/
             - run-smoke-tests:

--- a/.circleci/scripts/codecoverage-restore.sh
+++ b/.circleci/scripts/codecoverage-restore.sh
@@ -1,11 +1,12 @@
 #!/bin/sh -e
+
 cd ~/project
 for file in ~/code-coverage/target-*.zip; do
     FILENAME="$(basename "$file")"
     NUMBER="$(echo "$FILENAME" | cut -d. -f1 | cut -d- -f2-)"
     echo "* unpacking coverage reports $NUMBER:"
     unzip -qo "$file"
-    find . -type d -name failsafe-reports -o -name surefire-reports | while read DIR; do
+    find . -type d '!' -path './.git/*' -name failsafe-reports -o -name surefire-reports | while read -r DIR; do
       mkdir -p "${DIR}-${NUMBER}"
       mv "${DIR}"/* "${DIR}-${NUMBER}/"
       rm -rf "${DIR}"

--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -35,9 +35,6 @@ find_tests()
 echo "#### Making sure git is up-to-date"
 git fetch --all
 
-echo "#### Generate project structure .json"
-./compile.pl -s .circleci/scripts/structure-settings.xml --batch-mode --fail-at-end -Prun-expensive-tasks -Pbuild-bamboo org.opennms.maven.plugins:structure-maven-plugin:1.0:structure
-
 echo "#### Determining tests to run"
 cd ~/project
 find_tests

--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
+set -o pipefail
 
 # attempt to work around repository flakiness
 retry()
@@ -98,16 +99,16 @@ export MAVEN_OPTS="$MAVEN_OPTS -Xmx8g -XX:ReservedCodeCacheSize=1g"
 # shellcheck disable=SC3045
 ulimit -n 65536
 
-MAVEN_ARGS="install"
+MAVEN_ARGS=("install")
 
 case "${CIRCLE_BRANCH}" in
   "master"*|"release-"*|develop)
-    MAVEN_ARGS="-Dbuild.type=production $MAVEN_ARGS"
+    MAVEN_ARGS+=("-Dbuild.type=production")
   ;;
 esac
 
 echo "#### Building Assembly Dependencies"
-./compile.pl $MAVEN_ARGS \
+./compile.pl "${MAVEN_ARGS[@]}" \
            -P'!checkstyle' \
            -P'!production' \
            -Pbuild-bamboo \
@@ -122,7 +123,7 @@ echo "#### Building Assembly Dependencies"
            --projects "$(< /tmp/this_node_projects paste -s -d, -)"
 
 echo "#### Executing tests"
-./compile.pl $MAVEN_ARGS \
+./compile.pl "${MAVEN_ARGS[@]}" \
            -P'!checkstyle' \
            -P'!production' \
            -Pbuild-bamboo \

--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -14,8 +14,6 @@ find_tests()
     # Generate surefire & failsafe test list based on current
     # branch and the list of files changed
     # (The format of the output files contains the canonical class names i.e. org.opennms.core.soa.filter.FilterTest)
-    SYSTEM_PYTHON="$(python3 --version | sed -e 's,^Python *,,')"
-    pyenv local "${SYSTEM_PYTHON}"
     python3 .circleci/scripts/find-tests/find-tests.py generate-test-lists \
       --changes-only="${CCI_CHANGES_ONLY:-true}" \
       --output-unit-test-classes=surefire_classnames \
@@ -53,43 +51,16 @@ echo "#### Setting up Postgres"
 cd ~/project
 ./.circleci/scripts/postgres.sh
 
-echo "#### Installing other dependencies"
-# limit the sources we need to update
-sudo rm -f /etc/apt/sources.list.d/*
-
 # kill other apt commands first to avoid problems locking /var/lib/apt/lists/lock - see https://discuss.circleci.com/t/could-not-get-lock-var-lib-apt-lists-lock/28337/6
 sudo killall -9 apt || true && \
-            retry sudo apt update && \
-            retry sudo env DEBIAN_FRONTEND=noninteractive apt -y --no-install-recommends install \
-                ca-certificates \
-                tzdata \
-                software-properties-common \
-                debconf-utils
-
-# install some keys
-curl -sSf https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
-curl -sSf https://debian.opennms.org/OPENNMS-GPG-KEY | sudo tee -a /etc/apt/trusted.gpg.d/opennms_key.asc
-
-# limit more sources and add mirrors
-echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs) main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted" | sudo tee -a /etc/apt/sources.list
-sudo add-apt-repository -y 'deb http://debian.opennms.org stable main'
-
-# add the R repository
-sudo add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
-
 retry sudo apt update && \
             RRDTOOL_VERSION=$(apt-cache show rrdtool | grep Version: | grep -v opennms | awk '{ print $2 }') && \
-            echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections && \
-            retry sudo env DEBIAN_FRONTEND=noninteractive apt -f --no-install-recommends install \
-                r-base \
+            retry sudo /usr/local/bin/ghost-apt-install.sh \
                 "rrdtool=$RRDTOOL_VERSION" \
                 jrrd2 \
                 jicmp \
                 jicmp6 \
             || exit 1
-
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 export MAVEN_OPTS="$MAVEN_OPTS -Xmx8g -XX:ReservedCodeCacheSize=1g"
 

--- a/.circleci/scripts/lib-docker.sh
+++ b/.circleci/scripts/lib-docker.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 export DOCKER_CONTENT_TRUST=1
 
 export KEY_FOLDER="${HOME}/.docker/trust"
@@ -10,7 +12,8 @@ if [ -z "${DOCKER_SERVER}" ] || [ -z "${DOCKER_USERNAME}" ] || [ -z "${DOCKER_PA
 fi
 echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin "${DOCKER_SERVER}"
 
-export NOTARY_AUTH="$(printf "${DOCKER_USERNAME}:${DOCKER_PASSWORD}" | base64 -w0)"
+NOTARY_AUTH="$(printf '%s:%s' "${DOCKER_USERNAME}" "${DOCKER_PASSWORD}" | base64 -w0)"
+export NOTARY_AUTH
 
 # usage: create_and_push_manifest [registry] [source-tag] [target-tag]
 # ex: create_and_push_manifest docker.io "develop" "31-dev"
@@ -22,9 +25,9 @@ create_and_push_manifest() {
   local IMAGE_REF="${_repo}:${_source_tag}"
   local TARGET_REF="${_repo}:${_target_tag}"
   docker manifest create "${TARGET_REF}" \
-    ${IMAGE_REF}-linux-amd64 \
-    ${IMAGE_REF}-linux-arm64 \
-    ${IMAGE_REF}-linux-arm-v7 \
+    "${IMAGE_REF}-linux-amd64" \
+    "${IMAGE_REF}-linux-arm64" \
+    "${IMAGE_REF}-linux-arm-v7" \
     --amend
 
   DOCKER_IMAGE_SHA_256="$(docker manifest push "${TARGET_REF}" --purge | cut -d ':' -f 2)"
@@ -32,7 +35,7 @@ create_and_push_manifest() {
   echo "Image-Ref: ${IMAGE_REF}"
 
   MANIFEST_FROM_REG="$(docker manifest inspect "${TARGET_REF}" -v)";
-  DOCKER_IMAGE_BYTES_SIZE="$(printf "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor.size' | uniq)";
+  DOCKER_IMAGE_BYTES_SIZE="$(printf '%s' "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor.size' | uniq)";
   echo "Manifest-inspect BYTES: ${DOCKER_IMAGE_BYTES_SIZE}";
 
   #echo "Manifest contents:\n";

--- a/.circleci/scripts/lib.sh
+++ b/.circleci/scripts/lib.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 OPENNMS_POM_VERSION="$(~/project/.circleci/scripts/pom2version.sh ~/project/pom.xml || echo "0.0.0")"
+# shellcheck disable=SC2001
 OPENNMS_VERSION="$(echo "${OPENNMS_POM_VERSION}" | sed -e 's,^\([0-9\.][0-9\.]*\).*$,\1,g')"
 OPENNMS_SHORT_VERSION="$(echo "${OPENNMS_VERSION}" | cut -d. -f 1-2)"
 OPENNMS_MAJOR_VERSION="$(echo "${OPENNMS_VERSION}" | cut -d. -f1)"
@@ -43,6 +44,7 @@ fi
 
 # retry a command 3 times
 do_with_retries() {
+  # shellcheck disable=SC2034
   for try in 1 2 3; do
     if "$@"; then return 0; fi
   done

--- a/.circleci/scripts/makedeb.sh
+++ b/.circleci/scripts/makedeb.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-MYDIR="$(dirname "$0")"
-MYDIR="$(cd "$MYDIR" || exit 1; pwd)"
+MYDIR="$(cd "$(dirname "$0")" || exit 1; pwd)"
 
 if [ -z "$1" ]; then
 	echo "usage: $0 <package>"
@@ -11,7 +10,7 @@ fi
 
 PACKAGE_NAME="$1"
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "${MYDIR}/lib.sh"
 
 "$MYDIR/configure-signing.sh"

--- a/.circleci/scripts/makerpm.sh
+++ b/.circleci/scripts/makerpm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-MYDIR="$(dirname "$0")"
-MYDIR="$(cd "$MYDIR" || exit 1; pwd)"
+MYDIR="$(cd "$(dirname "$0")" || exit 1; pwd)"
 
 if [ -z "$1" ]; then
 	echo "usage: $0 <specfile>"
@@ -11,7 +10,7 @@ fi
 
 SPECFILE="$1"
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "${MYDIR}/lib.sh"
 
 "$MYDIR/configure-signing.sh"

--- a/.circleci/scripts/publish-azure.sh
+++ b/.circleci/scripts/publish-azure.sh
@@ -5,24 +5,27 @@ set -o pipefail
 
 MYDIR="$(cd "$(dirname "$0")"; pwd)"
 
+# shellcheck disable=SC1091
 . "${MYDIR}/lib.sh"
 
-echo "docker tags: ${DOCKER_TAGS[@]}"
+echo "docker tags: ${DOCKER_TAGS[*]}"
 echo ""
 
 export DOCKER_SERVER="opennmspubacr.azurecr.io"
 export DOCKER_USERNAME="${AZURE_SP}"
 export DOCKER_PASSWORD="${AZURE_SP_PASSWORD}"
 
+# shellcheck disable=SC1091
 . "${MYDIR}/lib-docker.sh"
 
-printf "${AZURE_DCT_CI_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${AZURE_DCT_CI_KEY_ID}.key"
-printf "${AZURE_DCT_REPO_MINION_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${AZURE_DCT_REPO_MINION_KEY_ID}.key"
+printf '%s' "${AZURE_DCT_CI_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${AZURE_DCT_CI_KEY_ID}.key"
+printf '%s' "${AZURE_DCT_REPO_MINION_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${AZURE_DCT_REPO_MINION_KEY_ID}.key"
 chmod 600 "${PRIVATE_KEY_FOLDER}"/*
 
 export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE="${AZURE_DCT_CI_PASSPHRASE}"
 docker trust key load "${PRIVATE_KEY_FOLDER}/${AZURE_DCT_CI_KEY_ID}.key"
 
+# shellcheck disable=SC2043
 for TYPE in minion; do
   export DOCKER_REPO="${DOCKER_SERVER}/opennms/${TYPE}"
 
@@ -30,7 +33,7 @@ for TYPE in minion; do
   find /tmp/artifacts/oci -name "${TYPE}-*.oci" | while read -r _file; do
     echo "* processing ${TYPE} image: ${_file}"
     _internal_tag="$(basename "${_file}" | sed -e 's,\.oci$,,')"
-    _arch_tag="$(printf "${_internal_tag}" | sed -e "s,^${TYPE}-,,")"
+    _arch_tag="$(printf '%s' "${_internal_tag}" | sed -e "s,^${TYPE}-,,")"
 
     _push_tag="${DOCKER_BRANCH_TAG}-${_arch_tag}"
     docker tag "${_internal_tag}" "${DOCKER_REPO}:${_push_tag}"

--- a/.circleci/scripts/publish-cloudsmith.sh
+++ b/.circleci/scripts/publish-cloudsmith.sh
@@ -46,12 +46,14 @@ for FILE in /tmp/artifacts/deb/*.deb; do
   cloudsmith push deb "${OPTS[@]}" "${PROJECT}/$REPO/any-distro/any-version" "$FILE"
 done
 
+# shellcheck disable=SC1091
 . "${MYDIR}/lib.sh"
 
 export DOCKER_SERVER="docker.cloudsmith.io"
 export DOCKER_USERNAME="${CLOUDSMITH_USERNAME}"
 export DOCKER_PASSWORD="${CLOUDSMITH_API_KEY}"
 
+# shellcheck disable=SC1091
 . "${MYDIR}/lib-docker.sh"
 
 export DOCKER_CONTENT_TRUST=0

--- a/.circleci/scripts/publish-dockerhub.sh
+++ b/.circleci/scripts/publish-dockerhub.sh
@@ -5,18 +5,20 @@ set -o pipefail
 
 MYDIR="$(cd "$(dirname "$0")"; pwd)"
 
+# shellcheck disable=SC1091
 . "${MYDIR}/lib.sh"
 
-echo "docker tags: ${DOCKER_TAGS[@]}"
+echo "docker tags: ${DOCKER_TAGS[*]}"
 echo ""
 
 export DOCKER_SERVER="docker.io"
 export DOCKER_USERNAME="${DOCKERHUB_LOGIN}"
 export DOCKER_PASSWORD="${DOCKERHUB_PASS}"
 
+# shellcheck disable=SC1091
 . "${MYDIR}/lib-docker.sh"
 
-printf "${DCT_DELEGATE_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${DCT_DELEGATE_KEY_NAME}.key"
+printf '%s' "${DCT_DELEGATE_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${DCT_DELEGATE_KEY_NAME}.key"
 chmod 600 "${PRIVATE_KEY_FOLDER}/${DCT_DELEGATE_KEY_NAME}.key"
 
 export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE="${DCT_DELEGATE_KEY_PASSPHRASE}"
@@ -26,19 +28,19 @@ for TYPE in horizon minion sentinel; do
   export DOCKER_REPO="${DOCKER_SERVER}/opennms/${TYPE}"
 
   # figure out DCT environment variables for $TYPE
-  _key_contents_variable="$(printf "DCT_REPO_${TYPE}_KEY" | tr '[:lower:]' '[:upper:]')"
-  _key_name_variable="$(printf "DCT_REPO_${TYPE}_KEY_NAME" | tr '[:lower:]' '[:upper:]')"
-  _key_passphrase_variable="$(printf "DCT_REPO_${TYPE}_KEY_PASSPHRASE" | tr '[:lower:]' '[:upper:]')"
+  _key_contents_variable="$(printf 'DCT_REPO_%s_KEY' "${TYPE}" | tr '[:lower:]' '[:upper:]')"
+  _key_name_variable="$(printf 'DCT_REPO_%s_KEY_NAME' "${TYPE}" | tr '[:lower:]' '[:upper:]')"
+  _key_passphrase_variable="$(printf 'DCT_REPO_%s_KEY_PASSPHRASE' "${TYPE}" | tr '[:lower:]' '[:upper:]')"
 
   # save $TYPE's key
-  printf "${!_key_contents_variable}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${!_key_name_variable}.key"
+  printf '%s' "${!_key_contents_variable}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${!_key_name_variable}.key"
   chmod 600 "${PRIVATE_KEY_FOLDER}/${!_key_name_variable}.key"
 
   # in dockerhub, only push the "branchname-arch" version of the individual ones
   find /tmp/artifacts/oci -name "${TYPE}-*.oci" | while read -r _file; do
     echo "* processing ${TYPE} image: ${_file}"
     _internal_tag="$(basename "${_file}" | sed -e 's,\.oci$,,')"
-    _arch_tag="$(printf "${_internal_tag}" | sed -e "s,^${TYPE}-,,")"
+    _arch_tag="$(printf '%s' "${_internal_tag}" | sed -e "s,^${TYPE}-,,")"
 
     _push_tag="${DOCKER_BRANCH_TAG}-${_arch_tag}"
     docker tag "${_internal_tag}" "${DOCKER_REPO}:${_push_tag}"

--- a/.circleci/scripts/release-lint.sh
+++ b/.circleci/scripts/release-lint.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-OPENNMS_FULL_VERSION="$1"; shift
-TYPE="$1"; shift
+if [ -n "$1" ]; then
+  OPENNMS_FULL_VERSION="$1"; shift
+fi
+
+if [ -n "$1" ]; then
+  TYPE="$1"; shift
+fi
 
 set -e
 

--- a/opennms-container/horizon/Makefile
+++ b/opennms-container/horizon/Makefile
@@ -29,8 +29,7 @@ help:
 	@echo "Makefile to build Horizon Docker container images and push to a registry."
 	@echo ""
 	@echo "Requirements to build images:"
-	@echo "  * Docker 18+"
-	@echo "  * Buildx CLI tools from https://github.com/docker/buildx/releases in search path as docker-buildx"
+	@echo "  * Docker 19.03+"
 	@echo "  * Horizon assembled with: ./assemble.pl -Dopennms.home=/opt/opennms -DskipTests"
 	@echo ""
 	@echo "Targets:"
@@ -62,19 +61,18 @@ help:
 	@echo ""
 
 test:
-	@echo "Test Docker Buildx installation and existence of the Horizon tarball ..."
+	@echo "Test Docker installation and existence of the Horizon tarball ..."
 	@command -v docker
-	@command -v docker-buildx
 	test -f ../../opennms-full-assembly/target/opennms-full-assembly-*-core.tar.gz
 
 build: test
 	@echo "Copy Horizon tarball to Docker context ..."
 	@mkdir -p tarball-root && tar -x -z -C ./tarball-root -f ../../opennms-full-assembly/target/opennms-full-assembly-*-core.tar.gz
 	@echo "Initialize builder instance ..."
-	if ! docker-buildx inspect $(DOCKERX_INSTANCE); then docker-buildx create --name $(DOCKERX_INSTANCE); fi;
-	docker-buildx use $(DOCKERX_INSTANCE)
+	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" "$(DOCKERX_INSTANCE)-context"; fi;
+	docker buildx use $(DOCKERX_INSTANCE)
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
-	docker-buildx build --platform=$(DOCKER_ARCH) \
+	docker buildx build --platform=$(DOCKER_ARCH) \
 	  --build-arg BASE_IMAGE=$(BASE_IMAGE) \
 	  --build-arg VERSION=$(VERSION) \
 	  --build-arg BUILD_DATE=$(BUILD_DATE) \
@@ -100,11 +98,11 @@ uninstall:
 
 clean:
 	@echo "Destroy builder environment: $(DOCKERX_INSTANCE) ..."
-	@docker-buildx rm $(DOCKERX_INSTANCE)
+	@docker buildx rm $(DOCKERX_INSTANCE)
 
 clean-all:
 	@echo "Destroy builder environment: $(DOCKERX_INSTANCE) ..."
-	@docker-buildx rm $(DOCKERX_INSTANCE) >/dev/null 2>&1 || :
+	@docker buildx rm $(DOCKERX_INSTANCE) >/dev/null 2>&1 || :
 	@echo "Delete tarball and artifacts ..."
 	@rm -rf images/*.oci
 	@rm -rf tarball-root

--- a/opennms-container/horizon/Makefile
+++ b/opennms-container/horizon/Makefile
@@ -63,14 +63,19 @@ help:
 test:
 	@echo "Test Docker installation and existence of the Horizon tarball ..."
 	@command -v docker
-	test -f ../../opennms-full-assembly/target/opennms-full-assembly-*-core.tar.gz
+	test -f ../../opennms-full-assembly/target/*-core.tar.gz
 
-build: test
-	@echo "Copy Horizon tarball to Docker context ..."
-	@mkdir -p tarball-root && tar -x -z -C ./tarball-root -f ../../opennms-full-assembly/target/opennms-full-assembly-*-core.tar.gz
+unpack-tarball: test
+	@if [ ! -e ./tarball-root/data/tmp/README ] || [ ../../opennms-full-assembly/target/*-core.tar.gz -nt ./tarball-root/data/tmp/README ]; then \
+	  echo "Unpacking Horizon tarball for Docker context..."; \
+	  mkdir -p tarball-root && \
+	  tar -x -z -C ./tarball-root -f ../../opennms-full-assembly/target/*-core.tar.gz && \
+	  touch ./tarball-root/data/tmp/README; \
+	fi
+
+build: test unpack-tarball
 	@echo "Initialize builder instance ..."
-	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" "$(DOCKERX_INSTANCE)-context"; fi;
-	docker buildx use $(DOCKERX_INSTANCE)
+	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" --driver docker-container --use "$(DOCKERX_INSTANCE)-context"; fi;
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
 	docker buildx build --platform=$(DOCKER_ARCH) \
 	  --build-arg BASE_IMAGE=$(BASE_IMAGE) \

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -36,8 +36,7 @@ help:
 	@echo "Makefile to build Minion Docker container images and push to a registry."
 	@echo ""
 	@echo "Requirements to build images:"
-	@echo "  * Docker 18+"
-	@echo "  * Buildx CLI tools from https://github.com/docker/buildx/releases in search path as docker-buildx"
+	@echo "  * Docker 19.03+"
 	@echo "  * Minion assembled with: ./assemble.pl -Dopennms.home=/opt/opennms -DskipTests"
 	@echo ""
 	@echo "Targets:"
@@ -71,17 +70,16 @@ help:
 test:
 	@echo "Test Docker Buildx installation and existence of the Minion tarball ..."
 	@command -v docker
-	@command -v docker-buildx
 	test -f ../../opennms-assemblies/minion/target/org.opennms.assemblies.minion-*-minion.tar.gz
 
 build: test minion-config-schema.yml
 	@echo "Copy Minion tarball to Docker context ..."
 	@mkdir -p tarball-root && tar -x -z --strip-components 1 -C ./tarball-root -f ../../opennms-assemblies/minion/target/org.opennms.assemblies.minion-*-minion.tar.gz
 	@echo "Initialize builder instance ..."
-	if ! docker-buildx inspect $(DOCKERX_INSTANCE); then docker-buildx create --name $(DOCKERX_INSTANCE); fi;
-	docker-buildx use $(DOCKERX_INSTANCE)
+	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" "$(DOCKERX_INSTANCE)-context"; fi;
+	docker buildx use $(DOCKERX_INSTANCE)
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
-	docker-buildx build --platform=$(DOCKER_ARCH) \
+	docker buildx build --platform=$(DOCKER_ARCH) \
 	  --build-arg BASE_IMAGE=$(BASE_IMAGE) \
 	  --build-arg VERSION=$(VERSION) \
 	  --build-arg BUILD_DATE=$(BUILD_DATE) \
@@ -107,7 +105,7 @@ uninstall:
 
 clean:
 	@echo "Destroy builder environment: $(DOCKERX_INSTANCE) ..."
-	@docker-buildx rm $(DOCKERX_INSTANCE) >/dev/null 2>&1 || :
+	@docker buildx rm $(DOCKERX_INSTANCE) >/dev/null 2>&1 || :
 
 clean-all: clean
 	@echo "Delete tarball and artifacts ..."

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -70,14 +70,19 @@ help:
 test:
 	@echo "Test Docker Buildx installation and existence of the Minion tarball ..."
 	@command -v docker
-	test -f ../../opennms-assemblies/minion/target/org.opennms.assemblies.minion-*-minion.tar.gz
+	test -f ../../opennms-assemblies/minion/target/*minion*.tar.gz
 
-build: test minion-config-schema.yml
-	@echo "Copy Minion tarball to Docker context ..."
-	@mkdir -p tarball-root && tar -x -z --strip-components 1 -C ./tarball-root -f ../../opennms-assemblies/minion/target/org.opennms.assemblies.minion-*-minion.tar.gz
+unpack-tarball: test
+	@if [ ! -e ./tarball-root/data/tmp/README ] || [ ../../opennms-assemblies/minion/target/*minion*.tar.gz -nt ./tarball-root/data/tmp/README ]; then \
+	  echo "Unpacking Minion tarball for Docker context..."; \
+	  mkdir -p tarball-root && \
+	  tar -x -z --strip-components 1 -C ./tarball-root -f ../../opennms-assemblies/minion/target/*minion*.tar.gz && \
+	  touch ./tarball-root/data/tmp/README; \
+	fi
+
+build: test unpack-tarball minion-config-schema.yml
 	@echo "Initialize builder instance ..."
-	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" "$(DOCKERX_INSTANCE)-context"; fi;
-	docker buildx use $(DOCKERX_INSTANCE)
+	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" --driver docker-container --use "$(DOCKERX_INSTANCE)-context"; fi;
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
 	docker buildx build --platform=$(DOCKER_ARCH) \
 	  --build-arg BASE_IMAGE=$(BASE_IMAGE) \

--- a/opennms-container/minion/build_container_image.sh
+++ b/opennms-container/minion/build_container_image.sh
@@ -15,7 +15,7 @@ cd "${MYDIR}"
 # shellcheck disable=SC1091
 source ../set-build-environment.sh
 
-TARBALL="$(find ../../opennms-assemblies/minion -name \*-minion.tar.gz -type f | head -n 1)"
+TARBALL="$(find ../../opennms-assemblies/minion -name \*minion\*.tar.gz -type f | head -n 1)"
 if [ -z "${TARBALL}" ]; then
   echo "unable to find minion tarball in opennms-assemblies"
   exit 1

--- a/opennms-container/sentinel/Makefile
+++ b/opennms-container/sentinel/Makefile
@@ -29,8 +29,7 @@ help:
 	@echo "Makefile to build Sentinel Docker container images and push to a registry."
 	@echo ""
 	@echo "Requirements to build images:"
-	@echo "  * Docker 18+"
-	@echo "  * Buildx CLI tools from https://github.com/docker/buildx/releases in search path as docker-buildx"
+	@echo "  * Docker 19.03+"
 	@echo "  * Sentinel assembled with: ./assemble.pl -Dopennms.home=/opt/opennms -DskipTests"
 	@echo ""
 	@echo "Targets:"
@@ -64,17 +63,16 @@ help:
 test:
 	@echo "Test Docker Buildx installation and existence of the Sentinel tarball ..."
 	@command -v docker
-	@command -v docker-buildx
 	test -f ../../opennms-assemblies/sentinel/target/org.opennms.assemblies.sentinel-*-sentinel.tar.gz
 
 build: test
 	@echo "Copy Sentinel tarball to Docker context ..."
 	@mkdir -p tarball-root && tar -x -z --strip-components 1 -C ./tarball-root -f ../../opennms-assemblies/sentinel/target/org.opennms.assemblies.sentinel-*-sentinel.tar.gz
 	@echo "Initialize builder instance ..."
-	if ! docker-buildx inspect $(DOCKERX_INSTANCE); then docker-buildx create --name $(DOCKERX_INSTANCE); fi;
-	docker-buildx use $(DOCKERX_INSTANCE)
+	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" "$(DOCKERX_INSTANCE)-context"; fi;
+	docker buildx use $(DOCKERX_INSTANCE)
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
-	docker-buildx build --platform=$(DOCKER_ARCH) \
+	docker buildx build --platform=$(DOCKER_ARCH) \
 	  --build-arg BASE_IMAGE=$(BASE_IMAGE) \
 	  --build-arg VERSION=$(VERSION) \
 	  --build-arg BUILD_DATE=$(BUILD_DATE) \
@@ -100,7 +98,7 @@ uninstall:
 
 clean:
 	@echo "Destroy builder environment: $(DOCKERX_INSTANCE) ..."
-	@docker-buildx rm $(DOCKERX_INSTANCE) >/dev/null 2>&1 || :
+	@docker buildx rm $(DOCKERX_INSTANCE) >/dev/null 2>&1 || :
 
 clean-all: clean
 	@echo "Delete tarball and artifacts ..."

--- a/opennms-container/sentinel/Makefile
+++ b/opennms-container/sentinel/Makefile
@@ -63,13 +63,21 @@ help:
 test:
 	@echo "Test Docker Buildx installation and existence of the Sentinel tarball ..."
 	@command -v docker
-	test -f ../../opennms-assemblies/sentinel/target/org.opennms.assemblies.sentinel-*-sentinel.tar.gz
+	test -f ../../opennms-assemblies/sentinel/target/*sentinel*.tar.gz
 
-build: test
+unpack-tarball: test
+	@if [ ! -e ./tarball-root/data/tmp/README ] || [ ../../opennms-assemblies/sentinel/target/*sentinel*.tar.gz -nt ./tarball-root/data/tmp/README ]; then \
+	  echo "Unpacking Sentinel tarball for Docker context..."; \
+	  mkdir -p tarball-root && \
+	  tar -x -z --strip-components 1 -C ./tarball-root -f ../../opennms-assemblies/sentinel/target/*sentinel*.tar.gz && \
+	  touch ./tarball-root/data/tmp/README; \
+	fi
+
+build: test unpack-tarball
 	@echo "Copy Sentinel tarball to Docker context ..."
-	@mkdir -p tarball-root && tar -x -z --strip-components 1 -C ./tarball-root -f ../../opennms-assemblies/sentinel/target/org.opennms.assemblies.sentinel-*-sentinel.tar.gz
+	@mkdir -p tarball-root && tar -x -z --strip-components 1 -C ./tarball-root -f ../../opennms-assemblies/sentinel/target/*sentinel*.tar.gz
 	@echo "Initialize builder instance ..."
-	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" "$(DOCKERX_INSTANCE)-context"; fi;
+	if ! docker buildx inspect $(DOCKERX_INSTANCE); then docker context create "$(DOCKERX_INSTANCE)-context" && docker buildx create --name "$(DOCKERX_INSTANCE)" --driver docker-container --use "$(DOCKERX_INSTANCE)-context"; fi;
 	docker buildx use $(DOCKERX_INSTANCE)
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
 	docker buildx build --platform=$(DOCKER_ARCH) \

--- a/opennms-container/sentinel/build_container_image.sh
+++ b/opennms-container/sentinel/build_container_image.sh
@@ -15,7 +15,7 @@ cd "${MYDIR}"
 # shellcheck disable=SC1091
 source ../set-build-environment.sh
 
-TARBALL="$(find ../../opennms-assemblies/sentinel -name \*-sentinel.tar.gz -type f | head -n 1)"
+TARBALL="$(find ../../opennms-assemblies/sentinel -name \*sentinel\*.tar.gz -type f | head -n 1)"
 if [ -z "${TARBALL}" ]; then
   echo "unable to find sentinel tarball in opennms-assemblies"
   exit 1

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -54,8 +54,9 @@ Source:        %{_name}-source-%{version}-%{releasenumber}.tar.gz
 URL:           http://www.opennms.org/wiki/Minion
 BuildRoot:     %{_tmppath}/%{name}-%{version}-root
 
-BuildRequires:	%{_java}
-BuildRequires:	libxslt
+# don't worry about buildrequires, the shell script will bomb quick  =)
+#BuildRequires:	%{_java}
+#BuildRequires:	libxslt
 
 Requires:       openssh
 Requires(pre):  /usr/bin/getent

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -54,8 +54,9 @@ Source:        %{_name}-source-%{version}-%{releasenumber}.tar.gz
 URL:           http://www.opennms.org/wiki/Sentinel
 BuildRoot:     %{_tmppath}/%{name}-%{version}-root
 
-BuildRequires:	%{_java}
-BuildRequires:	libxslt
+# don't worry about buildrequires, the shell script will bomb quick  =)
+#BuildRequires:	%{_java}
+#BuildRequires:	libxslt
 
 Requires:       openssh
 Requires(post): util-linux


### PR DESCRIPTION
This PR does a number of optimizations to our CircleCI workflows to attempt to minimize credit costs and network usage.

* only persist files to the workspace that are not already stored in git or maven caches
* replace most executor images with `cimg/base` where possible
* use new `build-env` for all package builds, based on CircleCI's `cimg/base`, to take advantage of cached layers
* no more machine types except smoke tests, which don't work with CircleCI's remote docker instances
* move (most) `apt-get` package installs to the build env
* docker image builds pull tarballs as artifacts, rather than attaching the workspace
* reduce resource class on docker image generation
* increase the amount of memory/CPU used by the `build` job to speed it up, since it can't be reduced to large (might as well use it all)

Total network usage went down by 2GB; also we are passing around less stuff in the workspace, but that is not accounted for in CircleCI's metrics. It probably actually went down by somewhere between 7 to 9 GB.

Image changes reduced the number of credits spent:
* `*-deb-*` and `*-rpm-*` jobs went from xlarge (40/min) to large (20/min)
* `tarball-assembly-only` went from machine xlarge (100/min) to docker large (20/min)
* `*-image-single-arch-linux-*` went from machine medium (10/min) to docker medium (10/min)