### PR TITLE
NMS-14773  Provide SubNetwork Classes for Enhanced Linkd

### DIFF
--- a/core/daemon/src/main/java/org/opennms/netmgt/scheduler/Executable.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/scheduler/Executable.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.scheduler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class Executable implements PriorityReadyRunnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Executable.class);
+
+    private boolean m_suspend = false;
+
+    private Integer m_priority = null;
+
+    public Integer getPriority() {
+          return m_priority;
+    }
+
+    public void setPriority(Integer priority) {
+        m_priority=priority;
+    }
+
+    public Executable() {
+    }
+
+    public Executable(int priority) {
+        m_priority=priority;
+    }
+
+    public abstract String getName();
+    public abstract void runExecutable();
+    
+    // run is called by a Thread for the runnable
+    // execute is where you got the stuff made
+    public void run() {
+        //if collection is suspended then
+        // schedule the collection
+        if (m_suspend) {
+            LOG.info( "run: suspended {}", 
+                      getInfo());
+            return;
+        }
+        LOG.info( "run: running {}", 
+                      getInfo());
+        runExecutable();
+    }
+
+    /**
+     * <p>
+     * suspend
+     * </p>
+     */
+    public void suspend() {
+        m_suspend = true;
+    }
+
+    /**
+     * <p>
+     * wakeUp
+     * </p>
+     */
+    public void wakeUp() {
+        m_suspend = false;
+    }
+
+    /**
+     * <p>
+     * getInfo
+     * </p>
+     * 
+     * @return a {@link java.lang.String} object.
+     */
+    public String getInfo() {
+        return  getName() + ": Priority: " + m_priority;
+    }
+
+}

--- a/core/daemon/src/main/java/org/opennms/netmgt/scheduler/LegacyPriorityExecutor.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/scheduler/LegacyPriorityExecutor.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.scheduler;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Comparator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.opennms.core.concurrent.LogPreservingThreadFactory;
+import org.opennms.core.fiber.PausableFiber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LegacyPriorityExecutor implements PausableFiber {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LegacyPriorityExecutor.class);
+
+    private final String m_parent;
+    private final ExecutorService priorityJobPoolExecutor;
+    private final PriorityBlockingQueue<PriorityReadyRunnable> priorityQueue;
+    private final ExecutorService m_worker = Executors.newSingleThreadExecutor();
+    private volatile int m_status;
+    public LegacyPriorityExecutor(String parent, Integer poolSize, Integer queueSize) {
+        m_parent=parent;
+        m_status = START_PENDING;
+        priorityJobPoolExecutor = Executors.newFixedThreadPool(poolSize, new LogPreservingThreadFactory(parent, poolSize));
+        priorityQueue = new PriorityBlockingQueue<>(
+                queueSize,
+                Comparator.comparing(PriorityReadyRunnable::getPriority));
+    }
+
+    public synchronized void addPriorityReadyRunnable(PriorityReadyRunnable job) {
+        priorityQueue.add(job);
+        LOG.info("addPriorityReadyRunnable: Added {}, total in queue: {}", job.getInfo(), priorityQueue.size());
+    }
+
+    @Override
+    public synchronized void pause() {
+        if (m_status == PAUSED) {
+            return;
+        }
+        m_status=PAUSE_PENDING;
+        notifyAll();
+    }
+
+    @Override
+    public synchronized void resume() {
+        if (m_status == RUNNING) {
+            return;
+        }
+        m_status=RESUME_PENDING;
+        notifyAll();
+    }
+
+    @Override
+    public void start() {
+        m_worker.execute(() -> {
+            synchronized (this) {
+                m_status = RUNNING;
+            }
+            LOG.info("run: Priority Executor {} running", m_parent);
+
+            while (true) {
+                try {
+                    LOG.debug("Taking");
+                    PriorityReadyRunnable executable = priorityQueue.take();
+                    LOG.debug("Taked: {}", executable.getInfo());
+                    while (m_status == PAUSE_PENDING || m_status == PAUSED) {
+                        if (m_status == PAUSE_PENDING) {
+                            LOG.info("run: pausing.");
+                        }
+                        m_status = PAUSED;
+                        synchronized (this) {
+                                wait();
+                        }
+                    }
+                    if (m_status == STOP_PENDING) {
+                        LOG.info("run: status = {}, time to exit", m_status);
+                        break;
+                    }
+                    if (m_status == RESUME_PENDING) {
+                        LOG.info("run: resuming.");
+                        m_status = RUNNING;
+                    }
+                    if (executable.isReady()) {
+                        priorityJobPoolExecutor.execute(executable);
+                        LOG.debug("run: added to priority job executor thread pool: {}", executable.getInfo());
+                        if (priorityJobPoolExecutor instanceof ThreadPoolExecutor) {
+                            ThreadPoolExecutor e = (ThreadPoolExecutor) priorityJobPoolExecutor;
+                            String ratio = String.format("%.3f",e.getTaskCount() > 0 ? BigDecimal.valueOf(e.getCompletedTaskCount()).divide(BigDecimal.valueOf(e.getTaskCount()), 2, RoundingMode.DOWN) : 0) ;
+                            LOG.debug("thread pool statistics: activeCount={}, taskCount={}, completedTaskCount={}, completedRatio={}, poolSize={}",
+                                    e.getActiveCount(), e.getTaskCount(), e.getCompletedTaskCount(), ratio, e.getPoolSize());
+                        }
+                    } else {
+                        executable.setPriority(executable.getPriority() + 1);
+                        addPriorityReadyRunnable(executable);
+                    }
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+        });
+
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (m_status == STOP_PENDING) {
+            return;
+        }
+        m_status=STOP_PENDING;
+        priorityJobPoolExecutor.shutdown();
+        m_worker.shutdown();
+    }
+
+    @Override
+    public synchronized int getStatus() {
+        if (m_worker.isShutdown()) {
+            m_status=STOPPED;
+        }
+        return m_status;
+    }
+
+
+    @Override
+    public String getName() {
+        return  priorityJobPoolExecutor.toString();
+    }
+
+}

--- a/core/daemon/src/main/java/org/opennms/netmgt/scheduler/PriorityReadyRunnable.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/scheduler/PriorityReadyRunnable.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.scheduler;
+
+import org.opennms.netmgt.scheduler.ReadyRunnable;
+
+public interface PriorityReadyRunnable extends ReadyRunnable {
+    void setPriority(Integer priority);
+    Integer getPriority();
+    String getInfo();
+}

--- a/core/daemon/src/main/java/org/opennms/netmgt/scheduler/Schedulable.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/scheduler/Schedulable.java
@@ -26,23 +26,14 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.enlinkd.common;
+package org.opennms.netmgt.scheduler;
 
-import org.opennms.netmgt.scheduler.LegacyScheduler;
-import org.opennms.netmgt.scheduler.ReadyRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * This class is designed to collect the necessary SNMP information from the
- * target address and store the collected information. When the class is
- * initially constructed no information is collected. The SNMP Session
- * creating and collection occurs in the main run method of the instance. This
- * allows the collection to occur in a thread if necessary.
- */
-public abstract class Discovery implements ReadyRunnable {
+public abstract class Schedulable implements ReadyRunnable {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Discovery.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Schedulable.class);
 
     /**
      * The scheduler object
@@ -53,34 +44,31 @@ public abstract class Discovery implements ReadyRunnable {
      * The interval, default value 30 minutes
      */
     private long m_poll_interval = 1800000;
-    private long m_initial_sleep_time = 600000;
-
     /**
      * The initial sleep time, default value 5 minutes
      */
+    private long m_initial_sleep_time = 600000;
 
     private boolean m_suspendCollection = false;
     private boolean m_unschedule = false;
     
     /**
-     * Constructs a new SNMP collector for a node using the passed interface
-     * as the collection point. The collection does not occur until the
-     * <code>run</code> method is invoked.
-     * 
+     * Constructs a new Schedulable
+     *
      * @param interval the time in msec between collections
      * @param initial the time in msec wait before performing a collection at all
-     *            The SnmpPeer object to collect from.
+     *
      */
-    public Discovery(long interval, long initial) {
+    public Schedulable(long interval, long initial) {
         m_poll_interval = interval;
         m_initial_sleep_time = initial;
     }
 
-    public Discovery() {
+    public Schedulable() {
     }
 
     public abstract String getName();
-    public abstract void runDiscovery();
+    public abstract void runSchedulable();
     
     // run is called by a Thread for the runnable
     // execute is where you got the stuff made
@@ -102,7 +90,7 @@ public abstract class Discovery implements ReadyRunnable {
         }
         LOG.info( "run: running {}", 
                       getInfo());
-        runDiscovery();            
+        runSchedulable();
         reschedule();
     }
 
@@ -222,7 +210,7 @@ public abstract class Discovery implements ReadyRunnable {
                     return false;
             if (getClass() != obj.getClass())
                     return false;
-            Discovery other = (Discovery) obj;
+            Schedulable other = (Schedulable) obj;
             if (m_initial_sleep_time != other.m_initial_sleep_time)
                     return false;
         return m_poll_interval == other.m_poll_interval;

--- a/core/daemon/src/main/java/org/opennms/netmgt/scheduler/SchedulableExecutableGroup.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/scheduler/SchedulableExecutableGroup.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.scheduler;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+
+public class SchedulableExecutableGroup extends Schedulable {
+    private static final Logger LOG = LoggerFactory.getLogger(SchedulableExecutableGroup.class);
+
+    private final Set<Executable> m_executables = new HashSet<>();
+
+    /**
+     *  The Executor Group
+     *  this will execute discovery
+     */
+    private final LegacyPriorityExecutor m_executor;
+
+    /**
+     * priority for executing runnables
+     */
+    private Integer m_priority;
+
+    /**
+     * name under which are executed runnables
+     */
+    private final String m_name;
+
+    /**
+     * Constructs a new Group of Collection. The collection is not scheduled until the
+     * <code>run</code> method is invoked.
+     *
+     * @param interval the time in msec between group of collections
+     * @param initial the time in msec wait before performing a collection at all
+     * @param executor the executor service that will perform the single collections
+     * @param priority the priority for executables
+     * @param name a unique name that identifies this group
+     */
+    public SchedulableExecutableGroup(long interval, long initial, LegacyPriorityExecutor executor, int priority, String name) {
+        super(interval,initial);
+        Assert.notNull(executor);
+        Assert.notNull(name);
+        m_executor=executor;
+        m_priority=priority;
+        m_name=name;
+    }
+
+    public String getName() {
+        return m_name;
+    }
+
+    public Integer getPriority() {
+        return m_priority;
+    }
+
+    public void setPriority(Integer priority) {
+        m_priority = priority;
+    }
+
+
+    public Set<Executable> getExecutables() {
+        return m_executables;
+    }
+
+
+    public void add(Executable discovery, Integer priority) {
+        synchronized (m_executables) {
+            if (m_executables.add(discovery)) {
+                discovery.setPriority(m_priority+priority);
+                LOG.info("add: {}", discovery.getInfo());
+            }
+        }
+    }
+
+    public void add(Executable discovery) {
+        synchronized (m_executables) {
+            if (m_executables.add(discovery)) {
+                discovery.setPriority(m_priority);
+                LOG.info("add: {}", discovery.getInfo());
+            }
+        }
+    }
+
+    public void remove(Executable discovery) {
+        synchronized (m_executables) {
+            if (m_executables.remove(discovery)) {
+                LOG.info("remove: {}", discovery.getInfo());
+                discovery.setPriority(null);
+            }
+        }
+    }
+
+    public void clear() {
+        synchronized (m_executables) {
+            m_executables.clear();
+        }
+    }
+
+    @Override
+    public void runSchedulable() {
+        LOG.info("run: {}", m_name);
+        m_executables.forEach(m_executor::addPriorityReadyRunnable);
+    }
+
+}

--- a/core/daemon/src/test/java/org/opennms/netmgt/scheduler/ExecutableTest.java
+++ b/core/daemon/src/test/java/org/opennms/netmgt/scheduler/ExecutableTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.scheduler;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExecutableTest extends Executable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutableTest.class);
+
+    private final String m_name;
+    public ExecutableTest(String name) {
+        super();
+        m_name=name;
+    }
+
+    public ExecutableTest(String name, int priority) {
+        super(priority);
+        m_name=name;
+    }
+
+    @Override
+    public String getName() {
+        return m_name;
+    }
+
+    @Override
+    public void runExecutable() {
+        LOG.info("Started: {}", m_name);
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        LOG.info("Ended: {}", m_name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ExecutableTest that = (ExecutableTest) o;
+
+        return Objects.equals(m_name, that.m_name);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (m_name != null ? m_name.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+}
+

--- a/core/daemon/src/test/java/org/opennms/netmgt/scheduler/LegacyPriorityExecutorTest.java
+++ b/core/daemon/src/test/java/org/opennms/netmgt/scheduler/LegacyPriorityExecutorTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.scheduler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Properties;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.core.fiber.PausableFiber;
+import org.opennms.core.test.MockLogAppender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LegacyPriorityExecutorTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LegacyPriorityExecutorTest.class);
+
+    @Before
+    public void setUp() {
+        Properties p = new Properties();
+        p.setProperty("log4j.logger.org.opennms.netmgt.scheduler", "DEBUG");
+        MockLogAppender.setupLogging(p);
+    }
+
+    @Test
+    public void testRun() {
+        ExecutableTest discoveryTestA = new ExecutableTest("testA");
+        discoveryTestA.setPriority(9);
+        assertTrue(discoveryTestA.isReady());
+        discoveryTestA.run();
+    }
+
+    @Test
+    public void testPauseAndResume() throws InterruptedException {
+        LegacyPriorityExecutor executor = new LegacyPriorityExecutor("CollectorGroupTest", 2, 5);
+        executor.addPriorityReadyRunnable(new ExecutableTest("A",10) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("B",10) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("C",20) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("D",20) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("E",20) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("F",30) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("G",30) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("H",30) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("I",40) );
+        executor.addPriorityReadyRunnable(new ExecutableTest("L",40) );
+
+        executor.start();
+        Thread.sleep(2);
+        executor.pause();
+        assertEquals(PausableFiber.PAUSE_PENDING, executor.getStatus());
+        Thread.sleep(3000);
+        assertEquals(PausableFiber.PAUSED, executor.getStatus());
+        executor.resume();
+        assertEquals(PausableFiber.RESUME_PENDING, executor.getStatus());
+        Thread.sleep(200);
+        assertEquals(PausableFiber.RUNNING, executor.getStatus());
+        Thread.sleep(5000);
+
+    }
+
+    @Test
+    public void testPriorityBlockingQueueOrder() {
+        PriorityBlockingQueue<Integer> queue = new PriorityBlockingQueue<>();
+        ArrayList<Integer> polledElements = new ArrayList<>();
+
+        queue.add(1);
+        queue.add(5);
+        queue.add(2);
+        queue.add(3);
+        queue.add(4);
+
+        queue.drainTo(polledElements);
+
+        assertEquals(polledElements.get(0).intValue(),1);
+        assertEquals(polledElements.get(1).intValue(),2);
+        assertEquals(polledElements.get(2).intValue(),3);
+        assertEquals(polledElements.get(3).intValue(),4);
+        assertEquals(polledElements.get(4).intValue(),5);
+    }
+
+    @Test
+    public void testPriorityBlockingQueueTake() throws InterruptedException {
+        PriorityBlockingQueue<Integer> queue = new PriorityBlockingQueue<>();
+
+        new Thread(() -> {
+            LOG.info("Polling...");
+            while(true) {
+            try {
+                LOG.info("Taking");
+                Integer poll = queue.take();
+                LOG.info("Taked: " + poll);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+
+            }            }
+        }).start();
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+        LOG.info("Adding to queue");
+        queue.add(1);
+        queue.add(2);
+        queue.add(3);
+    }
+}

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpGetter.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpGetter.java
@@ -26,16 +26,12 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.enlinkd.snmp;
+package org.opennms.netmgt.snmp;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.opennms.netmgt.snmp.SnmpAgentConfig;
-import org.opennms.netmgt.snmp.SnmpObjId;
-import org.opennms.netmgt.snmp.SnmpValue;
-import org.opennms.netmgt.snmp.TableTracker;
 import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/features/enlinkd/adapters/collectors/cdp/src/main/java/org/opennms/netmgt/enlinkd/snmp/CdpInterfacePortNameGetter.java
+++ b/features/enlinkd/adapters/collectors/cdp/src/main/java/org/opennms/netmgt/enlinkd/snmp/CdpInterfacePortNameGetter.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.enlinkd.snmp;
 
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpGetter;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;

--- a/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpLocPortGetter.java
+++ b/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpLocPortGetter.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.enlinkd.snmp;
 import org.opennms.core.utils.LldpUtils.LldpPortIdSubType;
 import org.opennms.netmgt.enlinkd.model.LldpLink;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpGetter;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;

--- a/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/TimeTetraLldpLocPortGetter.java
+++ b/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/TimeTetraLldpLocPortGetter.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.enlinkd.snmp;
 import org.opennms.core.utils.LldpUtils;
 import org.opennms.netmgt.enlinkd.model.LldpLink;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpGetter;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;

--- a/features/enlinkd/adapters/collectors/ospf/src/main/java/org/opennms/netmgt/enlinkd/snmp/OspfIpAddrTableGetter.java
+++ b/features/enlinkd/adapters/collectors/ospf/src/main/java/org/opennms/netmgt/enlinkd/snmp/OspfIpAddrTableGetter.java
@@ -36,6 +36,7 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.enlinkd.model.OspfElement;
 import org.opennms.netmgt.enlinkd.model.OspfLink;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpGetter;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;

--- a/features/enlinkd/adapters/common/src/main/java/org/opennms/netmgt/enlinkd/common/NodeCollector.java
+++ b/features/enlinkd/adapters/common/src/main/java/org/opennms/netmgt/enlinkd/common/NodeCollector.java
@@ -34,6 +34,7 @@ import java.net.InetAddress;
 
 import org.opennms.netmgt.config.SnmpPeerFactory;
 import org.opennms.netmgt.enlinkd.service.api.Node;
+import org.opennms.netmgt.scheduler.Schedulable;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;
 
@@ -44,7 +45,7 @@ import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;
  * creating and collection occurs in the main run method of the instance. This
  * allows the collection to occur in a thread if necessary.
  */
-public abstract class NodeCollector extends Discovery {
+public abstract class NodeCollector extends Schedulable {
     /**
      * The node ID of the system used to collect the SNMP information
      */
@@ -77,7 +78,7 @@ public abstract class NodeCollector extends Discovery {
      * thread context synchronization must be added.
      * </p>
      */
-    public void runDiscovery() {
+    public void runSchedulable() {
             collect();
     }
 

--- a/features/enlinkd/adapters/common/src/main/java/org/opennms/netmgt/enlinkd/common/TopologyUpdater.java
+++ b/features/enlinkd/adapters/common/src/main/java/org/opennms/netmgt/enlinkd/common/TopologyUpdater.java
@@ -40,6 +40,7 @@ import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
 import org.opennms.netmgt.enlinkd.service.api.Topology;
 import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.PrimaryType;
+import org.opennms.netmgt.scheduler.Schedulable;
 import org.opennms.netmgt.topologies.service.api.OnmsTopology;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyDao;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyMessage;
@@ -53,7 +54,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
-public abstract class TopologyUpdater extends Discovery implements OnmsTopologyUpdater {
+public abstract class TopologyUpdater extends Schedulable implements OnmsTopologyUpdater {
 
     public static OnmsTopologyProtocol create(ProtocolSupported protocol) {
             return OnmsTopologyProtocol.create(protocol.name());
@@ -138,7 +139,7 @@ public abstract class TopologyUpdater extends Discovery implements OnmsTopologyU
     }
 
     @Override
-    public synchronized void runDiscovery() {
+    public synchronized void runSchedulable() {
         LOG.debug("run: start {}", getName());
         final OnmsTopology oldTopology = m_topology.clone();
         final OnmsTopology newTopology = runDiscoveryInternally(oldTopology);

--- a/features/enlinkd/adapters/discovers/bridge/src/main/java/org/opennms/netmgt/enlinkd/DiscoveryBridgeDomains.java
+++ b/features/enlinkd/adapters/discovers/bridge/src/main/java/org/opennms/netmgt/enlinkd/DiscoveryBridgeDomains.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.opennms.netmgt.enlinkd.common.Discovery;
+import org.opennms.netmgt.scheduler.Schedulable;
 import org.opennms.netmgt.enlinkd.service.api.BridgeForwardingTableEntry;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyException;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;
@@ -50,7 +50,7 @@ import org.opennms.netmgt.enlinkd.service.api.DiscoveryBridgeTopology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DiscoveryBridgeDomains extends Discovery {
+public class DiscoveryBridgeDomains extends Schedulable {
 
     public static final int DOMAIN_MATCH_MIN_SIZE = 20;
     public static final float DOMAIN_MATCH_MIN_RATIO = 0.5f;
@@ -120,7 +120,7 @@ public class DiscoveryBridgeDomains extends Discovery {
     }
     
     @Override
-    public void runDiscovery() {
+    public void runSchedulable() {
         LOG.info("run: calculate topology on broadcast domains. Start");
         
         Map<Integer, Map<Integer, Set<BridgeForwardingTableEntry>>> nodeondomainbft 

--- a/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
+++ b/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
@@ -42,7 +42,7 @@ import org.opennms.netmgt.config.EnhancedLinkdConfig;
 import org.opennms.netmgt.config.datacollection.SnmpCollection;
 import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.enlinkd.api.ReloadableTopologyDaemon;
-import org.opennms.netmgt.enlinkd.common.Discovery;
+import org.opennms.netmgt.scheduler.Schedulable;
 import org.opennms.netmgt.enlinkd.common.NodeCollector;
 import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;
@@ -382,7 +382,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
     }
 
     public void runDiscoveryBridgeDomains() {
-            m_discoveryBridgeDomains.runDiscovery();
+            m_discoveryBridgeDomains.runSchedulable();
     }
 
     public void forceTopologyUpdaterRun(ProtocolSupported proto) {
@@ -436,40 +436,40 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
         switch (proto) {
             case CDP:
                 if (m_linkdConfig.useCdpDiscovery()) {
-                    m_cdpTopologyUpdater.runDiscovery();
+                    m_cdpTopologyUpdater.runSchedulable();
                 }
                 break;
       
             case LLDP:
                 if (m_linkdConfig.useLldpDiscovery()) {
-                    m_lldpTopologyUpdater.runDiscovery();
+                    m_lldpTopologyUpdater.runSchedulable();
                 }
                 break;
             
             case ISIS:
                 if (m_linkdConfig.useIsisDiscovery()) {
-                    m_isisTopologyUpdater.runDiscovery();
+                    m_isisTopologyUpdater.runSchedulable();
                 }
                 break;
             
             case OSPF:
                 if (m_linkdConfig.useOspfDiscovery()) {
-                    m_ospfTopologyUpdater.runDiscovery();
+                    m_ospfTopologyUpdater.runSchedulable();
                 }
                 break;
             
             case BRIDGE:
                 if (m_linkdConfig.useBridgeDiscovery()) {
-                    m_bridgeTopologyUpdater.runDiscovery();
+                    m_bridgeTopologyUpdater.runSchedulable();
                 }
                 break;
 
             case NODES:
-                m_nodesTopologyUpdater.runDiscovery();
+                m_nodesTopologyUpdater.runSchedulable();
                 break;
 
             case USERDEFINED:
-                m_userDefinedLinkTopologyUpdater.runDiscovery();
+                m_userDefinedLinkTopologyUpdater.runSchedulable();
                 break;
 
             default:
@@ -486,7 +486,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
             scheduleNodeCollection(nodeid);
             return;
         } 
-        m_nodes.get(nodeid).forEach(Discovery::wakeUp);
+        m_nodes.get(nodeid).forEach(Schedulable::wakeUp);
     }
 
     public void addNode() {
@@ -513,7 +513,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
         synchronized (m_nodes) {
             if (m_nodes.containsKey(nodeid)) {
                 m_nodes.remove(nodeid).
-                forEach(Discovery::unschedule);
+                forEach(Schedulable::unschedule);
             }        
         }
     }
@@ -531,7 +531,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
                         nodeid);   
         synchronized (m_nodes) {
                if (m_nodes.containsKey(nodeid)) {
-                   m_nodes.get(nodeid).forEach(Discovery::suspend);
+                   m_nodes.get(nodeid).forEach(Schedulable::suspend);
                } 
         }
     }

--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/IpInterfaceTopologyEntity.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/IpInterfaceTopologyEntity.java
@@ -41,16 +41,18 @@ import org.opennms.netmgt.model.ReadOnlyEntity;
 public class IpInterfaceTopologyEntity {
     private final Integer id;
     private final InetAddress ipAddress;
+    private final InetAddress netMask;
     private final String isManaged;
     private final PrimaryType isSnmpPrimary;
     private final Integer nodeId;
     private final Integer snmpInterfaceId;
 
     public IpInterfaceTopologyEntity(Integer id,
-            InetAddress ipAddress, String isManaged, PrimaryType isSnmpPrimary, Integer nodeId,
+            InetAddress ipAddress, InetAddress netMask, String isManaged, PrimaryType isSnmpPrimary, Integer nodeId,
             Integer snmpInterfaceId){
         this.id = id;
         this.ipAddress = ipAddress;
+        this.netMask = netMask;
         this.isManaged = isManaged;
         this.isSnmpPrimary = isSnmpPrimary;
         this.nodeId = nodeId;
@@ -58,15 +60,16 @@ public class IpInterfaceTopologyEntity {
     }
 
     public IpInterfaceTopologyEntity(Integer id,
-            InetAddress ipAddress, String isManaged, String snmpPrimary, Integer nodeId,
+            InetAddress ipAddress, InetAddress netMask, String isManaged, String snmpPrimary, Integer nodeId,
             Integer snmpInterfaceId){
-        this(id, ipAddress, isManaged, PrimaryType.get(snmpPrimary), nodeId, snmpInterfaceId);
+        this(id, ipAddress, netMask, isManaged, PrimaryType.get(snmpPrimary), nodeId, snmpInterfaceId);
     }
 
     public static IpInterfaceTopologyEntity create(OnmsIpInterface ipInterface) {
         return new IpInterfaceTopologyEntity(
                 ipInterface.getId(),
                 ipInterface.getIpAddress(),
+                ipInterface.getNetMask(),
                 ipInterface.getIsManaged(),
                 ipInterface.getIsSnmpPrimary(),
                 Optional.ofNullable(ipInterface.getNode()).map(OnmsNode::getId).orElse(null),
@@ -86,6 +89,10 @@ public class IpInterfaceTopologyEntity {
 
     public InetAddress getIpAddress() {
         return ipAddress;
+    }
+
+    public InetAddress getNetMask() {
+        return netMask;
     }
 
     public String getIsManaged() {
@@ -117,6 +124,7 @@ public class IpInterfaceTopologyEntity {
         return "IpInterfaceTopologyEntity{" +
                 "id=" + id +
                 ", ipAddress=" + ipAddress +
+                ", netMask=" + netMask +
                 ", isManaged='" + isManaged + '\'' +
                 ", isSnmpPrimary=" + isSnmpPrimary +
                 ", nodeId=" + nodeId +

--- a/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/TopologyEntityDaoHibernate.java
+++ b/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/TopologyEntityDaoHibernate.java
@@ -89,7 +89,7 @@ public class TopologyEntityDaoHibernate extends HibernateDaoSupport implements T
     public List<IpInterfaceTopologyEntity> getIpTopologyEntities() {
         return (List<IpInterfaceTopologyEntity>)getHibernateTemplate().find(
                 "select new org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity(" +
-                        "i.id, i.ipAddress, i.isManaged, i.snmpPrimary, i.node.id, i.snmpInterface.id) " +
+                        "i.id, i.ipAddress, i.netMask, i.isManaged, i.snmpPrimary, i.node.id, i.snmpInterface.id) " +
                         "from org.opennms.netmgt.model.OnmsIpInterface i");
     }
 

--- a/features/enlinkd/service/api/src/main/java/org/opennms/netmgt/enlinkd/service/api/NodeTopologyService.java
+++ b/features/enlinkd/service/api/src/main/java/org/opennms/netmgt/enlinkd/service/api/NodeTopologyService.java
@@ -29,6 +29,8 @@
 package org.opennms.netmgt.enlinkd.service.api;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
@@ -37,9 +39,19 @@ import org.opennms.netmgt.enlinkd.model.SnmpInterfaceTopologyEntity;
 public interface NodeTopologyService extends TopologyService {
 
     List<Node> findAllSnmpNode();
+    Set<SubNetwork> findAllSubNetwork();
+    Set<SubNetwork> findAllLegalSubNetwork();
+    Set<SubNetwork> findAllPointToPointSubNetwork();
+    Set<SubNetwork> findAllLegalPointToPointSubNetwork();
+    Set<SubNetwork> findAllLoopbacks();
+    Set<SubNetwork> findAllLegalLoopbacks();
+
+    Map<Integer, Integer> getNodeidPriorityMap(ProtocolSupported protocol);
 
     Node getSnmpNode(int nodeid);
-    
+    Set<SubNetwork> getSubNetworks(int nodeid);
+    Set<SubNetwork> getLegalSubNetworks(int nodeid);
+
     List<NodeTopologyEntity> findAllNode();
 
     List<IpInterfaceTopologyEntity> findAllIp();

--- a/features/enlinkd/service/api/src/main/java/org/opennms/netmgt/enlinkd/service/api/SubNetwork.java
+++ b/features/enlinkd/service/api/src/main/java/org/opennms/netmgt/enlinkd/service/api/SubNetwork.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.enlinkd.service.api;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
+import org.springframework.util.Assert;
+
+public class SubNetwork {
+
+    private final InetAddress m_network;
+    private final InetAddress m_netmask;
+
+    private final Map<Integer, Set<InetAddress>> m_nodeInterfaceMap = new HashMap<>();
+
+    public static SubNetwork createSubNetwork(IpInterfaceTopologyEntity ip) throws IllegalArgumentException {
+        Assert.notNull(ip);
+        return createSubNetwork(ip.getNodeId(), ip.getIpAddress(), ip.getNetMask());
+    }
+
+    public static SubNetwork createSubNetwork(Integer nodeid, InetAddress ip, InetAddress mask) throws IllegalArgumentException {
+        Assert.notNull(ip);
+        Assert.notNull(mask);
+        Assert.notNull(nodeid);
+        return new SubNetwork(nodeid, ip, mask);
+    }
+
+    private SubNetwork(final Integer nodeid, final InetAddress  ip, final InetAddress netmask) {
+        m_network=InetAddressUtils.getNetwork(ip,netmask);
+        m_netmask=netmask;
+        m_nodeInterfaceMap.put(nodeid, new HashSet<>());
+        m_nodeInterfaceMap.get(nodeid).add(ip);
+    }
+
+    public InetAddress getNetwork() {
+        return m_network;
+    }
+
+    public InetAddress getNetmask() {
+        return m_netmask;
+    }
+
+    public String getCidr() {
+        return m_network.getHostAddress()+"/"+InetAddressUtils.convertInetAddressMaskToCidr(m_netmask);
+    }
+
+    public Set<Integer> getNodeIds() {
+        return m_nodeInterfaceMap.keySet();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SubNetwork that = (SubNetwork) o;
+
+        if (!m_network.equals(that.m_network)) return false;
+        return m_netmask.equals(that.m_netmask);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = m_network.hashCode();
+        result = 31 * result + m_netmask.hashCode();
+        return result;
+    }
+
+    public boolean add(Integer nodeid, InetAddress ip) {
+        if (isInRange(ip)) {
+            if (!m_nodeInterfaceMap.containsKey(nodeid)) {
+                m_nodeInterfaceMap.put(nodeid, new HashSet<>());
+            }
+            return m_nodeInterfaceMap.get(nodeid).add(ip);
+        }
+        return false;
+    }
+
+    public boolean remove(Integer nodeid, InetAddress ip) {
+        if (m_nodeInterfaceMap.containsKey(nodeid)) {
+            boolean removed = m_nodeInterfaceMap.get(nodeid).remove(ip);
+            if (removed && m_nodeInterfaceMap.get(nodeid).size() == 0) {
+                m_nodeInterfaceMap.remove(nodeid);
+            }
+            return removed;
+        }
+        return false;
+    }
+
+    public boolean isInRange(InetAddress ip) {
+        return InetAddressUtils.inSameNetwork(ip,m_network,m_netmask);
+    }
+
+    public boolean hasDuplicatedAddress() {
+        Set<InetAddress> ips = new HashSet<>();
+        for (Set<InetAddress> addresses: m_nodeInterfaceMap.values()) {
+            for (InetAddress address: addresses) {
+                if (ips.contains(address)) {
+                    return true;
+                }
+                ips.add(address);
+            }
+        }
+        return false;
+    }
+    @Override
+    public String toString() {
+        return "SubNetwork{ " +
+                getCidr() +
+                ". NodeMap: " +
+                m_nodeInterfaceMap +
+                "}";
+    }
+}

--- a/features/enlinkd/service/api/src/test/java/org/opennms/netmgt/enlinkd/service/api/SubNetworkTest.java
+++ b/features/enlinkd/service/api/src/test/java/org/opennms/netmgt/enlinkd/service/api/SubNetworkTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.enlinkd.service.api;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.opennms.core.utils.InetAddressUtils.str;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.junit.Test;
+
+public class SubNetworkTest {
+
+    @Test
+    public void s() throws UnknownHostException {
+        SubNetwork ipv4 = SubNetwork.createSubNetwork(100, InetAddress.getByName("192.168.1.10"),InetAddress.getByName("255.255.255.0"));
+        assertEquals(ipv4.getCidr(),"192.168.1.0/24");
+        assertEquals(str(ipv4.getNetwork()),"192.168.1.0");
+        assertEquals(str(ipv4.getNetmask()),"255.255.255.0");
+        SubNetwork ipv4B = SubNetwork.createSubNetwork(101, InetAddress.getByName("192.168.1.100"),InetAddress.getByName("255.255.255.0"));
+        assertEquals(ipv4B.getCidr(),"192.168.1.0/24");
+        assertEquals(str(ipv4B.getNetwork()),"192.168.1.0");
+        assertEquals(str(ipv4B.getNetmask()),"255.255.255.0");
+        assertEquals(ipv4,ipv4B);
+        for (int i=1;i<255;i++) {
+            assertTrue(ipv4B.isInRange(InetAddress.getByName("192.168.1." + i)));
+        }
+        for (int i=0;i<256;i++) {
+            assertFalse(ipv4B.isInRange(InetAddress.getByName("192.168.0." + i)));
+        }
+        for (int i=0;i<256;i++) {
+            assertFalse(ipv4B.isInRange(InetAddress.getByName("192.168.2." + i)));
+        }
+        assertEquals(1,ipv4.getNodeIds().size());
+        assertTrue(ipv4.getNodeIds().contains(100));
+        assertEquals(1,ipv4B.getNodeIds().size());
+        assertTrue(ipv4B.getNodeIds().contains(101));
+
+        assertFalse(ipv4.remove(1, InetAddress.getByName("192.168.1.10")));
+        assertFalse(ipv4B.remove(100, InetAddress.getByName("192.168.1.100")));
+
+        assertTrue(ipv4B.remove(101, InetAddress.getByName("192.168.1.100")));
+        assertEquals(0,ipv4B.getNodeIds().size());
+
+    }
+
+    @Test
+    public void ipv6SubnetTest() throws UnknownHostException {
+        SubNetwork ipv6 = SubNetwork.createSubNetwork(200,InetAddress.getByName("2001:0db8:85a3:08d3:1319:8a2e:0370:7344"),InetAddress.getByName("FFFF:FF00:0000:0000:0000:0000:0000:0000"));
+        assertEquals(ipv6.getCidr(),"2001:d00:0:0:0:0:0:0/24");
+
+        SubNetwork ipv6A = SubNetwork.createSubNetwork(201,InetAddress.getByName("2001:0db8:85a3:08d3:1319:8a2e:0370:7344"),InetAddress.getByName("FFFF:FFFF:0000:0000:0000:0000:0000:0000"));
+        assertEquals(ipv6A.getCidr(),"2001:db8:0:0:0:0:0:0/32");
+
+        SubNetwork ipv6B = SubNetwork.createSubNetwork(202,InetAddress.getByName("2001:0db8:85a3:08d3:1319:8a2e:0370:7344"),InetAddress.getByName("FFFF:FFFF:FFFF:FFFF:0000:0000:0000:0000"));
+        assertEquals(ipv6B.getCidr(),"2001:db8:85a3:8d3:0:0:0:0/64");
+
+    }
+
+}

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/NodeTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/NodeTopologyServiceImpl.java
@@ -29,23 +29,34 @@
 package org.opennms.netmgt.enlinkd.service.impl;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.opennms.core.criteria.Alias;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.restrictions.EqRestriction;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.SnmpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.service.api.Node;
 import org.opennms.netmgt.enlinkd.service.api.NodeTopologyService;
+import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
+import org.opennms.netmgt.enlinkd.service.api.SubNetwork;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsNode.NodeType;
 import org.opennms.netmgt.model.PrimaryType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NodeTopologyServiceImpl extends TopologyServiceImpl implements NodeTopologyService {
+    private final static Logger LOG = LoggerFactory.getLogger(TopologyServiceImpl.class);
 
     private NodeDao m_nodeDao;
     @Override
@@ -70,6 +81,150 @@ public class NodeTopologyServiceImpl extends TopologyServiceImpl implements Node
     }
 
     @Override
+    public Set<SubNetwork> findAllLegalSubNetwork() {
+        return findAllSubNetwork().stream().filter(s -> s.getNodeIds().size() > 1 && !s.hasDuplicatedAddress()).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<SubNetwork> findAllPointToPointSubNetwork() {
+        return findAllSubNetwork()
+                .stream()
+                .filter(s -> InetAddressUtils.isPointToPointMask(s.getNetmask()))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<SubNetwork> findAllLegalPointToPointSubNetwork() {
+        return findAllLegalSubNetwork()
+                .stream()
+                .filter(s -> InetAddressUtils.isPointToPointMask(s.getNetmask()))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<SubNetwork> findAllLoopbacks() {
+        return findAllSubNetwork()
+                .stream()
+                .filter(s -> InetAddressUtils.isLoopbackMask(s.getNetmask()))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<SubNetwork> findAllLegalLoopbacks() {
+        return findAllSubNetwork()
+                .stream()
+                .filter(s -> InetAddressUtils.isLoopbackMask(s.getNetmask()) && s.getNodeIds().size() == 1)
+                .collect(Collectors.toSet());
+    }
+
+    private SubNetwork getNextSubnetwork(final Set<SubNetwork> subNetworks) {
+        SubNetwork starting = null;
+        for (SubNetwork subnet : subNetworks) {
+            if (starting == null) {
+                starting=subnet;
+                continue;
+            }
+            if (starting.getNodeIds().size() < subnet.getNodeIds().size()) {
+                starting = subnet;
+                continue;
+            }
+            if (starting.getNodeIds().size() == subnet.getNodeIds().size()
+                    &&
+                    InetAddressUtils.difference(starting.getNetwork(), subnet.getNetwork()).signum() > 0) {
+                starting = subnet;
+            }
+        }
+        return starting;
+    }
+
+    private int getConnected(final SubNetwork starting, final Set<SubNetwork> subnetworks, final Map<Integer, Integer> priorityMap,  int priority) {
+        Set<SubNetwork> downlevels = new HashSet<>();
+        for (SubNetwork subnet: subnetworks) {
+            Set<Integer> intersection = new HashSet<>(subnet.getNodeIds());
+            intersection.retainAll(starting.getNodeIds());
+            if (intersection.size() > 0) {
+                LOG.info("getConnected: match: {}, {} {}",intersection, subnet, starting);
+                downlevels.add(subnet);
+            }
+        }
+        downlevels.forEach(subnetworks::remove);
+        LOG.info("getConnected subnetworks.size: {}",  subnetworks.size());
+        for (SubNetwork subnetowrk: downlevels) {
+            LOG.info("getConnected: parsing: {}",  subnetowrk);
+            LOG.info("getConnected: priority: {}",  priority);
+            Set<Integer> addingNodes = new HashSet<>(subnetowrk.getNodeIds());
+            addingNodes.removeAll(priorityMap.keySet());
+            LOG.info("getConnected: adding: {}",  addingNodes);
+            if (addingNodes.isEmpty()) {
+                continue;
+            }
+            for (Integer nodeid: addingNodes) {
+                priorityMap.put(nodeid,priority);
+            }
+            LOG.info("getConnected: priorityMap: {}",  priorityMap);
+            priority++;
+        }
+
+        if (!downlevels.isEmpty() && subnetworks.size() > 0) {
+            for (SubNetwork level : downlevels) {
+                LOG.info("getConnected: iterating on: " + level);
+                priority = getConnected(level, subnetworks, priorityMap, priority);
+            }
+        }
+        return priority;
+    }
+
+    @Override
+    public Map<Integer, Integer> getNodeidPriorityMap(ProtocolSupported protocol) {
+        final Map<Integer, Integer> priorityMap = new HashMap<>();
+        Set<SubNetwork> allLegalSubnets = findAllLegalSubNetwork();
+        LOG.info("getNodeidPriorityMap: subnetworks.size: {}",  allLegalSubnets.size());
+        int priority = 0;
+        int loop = 0;
+        while (allLegalSubnets.size() > 0) {
+            loop++;
+            SubNetwork start = getNextSubnetwork(allLegalSubnets);
+            allLegalSubnets.remove(start);
+            LOG.info("getNodeidPriorityMap: loop-{}: start: {}", loop,  start);
+            LOG.info("getNodeidPriorityMap: loop-{}: priority: {}", loop,  priority);
+            LOG.info("getNodeidPriorityMap: loop-{}: subnetworks.size: {}",  loop, allLegalSubnets.size());
+            final int p = priority;
+            start.getNodeIds().forEach(n-> priorityMap.put(n, p));
+            LOG.info("getNodeidPriorityMap: loop-{}: priorityMap: {}", loop, priorityMap);
+            priority = getConnected(start,allLegalSubnets, priorityMap, ++priority);
+        }
+        return priorityMap;
+    }
+
+    @Override
+    public Set<SubNetwork> findAllSubNetwork() {
+        final Set<SubNetwork> subnets = new HashSet<>();
+        final List<IpInterfaceTopologyEntity> ips = findAllIp();
+        ips.stream().filter(ip -> ip.isManaged() && ip.getNetMask() != null ).forEach(ip -> {
+            boolean found = false;
+            for (SubNetwork s: subnets) {
+                if (s.isInRange(ip.getIpAddress()) && s.getNetmask().equals(ip.getNetMask())) {
+                    found=true;
+                    s.add(ip.getNodeId(),ip.getIpAddress());
+                    break;
+                }
+            }
+            if (!found) {
+                subnets.add(SubNetwork.createSubNetwork(ip));
+            }
+        });
+        ips.stream().filter(ip -> ip.isManaged() && ip.getNetMask() == null).forEach(ip -> {
+            for (SubNetwork s: subnets) {
+                if (s.isInRange(ip.getIpAddress())) {
+                    s.add(ip.getNodeId(),ip.getIpAddress());
+                }
+            }
+        });
+        return subnets;
+    }
+
+
+    @Override
     public Node getSnmpNode(final int nodeid) {
         final Criteria criteria = new Criteria(OnmsNode.class);
         criteria.setAliases(List.of(new Alias(
@@ -91,7 +246,17 @@ public class NodeTopologyServiceImpl extends TopologyServiceImpl implements Node
             return null;
         }
     }
-    
+
+    @Override
+    public Set<SubNetwork> getLegalSubNetworks(int nodeid) {
+        return findAllLegalSubNetwork().stream().filter(s -> s.getNodeIds().contains(nodeid)).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<SubNetwork> getSubNetworks(int nodeid) {
+        return findAllSubNetwork().stream().filter(s -> s.getNodeIds().contains(nodeid)).collect(Collectors.toSet());
+    }
+
     @Override
     public List<NodeTopologyEntity> findAllNode() {
         return getTopologyEntityCache().getNodeTopologyEntities();

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/NodeTopologyServiceIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/NodeTopologyServiceIT.java
@@ -29,35 +29,965 @@
 package org.opennms.netmgt.enlinkd;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
-import org.opennms.netmgt.enlinkd.service.api.NodeTopologyService;
+import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
+import org.opennms.netmgt.enlinkd.service.api.SubNetwork;
+import org.opennms.netmgt.nb.Nms0001NetworkBuilder;
+import org.opennms.netmgt.nb.Nms0002NetworkBuilder;
+import org.opennms.netmgt.nb.Nms003NetworkBuilder;
+import org.opennms.netmgt.nb.Nms007NetworkBuilder;
+import org.opennms.netmgt.nb.Nms0123NetworkBuilder;
+import org.opennms.netmgt.nb.Nms101NetworkBuilder;
+import org.opennms.netmgt.nb.Nms10205aNetworkBuilder;
+import org.opennms.netmgt.nb.Nms10205bNetworkBuilder;
+import org.opennms.netmgt.nb.Nms102NetworkBuilder;
+import org.opennms.netmgt.nb.Nms1055NetworkBuilder;
+import org.opennms.netmgt.nb.Nms13593NetworkBuilder;
+import org.opennms.netmgt.nb.Nms13637NetworkBuilder;
+import org.opennms.netmgt.nb.Nms13923NetworkBuilder;
 import org.opennms.netmgt.nb.Nms17216NetworkBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.opennms.netmgt.nb.Nms4005NetworkBuilder;
+import org.opennms.netmgt.nb.Nms4930NetworkBuilder;
+import org.opennms.netmgt.nb.Nms6802NetworkBuilder;
+import org.opennms.netmgt.nb.Nms7467NetworkBuilder;
+import org.opennms.netmgt.nb.Nms7563NetworkBuilder;
+import org.opennms.netmgt.nb.Nms7777DWNetworkBuilder;
+import org.opennms.netmgt.nb.Nms7918NetworkBuilder;
+import org.opennms.netmgt.nb.Nms8000NetworkBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NodeTopologyServiceIT extends EnLinkdBuilderITCase {
 
-    @Autowired
-    private NodeTopologyService nodeTopologyService;
+    private final static Logger LOG = LoggerFactory.getLogger(NodeTopologyServiceIT.class);
 
     @Test
-    public void verifyFindAll() {
+    public void nms0001SubnetworksTest() {
+        final Nms0001NetworkBuilder builder = new Nms0001NetworkBuilder();
+        m_nodeDao.save(builder.getFroh());
+        m_nodeDao.save(builder.getOedipus());
+        m_nodeDao.save(builder.getSiegFrie());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(3));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(50));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        System.err.println("---All Subnetwork");
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(36));
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork");
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(21));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork");
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(3));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks ");
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(6));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks ");
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(5));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        System.err.println("---All Legal Subnetwork");
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(4));
+
+        System.err.println("---Priority Map ");
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertThat(priorityMap.keySet(),hasSize(3));
+        priorityMap.values().forEach(v -> assertEquals(0,v.intValue()));
+    }
+
+    @Test
+    public void nms0002SubnetworksTest() {
+        final Nms0002NetworkBuilder builder = new Nms0002NetworkBuilder();
+        m_nodeDao.save(builder.getRluck001());
+        m_nodeDao.save(builder.getSluck001());
+        m_nodeDao.save(builder.getRPict001());
+        m_nodeDao.save(builder.getRNewt103());
+        m_nodeDao.save(builder.getRDeEssnBrue());
+        m_nodeDao.save(builder.getSDeEssnBrue081());
+        m_nodeDao.save(builder.getSDeEssnBrue121());
+        m_nodeDao.save(builder.getSDeEssnBrue142());
+        m_nodeDao.save(builder.getSDeEssnBrue165());
+        m_nodeDao.save(builder.getRSeMalmNobe013());
+        m_nodeDao.save(builder.getSSeMalmNobe561());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(11));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        assertThat(ips, hasSize(148));
+        ips.forEach(System.err::println);
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        System.err.println("---All Subnetwork " + subnets.size());
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(115));
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork " + ptpsubnets.size());
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(7));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork " + ptpLegalsubnets.size());
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(0));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks " + lpbsubnets.size());
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(12));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks " + lpblegalsubnets.size());
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(12));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        System.err.println("---All Legal Subnetwork " + legalsubnets.size());
+        legalsubnets.forEach(System.err::println);
+        int n = 0;
+        assertThat(legalsubnets, hasSize(3));
+        for (SubNetwork subnet: legalsubnets) {
+            n = n + subnet.getNodeIds().size();
+        }
+        assertEquals(9,n);
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        assertEquals(9,priorityMap.size());
+        LOG.info("{}", priorityMap);
+    }
+
+    @Test
+    public void nms003SubnetworkTests() {
+        final Nms003NetworkBuilder builder = new Nms003NetworkBuilder();
+        m_nodeDao.save(builder.getSwitch1());
+        m_nodeDao.save(builder.getSwitch2());
+        m_nodeDao.save(builder.getSwitch3());
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(3));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        assertThat(ips, hasSize(7));
+        ips.forEach(System.err::println);
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(1));
+        assertThat(subnets.iterator().next().getNodeIds(), hasSize(3));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        assertEquals(3,priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, v.intValue()));
+        LOG.info("{}", priorityMap);
+    }
+
+    @Test
+    public void nms007SubnetworkTest() {
+        final Nms007NetworkBuilder builder = new Nms007NetworkBuilder();
+        m_nodeDao.save(builder.getFireFly170());
+        m_nodeDao.save(builder.getFireFly171());
+        m_nodeDao.save(builder.getFireFly172());
+        m_nodeDao.save(builder.getFireFly173());
+        m_nodeDao.save(builder.getFireFly174());
+        m_nodeDao.save(builder.getFireFly175());
+        m_nodeDao.save(builder.getFireFly176());
+        m_nodeDao.save(builder.getFireFly177());
+        m_nodeDao.save(builder.getFireFly189());
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(9));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        assertThat(ips, hasSize(96));
+        ips.forEach(System.err::println);
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        System.err.println("---All Subnetworks---");
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(24));
+
+        assertThat(m_nodeTopologyService.findAllPointToPointSubNetwork(),hasSize(0));
+        assertThat(m_nodeTopologyService.findAllLegalPointToPointSubNetwork(),hasSize(0));
+
+        final Set<SubNetwork> lpsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks---" + lpsubnets.size());
+        lpsubnets.forEach(System.err::println);
+        assertThat(lpsubnets, hasSize(17));
+
+        final Set<SubNetwork> lplegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks---" + lplegalsubnets.size());
+        lplegalsubnets.forEach(System.err::println);
+        assertThat(lplegalsubnets, hasSize(9));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        System.err.println("---All Legal Subnetworks---");
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(6));
+
+
+        final Set<Integer> nodeids = new HashSet<>();
+        legalsubnets.forEach(lsn -> nodeids.addAll(lsn.getNodeIds()));
+        assertThat(nodeids, hasSize(9));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        assertEquals(9, priorityMap.size());
+        priorityMap.values().forEach(v -> assertTrue(v <6));
+        LOG.info("{}", priorityMap);
+
+    }
+
+    @Test
+    public void nms101SubnetworksTest() {
+        final Nms101NetworkBuilder builder = new Nms101NetworkBuilder();
+        m_nodeDao.save(builder.getCisco1700());
+        m_nodeDao.save(builder.getCisco1700b());
+        m_nodeDao.save(builder.getCisco2691());
+        m_nodeDao.save(builder.getCisco3600());
+        m_nodeDao.save(builder.getCisco3700());
+        m_nodeDao.save(builder.getCisco7200a());
+        m_nodeDao.save(builder.getCisco7200b());
+        m_nodeDao.save(builder.getLaptop());
+        m_nodeDao.save(builder.getExampleCom());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(9));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(20));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(11));
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork " + ptpsubnets.size());
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(0));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork " + ptpLegalsubnets.size());
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(0));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks " + lpbsubnets.size());
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(0));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks " + lpblegalsubnets.size());
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(0));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(6));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        assertEquals(6, priorityMap.size());
+        priorityMap.values().forEach(v -> assertTrue(v <6));
+        LOG.info("{}", priorityMap);
+
+    }
+
+    @Test
+    public void nms102SubnetworksTest() {
+        final Nms102NetworkBuilder builder = new Nms102NetworkBuilder();
+        m_nodeDao.save(builder.getMikrotik());
+        m_nodeDao.save(builder.getSamsung());
+        m_nodeDao.save(builder.getMac1());
+        m_nodeDao.save(builder.getMac2());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(4));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(5));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(2));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(1));
+
+        assertThat(legalsubnets.iterator().next().getNodeIds(),hasSize(4));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        assertEquals(4, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, v.intValue()));
+        LOG.info("{}", priorityMap);
+
+    }
+
+    @Test
+    public void nms0123SubnetworksTest() {
+        final Nms0123NetworkBuilder builder = new Nms0123NetworkBuilder();
+        m_nodeDao.save(builder.getItpn0111());
+        m_nodeDao.save(builder.getItpn0112());
+        m_nodeDao.save(builder.getItpn0113());
+        m_nodeDao.save(builder.getItpn0114());
+        m_nodeDao.save(builder.getItpn0121());
+        m_nodeDao.save(builder.getItpn0123());
+        m_nodeDao.save(builder.getItpn0201());
+        m_nodeDao.save(builder.getItpn0202());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(8));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        assertThat(ips, hasSize(8));
+        ips.forEach(System.err::println);
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(1));
+        assertEquals(8,subnets.iterator().next().getNodeIds().size());
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        assertEquals(8, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, v.intValue()));
+        LOG.info("{}", priorityMap);
+
+    }
+
+    @Test
+    public void nms1055SubnetworksTest() {
+        final Nms1055NetworkBuilder builder =new Nms1055NetworkBuilder();
+        m_nodeDao.save(builder.getAustin());
+        m_nodeDao.save(builder.getDelaware());
+        m_nodeDao.save(builder.getPenrose());
+        m_nodeDao.save(builder.getPhoenix());
+        m_nodeDao.save(builder.getSanjose());
+        m_nodeDao.save(builder.getRiovista());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(6));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        System.err.println("---");
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(80));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(43));
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork " + ptpsubnets.size());
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(7));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork " + ptpLegalsubnets.size());
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(6));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks " + lpbsubnets.size());
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(31));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks " + lpblegalsubnets.size());
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(28));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        System.err.println("---");
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(7));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(6, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, v.intValue()));
+
+    }
+
+    @Test
+    public void nms4005SubnetworksTest() {
+        final Nms4005NetworkBuilder builder = new Nms4005NetworkBuilder();
+        m_nodeDao.save(builder.getR1());
+        m_nodeDao.save(builder.getR2());
+        m_nodeDao.save(builder.getR3());
+        m_nodeDao.save(builder.getR4());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(4));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(9));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(5));
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork " + ptpsubnets.size());
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(0));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork " + ptpLegalsubnets.size());
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(0));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks " + lpbsubnets.size());
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(0));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks " + lpblegalsubnets.size());
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(0));
+
+        System.err.println("---");
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(4));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(4, priorityMap.size());
+        priorityMap.values().forEach(v -> assertTrue(v < 3));
+
+    }
+
+    @Test
+    public void nms4930SubnetworksTest() {
+        final Nms4930NetworkBuilder builder = new Nms4930NetworkBuilder();
+        m_nodeDao.save(builder.getDlink1());
+        m_nodeDao.save(builder.getDlink2());
+        m_nodeDao.save(builder.getHost1());
+        m_nodeDao.save(builder.getHost2());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(4));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(7));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(4));
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork " + ptpsubnets.size());
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(0));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork " + ptpLegalsubnets.size());
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(0));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks " + lpbsubnets.size());
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(0));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks " + lpblegalsubnets.size());
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(0));
+
+        System.err.println("---");
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(1));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(4, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, v.intValue()));
+
+    }
+
+    @Test
+    public void nms6802SubnetworksTest() {
+        final Nms6802NetworkBuilder builder = new Nms6802NetworkBuilder();
+        m_nodeDao.save(builder.getCiscoIosXrRouter());
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(1));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(1));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(0));
+
+    }
+
+    @Test
+    public void nms7467SubnetworksTest() {
+        final Nms7467NetworkBuilder builder = new Nms7467NetworkBuilder();
+        m_nodeDao.save(builder.getCiscoC870());
+        m_nodeDao.save(builder.getDarwin108());
+        m_nodeDao.save(builder.getLinuxUbuntu());
+        m_nodeDao.save(builder.getCiscoWsC2948());
+        m_nodeDao.save(builder.getNetGearSw108());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(5));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(26));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(8));
+
+        System.err.println("---");
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(1));
+        assertThat(legalsubnets.iterator().next().getNodeIds(),hasSize(5));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(5, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, v.intValue()));
+
+    }
+
+    @Test
+    public void nms7563SubnetworksTest() {
+        final Nms7563NetworkBuilder builder = new Nms7563NetworkBuilder();
+        m_nodeDao.save(builder.getCisco01());
+        m_nodeDao.save(builder.getHomeServer());
+        m_nodeDao.save(builder.getSwitch02());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(3));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(5));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(3));
+        System.err.println("---");
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(1));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(3, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, v.intValue()));
+
+    }
+
+    @Test
+    public void nms7777DWSubnetworksTest() {
+        final Nms7777DWNetworkBuilder builder = new Nms7777DWNetworkBuilder();
+        m_nodeDao.save(builder.getDragonWaveRouter());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(1));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(1));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(1));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(0));
+    }
+
+    @Test
+    public void nms7918SubnetworksTest() {
+        Nms7918NetworkBuilder builder = new Nms7918NetworkBuilder();
+
+        m_nodeDao.save(builder.getAsw01());
+        m_nodeDao.save(builder.getOspwl01());
+        m_nodeDao.save(builder.getPe01());
+        m_nodeDao.save(builder.getSamasw01());
+        m_nodeDao.save(builder.getStcasw01());
+        m_nodeDao.save(builder.getOspss01());
+        m_nodeDao.flush();
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(6));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(6));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(1));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        assertThat(legalsubnets, hasSize(1));
+        assertThat(legalsubnets.iterator().next().getNodeIds(), hasSize(6));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(6, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, v.intValue()));
+
+
+    }
+
+    @Test
+    public void nms8000SubbnetworksTest() {
+        final Nms8000NetworkBuilder builder = new Nms8000NetworkBuilder();
+
+        m_nodeDao.save(builder.getNMMR1());
+        m_nodeDao.save(builder.getNMMR2());
+        m_nodeDao.save(builder.getNMMR3());
+        m_nodeDao.save(builder.getNMMSW1());
+        m_nodeDao.save(builder.getNMMSW2());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(5));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(12));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(6));
+
+        System.err.println("---");
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(4));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(5, priorityMap.size());
+        priorityMap.values().forEach(v -> assertTrue(v < 3));
+
+
+    }
+
+    @Test
+    public void nms10205aSubnetworksTest() {
+        final Nms10205aNetworkBuilder builder = new Nms10205aNetworkBuilder();
+
+        m_nodeDao.save(builder.getBagmane());
+        m_nodeDao.save(builder.getMumbai());
+        m_nodeDao.save(builder.getMysore());
+        m_nodeDao.save(builder.getBangalore());
+        m_nodeDao.save(builder.getChennai());
+        m_nodeDao.save(builder.getDelhi());
+        m_nodeDao.save(builder.getJ635041());
+        m_nodeDao.save(builder.getJ635042());
+        m_nodeDao.save(builder.getSpaceExSw1());
+        m_nodeDao.save(builder.getSpaceExSw2());
+        m_nodeDao.save(builder.getSRX100());
+        m_nodeDao.save(builder.getSGG550());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(12));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(108));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(42));
+        System.err.println("---");
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork " + ptpsubnets.size());
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(17));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork " + ptpLegalsubnets.size());
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(15));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks " + lpbsubnets.size());
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(14));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks " + lpblegalsubnets.size());
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(9));
+
+        System.err.println("---All Legal ");
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(16));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(12, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, (int) v));
+
+
+    }
+
+    @Test
+    public void nms10205bSubnetworksTest() {
+        final Nms10205bNetworkBuilder builder = new Nms10205bNetworkBuilder();
+
+        m_nodeDao.save(builder.getBagmane());
+        m_nodeDao.save(builder.getMumbai());
+        m_nodeDao.save(builder.getMysore());
+        m_nodeDao.save(builder.getBangalore());
+        m_nodeDao.save(builder.getDelhi());
+        m_nodeDao.save(builder.getJ635042());
+        m_nodeDao.save(builder.getSpaceExSw1());
+        m_nodeDao.save(builder.getSpaceExSw2());
+        m_nodeDao.save(builder.getSRX100());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(9));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(92));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        System.err.println("---");
+        assertThat(subnets, hasSize(39));
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork " + ptpsubnets.size());
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(17));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork " + ptpLegalsubnets.size());
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(13));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks " + lpbsubnets.size());
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(14));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks " + lpblegalsubnets.size());
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(9));
+
+        System.err.println("---All Legal ");
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(14));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(9, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, (int) v));
+
+    }
+
+    @Test
+    public void nms13593SubnetworksTest() {
+        final Nms13593NetworkBuilder builder = new Nms13593NetworkBuilder();
+
+        m_nodeDao.save(builder.getZHBGO1Zsr001());
+        m_nodeDao.save(builder.getZHBGO1Zsr002());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(2));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(2));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(1));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        assertThat(legalsubnets, hasSize(1));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(2, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, (int) v));
+
+
+
+    }
+
+    @Test
+    public void nms13637SubnetworksTest() {
+        final Nms13637NetworkBuilder builder = new Nms13637NetworkBuilder();
+
+        m_nodeDao.save(builder.getRouter1());
+        m_nodeDao.save(builder.getRouter2());
+        m_nodeDao.save(builder.getRouter3());
+        m_nodeDao.save(builder.getCiscoHomeSw());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(4));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(4));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(2));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(1));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(3, priorityMap.size());
+        priorityMap.values().forEach(v -> assertEquals(0, (int) v));
+
+    }
+
+    @Test
+    public void nms13923SubnetworksTest() {
+        final Nms13923NetworkBuilder builder = new Nms13923NetworkBuilder();
+
+        m_nodeDao.save(builder.getSrv005());
+
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
+        nodes.forEach(System.err::println);
+        assertThat(nodes, hasSize(1));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
+        ips.forEach(System.err::println);
+        assertThat(ips, hasSize(1));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(1));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        assertThat(legalsubnets, hasSize(0));
+    }
+
+    @Test
+    public void nms17216SubnetworksTest() {
         final Nms17216NetworkBuilder builder = new Nms17216NetworkBuilder();
         m_nodeDao.save(builder.getSwitch1());
         m_nodeDao.save(builder.getSwitch2());
+        m_nodeDao.save(builder.getSwitch3());
+        m_nodeDao.save(builder.getSwitch4());
+        m_nodeDao.save(builder.getSwitch5());
+        m_nodeDao.save(builder.getRouter1());
+        m_nodeDao.save(builder.getRouter2());
+        m_nodeDao.save(builder.getRouter3());
+        m_nodeDao.save(builder.getRouter4());
 
-        final List<NodeTopologyEntity> nodes = nodeTopologyService.findAllNode();
+        final List<NodeTopologyEntity> nodes = m_nodeTopologyService.findAllNode();
         nodes.forEach(System.err::println);
-        assertThat(nodes, hasSize(2));
-        
-        final List<IpInterfaceTopologyEntity> ips = nodeTopologyService.findAllIp();
+        assertThat(nodes, hasSize(9));
+
+        final List<IpInterfaceTopologyEntity> ips = m_nodeTopologyService.findAllIp();
         ips.forEach(System.err::println);
-        
-        assertThat(ips, hasSize(6));
+        assertThat(ips, hasSize(18));
+
+        final Set<SubNetwork> ptpsubnets = m_nodeTopologyService.findAllPointToPointSubNetwork();
+        System.err.println("---All PointToPointSubnetwork " + ptpsubnets.size());
+        ptpsubnets.forEach(System.err::println);
+        assertThat(ptpsubnets, hasSize(3));
+
+        final Set<SubNetwork> ptpLegalsubnets = m_nodeTopologyService.findAllLegalPointToPointSubNetwork();
+        System.err.println("---All Legal PointToPointSubnetwork " + ptpLegalsubnets.size());
+        ptpLegalsubnets.forEach(System.err::println);
+        assertThat(ptpLegalsubnets, hasSize(3));
+
+        final Set<SubNetwork> lpbsubnets = m_nodeTopologyService.findAllLoopbacks();
+        System.err.println("---All Loopbacks " + lpbsubnets.size());
+        lpbsubnets.forEach(System.err::println);
+        assertThat(lpbsubnets,hasSize(0));
+
+        final Set<SubNetwork> lpblegalsubnets = m_nodeTopologyService.findAllLegalLoopbacks();
+        System.err.println("---All Legal Loopbacks " + lpblegalsubnets.size());
+        lpblegalsubnets.forEach(System.err::println);
+        assertThat(lpblegalsubnets,hasSize(0));
+
+        final Set<SubNetwork> subnets = m_nodeTopologyService.findAllSubNetwork();
+        System.err.println("---All  " + subnets.size());
+        subnets.forEach(System.err::println);
+        assertThat(subnets, hasSize(9));
+
+        final Set<SubNetwork> legalsubnets = m_nodeTopologyService.findAllLegalSubNetwork();
+        System.err.println("---All legal --- " + subnets.size());
+        legalsubnets.forEach(System.err::println);
+        assertThat(legalsubnets, hasSize(6));
+
+        Map<Integer,Integer> priorityMap = m_nodeTopologyService.getNodeidPriorityMap(ProtocolSupported.NODES);
+        LOG.info("{}", priorityMap);
+        assertEquals(9, priorityMap.size());
+        priorityMap.values().forEach(v -> assertTrue(v < 6));
+
+
     }
+
+
 }

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/TopologyUpdaterIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/TopologyUpdaterIT.java
@@ -118,7 +118,7 @@ public class TopologyUpdaterIT {
         final Runnable discoveryRunnable = () -> {
             long start = System.currentTimeMillis();
             LoggerFactory.getLogger("DISCOVERY").info("Start: {}", new Date());
-            updater.runDiscovery();
+            updater.runSchedulable();
             LoggerFactory.getLogger("DISCOVERY").info("Took {} ms", (System.currentTimeMillis() - start));
         };
         Future<?> future1 = executorService.submit(discoveryRunnable);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProviderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProviderTest.java
@@ -102,9 +102,9 @@ public class EnhancedLinkdTopologyProviderTest {
         m_nodesOnmsTopologyUpdater.register();
         m_lldpOnmsTopologyUpdater.register();
         m_ospfOnmsTopologyUpdater.register();
-        m_nodesOnmsTopologyUpdater.runDiscovery();
-        m_lldpOnmsTopologyUpdater.runDiscovery();
-        m_ospfOnmsTopologyUpdater.runDiscovery();
+        m_nodesOnmsTopologyUpdater.runSchedulable();
+        m_lldpOnmsTopologyUpdater.runSchedulable();
+        m_ospfOnmsTopologyUpdater.runSchedulable();
     }
 
     @Test


### PR DESCRIPTION
 Added Netmask to IpInterfaceTopologyEntity
    Created Subnetwork class
    Produce suitable methods to get subnetworks
    from IpInterfaceTopolgyEntity
    Check if network is legal or not (verify that subnetwork has no duplicated ip addresses)
    Also find PointToPoint Subnetworks and Loopbacks
    Finally provide a priority map based on Sunetworks.
    Priority is asigned starting from the first low legal subnetwork
    All the node under the Subnetwork have the same priority.
    Check connected node and increase priority
    Two subnetworks are connec ted if there is at least a common node (intersection is not null).

The branch is from develop but has been merged with the following branches

ar/jira/NMS-14771 [NMS-14771 Move Common Adapter Enlinkd classes to Core #5310](https://github.com/OpenNMS/opennms/pull/5310)

ar/jira/NMS-14763 [NMS-14763 Add Priority Executor Classes](https://github.com/OpenNMS/opennms/pull/5313) 

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14773

