### PR TITLE
geocoder doc restructure

### DIFF
--- a/docs/modules/operation/pages/admin/geocoder.adoc
+++ b/docs/modules/operation/pages/admin/geocoder.adoc
@@ -10,15 +10,68 @@ The geocoder service will only run against nodes that are missing latitute and l
 See the xref:provisioning/directed-discovery.adoc[provisioning] documentation for steps to define asset fields on a requisition.
 
 Resolved coordinates are stored in the database as node asset fields, but the geocoder service does not update requisitions.
-An alternative to the geocoder service is the xref:reference:provisioning/adapters/geoip.adoc[GeoIP provisioning adapter].
-This adapter can look up coordinates based on IP address, and will update the node's requisition definition, bypassing the need for the geocoder service to determine location based on address.
 
-== Configuration
+== Address-based geocoding
 
 To enable or configure the Geocoder Service, use the web-based configuration tool.
 In the web UI, click the menu:Gear Icon[Provisioning > Configure Geocoder Service].
 
 NOTE: If you would prefer to manually edit the config files, you can set the active Geocoder Service via the property `activeGeocoderId` in `$\{OPENNMS_HOME}/etc/org.opennms.features.geocoder.cfg`.
+
+=== Nominatim
+
+For more details, see the link:https://wiki.openstreetmap.org/wiki/Nominatim[official documentation]
+and check the link:https://operations.osmfoundation.org/policies/nominatim/[Nominatim Usage Policy] before using
+the geocoder service.
+
+[options="header"]
+[cols="2,3,1,2"]
+|===
+| Property
+| Description
+| Type
+| Default
+
+4+| *Required*
+
+| acceptUsageTerms
+| To use the Nominatim Geocoder Service you must accept the link:https://operations.osmfoundation.org/policies/nominatim/[Nominatim Usage Policy].
+Set this to `true` to agree to their terms.
+| Boolean
+| false
+
+| url
+| The URL template for the Nominatim Geocoder API.
+The `email` and `query` strings are substituted before making the request.
+| String
+| \https://nominatim.openstreetmap.org/search?format=json&amp;email=\{email}&limit=1&q=\{query}
+
+| email
+| According to the official documentation, provide this in case you are making a large number of requests.
+Alternatively, provide this information in the userAgent property.
+| String
+| empty string
+
+| referer
+| Note that either `referer` or `userAgent` is required.
+| String
+| empty string
+
+| userAgent
+| Note that either `referer` or `userAgent` is required.
+| String
+| OpenNMS-NominatimGeocoderService/2.0
+
+4+| *Optional*
+
+| useSystemProxy
+| Should the system-wide proxy settings be used?
+Configure the system proxy settings in <<admin/system-properties/introduction.adoc#ga-opennms-system-properties, system properties>>.
+| Boolean
+| false
+|===
+
+NOTE: These properties are recorded in `$\{OPENNMS_HOME}/etc/org.opennms.features.geocoder.nominatim.cfg`.
 
 === Google
 
@@ -110,57 +163,7 @@ Configure the system proxy settings in <<admin/system-properties/introduction.ad
 
 NOTE: These properties are recorded in `$\{OPENNMS_HOME}/etc/org.opennms.features.geocoder.mapquest.cfg`.
 
-=== Nominatim
+== IP-based geocoding
 
-For more details, see the link:https://wiki.openstreetmap.org/wiki/Nominatim[official documentation]
-and check the link:https://operations.osmfoundation.org/policies/nominatim/[Nominatim Usage Policy] before using
-the geocoder service.
-
-[options="header"]
-[cols="2,3,1,2"]
-|===
-| Property
-| Description
-| Type
-| Default
-
-4+| *Required*
-
-| acceptUsageTerms
-| To use the Nominatim Geocoder Service you must accept the link:https://operations.osmfoundation.org/policies/nominatim/[Nominatim Usage Policy].
-Set this to `true` to agree to their terms.
-| Boolean
-| false
-
-| url
-| The URL template for the Nominatim Geocoder API.
-The `email` and `query` strings are substituted before making the request.
-| String
-| \https://nominatim.openstreetmap.org/search?format=json&amp;email=\{email}&limit=1&q=\{query}
-
-| email
-| According to the official documentation, provide this in case you are making a large number of requests.
-Alternatively, provide this information in the userAgent property.
-| String
-| empty string
-
-| referer
-| Note that either `referer` or `userAgent` is required.
-| String
-| empty string
-
-| userAgent
-| Note that either `referer` or `userAgent` is required.
-| String
-| OpenNMS-NominatimGeocoderService/2.0
-
-4+| *Optional*
-
-| useSystemProxy
-| Should the system-wide proxy settings be used?
-Configure the system proxy settings in <<admin/system-properties/introduction.adoc#ga-opennms-system-properties, system properties>>.
-| Boolean
-| false
-|===
-
-NOTE: These properties are recorded in `$\{OPENNMS_HOME}/etc/org.opennms.features.geocoder.nominatim.cfg`.
+An alternative to the geocoder service is the xref:reference:provisioning/adapters/geoip.adoc[GeoIP provisioning adapter].
+This adapter can look up coordinates based on IP address, and will update the node's requisition definition, bypassing the need for the geocoder service to determine location based on address.


### PR DESCRIPTION
Slight restructure to the geocoder doc page.  Bring the Nominatim service to the top, as it's easiest to setup.

Make the reference for the GeoIP adapter easier to see.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* JIRA (Issue Tracker): No JIRA

