### PR TITLE
NMS-14622: Add KPI for startup time

### DIFF
--- a/core/daemon/src/main/java/org/opennms/netmgt/daemon/AbstractSpringContextJmxServiceDaemon.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/daemon/AbstractSpringContextJmxServiceDaemon.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.daemon;
 
 import java.lang.reflect.UndeclaredThrowableException;
+import java.time.Instant;
 import java.util.concurrent.Callable;
 
 import org.opennms.core.fiber.Fiber;
@@ -56,10 +57,11 @@ public abstract class AbstractSpringContextJmxServiceDaemon<T extends SpringServ
 
     private int m_status = Fiber.START_PENDING;
 
+    private long m_startTimeMilliseconds;
+
     /**
      * <p>Constructor for AbstractSpringContextJmxServiceDaemon.</p>
      *
-     * @param <T> a T object.
      */
     public AbstractSpringContextJmxServiceDaemon() {
         super();
@@ -126,6 +128,7 @@ public abstract class AbstractSpringContextJmxServiceDaemon<T extends SpringServ
                 SpringServiceDaemon daemon = getDaemon();
                 try {
                     daemon.start();
+                    setStartTimeMilliseconds(Instant.now().toEpochMilli());
                 } catch (Throwable t) {
                     LOG.error("Could not start daemon: {}", t, t);
                     
@@ -229,4 +232,8 @@ public abstract class AbstractSpringContextJmxServiceDaemon<T extends SpringServ
         return status();
     }
 
+    private void setStartTimeMilliseconds(long startTime){ m_startTimeMilliseconds = startTime; }
+
+    @Override
+    public long getStartTimeMilliseconds() { return m_startTimeMilliseconds; }
 }

--- a/core/daemon/src/main/java/org/opennms/netmgt/daemon/BaseOnmsMBean.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/daemon/BaseOnmsMBean.java
@@ -74,4 +74,6 @@ public interface BaseOnmsMBean {
      */
     String getStatusText();
 
+    long getStartTimeMilliseconds();
+
 }

--- a/core/daemon/src/test/java/org/opennms/netmgt/daemon/AbstractSpringContextJmxServiceDaemonTest.java
+++ b/core/daemon/src/test/java/org/opennms/netmgt/daemon/AbstractSpringContextJmxServiceDaemonTest.java
@@ -57,6 +57,10 @@ public class AbstractSpringContextJmxServiceDaemonTest {
         public String getLoggingPrefix() {
             return "thisIsABogusLoggingPrefix";
         }
+
+        @Override
+        public long getStartTimeMilliseconds() { return 0; }
+
     }
 
     public class MockServiceDaemon extends AbstractServiceDaemon {

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTO.java
@@ -94,6 +94,7 @@ public class UsageStatisticsReportDTO {
     private Map<String, Long> m_nodesWithDeviceConfigBySysOid = Collections.emptyMap();
     private int outages;
     private int notifications;
+    private long m_onmsStartupTimeSeconds;
 
     public int getNotifications() {return notifications;}
 
@@ -483,6 +484,10 @@ public class UsageStatisticsReportDTO {
     public void setNodesWithDeviceConfigBySysOid(Map<String, Long> nodesWithConfigBySysOid) {
         this.m_nodesWithDeviceConfigBySysOid = nodesWithConfigBySysOid;
     }
+
+    public long getOnmsStartupTimeSeconds() { return m_onmsStartupTimeSeconds; }
+
+    public void setOnmsStartupTimeSeconds(long onmsStartupTimeSeconds) { this.m_onmsStartupTimeSeconds = onmsStartupTimeSeconds; }
 
     public String toJson() {
         return toJson(false);

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReporter.java
@@ -104,6 +104,8 @@ public class UsageStatisticsReporter implements StateChangeHandler {
     private static final int MAX_DEP_RECURSION_DEPTH = 2;
     private static final String OIA_FEATURE_NAME = "opennms-integration-api";
     private static final String API_LAYER_FEATURE_NAME = "opennms-api-layer";
+    private static final String JMX_ATTR_START_TIME_MILLISECONDS = "StartTimeMilliseconds";
+    private static final String JMX_OBJ_OPENNMS_KARAF_STARTUP_MONITOR = "OpenNMS:Name=KarafStartupMonitor";
 
     private String m_url;
 
@@ -284,11 +286,18 @@ public class UsageStatisticsReporter implements StateChangeHandler {
         usageStatisticsReport.setRpcStrategy(RpcStrategy.getRpcStrategy().getName());
         usageStatisticsReport.setTssStrategies(TimeSeries.getTimeseriesStrategy().getName());
         usageStatisticsReport.setNodesWithDeviceConfigBySysOid(m_deviceConfigDao.getNumberOfNodesWithDeviceConfigBySysOid());
-
+        usageStatisticsReport.setOnmsStartupTimeSeconds(getStartupTimeSeconds());
         setDatasourceInfo(usageStatisticsReport);
 
         return usageStatisticsReport;
     }
+
+    private long getStartupTimeSeconds(){
+        long jvmStartTime = ManagementFactory.getRuntimeMXBean().getStartTime();
+        long karafStartupMonitorStartTime = Long.parseLong(getJmxAttribute(JMX_OBJ_OPENNMS_KARAF_STARTUP_MONITOR, JMX_ATTR_START_TIME_MILLISECONDS).toString());
+        return (karafStartupMonitorStartTime - jvmStartTime) / 1000;
+    }
+
     private void setJmxAttributes(UsageStatisticsReportDTO usageStatisticsReport) {
         setSystemJmxAttributes(usageStatisticsReport);
         setOpenNmsJmxAttributes(usageStatisticsReport);

--- a/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTOTest.java
+++ b/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTOTest.java
@@ -66,6 +66,7 @@ public class UsageStatisticsReportDTOTest {
         usageStatisticsReport.setDestinationPathCount(-1);
         usageStatisticsReport.setUsers(0);
         usageStatisticsReport.setGroups(0);
+        usageStatisticsReport.setOnmsStartupTimeSeconds(1000L);
         String actualJson = usageStatisticsReport.toJson();
         System.err.println(actualJson);
 
@@ -97,6 +98,7 @@ public class UsageStatisticsReportDTOTest {
             "\"notificationEnablementStatus\":null," +
             "\"notifications\":0," +
             "\"onCallRoleCount\":1," +
+            "\"onmsStartupTimeSeconds\":1000," +
             "\"osArch\":null," +
             "\"osName\":null," +
             "\"osVersion\":null," +

--- a/opennms-correlation/opennms-correlator/src/main/java/org/opennms/netmgt/correlation/jmx/Correlator.java
+++ b/opennms-correlation/opennms-correlator/src/main/java/org/opennms/netmgt/correlation/jmx/Correlator.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.correlation.jmx;
 
 import java.util.Map;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.opennms.core.fiber.Fiber;
 import org.opennms.core.logging.Logging;
 import org.opennms.core.spring.BeanUtils;
@@ -89,6 +90,11 @@ public class Correlator implements CorrelatorMBean {
     @Override
     public String getStatusText() {
         return Fiber.STATUS_NAMES[getStatus()];
+    }
+
+    @Override
+    public long getStartTimeMilliseconds() {
+        throw new NotImplementedException();
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/actiond/jmx/Actiond.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/actiond/jmx/Actiond.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.actiond.jmx;
 
 import java.lang.reflect.UndeclaredThrowableException;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.opennms.netmgt.config.ActiondConfigFactory;
 
 /**
@@ -104,5 +105,10 @@ public class Actiond implements ActiondMBean {
     @Override
     public String getStatusText() {
         return org.opennms.core.fiber.Fiber.STATUS_NAMES[getStatus()];
+    }
+
+    @Override
+    public long getStartTimeMilliseconds() {
+        throw new NotImplementedException();
     }
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/passive/jmx/PassiveStatusd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/passive/jmx/PassiveStatusd.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.passive.jmx;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.opennms.core.db.DataSourceFactory;
 import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.events.api.EventIpcManager;
@@ -93,6 +94,11 @@ public class PassiveStatusd extends AbstractServiceDaemon implements PassiveStat
     @Override
     public int getStatus() {
         return getPassiveStatusKeeper().getStatus();
+    }
+
+    @Override
+    public long getStartTimeMilliseconds() {
+        throw new NotImplementedException();
     }
 
     private PassiveStatusKeeper getPassiveStatusKeeper() {

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/jmx/Scriptd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/jmx/Scriptd.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.scriptd.jmx;
 
+import org.apache.commons.lang.NotImplementedException;
+
 /**
  * <p>Scriptd class.</p>
  *
@@ -91,5 +93,10 @@ public class Scriptd implements ScriptdMBean {
     @Override
     public String getStatusText() {
         return org.opennms.core.fiber.Fiber.STATUS_NAMES[getStatus()];
+    }
+
+    @Override
+    public long getStartTimeMilliseconds() {
+        throw new NotImplementedException();
     }
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/translator/jmx/EventTranslator.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/translator/jmx/EventTranslator.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.sql.SQLException;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.opennms.core.db.DataSourceFactory;
 import org.opennms.netmgt.config.EventTranslatorConfigFactory;
 import org.opennms.netmgt.daemon.AbstractServiceDaemon;
@@ -118,6 +119,11 @@ public class EventTranslator extends AbstractServiceDaemon implements EventTrans
     @Override
     public int getStatus() {
         return getEventTranslator().getStatus();
+    }
+
+    @Override
+    public long getStartTimeMilliseconds() {
+        throw new NotImplementedException();
     }
 
     private org.opennms.netmgt.translator.EventTranslator getEventTranslator() {

--- a/opennms-services/src/main/java/org/opennms/netmgt/vacuumd/jmx/Vacuumd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/vacuumd/jmx/Vacuumd.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.vacuumd.jmx;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
 
@@ -127,6 +128,11 @@ public class Vacuumd implements VacuumdMBean {
     @Override
     public String getStatusText() {
         return org.opennms.core.fiber.Fiber.STATUS_NAMES[getStatus()];
+    }
+
+    @Override
+    public long getStartTimeMilliseconds() {
+        throw new NotImplementedException();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Added getStartTimeMilliseconds method to BaseOnmsMBean.java to be able to track start time for any managed bean. This way we don't just track ONMS startup time but start time for every managed bean invoked during startup.

Some managed Beans don't extend core/daemon/src/main/java/org/opennms/netmgt/daemon/AbstractSpringContextJmxServiceDaemon.java
In those cases the implementation currently will throw a NotImplementedException.

Probably this could be handle with 
core/daemon/src/main/java/org/opennms/netmgt/daemon/AbstractServiceDaemon.java

But is not required for this ticket.

Not sure if this is too much for what is needed but I was thinking it would be nice to track more initialization times ...




* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14622

