### PR TITLE
NMS-14784: Grafana Dashboard report fails on "row"

### DIFF
--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/PanelDeserializer.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/PanelDeserializer.java
@@ -86,6 +86,8 @@ public class PanelDeserializer implements JsonDeserializer<Panel> {
             } else if (prop.isJsonObject()) {
                 // newer contain an object with { uid: ..., type: ... }
                 p.setDatasource(prop.getAsJsonObject().get("uid").getAsJsonPrimitive().getAsString());
+            } else if (p.getType().equals("row") && prop.isJsonNull()) {
+                // do nothing, let the datasource be null, since rows are skipped from the report
             } else {
                 throw new JsonParseException("JSON element 'datasource' was expected to be either a uid string, or an object containing a uid string and optional type string, but instead was: " + jsonElement);
             }


### PR DESCRIPTION
Fixed issue when Panel type row from older versions is passed (which has a datasource value of null)

Currently Panel type row is not being printed in the report. I think this should be handled on a different jira as an enhancement (see below)

https://github.com/OpenNMS/opennms/blob/07024cd96a8fee67375bd802fc55bc4802374412/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/grafana/GrafanaPanelDatasource.java#L78


* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14784

