### PR TITLE
NMS-14791 Topology-Map Layer broken

### DIFF
--- a/features/enlinkd/adapters/updaters/nodes/src/main/java/org/opennms/netmgt/enlinkd/NodesOnmsTopologyUpdater.java
+++ b/features/enlinkd/adapters/updaters/nodes/src/main/java/org/opennms/netmgt/enlinkd/NodesOnmsTopologyUpdater.java
@@ -41,14 +41,6 @@ import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
 
 public class NodesOnmsTopologyUpdater extends TopologyUpdater {
 
-    public static NodesOnmsTopologyUpdater clone (NodesOnmsTopologyUpdater bpu) {
-        NodesOnmsTopologyUpdater update = new NodesOnmsTopologyUpdater(bpu.getTopologyDao(), bpu.getNodeTopologyService());
-        update.setRunned(bpu.isRunned());
-        update.setTopology(bpu.getTopology());
-        return update;
- 
-    }
-    
     public NodesOnmsTopologyUpdater(
             OnmsTopologyDao topologyDao, NodeTopologyService nodeTopologyService) {
         super(nodeTopologyService, topologyDao,nodeTopologyService);
@@ -65,10 +57,6 @@ public class NodesOnmsTopologyUpdater extends TopologyUpdater {
         OnmsTopology topology = new OnmsTopology();
         for (NodeTopologyEntity element: getNodeMap().values()) {
             topology.getVertices().add(create(element,ipMap.get(element.getId())));
-        }
-        NodeTopologyEntity defaultFocusPoint = getDefaultFocusPoint();
-        if (defaultFocusPoint != null) {
-            topology.setDefaultVertex(create(defaultFocusPoint,ipMap.get(defaultFocusPoint.getId())));
         }
         return topology;
     }

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/IpLikeSearchProvider.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/IpLikeSearchProvider.java
@@ -254,7 +254,7 @@ public class IpLikeSearchProvider extends AbstractSearchProvider implements Hist
 	public void addVertexHopCriteria(SearchResult searchResult, GraphContainer container) {
     	LOG.debug("SearchProvider->addVertexHopCriteria: called with search result: '{}'", searchResult);
 
-		IpLikeHopCriteria criterion = createCriteria(searchResult);
+		IpLikeHopCriteria criterion = createCriteria(searchResult, container);
 		container.addCriteria(criterion);
 		
         LOG.debug("SearchProvider->addVertexHop: adding hop criteria {}.", criterion);
@@ -297,7 +297,7 @@ public class IpLikeSearchProvider extends AbstractSearchProvider implements Hist
 
 	@Override
 	public org.opennms.features.topology.api.topo.Criteria buildCriteriaFromQuery(SearchResult input, GraphContainer container) {
-		IpLikeHopCriteria criteria = createCriteria(input);
+		IpLikeHopCriteria criteria = createCriteria(input, container);
 		return criteria;
 	}
 
@@ -325,7 +325,7 @@ public class IpLikeSearchProvider extends AbstractSearchProvider implements Hist
         return null;
     }
 
-	private IpLikeHopCriteria createCriteria(SearchResult searchResult) {
-		return new IpLikeHopCriteria(searchResult, this.ipInterfaceProvider);
+	private IpLikeHopCriteria createCriteria(SearchResult searchResult, GraphContainer graphContainer) {
+		return new IpLikeHopCriteria(searchResult, this.ipInterfaceProvider, graphContainer);
 	}
 }

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/IpLikeSearchProvider.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/IpLikeSearchProvider.java
@@ -87,7 +87,7 @@ public class IpLikeSearchProvider extends AbstractSearchProvider implements Hist
 
     @Override
     public boolean contributesTo(String namespace) {
-        return CONTRIBUTES_TO_NAMESPACE.equals(namespace);
+        return (namespace != null ? namespace.startsWith(CONTRIBUTES_TO_NAMESPACE) : false);
     }
 
     /**

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IpLikeHopCriteria.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IpLikeHopCriteria.java
@@ -98,7 +98,6 @@ public class IpLikeHopCriteria extends VertexHopCriteria implements SearchCriter
 		Objects.requireNonNull(graphContainer.getTopologyServiceClient());
         m_collapsedVertex.setChildren(getVertices());
         setId(searchResult.getId());
-		LOG.info("IpLikeHopCriteria: called constructor: {}", m_graphContainer.getMetaTopologyId());
     }
 
 	@Override
@@ -134,12 +133,9 @@ public class IpLikeHopCriteria extends VertexHopCriteria implements SearchCriter
 		
 		CriteriaBuilder bldr = new CriteriaBuilder(OnmsIpInterface.class);
 
-		LOG.info("getVertices: queryString: {}", m_ipQuery);
 		bldr.iplike("ipAddr", m_ipQuery);
 		final Set<Integer> nodeids = ipInterfaceProvider.findMatching(bldr.toCriteria()).stream().map(ip -> ip.getNode().getId()).collect(Collectors.toSet());
-		LOG.info("getVertices: nodeids: {}", nodeids);
-//		LOG.info("getVertices(): namespace: {}", m_graphContainer.getTopologyServiceClient().getNamespace());
-		LOG.info("getVertices(): namespace: {}", m_graphContainer.getTopologyServiceClient().getInfo().getName());
+		LOG.debug("getVertices: nodeids: {}", nodeids);
 		final GraphProvider graphProvider = m_graphContainer.getTopologyServiceClient().getGraphProviderBy(m_graphContainer.getTopologyServiceClient().getNamespace());
 		final BackendGraph currentGraph = graphProvider.getCurrentGraph();
 		return currentGraph.getVertices().stream().filter(v -> v.getNodeID() != null && nodeids.contains(v.getNodeID())).collect(Collectors.toSet());

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IpLikeHopCriteria.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IpLikeHopCriteria.java
@@ -94,7 +94,7 @@ public class IpLikeHopCriteria extends VertexHopCriteria implements SearchCriter
         m_ipQuery = searchResult.getQuery();
         this.ipInterfaceProvider = Objects.requireNonNull(ipInterfaceProvider);
         m_collapsedVertex = new IPVertex(m_ipQuery);
-		m_graphContainer = Objects.requireNonNull(graphContainer);
+	m_graphContainer = Objects.requireNonNull(graphContainer);
 		Objects.requireNonNull(graphContainer.getTopologyServiceClient());
         m_collapsedVertex.setChildren(getVertices());
         setId(searchResult.getId());

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IpLikeHopCriteria.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IpLikeHopCriteria.java
@@ -95,7 +95,7 @@ public class IpLikeHopCriteria extends VertexHopCriteria implements SearchCriter
         this.ipInterfaceProvider = Objects.requireNonNull(ipInterfaceProvider);
         m_collapsedVertex = new IPVertex(m_ipQuery);
 	m_graphContainer = Objects.requireNonNull(graphContainer);
-		Objects.requireNonNull(graphContainer.getTopologyServiceClient());
+	Objects.requireNonNull(graphContainer.getTopologyServiceClient());
         m_collapsedVertex.setChildren(getVertices());
         setId(searchResult.getId());
     }

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IpLikeHopCriteria.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IpLikeHopCriteria.java
@@ -32,11 +32,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.features.topology.api.GraphContainer;
 import org.opennms.features.topology.api.support.hops.VertexHopCriteria;
 import org.opennms.features.topology.api.topo.AbstractCollapsibleVertex;
+import org.opennms.features.topology.api.topo.BackendGraph;
 import org.opennms.features.topology.api.topo.DefaultVertexRef;
+import org.opennms.features.topology.api.topo.GraphProvider;
 import org.opennms.features.topology.api.topo.RefComparator;
 import org.opennms.features.topology.api.topo.SearchCriteria;
 import org.opennms.features.topology.api.topo.SearchResult;
@@ -45,6 +49,8 @@ import org.opennms.features.topology.api.topo.VertexRef;
 import org.opennms.features.topology.app.internal.IpInterfaceProvider;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This <Criteria> implementation supports the users selection of search results from an IPLIKE query
@@ -65,6 +71,10 @@ public class IpLikeHopCriteria extends VertexHopCriteria implements SearchCriter
 
 	private IpInterfaceProvider ipInterfaceProvider;
 
+	private GraphContainer m_graphContainer;
+
+	private final Logger LOG = LoggerFactory.getLogger(IpLikeHopCriteria.class);
+
 	@Override
 	public String getSearchString() {
 		return m_ipQuery;
@@ -78,14 +88,17 @@ public class IpLikeHopCriteria extends VertexHopCriteria implements SearchCriter
 		}
     }
 
-	public IpLikeHopCriteria(SearchResult searchResult, IpInterfaceProvider ipInterfaceProvider) {
+	public IpLikeHopCriteria(SearchResult searchResult, IpInterfaceProvider ipInterfaceProvider, GraphContainer graphContainer) {
     	super(searchResult.getQuery());
     	m_collapsed = searchResult.isCollapsed();
         m_ipQuery = searchResult.getQuery();
         this.ipInterfaceProvider = Objects.requireNonNull(ipInterfaceProvider);
         m_collapsedVertex = new IPVertex(m_ipQuery);
+		m_graphContainer = Objects.requireNonNull(graphContainer);
+		Objects.requireNonNull(graphContainer.getTopologyServiceClient());
         m_collapsedVertex.setChildren(getVertices());
         setId(searchResult.getId());
+		LOG.info("IpLikeHopCriteria: called constructor: {}", m_graphContainer.getMetaTopologyId());
     }
 
 	@Override
@@ -121,16 +134,15 @@ public class IpLikeHopCriteria extends VertexHopCriteria implements SearchCriter
 		
 		CriteriaBuilder bldr = new CriteriaBuilder(OnmsIpInterface.class);
 
+		LOG.info("getVertices: queryString: {}", m_ipQuery);
 		bldr.iplike("ipAddr", m_ipQuery);
-		List<OnmsIpInterface> ips = ipInterfaceProvider.findMatching(bldr.toCriteria());
-
-		Set<VertexRef> vertices = new TreeSet<VertexRef>(new RefComparator());
-		for (OnmsIpInterface ip : ips) {
-			OnmsNode node = ip.getNode();
-			vertices.add(new DefaultVertexRef("nodes", String.valueOf(node.getId()), node.getLabel()));
-		}
-		
-		return vertices;
+		final Set<Integer> nodeids = ipInterfaceProvider.findMatching(bldr.toCriteria()).stream().map(ip -> ip.getNode().getId()).collect(Collectors.toSet());
+		LOG.info("getVertices: nodeids: {}", nodeids);
+//		LOG.info("getVertices(): namespace: {}", m_graphContainer.getTopologyServiceClient().getNamespace());
+		LOG.info("getVertices(): namespace: {}", m_graphContainer.getTopologyServiceClient().getInfo().getName());
+		final GraphProvider graphProvider = m_graphContainer.getTopologyServiceClient().getGraphProviderBy(m_graphContainer.getTopologyServiceClient().getNamespace());
+		final BackendGraph currentGraph = graphProvider.getCurrentGraph();
+		return currentGraph.getVertices().stream().filter(v -> v.getNodeID() != null && nodeids.contains(v.getNodeID())).collect(Collectors.toSet());
 	}
 
 	@Override

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/ui/SearchBox.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/ui/SearchBox.java
@@ -308,7 +308,7 @@ public class SearchBox extends AbstractComponent implements SelectionListener, G
                 if (provider.supportsPrefix(query)) {
                     // If there is an '=' divider, strip it off. Otherwise, use an empty query string
                     String queryOnly = query.indexOf('=') > 0 ? query.substring(query.indexOf('=') + 1) : "";
-                    List<SearchResult> q = provider.    query(getSearchQuery(queryOnly), m_operationContext.getGraphContainer());
+                    List<SearchResult> q = provider.query(getSearchQuery(queryOnly), m_operationContext.getGraphContainer());
                     results.addAll(q);
 
                     if (m_suggestionMap.containsKey(provider)) {

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/ui/SearchBox.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/ui/SearchBox.java
@@ -308,7 +308,7 @@ public class SearchBox extends AbstractComponent implements SelectionListener, G
                 if (provider.supportsPrefix(query)) {
                     // If there is an '=' divider, strip it off. Otherwise, use an empty query string
                     String queryOnly = query.indexOf('=') > 0 ? query.substring(query.indexOf('=') + 1) : "";
-                    List<SearchResult> q = provider.query(getSearchQuery(queryOnly), m_operationContext.getGraphContainer());
+                    List<SearchResult> q = provider.    query(getSearchQuery(queryOnly), m_operationContext.getGraphContainer());
                     results.addAll(q);
 
                     if (m_suggestionMap.containsKey(provider)) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.history/src/test/java/org/opennms/features/topology/plugins/topo/BundleContextHistoryManagerTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.history/src/test/java/org/opennms/features/topology/plugins/topo/BundleContextHistoryManagerTest.java
@@ -368,7 +368,7 @@ public class BundleContextHistoryManagerTest  {
 
         // Initializing available (initial) Criteria
         this.startingCriteria.put(CriteriaTypes.category, new CategoryHopCriteria(sResultCategory, vertexProvider, graphContainerMock));
-        this.startingCriteria.put(CriteriaTypes.ipLike, new IpLikeHopCriteria(sResultIpLike, ipInterfaceProvider));
+        this.startingCriteria.put(CriteriaTypes.ipLike, new IpLikeHopCriteria(sResultIpLike, ipInterfaceProvider, graphContainerMock));
         this.startingCriteria.put(CriteriaTypes.alarm, new AlarmHopCriteria(new AlarmSearchProvider(alarmProvider).new AlarmSearchResult(sResultAlarm), alarmProvider));
     }
 

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdSelectionAware.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdSelectionAware.java
@@ -74,7 +74,7 @@ public class LinkdSelectionAware implements SelectionAware {
     protected List<Integer> extractNodeIds(Collection<VertexRef> vertices) {
         List<Integer> nodeIdList = new ArrayList<>();
         for (VertexRef eachRef : vertices) {
-            if (m_linkdTopologyFactory.getActiveNamespace().equals(eachRef.getNamespace())) {
+            if (m_linkdTopologyFactory.getActiveNamespace().startsWith(eachRef.getNamespace())) {
                 try {
                     nodeIdList.add(Integer.valueOf(eachRef.getId()));
                 } catch (NumberFormatException e) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProvider.java
@@ -122,6 +122,7 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
 
     @Override
     public void refresh() {
+        LOG.info("refresh: {}: protocolSupported: {}",getNamespace(), m_supportedSet);
         m_linkdTopologyFactory.setDelegate(this);
         graph.resetContainer();
         m_linkdTopologyFactory.doRefresh(m_supportedSet, graph);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -31,8 +31,8 @@ xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
 
     <!-- Factory -->
     <bean id="linkdTopologyFactory" scope="singleton" class="org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyFactory">
-        <argument ref="metricRegistry" />
-        <property name="onmsTopologyDao" ref="onmsTopologyDao"/>
+        <argument ref="metricRegistry" index="0"/>
+        <argument ref="onmsTopologyDao" index="1"/>
     </bean>
 
     <!-- Providers -->

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdMockDataPopulator.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdMockDataPopulator.java
@@ -94,8 +94,8 @@ public class EnhancedLinkdMockDataPopulator {
         final String snmp = "SNMP";
         final String http = "HTTP";
 
-        m_nodes = new ArrayList<OnmsNode>();
-        m_lldpnodes = new ArrayList<LldpElement>();
+        m_nodes = new ArrayList<>();
+        m_lldpnodes = new ArrayList<>();
         m_ospfnodes = new ArrayList<>();
         final NetworkBuilder builder = new NetworkBuilder();
 

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProviderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProviderTest.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,21 +72,27 @@ public class EnhancedLinkdTopologyProviderTest {
 
     @Autowired
     private LinkdTopologyFactory m_topologyFactory;
+
     @Autowired
     private LinkdTopologyProvider m_topologyProvider;
+
     @Autowired
     private EnhancedLinkdMockDataPopulator m_databasePopulator;
+
     @Autowired
     private OnmsTopologyDao m_onmsTopologyDao;    
+
     @Autowired
     private NodesOnmsTopologyUpdater m_nodesOnmsTopologyUpdater;
+
     @Autowired
     private LldpOnmsTopologyUpdater m_lldpOnmsTopologyUpdater;    
-    @Autowired 
+
+    @Autowired
     private OspfOnmsTopologyUpdater m_ospfOnmsTopologyUpdater;
 
     @Before
-    public void setUp() throws Exception{
+    public void setUp() {
         MockLogAppender.setupLogging();
 
         m_databasePopulator.populateDatabase();
@@ -136,6 +141,9 @@ public class EnhancedLinkdTopologyProviderTest {
     @Test
     public void testGetDefaultTopologyLoaded() {
         m_topologyProvider.refresh();
+        assertEquals("nodes", m_topologyProvider.getNamespace());
+        assertNotNull(m_onmsTopologyDao.getTopology(m_topologyProvider.getNamespace()));
+        assertNotNull(m_onmsTopologyDao.getTopology(m_topologyProvider.getNamespace()).getDefaultVertex());
         Defaults defaults = m_topologyProvider.getDefaults();
         assertEquals(Defaults.DEFAULT_SEMANTIC_ZOOM_LEVEL, defaults.getSemanticZoomLevel());
         assertEquals("D3 Layout", defaults.getPreferredLayout());
@@ -161,23 +169,23 @@ public class EnhancedLinkdTopologyProviderTest {
         Vertex vertex6 = m_topologyProvider.getCurrentGraph().getVertex(LinkdTopologyProvider.TOPOLOGY_NAMESPACE_LINKD, "6");
         Vertex vertex7 = m_topologyProvider.getCurrentGraph().getVertex(LinkdTopologyProvider.TOPOLOGY_NAMESPACE_LINKD, "7");
         Vertex vertex8 = m_topologyProvider.getCurrentGraph().getVertex(LinkdTopologyProvider.TOPOLOGY_NAMESPACE_LINKD, "8");
-        Assert.assertTrue("linkd.system.snmp.1.3.6.1.4.1.5813.1.25".equals(vertex1.getIconKey()));
-        Assert.assertTrue("linkd.system".equals(vertex2.getIconKey()));
-        Assert.assertTrue("linkd.system".equals(vertex3.getIconKey()));
-        Assert.assertTrue("linkd.system".equals(vertex4.getIconKey()));
-        Assert.assertTrue("linkd.system".equals(vertex5.getIconKey()));
-        Assert.assertTrue("linkd.system".equals(vertex6.getIconKey()));
-        Assert.assertTrue("linkd.system".equals(vertex7.getIconKey()));
-        Assert.assertTrue("linkd.system".equals(vertex8.getIconKey()));
+        assertEquals("linkd.system.snmp.1.3.6.1.4.1.5813.1.25", vertex1.getIconKey());
+        assertEquals("linkd.system", vertex2.getIconKey());
+        assertEquals("linkd.system", vertex3.getIconKey());
+        assertEquals("linkd.system", vertex4.getIconKey());
+        assertEquals("linkd.system", vertex5.getIconKey());
+        assertEquals("linkd.system", vertex6.getIconKey());
+        assertEquals("linkd.system", vertex7.getIconKey());
+        assertEquals("linkd.system", vertex8.getIconKey());
     }
 
     @Test
-    public void test() throws Exception {
+    public void test() {
         m_topologyProvider.refresh();
         assertEquals(8, m_topologyProvider.getCurrentGraph().getVertices().size());
 
         // Add v0 vertex
-        Vertex vertexA = new SimpleLeafVertex(m_topologyProvider.getNamespace(), "v0", 50, 100);
+        AbstractVertex vertexA = new SimpleLeafVertex(m_topologyProvider.getNamespace(), "v0", 50, 100);
         m_topologyProvider.getCurrentGraph().addVertices(vertexA);
         assertEquals(9, m_topologyProvider.getCurrentGraph().getVertices().size());
         assertEquals("v0", vertexA.getId());
@@ -186,7 +194,7 @@ public class EnhancedLinkdTopologyProviderTest {
         assertTrue(m_topologyProvider.getCurrentGraph().containsVertexId(new DefaultVertexRef("nodes", "v0",m_topologyProvider.getNamespace() + ":" + "v0")));
         assertFalse(m_topologyProvider.getCurrentGraph().containsVertexId(new DefaultVertexRef("nodes", "v1",m_topologyProvider.getNamespace() + ":" + "v1")));
 
-        ((AbstractVertex)vertexA).setIpAddress("10.0.0.4");
+        vertexA.setIpAddress("10.0.0.4");
 
         // Search by VertexRef
         VertexRef vertexAref = new DefaultVertexRef(m_topologyProvider.getNamespace(), "v0",m_topologyProvider.getNamespace() + ":" + "v0");
@@ -199,7 +207,6 @@ public class EnhancedLinkdTopologyProviderTest {
         m_topologyProvider.getCurrentGraph().addVertices(vertexB);
         assertEquals("v1", vertexB.getId());
         assertTrue(m_topologyProvider.getCurrentGraph().containsVertexId(vertexB));
-        assertTrue(m_topologyProvider.getCurrentGraph().containsVertexId("v1"));
         assertEquals(1, m_topologyProvider.getCurrentGraph().getVertices(Collections.singletonList(vertexBref)).size());
 
         // Added 3 more vertices
@@ -247,39 +254,39 @@ public class EnhancedLinkdTopologyProviderTest {
     }
 
     @Test
-    public void testLoadSimpleGraph() throws Exception {
+    public void testLoadSimpleGraph() {
         m_topologyProvider.refresh();
         assertEquals(8, m_topologyProvider.getCurrentGraph().getVertices().size());
         assertEquals(9, m_topologyProvider.getCurrentGraph().getEdges().size());
 
         LinkdVertex v1 = (LinkdVertex)m_topologyProvider.getCurrentGraph().getVertex("nodes", "1");
-        assertEquals(true,v1.getProtocolSupported().contains(ProtocolSupported.LLDP));
-        assertEquals(true,v1.getProtocolSupported().contains(ProtocolSupported.OSPF));
-        assertEquals(false,v1.getProtocolSupported().contains(ProtocolSupported.CDP));
-        assertEquals(false,v1.getProtocolSupported().contains(ProtocolSupported.ISIS));
-        assertEquals(false,v1.getProtocolSupported().contains(ProtocolSupported.BRIDGE));
+        assertTrue(v1.getProtocolSupported().contains(ProtocolSupported.LLDP));
+        assertTrue(v1.getProtocolSupported().contains(ProtocolSupported.OSPF));
+        assertFalse(v1.getProtocolSupported().contains(ProtocolSupported.CDP));
+        assertFalse(v1.getProtocolSupported().contains(ProtocolSupported.ISIS));
+        assertFalse(v1.getProtocolSupported().contains(ProtocolSupported.BRIDGE));
         LinkdVertex v2 = (LinkdVertex)m_topologyProvider.getCurrentGraph().getVertex("nodes", "2");
-        assertEquals(true,v2.getProtocolSupported().contains(ProtocolSupported.LLDP));
-        assertEquals(true,v2.getProtocolSupported().contains(ProtocolSupported.OSPF));
-        assertEquals(false,v2.getProtocolSupported().contains(ProtocolSupported.CDP));
-        assertEquals(false,v2.getProtocolSupported().contains(ProtocolSupported.ISIS));
-        assertEquals(false,v2.getProtocolSupported().contains(ProtocolSupported.BRIDGE));
+        assertTrue(v2.getProtocolSupported().contains(ProtocolSupported.LLDP));
+        assertTrue(v2.getProtocolSupported().contains(ProtocolSupported.OSPF));
+        assertFalse(v2.getProtocolSupported().contains(ProtocolSupported.CDP));
+        assertFalse(v2.getProtocolSupported().contains(ProtocolSupported.ISIS));
+        assertFalse(v2.getProtocolSupported().contains(ProtocolSupported.BRIDGE));
         LinkdVertex v3 = (LinkdVertex)m_topologyProvider.getCurrentGraph().getVertex("nodes", "3");
-        assertEquals(true,v3.getProtocolSupported().contains(ProtocolSupported.LLDP));
-        assertEquals(false,v3.getProtocolSupported().contains(ProtocolSupported.OSPF));
-        assertEquals(false,v3.getProtocolSupported().contains(ProtocolSupported.CDP));
-        assertEquals(false,v3.getProtocolSupported().contains(ProtocolSupported.ISIS));
-        assertEquals(false,v3.getProtocolSupported().contains(ProtocolSupported.BRIDGE));
+        assertTrue(v3.getProtocolSupported().contains(ProtocolSupported.LLDP));
+        assertFalse(v3.getProtocolSupported().contains(ProtocolSupported.OSPF));
+        assertFalse(v3.getProtocolSupported().contains(ProtocolSupported.CDP));
+        assertFalse(v3.getProtocolSupported().contains(ProtocolSupported.ISIS));
+        assertFalse(v3.getProtocolSupported().contains(ProtocolSupported.BRIDGE));
         LinkdVertex v4 = (LinkdVertex)m_topologyProvider.getCurrentGraph().getVertex("nodes", "4");
         LinkdVertex v5 = (LinkdVertex)m_topologyProvider.getCurrentGraph().getVertex("nodes", "5");
         LinkdVertex v6 = (LinkdVertex)m_topologyProvider.getCurrentGraph().getVertex("nodes", "6");
         assertEquals("node1", v1.getLabel());
         assertEquals("192.168.1.1", v1.getIpAddress());
-        assertEquals(false, v1.isLocked());
-        assertEquals(new Integer(1), v1.getNodeID());
-        assertEquals(false, v1.isSelected());
-        assertEquals(new Integer(0), v1.getX());
-        assertEquals(new Integer(0), v1.getY());
+        assertFalse(v1.isLocked());
+        assertEquals(Integer.valueOf(1), v1.getNodeID());
+        assertFalse(v1.isSelected());
+        assertEquals(Integer.valueOf(0), v1.getX());
+        assertEquals(Integer.valueOf(0), v1.getY());
 
         final CollapsibleGraph collapsibleGraph = new CollapsibleGraph(m_topologyProvider.getCurrentGraph());
         collapsibleGraph.getVertices();

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-LinkdTopologyProviderTestIT.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-LinkdTopologyProviderTestIT.xml
@@ -208,8 +208,8 @@
     </bean>
 
     <bean id="linkdTopologyFactory" class="org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyFactory">
-        <constructor-arg ref="metricRegistry"/>
-        <property name="onmsTopologyDao" ref="onmsTopologyDao" />
+        <constructor-arg ref="metricRegistry" />
+        <constructor-arg ref="onmsTopologyDao" />
     </bean>
 
     <bean id="enlinkdTopologyProviderInfo" class="org.opennms.features.topology.api.topo.DefaultTopologyProviderInfo">

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-enhanced-mock.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-enhanced-mock.xml
@@ -59,7 +59,7 @@
 
     <bean id="linkdTopologyFactory" class="org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyFactory">
         <constructor-arg ref="metricRegistry"/>
-        <property name="onmsTopologyDao" ref="onmsTopologyDao" />
+        <constructor-arg ref="onmsTopologyDao" />
     </bean>
 
     <bean id="enlinkdTopologyProviderInfo" class="org.opennms.features.topology.api.topo.DefaultTopologyProviderInfo">


### PR DESCRIPTION

    Fixed DefaultVertex in enlinkd topology updaters
    Let IplikeSearchProvider be available for all nodes related namespaces
    Fixed IpLikeHopCriteria getVertices getting vertices from the graph namespace

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14791

