### PR TITLE
NMS-14853: Reset flags before NodeScans are run

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeScan.java
@@ -268,6 +268,7 @@ public class NodeScan implements Scan {
     @Override
     public void run(final BatchTask parent) {
         LOG.info("Scanning node {}/{}/{}", m_nodeId, m_foreignSource, m_foreignId);
+        reset();
         if (monitor != null) {
             monitor.beginScanning(this);
         }
@@ -397,6 +398,11 @@ public class NodeScan implements Scan {
 
     NoAgentScan createNoAgentScan() {
         return new NoAgentScan(getNodeId(), getNode());
+    }
+
+    private void reset() {
+        m_aborted = false;
+        m_agentFound = false;
     }
 
     /**

--- a/opennms-provision/opennms-provisiond/src/test/resources/single_node.xml
+++ b/opennms-provision/opennms-provisiond/src/test/resources/single_node.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model-import last-import="2012-05-03T03:51:43.022-05:00" foreign-source="empty" date-stamp="2012-05-03T03:51:42.441-05:00" xmlns="http://xmlns.opennms.org/xsd/config/model-import">
+    <node node-label="node1" foreign-id="1">
+        <interface snmp-primary="P" status="1" ip-addr="192.168.0.1" descr="eth0">
+            <monitored-service service-name="ICMP"/>
+        </interface>
+    </node>
+</model-import>


### PR DESCRIPTION
NodeScan objects are reused for scheduled scans, so the flags that are tracked per-scan should be reset between each scan run.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14853

