### PR TITLE
NMS-14801: Add Menu Rest Service

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/HttpMenuRequestContext.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/HttpMenuRequestContext.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import javax.servlet.http.HttpServletRequest;
+import org.opennms.core.time.CentralizedDateTimeFormat;
+import org.opennms.netmgt.config.NotifdConfigFactory;
+
+public class HttpMenuRequestContext implements MenuRequestContext {
+    final private HttpServletRequest request;
+    final private CentralizedDateTimeFormat dateTimeFormat = new CentralizedDateTimeFormat();
+
+    public HttpMenuRequestContext(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    public String getRemoteUser() {
+        return request.getRemoteUser();
+    }
+
+    public String calculateUrlBase() {
+        return org.opennms.web.api.Util.calculateUrlBase(this.request);
+    }
+
+    public boolean isUserInRole(final String role) {
+        return this.request.isUserInRole(role);
+    }
+
+    public String getFormattedTime() {
+        return this.dateTimeFormat.format(Instant.now(), extractUserTimeZone());
+    }
+
+    public String getNoticeStatus() {
+        try {
+            return NotifdConfigFactory.getPrettyStatus();
+        } catch (final Throwable ignored) {
+        }
+
+        return "Unknown";
+    }
+
+    private ZoneId extractUserTimeZone() {
+        ZoneId timeZoneId = (ZoneId) this.request.getSession().getAttribute(CentralizedDateTimeFormat.SESSION_PROPERTY_TIMEZONE_ID);
+
+        if (timeZoneId == null) {
+            timeZoneId = ZoneId.systemDefault();
+        }
+
+        return timeZoneId;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MainMenu.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MainMenu.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MainMenu {
+    public String baseHref;
+    public String formattedTime;
+    public String noticeStatus;
+    public String username;
+
+    final public List<TopMenuEntry> menus = new ArrayList<>();
+    public TopMenuEntry helpMenu;
+    public TopMenuEntry selfServiceMenu;
+    public TopMenuEntry userNotificationMenu;
+    public MenuEntry provisionMenu;
+    public MenuEntry flowsMenu;
+    public MenuEntry configurationMenu; // aka admin menu, the "cogs"
+    public Notices notices;
+
+    public void addTopMenu(TopMenuEntry entry) {
+        this.menus.add(entry);
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuEntry.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuEntry.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu;
+
+// Similar to org.opennms.web.navigate.MenuEntry
+public class MenuEntry {
+    public String id;
+    public String className;
+    public String name;
+    public String url;
+    public String locationMatch;
+    public String icon;
+    /** The icon type, "fa" for font-awesome, "feather" for FeatherDS */
+    public String iconType;  // "fa" or "feather"
+    /** If true, display an icon only, no name/title. */
+    public Boolean isIconOnly;
+    public Boolean isVueLink;
+    /** Comma-separated list of roles. If present, user must have at least one of these roles to display */
+    public String roles;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuProvider.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuProvider.java
@@ -1,0 +1,428 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu;
+
+import com.google.common.base.Strings;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import org.opennms.web.api.Authentication;
+import org.opennms.web.rest.support.menu.xml.MenuXml;
+
+/**
+ * Creates a MainMenu object that is used by the MenuRestService, which provides this data to the
+ * new Vue UI Menubar.
+ *
+ * Reads opennms-webapp 'dispatcher-servlet.xml' to determine most of the menu structure, this allows old JSP and
+ * new Vue Menubar to be in sync (note, there are some special case differences due to additional processing done
+ * in navbar.ftl, etc.).
+ *
+ * This class does not convert items in 'dispatcher-servlet.xml' to actual Java Beans and evaluate them,
+ * or read the full file, but reimplements just the needed functionality.
+ *
+ * TopMenuEntry and MenuEntry are similar to NavBarEntry in opennms-webapp, but redefined and reimplemented here
+ * partly to avoid 'opennms-webapp-rest' having a dependency on 'opennms-webapp'.
+ *
+ * This does some special-casing of role-based authentication (i.e. including or excluding menu entries based
+ * on user roles), but will also respect items in 'dispatcher.servlet.xml' marked as 'RoleBasedNavBarEntry'.
+ */
+public class MenuProvider {
+    /** Full file path to dispatcher.servlet.xml file, see "applicationContext-cxf-rest-v2.xml" */
+    final private String dispatcherServletPath;
+
+    /** Fully qualified classname of RoleBasedNavBarEntry class, from opennms-webapp. */
+    final private String ROLE_BASED_NAV_BAR_ENTRY_CLASS = "org.opennms.web.navigate.RoleBasedNavBarEntry";
+
+    public MenuProvider(String dispatcherServletPath) {
+        this.dispatcherServletPath = dispatcherServletPath;
+    }
+
+    public MainMenu getMainMenu(final MenuRequestContext context) throws Exception, IOException {
+        MainMenu mainMenu = new MainMenu();
+
+        try {
+            final boolean isProvision = context.isUserInRole(Authentication.ROLE_PROVISION);
+            final boolean isFlow = context.isUserInRole(Authentication.ROLE_FLOW_MANAGER);
+            final boolean isAdmin = context.isUserInRole(Authentication.ROLE_ADMIN);
+
+            mainMenu.baseHref = context.calculateUrlBase();
+            mainMenu.formattedTime = context.getFormattedTime();
+            mainMenu.username = context.getRemoteUser();
+            mainMenu.noticeStatus = context.getNoticeStatus();
+            // TODO: Remove
+            mainMenu.notices = buildNotices(context);
+
+            // Parse out menu data from "dispatcher-servlet.xml"
+            MenuXml.BeansElement xBeans = null;
+
+            final String path = this.dispatcherServletPath;
+
+            try (var fis = new FileInputStream(path)) {
+                xBeans = parseDispatcherServletXml(fis);
+            } catch (FileNotFoundException fnfe) {
+                throw fnfe;
+            }
+
+            List<TopMenuEntry> topMenuEntries = this.parseXmlToMenuEntries(xBeans);
+            // Remove any MenuEntry items marked as RoleBased where user does not have any required role
+            evaluateRoleBasedEntries(topMenuEntries, context);
+
+            for (var topMenu : topMenuEntries) {
+                mainMenu.addTopMenu(topMenu);
+            }
+
+            // These are taken from "navbar.ftl" and handled somewhat specially
+            mainMenu.helpMenu = getHelpMenuEntry(isAdmin);
+            mainMenu.selfServiceMenu = getSelfServiceMenuEntry(context.getRemoteUser());
+            mainMenu.userNotificationMenu = getUserNotificationMenu(context.getRemoteUser());
+
+            if (isAdmin || isProvision) {
+                mainMenu.provisionMenu = getProvisionMenu();
+            }
+
+            if (isFlow) {
+                mainMenu.flowsMenu = getFlowsMenu();
+            }
+
+            if (isAdmin) {
+                mainMenu.configurationMenu = getConfigurationMenu();
+            }
+        } catch (IOException ioe) {
+            throw ioe;
+        }
+
+        return mainMenu;
+    }
+
+    public MenuXml.BeansElement parseDispatcherServletXml(InputStream inputStream) {
+        MenuXml.BeansElement xBeansElem = null;
+
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(MenuXml.BeansElement.class);
+            Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+            xBeansElem = (MenuXml.BeansElement) jaxbUnmarshaller.unmarshal(inputStream);
+        } catch (JAXBException e) {
+            String msg = e.getMessage();
+        }
+
+        return xBeansElem;
+    }
+
+    public List<TopMenuEntry> parseXmlToMenuEntries(MenuXml.BeansElement xBeansElem) throws Exception {
+        List<TopMenuEntry> topMenuEntries = new ArrayList<>();
+
+        Optional<MenuXml.BeanElement> xNavBarEntriesElem =
+            xBeansElem.getBeans().stream()
+                .filter(b -> b.getId() != null && b.getId().equals("navBarEntries"))
+                .findFirst();
+
+        if (!xNavBarEntriesElem.isPresent() || xNavBarEntriesElem.get().getConstructorArgElement() == null) {
+            throw new Exception("Could not find 'navBarEntries' item");
+        }
+
+        List<MenuXml.BeanOrRefElement> xBeansOrRefs = xNavBarEntriesElem.get().getConstructorArgElement().getBeansOrRefs();
+
+        for (MenuXml.BeanOrRefElement xTopLevelBeanOrRef : xBeansOrRefs) {
+            Optional<TopMenuEntry> topEntry = Optional.empty();
+
+            if (xTopLevelBeanOrRef instanceof MenuXml.BeanElement) {
+                topEntry = parseTopMenuEntry((MenuXml.BeanElement) xTopLevelBeanOrRef);
+            } else if (xTopLevelBeanOrRef instanceof MenuXml.BeanRefElement) {
+                topEntry = parseTopMenuEntryFromRef((MenuXml.BeanRefElement) xTopLevelBeanOrRef, xBeansElem);
+            }
+
+            topEntry.ifPresent(topMenuEntries::add);
+        }
+
+        return topMenuEntries;
+    }
+
+    /**
+     * Evaluate a list of TopMenuEntry and child MenuEntry items, removing any that are RoleBased
+     * and where current user does not have the required role.
+     * Note, this modifies the passed-in 'topMenuEntries' parameter!
+     */
+    private void evaluateRoleBasedEntries(List<TopMenuEntry> topMenuEntries, final MenuRequestContext context) {
+        for (TopMenuEntry topEntry : topMenuEntries) {
+            // For now, we don't evaluate the TopMenuEntries
+            if (topEntry.items != null && !topEntry.items.isEmpty()) {
+                for (int i = topEntry.items.size() - 1; i >= 0; i--) {
+                    if (!evaluateRoleBasedMenuEntry(topEntry.items.get(i), context)) {
+                        topEntry.items.remove(i);
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean evaluateRoleBasedMenuEntry(MenuEntry menuEntry, final MenuRequestContext context) {
+        if (menuEntry.className != null &&
+            menuEntry.className.equals(ROLE_BASED_NAV_BAR_ENTRY_CLASS)) {
+            List<String> roles = rolesAsList(menuEntry.roles);
+
+            if (!roles.isEmpty() && roles.stream().noneMatch(context::isUserInRole)) {
+                return false;
+            }
+        }
+
+       return true;
+    }
+
+    private Optional<TopMenuEntry> parseTopMenuEntry(MenuXml.BeanElement xTopLevelBean) {
+        // Top level menu items, like "Info", "Status"
+        TopMenuEntry topEntry = new TopMenuEntry();
+        topEntry.id = xTopLevelBean.getId();
+        topEntry.className = xTopLevelBean.getClassName();
+
+        for (var prop : xTopLevelBean.getProperties()) {
+            setFromBeanProperty(prop, "name", (s) -> topEntry.name = s);
+            setFromBeanProperty(prop, "url", (s) -> topEntry.url = s);
+            setFromBeanProperty(prop, "locationMatch", (s) -> topEntry.locationMatch = s);
+            setFromBeanProperty(prop, "roles", (s) -> topEntry.roles = s);
+        }
+
+        boolean isValid = false;
+
+        if (!Strings.isNullOrEmpty(topEntry.name) && !Strings.isNullOrEmpty(topEntry.url)) {
+            isValid = true;
+
+            MenuXml.BeanPropertyElement xEntries =
+                xTopLevelBean.getProperties().stream()
+                    .filter(p -> !Strings.isNullOrEmpty(p.getName()) && p.getName().equals("entries"))
+                    .findFirst().orElse(null);
+
+            if (xEntries != null) {
+                for (var xBean : xEntries.getBeans()) {
+                    MenuEntry menuEntry = new MenuEntry();
+                    menuEntry.id = xBean.getId();
+                    menuEntry.className = xBean.getClassName();
+
+                    for (var prop : xBean.getProperties()) {
+                        setFromBeanProperty(prop, "name", (s) -> menuEntry.name = s);
+                        setFromBeanProperty(prop, "url", (s) -> menuEntry.url = s);
+                        setFromBeanProperty(prop, "locationMatch", (s) -> menuEntry.locationMatch = s);
+                        setFromBeanProperty(prop, "roles", (s) -> menuEntry.roles = s);
+                    }
+
+                    if (!Strings.isNullOrEmpty(menuEntry.name) && !Strings.isNullOrEmpty(menuEntry.url)) {
+                        topEntry.addItem(menuEntry);
+                    }
+                }
+            }
+        }
+
+        return isValid ? Optional.of(topEntry) : Optional.empty();
+    }
+
+    /**
+     * This and the following are in navbar.ftl, we add them here as if they were just another menu entry.
+     */
+    private TopMenuEntry getHelpMenuEntry(boolean isAdmin) {
+        TopMenuEntry helpMenu = new TopMenuEntry();
+        helpMenu.name = "Help";
+
+        MenuEntry helpEntry = new MenuEntry();
+        helpEntry.name = "Help";
+        helpEntry.url = "help/index.jsp";
+        helpEntry.iconType = "fa";
+        helpEntry.icon = "fa-question-circle";
+        helpMenu.addItem(helpEntry);
+
+        MenuEntry aboutEntry = new MenuEntry();
+        aboutEntry.name = "About";
+        aboutEntry.url = "about/index.jsp";
+        aboutEntry.iconType = "fa";
+        aboutEntry.icon = "fa-info-circle";
+        helpMenu.addItem(aboutEntry);
+
+        // only admin gets Support menu
+        if (isAdmin) {
+            MenuEntry supportEntry = new MenuEntry();
+            supportEntry.name = "Support";
+            supportEntry.url = "support/index.jsp";
+            supportEntry.iconType = "fa";
+            supportEntry.icon = "fa-life-ring";
+            mergeRole(supportEntry, Authentication.ROLE_ADMIN);
+            helpMenu.addItem(supportEntry);
+        }
+
+        return helpMenu;
+    }
+
+    private TopMenuEntry getSelfServiceMenuEntry(String username) {
+        TopMenuEntry selfServiceMenu = new TopMenuEntry();
+        selfServiceMenu.name = username;
+        selfServiceMenu.url = "account/selfService/index.jsp";
+        selfServiceMenu.iconType = "fa";
+        selfServiceMenu.icon = "fa-user";
+
+        MenuEntry changePasswordMenu = new MenuEntry();
+        changePasswordMenu.name = "Change Password";
+        changePasswordMenu.iconType = "fa";
+        changePasswordMenu.icon = "fa-key";
+        changePasswordMenu.url = "account/selfService/newPasswordEntry";
+        selfServiceMenu.addItem(changePasswordMenu);
+
+        MenuEntry logoutMenu = new MenuEntry();
+        logoutMenu.name = "Log Out";
+        logoutMenu.iconType = "fa";
+        logoutMenu.icon = "fa-sign-out";
+        logoutMenu.url = "j_spring_security_logout";
+        selfServiceMenu.addItem(logoutMenu);
+
+        return selfServiceMenu;
+    }
+
+    private TopMenuEntry getUserNotificationMenu(String username) {
+        TopMenuEntry notificationsMenu = new TopMenuEntry();
+
+        // Note that the top menu is actually 2 items with notification counts,
+        // UI implementation will need to add that
+        MenuEntry userMenu = new MenuEntry();
+        userMenu.url = "notification/browse?acktype=unack&filter=user==" + username;
+        userMenu.id = "user";
+        userMenu.icon = "fa-user";
+        userMenu.iconType = "fa";
+        notificationsMenu.addItem(userMenu);
+
+        MenuEntry teamMenu = new MenuEntry();
+        teamMenu.url = "notification/browse?acktype=unack";
+        teamMenu.id = "team";
+        teamMenu.icon = "fa-users";
+        teamMenu.iconType = "fa";
+        notificationsMenu.addItem(teamMenu);
+
+        MenuEntry onCallMenu = new MenuEntry();
+        onCallMenu.id = "oncall";
+        onCallMenu.url = "roles";
+        onCallMenu.name = "On-Call Schedule";
+        onCallMenu.icon = "fa-calendar";
+        onCallMenu.iconType = "fa";
+        notificationsMenu.addItem(onCallMenu);
+
+        return notificationsMenu;
+    }
+
+    private MenuEntry getProvisionMenu() {
+        MenuEntry provisionMenu = new MenuEntry();
+        provisionMenu.name = "Quick-Add Node";
+        provisionMenu.url = "admin/ng-requisitions/quick-add-node.jsp#/";
+        provisionMenu.iconType = "fa";
+        provisionMenu.icon = "fa-plus-circle";
+        mergeRole(provisionMenu, Authentication.ROLE_ADMIN);
+        mergeRole(provisionMenu, Authentication.ROLE_PROVISION);
+
+        return provisionMenu;
+    }
+
+    private MenuEntry getFlowsMenu() {
+        MenuEntry flowsMenu = new MenuEntry();
+        flowsMenu.name = "Flows Management";
+        flowsMenu.url = "admin/classification/index.jsp";
+        flowsMenu.iconType = "fa";
+        flowsMenu.icon = "fa-minus-circle";
+        mergeRole(flowsMenu, Authentication.ROLE_FLOW_MANAGER);
+
+        return flowsMenu;
+    }
+
+    private MenuEntry getConfigurationMenu() {
+        MenuEntry configurationMenu = new MenuEntry();
+        configurationMenu.name = "Configure OpenNMS";
+        configurationMenu.url = "admin/index.jsp";
+        configurationMenu.iconType = "fa";
+        configurationMenu.icon = "fa-cogs";
+        mergeRole(configurationMenu, Authentication.ROLE_ADMIN);
+
+        return configurationMenu;
+    }
+
+    // TODO: Remove, we are handling this in UI with separate Rest call to 'rest/notifications/summary'
+    private Notices buildNotices(MenuRequestContext context) {
+        Notices notices = new Notices();
+
+        notices.status = context.getNoticeStatus();
+
+        return notices;
+    }
+
+    private Optional<TopMenuEntry> parseTopMenuEntryFromRef(MenuXml.BeanRefElement xBeanRefElement, MenuXml.BeansElement xBeansElem) {
+        String refName = xBeanRefElement.getBeanRef();
+
+        Optional<MenuXml.BeanElement> xBean =
+            xBeansElem.getBeans().stream()
+                .filter(b -> b.getName() != null && b.getName().equals(refName))
+                .findFirst();
+
+        if (xBean.isPresent()) {
+            return parseTopMenuEntry(xBean.get());
+        }
+
+        return Optional.empty();
+    }
+
+    private void setFromBeanProperty(MenuXml.BeanPropertyElement propElem, String name, Consumer<String> consumer) {
+        if (propElem.getName() != null && propElem.getName().equals(name)) {
+            consumer.accept(propElem.getValue());
+        }
+    }
+
+    private void mergeRole(MenuEntry entry, String role) {
+        final String trimmedRole = role.trim();
+
+        if (Strings.isNullOrEmpty(entry.roles)) {
+            entry.roles = trimmedRole;
+            return;
+        }
+
+        List<String> roles = rolesAsList(entry.roles);
+
+        if (roles.stream().noneMatch(s -> s.equals(trimmedRole))) {
+            roles.add(trimmedRole);
+            entry.roles = String.join(",", roles);
+        }
+    }
+
+    private List<String> rolesAsList(String roles) {
+        if (Strings.isNullOrEmpty(roles)) {
+            return new ArrayList<>();
+        }
+
+        return new ArrayList<String>(Arrays.asList(roles.split(",")));
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuRequestContext.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuRequestContext.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu;
+
+public interface MenuRequestContext {
+    String getRemoteUser();
+
+    String calculateUrlBase();
+
+    boolean isUserInRole(String role);
+
+    String getFormattedTime();
+
+    String getNoticeStatus();
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/Notices.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/Notices.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu;
+
+public class Notices {
+    public Integer countUser;
+    public Integer countNonUser;
+    public String linkUser;
+    public String linkNonUser;
+    public String status;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/TopMenuEntry.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/TopMenuEntry.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Similar to org.opennms.web.navigate.MenuEntry
+public class TopMenuEntry extends MenuEntry {
+    public List<MenuEntry> items;
+
+    public void addItem(MenuEntry menuEntry) {
+        if (items == null) {
+            items = new ArrayList<>();
+        }
+
+        items.add(menuEntry);
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/xml/MenuXml.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/xml/MenuXml.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+public class MenuXml {
+    public static class ConstructorArgElement {
+        // List of BeanElement and/or BeanRefElement
+        private List<BeanOrRefElement> beansOrRefs = new ArrayList<>();
+
+        // <constructor-arg>
+        //   <list>
+        //     <bean>
+        //     <ref>
+        @XmlElementWrapper(name="list")
+        @XmlElements({
+            @XmlElement(name="bean", type=BeanElement.class),
+            @XmlElement(name="ref", type=BeanRefElement.class)
+        })
+        public List<BeanOrRefElement> getBeansOrRefs() {
+            return this.beansOrRefs;
+        }
+
+        public void setBeansOrRefs(List<BeanOrRefElement> list) {
+            this.beansOrRefs = list;
+        }
+    }
+
+    // wrapper class
+    // <constructor-arg><list> can include either <bean> or <ref @bean> elements.
+    public static abstract class BeanOrRefElement {
+    }
+
+    public static class BeanPropertyElement {
+        private String name;
+        private String value;
+        private List<BeanElement> beans = new ArrayList<>();
+
+        @XmlAttribute(name="name")
+        public String getName() {
+            return this.name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @XmlAttribute(name="value")
+        public String getValue() {
+            return this.value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        // <property name="entries">
+        //   <list>
+        //     <bean>
+        @XmlElementWrapper(name="list")
+        @XmlElement(name="bean")
+        public List<BeanElement> getBeans() {
+            return this.beans;
+        }
+
+        public void setList(List<BeanElement> list) {
+            this.beans = list;
+        }
+    }
+
+    public static class BeanElement extends BeanOrRefElement {
+        private String id;
+        private String name;
+        private String className;
+        private List<BeanPropertyElement> properties = new ArrayList<>();
+        private ConstructorArgElement constructorArgElement;
+
+        @XmlAttribute(name="id")
+        public String getId() {
+            return this.id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @XmlAttribute(name="name")
+        public String getName() {
+            return this.name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @XmlAttribute(name="class")
+        public String getClassName() {
+            return this.className;
+        }
+
+        public void setClassName(String s) {
+            this.className = s;
+        }
+
+        @XmlElement(name="property", type=BeanPropertyElement.class)
+        public List<BeanPropertyElement> getProperties() {
+            return this.properties;
+        }
+
+        public void setProperties(List<BeanPropertyElement> properties) {
+            this.properties = properties;
+        }
+
+        @XmlElement(name="constructor-arg", type=ConstructorArgElement.class)
+        public ConstructorArgElement getConstructorArgElement() {
+            return this.constructorArgElement;
+        }
+
+        public void setConstructorArgElement(ConstructorArgElement c) {
+            this.constructorArgElement = c;
+        }
+    }
+
+    public static class BeanRefElement extends BeanOrRefElement{
+        private String beanRef;
+
+        @XmlAttribute(name="bean")
+        public String getBeanRef() {
+            return this.beanRef;
+        }
+
+        public void setBeanRef(String s) {
+            this.beanRef = s;
+        }
+    }
+
+    @XmlRootElement(name="beans")
+    public static class BeansElement {
+        private List<BeanElement> beans = new ArrayList<>();
+
+        @XmlElement(name="bean", type=BeanElement.class)
+        public List<BeanElement> getBeans() {
+            return this.beans;
+        }
+
+        public void setBeans(List<BeanElement> beans) {
+            this.beans = beans;
+        }
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/xml/package-info.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/xml/package-info.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+@XmlSchema(
+    namespace="http://www.springframework.org/schema/beans",
+    elementFormDefault = XmlNsForm.QUALIFIED
+)package org.opennms.web.rest.support.menu.xml;
+
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MenuRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MenuRestService.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v2;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.opennms.core.time.CentralizedDateTimeFormat;
+import org.opennms.web.rest.support.menu.HttpMenuRequestContext;
+import org.opennms.web.rest.support.menu.MainMenu;
+import org.opennms.web.rest.support.menu.MenuProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Web Service using REST for retrieving information to dynamically build the Vue webapp's Menubar component.
+ */
+@Component
+@Path("menu")
+public class MenuRestService {
+    private static final Logger LOG = LoggerFactory.getLogger(MenuRestService.class);
+    private CentralizedDateTimeFormat dateTimeFormat = new CentralizedDateTimeFormat();
+
+    @Autowired
+    private MenuProvider menuProvider;
+
+    @GET
+    @Path("/")
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response getMainMenu(final @Context HttpServletRequest request) {
+        MainMenu mainMenu = buildMenu(request);
+
+        return Response.ok(mainMenu).build();
+    }
+
+    /**
+     * Build the menu definition.
+     * Should correspond to logic in opennms-webapp org.opennms.web.controller.NavBarController
+     * as well as opennms-webapp webapp/WEB-INF/templates/navbar.ftl.
+     */
+    private MainMenu buildMenu(final HttpServletRequest request) {
+        MainMenu mainMenu = null;
+
+        if (this.menuProvider != null) {
+            try {
+                HttpMenuRequestContext context = new HttpMenuRequestContext(request);
+                mainMenu = this.menuProvider.getMainMenu(context);
+            } catch (Exception e) {
+                LOG.error("Error creating menu entries: " + e.getMessage(), e);
+            }
+        }
+
+        return mainMenu;
+    }
+}

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
@@ -53,6 +53,13 @@
         <property name="securityDefinitions" ref="securityDefinitionsMap" />
         <property name="customizer" ref="openApiCustomizer" />
     </bean>
+    <!-- Used by MenuRestService -->
+    <bean id="dispatcherServletPath" class="java.lang.String">
+        <constructor-arg value="${opennms.home}/jetty-webapps/opennms/WEB-INF/dispatcher-servlet.xml" />
+    </bean>
+    <bean id="menuProvider" class="org.opennms.web.rest.support.menu.MenuProvider">
+        <constructor-arg ref="dispatcherServletPath"/>
+    </bean>
 
     <jaxrs:server id="cxf-rest-v2" address="/" basePackages="org.opennms.web.rest.v2,org.opennms.web.rest.v2.bsm,,org.opennms.web.rest.v2.status">
       <jaxrs:properties>

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/menu/MenuProviderTest.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/menu/MenuProviderTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.menu;
+
+import java.io.FileInputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opennms.web.rest.support.menu.xml.MenuXml;
+
+public class MenuProviderTest {
+    final static String RESOURCE_PATH = "src/test/resources/dispatcher-servlet.xml";
+
+    @Test
+    public void testParseBeansXml() {
+        MenuProvider provider = new MenuProvider(getResourcePath());
+        MenuXml.BeansElement xBeansElem = null;
+
+        try (var inputStream = new FileInputStream(getResourcePath())) {
+            xBeansElem = provider.parseDispatcherServletXml(inputStream);
+        } catch (Exception e) {
+            Assert.fail("Could not open file resource: " + e.getMessage());
+        }
+
+        Assert.assertNotNull(xBeansElem);
+
+        List<MenuXml.BeanElement> topLevelBeans = xBeansElem.getBeans();
+
+        Optional<MenuXml.BeanElement> navBarBean = topLevelBeans.stream()
+            .filter(e -> e.getId() != null && e.getId().equals("navBarEntries"))
+            .findFirst();
+
+        if (navBarBean.isPresent()) {
+            List<TopMenuEntry> topMenuEntries = null;
+
+            try {
+                topMenuEntries = provider.parseXmlToMenuEntries(xBeansElem);
+            } catch (Exception e) {
+                Assert.fail("Error parsing XML to MenuEntries: " + e.getMessage());
+            }
+        }
+
+        Assert.assertTrue(topLevelBeans.size() > 0);
+    }
+
+    @Test
+    public void testParseMainMenu() {
+        MainMenu mainMenu = null;
+        MenuRequestContext context = new TestMenuRequestContext();
+
+        try {
+            MenuProvider provider = new MenuProvider(getResourcePath());
+            mainMenu = provider.getMainMenu(context);
+        } catch (Exception e) {
+            Assert.fail("Error in MenuProvider.getMainMenu: " + e.getMessage());
+        }
+    }
+
+    private String getResourcePath() {
+        Path p = Paths.get(RESOURCE_PATH);
+        return p.toFile().getAbsolutePath();
+    }
+
+    public static class TestMenuRequestContext implements MenuRequestContext {
+        public String getRemoteUser() {
+            return "admin1";
+        }
+
+        public String calculateUrlBase() {
+            return "opennms/";
+        }
+
+        public boolean isUserInRole(String role) {
+            return true;
+        }
+
+        public String getFormattedTime() {
+            return "2022-10-11T20:30:00.000Z";
+        }
+
+        public String getNoticeStatus() {
+            return "On";
+        }
+    }
+}

--- a/opennms-webapp-rest/src/test/resources/dispatcher-servlet.xml
+++ b/opennms-webapp-rest/src/test/resources/dispatcher-servlet.xml
@@ -1,0 +1,662 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi" 
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
+       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.2.xsd
+       http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd"
+        >
+
+    <tx:annotation-driven/>
+    <context:annotation-config/>
+
+    <!-- Scan the following packages for controllers that are annotated with the @Controller annotation -->
+    <context:component-scan base-package="org.opennms.web.controller"/>
+
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
+        <!-- 
+          We need to ignore unresolvable placeholders since if multiple PropertyPlaceholderConfigurer
+          preprocessors are in use in a single context (such as inside unit tests), Spring will encounter
+          the issue documented here:
+
+          https://jira.springsource.org/browse/SPR-6428
+
+          TODO: Fix this behavior after upgrading to Spring 3.1.
+        -->
+        <property name="ignoreUnresolvablePlaceholders" value="true"/>
+    </bean>
+
+    <!-- Map controllers based on their bean name -->
+    <bean class="org.springframework.web.servlet.handler.BeanNameUrlHandlerMapping">
+        <property name="order" value="0"/>
+    </bean>
+
+    <!-- These HandlerMapping beans ensure that @RequestMapping-annotated classes and methods are resolvable -->
+    <bean class="org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping"/>
+    <bean class="org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter"/>
+
+    <bean id="defaultViewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
+        <property name="viewClass" value="org.springframework.web.servlet.view.JstlView"/>
+        <property name="order" value="1"/>
+        <property name="prefix" value="/WEB-INF/jsp/"/>
+        <property name="suffix" value=".jsp"/>
+    </bean>
+
+    <bean id="messageSource" class="org.springframework.context.support.ReloadableResourceBundleMessageSource">
+        <property name="basename">
+            <value>/WEB-INF/messages</value>
+        </property>
+        <property name="cacheSeconds">
+            <value>2</value>
+        </property>
+    </bean>
+
+    <!-- Dispatches requests mapped to org.springframework.web.servlet.mvc.Controller implementations -->
+    <bean class="org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter"/>
+
+    <bean name="defaultForeignSourceService" class="org.opennms.netmgt.provision.persist.DefaultForeignSourceService">
+        <property name="pendingForeignSourceRepository" ref="selectedPendingForeignSourceRepository"/>
+        <property name="deployedForeignSourceRepository" ref="selectedDeployedForeignSourceRepository"/>
+    </bean>
+
+    <bean name="/admin/sendevent.htm" class="org.opennms.web.controller.SendEventController">
+          <property name="eventConfDao" ref="eventConfDao"/>
+    </bean>
+
+    <bean name="/admin/applications.htm"
+          class="org.opennms.web.controller.ApplicationController">
+        <property name="adminApplicationService" ref="adminApplicationService"/>
+    </bean>
+
+    <bean name="/admin/categories.htm"
+          class="org.opennms.web.controller.CategoryController">
+        <property name="adminCategoryService" ref="adminCategoryService"/>
+        <property name="surveillanceViewConfigDao" ref="surveillanceViewConfigDao"/>
+    </bean>
+    <!-- -->
+    <bean name="/support/groups/setACLUserGroups" class="org.opennms.web.admin.groups.SetUserGroupController">
+        <property name="filterManager" ref="filterManager" />
+        <property name="groupDao" ref="groupDao" />
+    </bean>
+
+    <bean name="/admin/userGroupView/groups/list.htm"
+          class="org.opennms.web.controller.admin.group.GroupListController">
+        <property name="groupManager" ref="groupManager"/>
+    </bean>
+
+    <!-- Converted from a Dispatcher to controller -->
+    <!-- This one uses Autowired -->
+    <bean name="/admin/userGroupView/groups/modifyGroup"
+          class="org.opennms.web.controller.admin.group.GroupController"/>
+
+    <bean name="systemReport" class="org.opennms.systemreport.SystemReport">
+        <property name="serviceRegistry" ref="serviceRegistry"/>
+    </bean>
+
+    <bean name="/admin/support/systemReport.htm"
+          class="org.opennms.web.controller.admin.support.SystemReportController">
+        <property name="systemReport" ref="systemReport"/>
+    </bean>
+
+    <bean name="/admin/support/systemReportList.htm"
+          class="org.opennms.web.controller.admin.support.SystemReportListController">
+        <property name="systemReport" ref="systemReport"/>
+    </bean>
+
+    <bean name="/aggregateStatus.htm"
+          class="org.opennms.web.controller.SiteStatusViewController">
+        <property name="service" ref="siteStatusViewService"/>
+    </bean>
+
+    <bean name="/siteStatusView.htm"
+          class="org.opennms.web.controller.SiteStatusViewController">
+        <property name="service" ref="siteStatusViewService"/>
+    </bean>
+
+    <bean name="/surveillanceView.htm"
+          class="org.opennms.web.controller.SurveillanceViewController">
+        <property name="service" ref="surveillanceService"/>
+    </bean>
+
+    <bean name="/alarm/ticket/create.htm" class="org.opennms.web.controller.alarm.AlarmTicketController">
+        <property name="troubleTicketProxy" ref="troubleTicketProxy"/>
+    </bean>
+    <bean name="/alarm/ticket/update.htm" class="org.opennms.web.controller.alarm.AlarmTicketController">
+        <property name="troubleTicketProxy" ref="troubleTicketProxy"/>
+    </bean>
+    <bean name="/alarm/ticket/close.htm" class="org.opennms.web.controller.alarm.AlarmTicketController">
+        <property name="troubleTicketProxy" ref="troubleTicketProxy"/>
+    </bean>
+
+    <bean name="/alarm/acknowledge" class="org.opennms.web.controller.alarm.AcknowledgeAlarmController">
+        <property name="alarmRepository" ref="alarmRepository"/>
+        <property name="redirectView" value="/alarm/list.htm"/>
+    </bean>
+
+    <bean name="/alarm/acknowledgeByFilter" class="org.opennms.web.controller.alarm.AcknowledgeAlarmByFilterController">
+        <property name="alarmRepository" ref="alarmRepository"/>
+        <property name="redirectView" value="/alarm/list.htm"/>
+    </bean>
+
+    <bean name="/alarm/changeSeverity" class="org.opennms.web.controller.alarm.AlarmSeverityChangeController">
+        <property name="alarmRepository" ref="alarmRepository"/>
+        <property name="redirectView" value="/alarm/list.htm"/>
+    </bean>
+
+    <bean name="/alarm/createFavorite" class="org.opennms.web.controller.alarm.AlarmFilterController"/>
+
+    <bean name="/alarm/deleteFavorite" class="org.opennms.web.controller.alarm.AlarmFilterController"/>
+
+    <alias name="/alarm/index.htm" alias="/alarm/index"/>
+    <bean name="/alarm/index.htm" class="org.opennms.web.controller.alarm.AlarmFilterController"/>
+
+    <alias name="/alarm/list.htm" alias="/alarm/list"/>
+    <bean name="/alarm/list.htm" class="org.opennms.web.controller.alarm.AlarmFilterController"/>
+
+    <alias name="/alarm/detail.htm" alias="/alarm/detail.jsp"/>
+    <bean name="/alarm/detail.htm" class="org.opennms.web.controller.alarm.AlarmDetailController">
+        <property name="alarmRepository" ref="alarmRepository"/>
+        <property name="webEventRepository" ref="webEventRepository"/>
+        <property name="defaultShortLimit" value="20"/>
+    </bean>
+
+    <bean name="/alarm/saveStickyMemo.htm" class="org.opennms.web.controller.alarm.AlarmDetailController">
+        <property name="alarmRepository" ref="alarmRepository"/>
+    </bean>
+    
+    <bean name="/alarm/removeStickyMemo.htm" class="org.opennms.web.controller.alarm.AlarmDetailController">
+        <property name="alarmRepository" ref="alarmRepository"/>
+    </bean>
+
+    <bean name="/alarm/saveJournalMemo.htm" class="org.opennms.web.controller.alarm.AlarmDetailController">
+        <property name="alarmRepository" ref="alarmRepository"/>
+    </bean>
+    
+    <bean name="/alarm/removeJournalMemo.htm" class="org.opennms.web.controller.alarm.AlarmDetailController">
+        <property name="alarmRepository" ref="alarmRepository"/>
+    </bean>
+    
+    <bean name="/alarm/summary-box.htm" class="org.opennms.web.controller.alarm.AlarmBoxController">
+        <property name="successView" value="alarm/summary-box"/>
+        <property name="alarmRepository" ref="alarmRepository"/>
+    </bean>
+
+    <bean name="/situation/summary-box.htm" class="org.opennms.web.controller.situation.SituationBoxController">
+        <property name="successView" value="situation/summary-box"/>
+        <property name="alarmRepository" ref="alarmRepository"/>
+    </bean>
+
+    <bean name="/bsm/summary-box.htm" class="org.opennms.web.controller.bsm.BusinessServicesBoxController">
+        <property name="successView" value="bsm/summary-box"/>
+        <property name="businessServiceManager" ref="businessServiceManager"/>
+    </bean>
+
+    <bean name="/trend/trend.htm" class="org.opennms.web.controller.trend.TrendController">
+    </bean>
+
+    <bean name="/trend/trend-box.htm" class="org.opennms.web.controller.trend.TrendBoxController">
+    </bean>
+
+    <bean name="/application/summary-box.htm" class="org.opennms.web.controller.application.ApplicationBoxController">
+        <property name="successView" value="application/summary-box"/>
+        <property name="applicationDao" ref="applicationDao"/>
+    </bean>
+
+   	<bean name="/event/*" class="org.opennms.web.controller.event.EventController">
+    </bean>
+
+
+    <bean name="/notification/acknowledge"
+          class="org.opennms.web.controller.notification.AcknowledgeNotificationController">
+        <property name="webNotificationRepository" ref="webNotificationRepository"/>
+        <property name="redirectView" value="/notification/list.htm"/>
+    </bean>
+
+    <alias name="/notification/list.htm" alias="/notification/browse"/>
+    <bean name="/notification/list.htm" class="org.opennms.web.controller.notification.NotificationFilterController">
+        <property name="successView" value="notification/list"/>
+        <property name="defaultShortLimit" value="20"/>
+        <property name="defaultLongLimit" value="10"/>
+        <property name="defaultSortStyle" value="ID"/>
+        <property name="webNotificationRepository" ref="webNotificationRepository"/>
+        <property name="webEventRepository" ref="webEventRepository"/>
+        <property name="nodeDao" ref="nodeDao"/>
+    </bean>
+
+    <alias name="/outage/list.htm" alias="/outage/list"/>
+    <bean name="/outage/list.htm" class="org.opennms.web.controller.outage.OutageFilterController">
+        <property name="successView" value="outage/list"/>
+        <property name="defaultShortLimit" value="20"/>
+        <property name="defaultLongLimit" value="10"/>
+        <property name="defaultOutageType" value="CURRENT"/>
+        <property name="defaultSortStyle" value="ID"/>
+        <property name="webOutageRepository" ref="webOutageRepository"/>
+    </bean>
+
+    <alias name="/outage/detail.htm" alias="/outage/detail.jsp"/>
+    <bean name="/outage/detail.htm" class="org.opennms.web.controller.outage.OutageDetailController">
+        <property name="successView" value="outage/detail"/>
+        <property name="webOutageRepository" ref="webOutageRepository"/>
+    </bean>
+
+    <bean name="/outage/servicesdown-box.htm" class="org.opennms.web.controller.outage.OutageBoxController">
+        <property name="successView" value="outage/servicesdown-box"/>
+        <property name="webOutageRepository" ref="webOutageRepository"/>
+    </bean>
+
+    <bean name="/outage/nodeOutages-box.htm" class="org.opennms.web.controller.outage.NodeOutagesController">
+        <property name="successView" value="outage/nodeOutages-box"/>
+        <property name="webOutageRepository" ref="webOutageRepository"/>
+    </bean>
+
+    <bean name="/outage/interfaceOutages-box.htm" class="org.opennms.web.controller.outage.InterfaceOutagesController">
+        <property name="successView" value="outage/interfaceOutages-box"/>
+        <property name="webOutageRepository" ref="webOutageRepository"/>
+    </bean>
+
+    <bean name="/outage/serviceOutages-box.htm" class="org.opennms.web.controller.outage.ServiceOutagesController">
+        <property name="successView" value="outage/serviceOutages-box"/>
+        <property name="webOutageRepository" ref="webOutageRepository"/>
+    </bean>
+
+    <bean name="/admin/thresholds/index.htm" class="org.opennms.web.controller.admin.thresholds.ThresholdController">
+        <property name="resourceDao" ref="resourceDao"/>
+        <property name="eventConfDao" ref="eventConfDao"/>
+    </bean>
+
+    <bean name="mapMenuEntries" class="org.opennms.web.navigate.MenuDropdownNavBarEntry">
+        <property name="name" value="Maps" />
+        <property name="url" value="maps.htm" />
+        <property name="entries">
+            <list>
+                <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                    <property name="name" value="Topology"/>
+                    <property name="url" value="topology"/>
+                    <property name="locationMatch" value="topology"/>
+                </bean>
+                <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                    <property name="name" value="Geographical (Legacy)"/>
+                    <property name="url" value="node-maps"/>
+                    <property name="locationMatch" value="node-maps"/>
+                </bean>
+                <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                    <property name="name" value="Geographical"/>
+                    <property name="url" value="ui/index.html#/map"/>
+                    <property name="locationMatch" value="node-maps"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="/maps.htm" class="org.opennms.web.controller.MapsController">
+        <property name="mapMenuEntries" ref="mapMenuEntries" />
+    </bean>
+
+    <bean name="dashboardMenuEntries" class="org.opennms.web.navigate.MenuDropdownNavBarEntry">
+        <property name="name" value="Dashboards" />
+        <property name="url" value="dashboards.htm" />
+        <property name="entries">
+            <list>
+                <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                    <property name="name" value="Dashboard"/>
+                    <property name="url" value="dashboard.jsp"/>
+                    <property name="locationMatch" value="dashboard"/>
+                </bean>
+                <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                    <property name="name" value="Ops Board"/>
+                    <property name="url" value="vaadin-wallboard"/>
+                    <property name="locationMatch" value="vaadin-wallboard"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="/dashboards.htm" class="org.opennms.web.controller.DashboardController">
+        <property name="dashboardMenuEntries" ref="dashboardMenuEntries" />
+    </bean>
+
+    <!--  "includes" -->
+    <bean id="navBarEntries" class="java.util.ArrayList">
+        <constructor-arg>
+            <list>
+                <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                    <property name="name" value="Search"/>
+                    <property name="url" value="element/index.jsp"/>
+                    <property name="locationMatch" value="element"/>
+                </bean>
+
+                <bean class="org.opennms.web.navigate.MenuDropdownNavBarEntry">
+                    <property name="name" value="Info" />
+                    <property name="url" value="#" />
+                    <property name="entries">
+                        <list>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Nodes"/>
+                                <property name="url" value="element/nodeList.htm"/>
+                                <property name="locationMatch" value="nodelist"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Assets"/>
+                                <property name="url" value="asset/index.jsp"/>
+                                <property name="locationMatch" value="asset"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Path Outages"/>
+                                <property name="url" value="pathOutage/index.jsp"/>
+                                <property name="locationMatch" value="pathOutage"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.RoleBasedNavBarEntry">
+                                <property name="name" value="Device Configs"/>
+                                <property name="url" value="ui/index.html#/device-config-backup"/>
+                                <property name="locationMatch" value="configurationManagement"/>
+                                <property name="roles" value="ROLE_ADMIN,ROLE_REST,ROLE_DEVICE_CONFIG_BACKUP"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="External Requisitions"/>
+                                <property name="url" value="ui/index.html#/configuration"/>
+                                <property name="locationMatch" value="configurationManagement"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.RoleBasedNavBarEntry">
+                                <property name="name" value="File Editor"/>
+                                <property name="url" value="ui/index.html#/file-editor"/>
+                                <property name="locationMatch" value="configurationManagement"/>
+                                <property name="roles" value="ROLE_FILESYSTEM_EDITOR"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.RoleBasedNavBarEntry">
+                                <property name="name" value="Logs"/>
+                                <property name="url" value="ui/index.html#/logs"/>
+                                <property name="locationMatch" value="configurationManagement"/>
+                                <property name="roles" value="ROLE_ADMIN"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Endpoints"/>
+                                <property name="url" value="ui/index.html#/open-api"/>
+                                <property name="locationMatch" value="configurationManagement"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.RoleBasedNavBarEntry">
+                                <property name="name" value="Secure Credentials Vault"/>
+                                <property name="url" value="ui/index.html#/scv"/>
+                                <property name="locationMatch" value="configurationManagement"/>
+                                <property name="roles" value="ROLE_ADMIN"/>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
+
+                <bean class="org.opennms.web.navigate.MenuDropdownNavBarEntry">
+                    <property name="name" value="Status" />
+                    <property name="url" value="#" />
+                    <property name="entries">
+                        <list>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Events"/>
+                                <property name="url" value="event/index"/>
+                                <property name="locationMatch" value="event"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Alarms"/>
+                                <property name="url" value="alarm/index.htm"/>
+                                <property name="locationMatch" value="alarm"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Notifications"/>
+                                <property name="url" value="notification/index.jsp"/>
+                                <property name="locationMatch" value="notification"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Outages"/>
+                                <property name="url" value="outage/index.jsp"/>
+                                <property name="locationMatch" value="outage"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Surveillance"/>
+                                <property name="url" value="surveillance-view.jsp"/>
+                                <property name="locationMatch" value="surveillance-view"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Heatmap"/>
+                                <property name="url" value="heatmap/index.jsp"/>
+                                <property name="locationMatch" value="heatmap"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Trend"/>
+                                <property name="url" value="trend/index.jsp"/>
+                                <property name="locationMatch" value="trend"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Application"/>
+                                <property name="url" value="application/index.jsp"/>
+                                <property name="locationMatch" value="application"/>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
+
+                <bean class="org.opennms.web.navigate.MenuDropdownNavBarEntry">
+                    <property name="name" value="Reports" />
+                    <property name="url" value="report/index.jsp" />
+                    <property name="entries">
+                        <list>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Charts"/>
+                                <property name="url" value="charts/index.jsp"/>
+                                <property name="locationMatch" value="chart"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Resource Graphs"/>
+                                <property name="url" value="graph/index.jsp"/>
+                                <property name="locationMatch" value="performance"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="KSC Reports"/>
+                                <property name="url" value="KSC/index.jsp"/>
+                                <property name="locationMatch" value="ksc"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Database Reports"/>
+                                <property name="url" value="report/database/index.jsp"/>
+                                <property name="locationMatch" value="database-reports"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Statistics"/>
+                                <property name="url" value="statisticsReports/index.htm"/>
+                                <property name="locationMatch" value="reports"/>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
+
+                <ref bean="dashboardMenuEntries" />
+
+                <ref bean="mapMenuEntries" />
+
+<!-- called "Configure OpenNMS" in the user menu now
+                <bean class="org.opennms.web.navigate.AdminUserNavBarEntry">
+                    <property name="name" value="Admin"/>
+                    <property name="url" value="admin/index.jsp"/>
+                    <property name="locationMatch" value="admin"/>
+                </bean>
+-->
+
+<!-- called "Help/Support" in the user menu now
+                <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                    <property name="name" value="Support"/>
+                    <property name="url" value="support/index.htm"/>
+                    <property name="locationMatch" value="support"/>
+                </bean>
+-->
+
+            </list>
+        </constructor-arg>
+    </bean>
+
+    <bean id="headerProvider" name="/navBar.htm" class="org.opennms.web.controller.NavBarController">
+        <property name="navBarItems" ref="navBarEntries" />
+    </bean>
+
+  <onmsgi:service ref="headerProvider">
+      <onmsgi:interfaces>
+          <value>org.opennms.web.api.OnmsHeaderProvider</value>
+          <value>org.opennms.web.api.MenuProvider</value>
+      </onmsgi:interfaces>
+  </onmsgi:service>
+
+    <bean name="/includes/nodeCategory-box.htm" class="org.opennms.web.controller.NodeCategoryBoxController">
+        <property name="adminCategoryService" ref="adminCategoryService"/>
+    </bean>
+
+    <bean name="/includes/serviceApplication-box.htm"
+          class="org.opennms.web.controller.ServiceApplicationBoxController">
+        <property name="adminApplicationService" ref="adminApplicationService"/>
+    </bean>
+
+    <bean name="/graph/results.htm" class="org.opennms.web.controller.GraphResultsController">
+        <property name="graphResultsService" ref="graphResultsService"/>
+    </bean>
+
+    <bean name="/graph/graph.png" class="org.opennms.web.controller.RrdGraphController">
+        <property name="rrdGraphService" ref="rrdGraphService"/>
+    </bean>
+
+    <!-- KSC reports -->
+
+    <bean name="/KSC/formProcMain.htm" class="org.opennms.web.controller.ksc.FormProcMainController">
+        <property name="kscReportFactory" ref="kscReportFactory"/>
+    </bean>
+
+    <bean name="/KSC/formProcGraph.htm" class="org.opennms.web.controller.ksc.FormProcGraphController">
+        <property name="kscReportFactory" ref="kscReportFactory"/>
+        <property name="kscReportService" ref="kscReportService"/>
+    </bean>
+
+    <bean name="/KSC/formProcReport.htm" class="org.opennms.web.controller.ksc.FormProcReportController">
+        <property name="kscReportFactory" ref="kscReportFactory"/>
+        <property name="kscReportService" ref="kscReportService"/>
+    </bean>
+
+    <bean name="/KSC/formProcView.htm" class="org.opennms.web.controller.ksc.FormProcViewController">
+        <property name="kscReportFactory" ref="kscReportFactory"/>
+        <property name="kscReportService" ref="kscReportService"/>
+    </bean>
+
+    <bean name="/KSC/customView.htm" class="org.opennms.web.controller.ksc.CustomViewController">
+        <property name="kscReportFactory" ref="kscReportFactory"/>
+        <property name="kscReportService" ref="kscReportService"/>
+        <property name="resourceService" ref="resourceService"/>
+        <property name="defaultGraphsPerLine" value="${ksc.default.graphsPerLine}"/>
+    </bean>
+
+    <bean name="/KSC/customReport.htm" class="org.opennms.web.controller.ksc.CustomReportController">
+        <property name="kscReportFactory" ref="kscReportFactory"/>
+        <property name="kscReportService" ref="kscReportService"/>
+        <property name="resourceService" ref="resourceService"/>
+    </bean>
+
+    <bean name="/KSC/customGraphEditDetails.htm"
+          class="org.opennms.web.controller.ksc.CustomGraphEditDetailsController">
+        <property name="kscReportFactory" ref="kscReportFactory"/>
+        <property name="kscReportService" ref="kscReportService"/>
+        <property name="resourceService" ref="resourceService"/>
+    </bean>
+
+    <bean id="statisticsReportCommandValidator" class="org.opennms.web.validator.StatisticsReportCommandValidator">
+        <property name="statisticsReportDao" ref="statisticsReportDao"/>
+    </bean>
+
+    <bean name="/statisticsReports/index.htm" class="org.opennms.web.controller.statisticsReports.ListController">
+        <property name="statisticsReportService" ref="statisticsReportService"/>
+    </bean>
+
+
+    <!--  Rancid Integration -->
+    <!-- RANCID stuff -->
+    <bean name="/inventory/rancid.htm" class="org.opennms.web.controller.inventory.RancidController">
+        <property name="inventoryService" ref="inventoryService"/>
+    </bean>
+
+    <bean name="/inventory/rancidList.htm" class="org.opennms.web.controller.inventory.RancidListController">
+        <property name="inventoryService" ref="inventoryService"/>
+    </bean>
+
+    <bean name="/inventory/invnode.htm" class="org.opennms.web.controller.inventory.InvNodeController">
+        <property name="inventoryService" ref="inventoryService"/>
+    </bean>
+
+    <bean name="/inventory/rancidViewVc.htm" class="org.opennms.web.controller.inventory.RancidViewVcController">
+        <property name="inventoryService" ref="inventoryService"/>
+    </bean>
+
+    <bean name="/inventory/rancidReport.htm" class="org.opennms.web.controller.inventory.RancidReportController">
+        <property name="inventoryService" ref="inventoryService"/>
+    </bean>
+
+    <bean name="/admin/rancid/rancidAdmin.htm" class="org.opennms.web.controller.inventory.AdminRancidController">
+        <property name="inventoryService" ref="inventoryService"/>
+    </bean>
+
+
+    <bean name="/admin/storage/storageAdmin.htm" class="org.opennms.web.controller.inventory.AdminStorageController">
+        <property name="inventoryService" ref="inventoryService"/>
+    </bean>
+
+    <bean name="/admin/storage/storageDeleteBucketItem.htm"
+          class="org.opennms.web.controller.inventory.AdminStorageDeleteBucketItemController">
+        <property name="inventoryService" ref="inventoryService"/>
+    </bean>
+
+    <bean id="notifdConfigFactory-init" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod"><value>org.opennms.netmgt.config.NotifdConfigFactory.init</value></property>
+    </bean>
+
+    <bean id="notificationFactory-init" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" depends-on="notifdConfigFactory-init">
+        <property name="staticMethod"><value>org.opennms.netmgt.config.NotificationFactory.init</value></property>
+    </bean>
+
+    <bean id="notificationFactory" class="org.opennms.netmgt.config.NotificationFactory" depends-on="notificationFactory-init" factory-method="getInstance"/>
+
+    <bean name="/admin/notification/noticeWizard/eventNotices.htm"
+          class="org.opennms.web.controller.admin.notifications.EventNoticesController">
+        <property name="eventConfDao" ref="eventConfDao"/>
+        <property name="notificationFactory" ref="notificationFactory"/>
+    </bean>
+
+    <bean name="/admin/notification/noticeWizard/chooseUeis.htm"
+          class="org.opennms.web.controller.admin.notifications.ChooseUeisController">
+        <property name="eventConfDao" ref="eventConfDao"/>
+    </bean>
+
+    <!-- Examples
+         <bean name="/nodes.htm" class="org.opennms.controller.NodeController">
+           <property name="entityService" ref="entityService" />
+         </bean>
+
+         <bean name="/interfaces.htm" class="org.opennms.controller.InterfaceController">
+           <property name="entityService" ref="entityService" />
+         </bean>
+
+         <bean name="/node-edit.htm" class="org.opennms.controller.NodeEditController">
+           <property name="entityService" ref="entityService" />
+           <property name="commandName" value="node" />
+           <property name="formView" value="node-edit" />
+           <property name="successView" value="processed" />
+         </bean>
+     -->
+
+    <mvc:default-servlet-handler />
+
+    <mvc:resources mapping="/assets/**" location="/assets/">
+        <mvc:resource-chain resource-cache="true">
+            <mvc:resolvers>
+                <ref bean="assetLocator" />
+            </mvc:resolvers>
+        </mvc:resource-chain>
+    </mvc:resources>
+
+    <mvc:annotation-driven/>
+</beans>

--- a/opennms-webapp/src/main/java/org/opennms/web/navigate/RoleBasedNavBarEntry.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/navigate/RoleBasedNavBarEntry.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.navigate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import com.google.common.base.Strings;
+
+public class RoleBasedNavBarEntry extends LocationBasedNavBarEntry {
+    /** comma-separated list of roles */
+    private String roles;
+
+    public String getRoles() {
+        return this.roles;
+    }
+
+    public void setRoles(String roles) {
+        this.roles = roles;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public DisplayStatus evaluate(MenuContext context) {
+        if (!Strings.isNullOrEmpty(this.roles)) {
+            List<String> roleList = Arrays.stream(this.roles.split(",")).map(String::trim).collect(Collectors.toList());
+
+            boolean anyMatch = roleList.stream().anyMatch(context::isUserInRole);
+
+            return anyMatch ? super.evaluate(context) : DisplayStatus.NO_DISPLAY;
+        }
+
+        return DisplayStatus.NO_DISPLAY;
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/navigate/RoleBasedNavBarEntry.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/navigate/RoleBasedNavBarEntry.java
@@ -28,10 +28,8 @@
 
 package org.opennms.web.navigate;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import com.google.common.base.Strings;
+import java.util.Arrays;
 
 public class RoleBasedNavBarEntry extends LocationBasedNavBarEntry {
     /** comma-separated list of roles */
@@ -49,9 +47,7 @@ public class RoleBasedNavBarEntry extends LocationBasedNavBarEntry {
     @Override
     public DisplayStatus evaluate(MenuContext context) {
         if (!Strings.isNullOrEmpty(this.roles)) {
-            List<String> roleList = Arrays.stream(this.roles.split(",")).map(String::trim).collect(Collectors.toList());
-
-            boolean anyMatch = roleList.stream().anyMatch(context::isUserInRole);
+            boolean anyMatch = Arrays.stream(this.roles.split(",")).map(String::trim).anyMatch(context::isUserInRole);
 
             return anyMatch ? super.evaluate(context) : DisplayStatus.NO_DISPLAY;
         }


### PR DESCRIPTION
Add a MenuRestService. This is part of the UI Preview Foldin for Horizon 31.

This service will be used by the Vue "new UI" menubar to determine how to display the menu links. Also uses mostly the same data sources as the "old" menubar so changes to `dispatcher-servlet.xml` will be picked up by both.

Does the following:

- reads parts of `dispatcher-servlet.xml` to determine most links
- Adds `RoleBasedNavBarEntry` class to allow menu items in `dispatcher-servlet.xml` to be included/excluded based on roles (works for old and new menubars)
- Rest service exposing the `MainMenu` class as Json
- 'Notices' may get removed in the future as user notifications may be handled a different way
- `MenuRequestContext` and `HttpMenuRequestContext` are abstractions so we don't have to pass around `HttpServletRequest` explicitly

Note that this PR does not include any changes to `dispatcher-servlet.xml` or `navbar.ftl`, those will be included in subsequent PRs.

Note, this and some subsequent PRs will target `feature/ui-preview-foldin` branch (which is based on `develop`). Once all the work for this Epic has been completed, this branch will be merged into `develop` and/or Horizon 31 release branch.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14801

