### PR TITLE
NMS-14754: opennms:metadata-test command is not present in Karaf shell

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -580,6 +580,7 @@
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.utils/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.mate/org.opennms.core.mate.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.mate/org.opennms.core.mate.model/${project.version}</bundle>
+        <bundle>mvn:org.opennms.core.mate/org.opennms.core.mate.shell-commands/${project.version}</bundle>
     </feature>
     <feature name="opennms-core-ipc-rpc-jms" version="${project.version}" description="OpenNMS :: Core :: IPC :: RPC :: JMS Impl.">
         <feature>opennms-core-ipc-rpc-api</feature>

--- a/core/mate/shell-commands/pom.xml
+++ b/core/mate/shell-commands/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Karaf-Commands>*</Karaf-Commands>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
NMS-14754: added changes to features.xml and pom.xml so metadata-test command shows in karaf shell

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14754

