### PR TITLE
NMS-10469: Provisiond import errors don't appear as event reason

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
@@ -564,10 +564,10 @@ public class Provisioner implements SpringServiceDaemon {
     
             send(importSuccessEvent(monitor, url, rescanExisting, foreignSource), monitor);
     
-        } catch (final Throwable t) {
+        } catch (Exception e) {
             final String msg = "Exception importing "+url;
-            LOG.error("Exception importing {} using rescanExisting={}", url, rescanExisting, t);
-            send(importFailedEvent((msg+": "+t.getMessage()), url, rescanExisting), monitor);
+            LOG.error("Exception importing {} using rescanExisting={}", url, rescanExisting, e);
+            send(importFailedEvent((msg+": "+e), url, rescanExisting), monitor);
         }
     }
 


### PR DESCRIPTION
This PR is based on https://github.com/OpenNMS/opennms/pull/5427
Since PR from external contributors cannot be run by circle ci we need to use this workaround.
Original PR from from @FrancescoBuc86

Jira: https://issues.opennms.org/browse/NMS-10469

