### PR TITLE
NMS-14653: Add 'I' option to poll flag

### DIFF
--- a/core/test-api/db/src/main/java/org/opennms/core/test/db/MockDatabase.java
+++ b/core/test-api/db/src/main/java/org/opennms/core/test/db/MockDatabase.java
@@ -143,8 +143,8 @@ public class MockDatabase extends TemporaryDatabasePostgreSQL implements EventWr
     public Integer writeSnmpInterface(MockInterface iface) {
         Integer nextId = getNextSnmpInterfaceId();
         LOG.info("Inserting into snmpInterface {} {} {} {}", nextId, Integer.valueOf(iface.getNodeId()), iface.getIfAlias(), iface.getIfIndex() );
-        Object[] values = { nextId, Integer.valueOf(iface.getNodeId()), iface.getIfAlias(), iface.getIfAlias(), iface.getIfIndex() };
-        update("insert into snmpInterface (id, nodeID, snmpifAlias, snmpifDescr, snmpIfIndex) values (?, ?, ?, ?, ?);", values);
+        Object[] values = { nextId, Integer.valueOf(iface.getNodeId()), iface.getIfAlias(), iface.getIfAlias(), iface.getIfIndex(), iface.getIfType(), "P" };
+        update("insert into snmpInterface (id, nodeID, snmpifAlias, snmpifDescr, snmpIfIndex, snmpiftype, snmppoll) values (?, ?, ?, ?, ?, ?, ?);", values);
         return nextId;
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/DefaultPollContext.java
@@ -234,6 +234,7 @@ public class DefaultPollContext implements PollContext {
     		dbSnmpInterface.setIfOperStatus(snmpinterface.getIfOperStatus());
     		dbSnmpInterface.setIfAdminStatus(snmpinterface.getIfAdminStatus());
     		dbSnmpInterface.setLastSnmpPoll(snmpinterface.getLastSnmpPoll());
+            dbSnmpInterface.setPoll(snmpinterface.getPoll());
     		log().debug("updating SnmpInterface: " + dbSnmpInterface.toString());
     		getSnmpInterfaceDao().update(dbSnmpInterface);
     	}

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/DefaultPollContext.java
@@ -88,6 +88,11 @@ public class DefaultPollContext implements PollContext {
         return m_ipInterfaceDao;
     }
 
+    public void setIpInterfaceDao(IpInterfaceDao ipInterfaceDao) {
+        this.m_ipInterfaceDao = ipInterfaceDao;
+    }
+
+
     /**
      * <p>getSnmpInterfaceDao</p>
      *
@@ -95,6 +100,18 @@ public class DefaultPollContext implements PollContext {
      */
     public SnmpInterfaceDao getSnmpInterfaceDao() {
         return m_snmpInterfaceDao;
+    }
+
+    public void setSnmpInterfaceDao(SnmpInterfaceDao snmpInterfaceDao) {
+        this.m_snmpInterfaceDao = snmpInterfaceDao;
+    }
+
+    public NodeDao getNodeDao() {
+        return m_nodeDao;
+    }
+
+    public void setNodeDao(NodeDao nodeDao) {
+        this.m_nodeDao = nodeDao;
     }
 
     /**

--- a/opennms-services/src/test/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPollerIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPollerIT.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.snmpinterfacepoller;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.MockDatabase;
+import org.opennms.core.test.db.TemporaryDatabaseAware;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.config.SnmpInterfacePollerConfig;
+import org.opennms.netmgt.config.SnmpInterfacePollerConfigFactory;
+import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
+import org.opennms.netmgt.mock.MockNetwork;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
+import org.opennms.netmgt.snmpinterfacepoller.pollable.PollableNetwork;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-proxy-snmp.xml",
+        "classpath:/META-INF/opennms/applicationContext-snmpPollerTest.xml"
+})
+@JUnitTemporaryDatabase(tempDbClass=MockDatabase.class,reuseDatabase=false)
+public class SnmpPollerIT implements TemporaryDatabaseAware<MockDatabase> {
+
+    private MockDatabase m_database;
+
+    private MockNetwork m_network;
+
+    private SnmpInterfacePollerConfig m_pollerConfig;
+
+    @Autowired
+    private ResourceLoader m_resourceLoader;
+
+    @Autowired
+    private PollableNetwork m_pollableNetwork;
+
+    private SnmpPoller m_poller;
+
+    //
+    // SetUp and TearDown
+    //
+    @Before
+    public void setUp() throws Exception {
+
+        m_network = new MockNetwork();
+
+        m_network.addNode(1, "node1");
+        m_network.addInterface(1, "192.168.1.1")
+                        .setIfType(6);
+        m_network.addInterface(1, "192.168.1.2")
+                        .setIfType(2);
+        m_database.populate(m_network);
+
+        InputStream configFile = m_resourceLoader.getResource("classpath:/etc/snmp-interface-poller-configuration.xml").getInputStream();
+        m_pollerConfig = new SnmpInterfacePollerConfigFactory(1L, configFile);
+
+        m_poller = new SnmpPoller();
+        m_poller.setNetwork(m_pollableNetwork);
+        m_poller.setPollerConfig(m_pollerConfig);
+        m_poller.onInit();
+
+    }
+
+    @Test
+    public void testIgnoredInterfaces() throws Exception {
+        SnmpInterfaceDao snmpInterfaceDao = ((DefaultPollContext)m_pollableNetwork.getContext()).getSnmpInterfaceDao();
+
+        var interfaces = snmpInterfaceDao.findAll();
+
+        OnmsSnmpInterface ethIf = interfaces.stream().filter(snmpIf -> snmpIf.getIfType() == 6).findFirst().orElseThrow();
+        OnmsSnmpInterface otherIf = interfaces.stream().filter(snmpIf -> snmpIf.getIfType() == 2).findFirst().orElseThrow();
+
+        assertEquals(ethIf.getPoll(), "P");
+        assertEquals(otherIf.getPoll(), "I");
+    }
+
+    @Override
+    public void setTemporaryDatabase(MockDatabase database) {
+        m_database = database;
+    }
+}

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-snmpPollerTest.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-snmpPollerTest.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:tx="http://www.springframework.org/schema/tx"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:util="http://www.springframework.org/schema/util"
+  xmlns:aop="http://www.springframework.org/schema/aop"
+  xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
+  xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
+  xsi:schemaLocation="
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.2.xsd
+  http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
+">
+
+    <context:annotation-config />
+    <tx:annotation-driven/>
+    <aop:aspectj-autoproxy proxy-target-class="true" />
+    
+  <bean id="dataSource" class="org.opennms.core.db.DataSourceFactoryBean" />
+    
+  <bean id="sessionFactory" class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">
+    <property name="dataSource" ref="dataSource" />
+    <property name="packagesToScan">
+      <list>
+        <value>org.opennms.netmgt.dao.hibernate</value>
+        <value>org.opennms.netmgt.model</value>
+        <value>org.opennms.netmgt.enlinkd</value>
+      </list>
+    </property>
+    <!--  property name="schemaUpdate" value="true">
+      </property -->
+    <property name="annotatedPackages">
+      <list>
+        <value>org.opennms.netmgt.dao.hibernate</value>
+        <value>org.opennms.netmgt.model</value>
+      </list>
+    </property>
+    <property name="hibernateProperties">
+      <value>
+        hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+        hibernate.cache.use_second_level_cache=false
+        hibernate.cache=false
+        hibernate.cache.use_query_cache=false
+        hibernate.jdbc.batch_size=0
+        <!-- hibernate.format_sql=true -->
+      </value>
+    </property>
+  </bean>
+
+  <bean id="transactionManager" class="org.springframework.orm.hibernate3.HibernateTransactionManager">
+    <property name="sessionFactory" ref="sessionFactory" />
+    <property name="nestedTransactionAllowed" value="true"/>
+  </bean>
+  
+  <bean id="transactionTemplate" class="org.springframework.transaction.support.TransactionTemplate">
+    <property name="transactionManager" ref="transactionManager" />
+  </bean>
+
+  	<bean id="nodeDao" class="org.opennms.netmgt.dao.hibernate.NodeDaoHibernate">
+    	<property name="sessionFactory" ref="sessionFactory" />
+  	</bean>
+  
+    <bean id="ipInterfaceDao" class="org.opennms.netmgt.dao.hibernate.IpInterfaceDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
+    <bean id="snmpInterfaceDao" class="org.opennms.netmgt.dao.hibernate.SnmpInterfaceDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
+    <bean id="'monitoredServiceDao" class="org.opennms.netmgt.dao.mock.MockMonitoredServiceDao"/>
+
+    <bean id="serviceRegistry" class="org.opennms.core.soa.support.DefaultServiceRegistry" />
+    
+    <bean name="entityScopeProvider" class="org.opennms.core.mate.model.EntityScopeProviderImpl" primary="true"/>
+
+    <bean id="sessionUtils" class="org.opennms.netmgt.dao.hibernate.DefaultSessionUtils" />
+
+    <bean name="pollContext" class="org.opennms.netmgt.snmpinterfacepoller.DefaultPollContext">
+      <property name="snmpInterfaceDao" ref="snmpInterfaceDao" />
+      <property name="ipInterfaceDao" ref="ipInterfaceDao" />
+      <property name="nodeDao" ref="nodeDao" />
+      <property name="locationAwareSnmpClient" ref="locationAwareSnmpClient" />
+      <property name="name" value="OpenNMS:Test SNMP Poll Context" />
+      <property name="localHostName" value="localhost" />
+      <property name="serviceName" value="SNMP" />
+    </bean>
+    
+    <bean name="pollableNetwork" class="org.opennms.netmgt.snmpinterfacepoller.pollable.PollableNetwork">
+        <constructor-arg ref="pollContext" />
+    </bean>
+
+</beans>

--- a/opennms-services/src/test/resources/etc/snmp-interface-poller-configuration.xml
+++ b/opennms-services/src/test/resources/etc/snmp-interface-poller-configuration.xml
@@ -1,0 +1,12 @@
+<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP" up-values="1" down-values="2" useCriteriaFilters="true">
+   <node-outage>
+      <critical-service name="ICMP"/>
+      <critical-service name="SNMP"/>
+   </node-outage>
+   <package name="whole-subnet">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="192.168.1.1" end="192.168.1.254"/>
+      <include-range begin="::1" end="::1"/>
+      <interface name="Ethernet" criteria="snmpiftype = 6" interval="300000" user-defined="false" status="on" port="161" timeout="1000" retry="1" max-vars-per-pdu="10" />
+  </package>
+</snmp-interface-poller-configuration>

--- a/opennms-webapp/src/main/java/org/opennms/web/element/ElementUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/ElementUtil.java
@@ -90,6 +90,7 @@ public abstract class ElementUtil {
         
         m_interfaceSnmpStatusMap = new HashMap<Character, String>();
         m_interfaceSnmpStatusMap.put('P', "Polled");
+        m_interfaceSnmpStatusMap.put('I', "Not Polled");
         m_interfaceSnmpStatusMap.put('N', "Not Monitored");
         
         m_serviceStatusMap = new HashMap<Character, String>();

--- a/tests/mock-elements/src/main/java/org/opennms/netmgt/mock/MockInterface.java
+++ b/tests/mock-elements/src/main/java/org/opennms/netmgt/mock/MockInterface.java
@@ -54,6 +54,8 @@ public class MockInterface extends MockContainer<MockNode,MockService> {
 	private String m_ifAlias;
     private final InetAddress m_inetAddr;
     private int m_ifIndex;
+
+    private int m_ifType;
     
 
     /**
@@ -226,6 +228,7 @@ public class MockInterface extends MockContainer<MockNode,MockService> {
     		.append("ifIndex", m_ifIndex)
     		.append("inetAddr", InetAddressUtils.str(m_inetAddr))
     		.append("members", getMembers())
+                .append("ifType", m_ifType)
     		.toString();
     }
 
@@ -322,5 +325,13 @@ public class MockInterface extends MockContainer<MockNode,MockService> {
      */
     public void setIfIndex(int ifIndex) {
         m_ifIndex = ifIndex;
+    }
+
+    public int getIfType() {
+        return m_ifType;
+    }
+
+    public void setIfType(int ifType) {
+        m_ifType = ifType;
     }
 }


### PR DESCRIPTION
This adds a new option to the `pollFlag` value in SnmpInterface DB objects. 

Currently, if an interface matched a `MatchingSnmpInterfacePolicy` with the `ENABLE_POLLING` action in the foreign source definition, then it would be marked `P`/ `Polled`. This list of `Polled` interfaces is then compared against package definitions in `snmp-interface-poller.configuration.xml`, and any not matching the criteria of their respective package are not actually polled.

This change sets the flag for those ignored interfaces to `I`, and displays their polling status as `Not Polled` in the UI.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14653

