### PR TITLE
NMS-14800: UI notification updates, DCB links, search includes actions/plugins

### DIFF
--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -143,10 +143,16 @@
             />
           </td>
           <td>
+            <a
+              :href="computeNodeLink(config.nodeId)"
+              @click="onNodeLinkClick(config.nodeId)"
+              target="_blank">
+            <!--
             <router-link
               :to="`/node/${config.nodeId}`"
               target="_blank"
             >
+            -->
               {{ config.deviceName }}
               <FeatherTooltip
                 :title="config.configName"
@@ -157,7 +163,7 @@
                   :icon="Speed"
                 />
               </FeatherTooltip>
-            </router-link>
+            </a>
           </td>
           <td>{{ config.ipAddress }}</td>
           <td>{{ config.location }}</td>
@@ -232,6 +238,7 @@ import DCBModalViewHistoryContentVue from './DCBModalViewHistoryContent.vue'
 import DCBModalConfigDiffContent from './DCBModalConfigDiffContent.vue'
 import { DeviceConfigBackup, DeviceConfigQueryParams } from '@/types/deviceConfig'
 import DCBTableStatusDropdown from './DCBTableStatusDropdown.vue'
+import { MainMenu } from '@/types/mainMenu'
 
 enum DCBModalContentComponentNames {
   DCBModalLastBackupContent = 'DCBModalLastBackupContent',
@@ -240,6 +247,7 @@ enum DCBModalContentComponentNames {
 }
 
 const store = useStore()
+const mainMenu = computed<MainMenu>(() => store.state.menuModule.mainMenu)
 const dcbModalVisible = ref(false)
 const dcbModalContentComponentName = ref('')
 const all = ref(false)
@@ -256,6 +264,14 @@ const sortStates: Record<string, SORT> = reactive({
 const { arrivedState, directions } = useScroll(tableWrap, {
   offset: { bottom: 300 }
 })
+
+const computeNodeLink = (nodeId: number) => {
+  return `${mainMenu.value.baseHref}${mainMenu.value.baseNodeUrl}${nodeId}`
+}
+
+const onNodeLinkClick = (nodeId: number) => {
+  window.location.assign(computeNodeLink(nodeId))
+}
 
 watch(() => directions.bottom, () => {
   if (!directions.bottom && arrivedState.bottom) {

--- a/ui/src/store/search/actions.ts
+++ b/ui/src/store/search/actions.ts
@@ -5,10 +5,10 @@ const search = async (context: VuexContext, searchStr: string) => {
   const responses = await API.search(searchStr)
 
   if (responses) {
-    // add label and filter actions for dropdown display
+    // add label for dropdown display
     const results = responses.filter((resp) => {
       resp.label = resp.context.name
-      if (resp.label !== 'Action') return resp
+      return resp
     })
     context.commit('SAVE_SEARCH_RESULTS', results)
   }


### PR DESCRIPTION
Fix new UI notification badge colors using logic ported from classic UI. Have notification dropdown links link to classic Notification detail screen. Remove temporary notification dialog.

Fix DCB node links to go to classic UI node details page (since new Node UI will be removed).

Update new UI Search box to display Actions and Plugins and include context display (e.g. "Actions:" or "Plugins:") and link to proper URL. Note this isn't always working due to some issues with the Feather Autocomplete control, to be fixed in a subsequent PR.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14800

