### PR TITLE
NMS-14918: Alarms and Events: filter and advanced search / method POST is not supported

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/AlarmQueryServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/AlarmQueryServlet.java
@@ -76,7 +76,7 @@ import org.opennms.web.servlet.MissingParameterException;
  */
 public class AlarmQueryServlet extends HttpServlet {
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 9140535159580534211L;
 
@@ -84,7 +84,7 @@ public class AlarmQueryServlet extends HttpServlet {
      * The list of parameters that are extracted by this servlet and not passed
      * on to the {@link AlarmFilterController AlarmFilterController}.
      */
-    protected static String[] IGNORE_LIST = new String[] { "alarmtext", "msgsub", "msgmatchany", "nodenamelike", "service", "iplike", "severity", "relativetime", "usebeforetime", "beforehour", "beforeminute", "beforeampm", "beforedate", "beforemonth", "beforeyear", "useaftertime", "afterhour", "afterminute", "afterampm", "afterdate", "aftermonth", "afteryear", "category" };
+    protected static String[] IGNORE_LIST = new String[]{"alarmtext", "msgsub", "msgmatchany", "nodenamelike", "service", "iplike", "severity", "relativetime", "usebeforetime", "beforehour", "beforeminute", "beforeampm", "beforedate", "beforemonth", "beforeyear", "useaftertime", "afterhour", "afterminute", "afterampm", "afterdate", "aftermonth", "afteryear", "category", "_csrf"};
 
     /**
      * The URL for the {@link AlarmFilterController AlarmFilterController}. The
@@ -115,7 +115,7 @@ public class AlarmQueryServlet extends HttpServlet {
      * the {@link AlarmFilterController AlarmFilterController}.
      */
     @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         List<Filter> filterArray = new ArrayList<>();
 
         // convenient syntax for AlarmTextFilter

--- a/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
@@ -72,7 +72,7 @@ import org.owasp.encoder.Encode;
  */
 public class EventQueryServlet extends HttpServlet {
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1226547298266948865L;
 
@@ -80,7 +80,7 @@ public class EventQueryServlet extends HttpServlet {
      * The list of parameters that are extracted by this servlet and not passed
      * on to the servlet.
      */
-    protected static String[] IGNORE_LIST = new String[] { "eventid", "eventtext", "msgsub", "msgmatchany", "nodenamelike", "exactuei", "location", "nodelocation", "systemId", "service", "iplike", "severity", "eventId", "relativetime", "usebeforetime", "beforehour", "beforeminute", "beforeampm", "beforedate", "beforemonth", "beforeyear", "useaftertime", "afterhour", "afterminute", "afterampm", "afterdate", "aftermonth", "afteryear" };
+    protected static String[] IGNORE_LIST = new String[]{"eventid", "eventtext", "msgsub", "msgmatchany", "nodenamelike", "exactuei", "location", "nodelocation", "systemId", "service", "iplike", "severity", "eventId", "relativetime", "usebeforetime", "beforehour", "beforeminute", "beforeampm", "beforedate", "beforemonth", "beforeyear", "useaftertime", "afterhour", "afterminute", "afterampm", "afterdate", "aftermonth", "afteryear", "_csrf"};
 
     /**
      * The URL for the servlet. The
@@ -111,7 +111,7 @@ public class EventQueryServlet extends HttpServlet {
      * the event filter.
      */
     @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         List<Filter> filterArray = new ArrayList<>();
 
         // convenient syntax for EventTextFilter

--- a/opennms-webapp/src/test/java/org/opennms/web/event/NMS12517_Test.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/event/NMS12517_Test.java
@@ -43,7 +43,7 @@ public class NMS12517_Test {
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.setParameter("eventtext", "'öäü<>'");
 
-        eventQueryServlet.doGet(request, response);
+        eventQueryServlet.doPost(request, response);
 
         assertEquals(302, response.getStatus());
         System.err.println("->"+response.getHeader("Location")+"<-");


### PR DESCRIPTION
Issue occurred on especific alarm/query and evnt/query servlets that only supported GET requests. 
When adding CSRF parameters the method switched to POST requests.

Also added the `_csrf` parameter to the ignored parameters in the search query generated

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14918

