### PR TITLE
NMS-14885: Add support for rows in Grafana Dashboard Report

### DIFF
--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/grafana/GrafanaPanelDatasource.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/grafana/GrafanaPanelDatasource.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jdk.internal.joptsimple.internal.Strings;
 import org.opennms.netmgt.endpoints.grafana.api.Dashboard;
 import org.opennms.netmgt.endpoints.grafana.api.GrafanaClient;
 import org.opennms.netmgt.endpoints.grafana.api.Panel;
@@ -60,6 +61,7 @@ public class GrafanaPanelDatasource implements JRRewindableDataSource {
     public static final String TITLE_FIELD_NAME = "title";
     public static final String DATASOURCE_FIELD_NAME = "datasource";
     public static final String DESCRIPTION_FIELD_NAME = "description";
+    public static final String ROW_TITLE_FIELD_NAME = "rowTitle";
 
     private final GrafanaClient client;
     private final Dashboard dashboard;
@@ -114,6 +116,8 @@ public class GrafanaPanelDatasource implements JRRewindableDataSource {
             return currentPanel.getDatasource();
         } else if (Objects.equals(DESCRIPTION_FIELD_NAME, fieldName)) {
             return currentPanel.getDescription();
+        } else if (Objects.equals(ROW_TITLE_FIELD_NAME, fieldName)) {
+            return getRowTitle(currentPanel);
         } else if (Objects.equals(IMAGE_FIELD_NAME, fieldName)) {
             try {
                 maybeRenderPanels();
@@ -147,6 +151,26 @@ public class GrafanaPanelDatasource implements JRRewindableDataSource {
                     query.getFrom().getTime(), query.getTo().getTime(), query.getTimezone(), query.getVariables());
             panelRenders.put(panel, panelImageBytes);
         }
+    }
+
+    /**
+     * Gets the current panel the previous row panel title if it has one.
+     * @param panel
+     * @return String with the row panel title if exists or an empty string if not.
+     */
+    private String getRowTitle(final Panel panel){
+        String currentRowPanel = Strings.EMPTY;
+        for(final Panel p : this.dashboard.getPanels()){
+            if(p.getType().equals("row")){
+                currentRowPanel = p.getTitle().trim();
+            } else if (p.equals(panel)){
+                return currentRowPanel;
+            } else {
+                // clear the title right after passing the first panel after the row panel.
+                currentRowPanel = Strings.EMPTY;
+            }
+        }
+        return currentRowPanel;
     }
 
 }

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-1ppp.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-1ppp.jrxml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.3.0.final using JasperReports Library version 6.3.0  -->
-<!-- 2019-07-08T15:03:09 -->
+<!-- Created with Jaspersoft Studio version 6.20.0.final using JasperReports Library version 6.20.0-2bc7ab61c56f459e8176eb05c7705e145cd400ad  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Blank_A4" pageWidth="1190" pageHeight="1684" columnWidth="1150" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="9967c600-878d-4d17-9b00-8ca2f00e9c39">
-  <property name="com.jaspersoft.studio.unit." value="pixel"/>
-  <parameter name="reportTitle" class="java.lang.String">
-    <parameterDescription><![CDATA[Report Title]]></parameterDescription>
-    <defaultValueExpression><![CDATA["Grafana Dashboard Report"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="reportDescription" class="java.lang.String">
-    <parameterDescription><![CDATA[Report Description]]></parameterDescription>
-    <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-  </parameter>
-  <parameter name="ONMS_REPORT_DIR" class="java.lang.String" isForPrompting="false">
-    <parameterDescription><![CDATA[The directory where all reports can be found]]></parameterDescription>
-    <defaultValueExpression><![CDATA["${install.dir}/etc/report-templates/"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="timezone" class="java.time.ZoneId">
-    <parameterDescription><![CDATA[Report Timezone]]></parameterDescription>
-    <defaultValueExpression><![CDATA[java.time.ZoneId.systemDefault()]]></defaultValueExpression>
-  </parameter>
-  <parameter name="startDate" class="java.util.Date">
-    <parameterDescription><![CDATA[Report Start Date]]></parameterDescription>
-    <defaultValueExpression><![CDATA[new java.util.Date(
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<parameter name="reportTitle" class="java.lang.String">
+		<parameterDescription><![CDATA[Report Title]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Grafana Dashboard Report"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="reportDescription" class="java.lang.String">
+		<parameterDescription><![CDATA[Report Description]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="ONMS_REPORT_DIR" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[The directory where all reports can be found]]></parameterDescription>
+		<defaultValueExpression><![CDATA["${install.dir}/etc/report-templates/"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="timezone" class="java.time.ZoneId">
+		<parameterDescription><![CDATA[Report Timezone]]></parameterDescription>
+		<defaultValueExpression><![CDATA[java.time.ZoneId.systemDefault()]]></defaultValueExpression>
+	</parameter>
+	<parameter name="startDate" class="java.util.Date">
+		<parameterDescription><![CDATA[Report Start Date]]></parameterDescription>
+		<defaultValueExpression><![CDATA[new java.util.Date(
 new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianCalendar().get(Calendar.MONTH), new GregorianCalendar().get(Calendar.DATE) - 1).getTimeInMillis()
 )]]></defaultValueExpression>
-  </parameter>
-  <parameter name="endDate" class="java.util.Date">
-    <parameterDescription><![CDATA[Report End Date]]></parameterDescription>
-    <defaultValueExpression><![CDATA[new java.util.Date(
+	</parameter>
+	<parameter name="endDate" class="java.util.Date">
+		<parameterDescription><![CDATA[Report End Date]]></parameterDescription>
+		<defaultValueExpression><![CDATA[new java.util.Date(
 new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianCalendar().get(Calendar.MONTH), new GregorianCalendar().get(Calendar.DATE)).getTimeInMillis()
 )]]></defaultValueExpression>
-  </parameter>
-  <parameter name="startDateTime" class="java.lang.Long" isForPrompting="false">
-    <defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{startDate}, $P{timezone})]]></defaultValueExpression>
-  </parameter>
-  <parameter name="endDateTime" class="java.lang.Long" isForPrompting="false">
-    <defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{endDate}, $P{timezone})]]></defaultValueExpression>
-  </parameter>
-  <parameter name="dateFormat" class="java.lang.String">
-    <defaultValueExpression><![CDATA["EEE dd MMM yyyy HH:mm:ss"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="GRAFANA_DASHBOARD_UID" class="java.lang.String">
-    <defaultValueExpression><![CDATA["mjkV0rkZk"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="GRAFANA_ENDPOINT_UID" class="java.lang.String">
-    <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-  </parameter>
-  <queryString language="grafana"><![CDATA[{
+	</parameter>
+	<parameter name="startDateTime" class="java.lang.Long" isForPrompting="false">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{startDate}, $P{timezone})]]></defaultValueExpression>
+	</parameter>
+	<parameter name="endDateTime" class="java.lang.Long" isForPrompting="false">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{endDate}, $P{timezone})]]></defaultValueExpression>
+	</parameter>
+	<parameter name="dateFormat" class="java.lang.String">
+		<defaultValueExpression><![CDATA["EEE dd MMM yyyy HH:mm:ss"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="GRAFANA_DASHBOARD_UID" class="java.lang.String">
+		<defaultValueExpression><![CDATA["mjkV0rkZk"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="GRAFANA_ENDPOINT_UID" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<queryString language="grafana">
+		<![CDATA[{
                         "dashboard": {
                         "uid": "$P{GRAFANA_DASHBOARD_UID}"
                         },
@@ -61,134 +61,148 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
                           "theme": "light"
                         },
                         "variables": {}
-                }]]></queryString>
-  <field name="png" class="java.lang.Object"/>
-  <field name="title" class="java.lang.String"/>
-  <field name="description" class="java.lang.String"/>
-  <field name="datasource" class="java.lang.String"/>
-  <field name="width" class="java.lang.Integer"/>
-  <field name="height" class="java.lang.Integer"/>
-  <title>
-    <band splitType="Stretch"/>
-  </title>
-  <pageHeader>
-    <band height="119" splitType="Stretch">
-      <image scaleImage="FillFrame">
-        <reportElement x="0" y="10" width="1149" height="69" uuid="b2b14931-9b7b-49fd-85ca-becf00f3b41f"/>
-        <imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/background.png"]]></imageExpression>
-      </image>
-      <rectangle>
-        <reportElement mode="Transparent" x="0" y="10" width="1149" height="69" uuid="67fa5b5c-98bb-4500-be31-b9e7c9ffd5f1"/>
-      </rectangle>
-      <textField>
-        <reportElement x="1" y="10" width="1148" height="68" uuid="2a2325ca-d32c-43ec-a930-970f17c2286c"/>
-        <textElement textAlignment="Center" verticalAlignment="Middle">
-          <font size="26"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{reportTitle}]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="7" y="89" width="702" height="20" uuid="0dad4f9e-c982-4147-8e27-5da3acdb4ced"/>
-        <textElement>
-          <font size="12"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{reportDescription}]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="500" y="89" width="210" height="20" forecolor="#000000" uuid="ac9d2b31-2a51-4768-90e9-b5a1f1698b67"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{startDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="700" y="89" width="219" height="20" forecolor="#000000" uuid="558f5fde-80e7-4515-976e-643bc23ad397"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{endDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="870" y="89" width="300" height="20" forecolor="#000000" uuid="d4f139e5-6af9-44fa-bb50-eca765c5b6f3"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{timezone} + " " + org.opennms.netmgt.jasper.helper.TimezoneHelper.getUtcOffset($P{timezone}, $P{startDate})]]></textFieldExpression>
-      </textField>
-      <staticText>
-        <reportElement x="470" y="89" width="34" height="20" uuid="30cb5bcf-d0b2-48cd-940e-f6bef7bcc753">
-          <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-          <property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-        </reportElement>
-        <textElement verticalAlignment="Middle">
-          <font size="12"/>
-        </textElement>
-        <text><![CDATA[Start:]]></text>
-      </staticText>
-      <staticText>
-        <reportElement x="670" y="89" width="30" height="20" uuid="4bcd92a9-04e0-4706-b6dc-02ab02356f40"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12"/>
-        </textElement>
-        <text><![CDATA[End:]]></text>
-      </staticText>
-      <image hAlign="Center" vAlign="Middle">
-        <reportElement x="10" y="12" width="197" height="65" uuid="84f9fb75-2b8c-4a2a-ac51-f245ae29dcc3"/>
-        <imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/logo_flat.png"]]></imageExpression>
-      </image>
-    </band>
-  </pageHeader>
-  <detail>
-    <band height="1500" splitType="Stretch">
-      <textField>
-        <reportElement x="1" y="0" width="1149" height="20" uuid="3340166d-e746-4839-9c74-0ba3defb70e4"/>
-        <textElement textAlignment="Center"/>
-        <textFieldExpression><![CDATA[$F{description} + " from datasource: " + $F{datasource} + " rendered at: " + $F{width} + "x" + $F{height} + " px"]]></textFieldExpression>
-      </textField>
-      <image>
-        <reportElement stretchType="RelativeToBandHeight" x="1" y="20" width="1148" height="1479" uuid="6d3caa20-5995-424f-893c-fcb1c220be6f">
-          <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-        </reportElement>
-        <imageExpression><![CDATA[new java.io.ByteArrayInputStream((byte[])$F{png})]]></imageExpression>
-      </image>
-    </band>
-  </detail>
-  <columnFooter>
-    <band splitType="Stretch"/>
-  </columnFooter>
-  <pageFooter>
-    <band height="25" splitType="Stretch">
-      <frame>
-        <reportElement mode="Opaque" x="1" y="1" width="1148" height="24" uuid="10dfd2c7-7881-4dbd-b1f2-b2b550d2f003"/>
-        <textField evaluationTime="Report">
-          <reportElement x="590" y="1" width="40" height="20" uuid="f7ae35fa-8f6c-4c3e-a111-a7b868a83134"/>
-          <textElement verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
-        </textField>
-        <textField>
-          <reportElement x="510" y="1" width="80" height="20" uuid="871f4010-1065-40d8-b55d-aa238d80a59d"/>
-          <textElement textAlignment="Right" verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
-        </textField>
-        <staticText>
-          <reportElement x="0" y="2" width="78" height="20" uuid="ef96d5b1-2bfc-4111-8176-6a01e0daafd8"/>
-          <textElement textAlignment="Right" verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <text><![CDATA[Rendered at:]]></text>
-        </staticText>
-        <textField>
-          <reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
-          <textElement verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
-        </textField>
-      </frame>
-    </band>
-  </pageFooter>
+                }]]>
+	</queryString>
+	<field name="png" class="java.lang.Object"/>
+	<field name="title" class="java.lang.String"/>
+	<field name="description" class="java.lang.String"/>
+	<field name="datasource" class="java.lang.String"/>
+	<field name="width" class="java.lang.Integer"/>
+	<field name="height" class="java.lang.Integer"/>
+	<field name="rowTitle" class="java.lang.String"/>
+	<title>
+		<band splitType="Stretch"/>
+	</title>
+	<pageHeader>
+		<band height="119" splitType="Stretch">
+			<image scaleImage="FillFrame">
+				<reportElement x="0" y="10" width="1149" height="69" uuid="b2b14931-9b7b-49fd-85ca-becf00f3b41f"/>
+				<imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/background.png"]]></imageExpression>
+			</image>
+			<rectangle>
+				<reportElement mode="Transparent" x="0" y="10" width="1149" height="69" uuid="67fa5b5c-98bb-4500-be31-b9e7c9ffd5f1"/>
+			</rectangle>
+			<textField>
+				<reportElement x="1" y="10" width="1148" height="68" uuid="2a2325ca-d32c-43ec-a930-970f17c2286c"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="26"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{reportTitle}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="7" y="89" width="702" height="20" uuid="0dad4f9e-c982-4147-8e27-5da3acdb4ced"/>
+				<textElement>
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{reportDescription}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="500" y="89" width="210" height="20" forecolor="#000000" uuid="ac9d2b31-2a51-4768-90e9-b5a1f1698b67"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{startDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="700" y="89" width="219" height="20" forecolor="#000000" uuid="558f5fde-80e7-4515-976e-643bc23ad397"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{endDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="870" y="89" width="300" height="20" forecolor="#000000" uuid="d4f139e5-6af9-44fa-bb50-eca765c5b6f3"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{timezone} + " " + org.opennms.netmgt.jasper.helper.TimezoneHelper.getUtcOffset($P{timezone}, $P{startDate})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="470" y="89" width="34" height="20" uuid="30cb5bcf-d0b2-48cd-940e-f6bef7bcc753">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<text><![CDATA[Start:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="670" y="89" width="30" height="20" uuid="4bcd92a9-04e0-4706-b6dc-02ab02356f40"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<text><![CDATA[End:]]></text>
+			</staticText>
+			<image hAlign="Center" vAlign="Middle">
+				<reportElement x="10" y="12" width="197" height="65" uuid="84f9fb75-2b8c-4a2a-ac51-f245ae29dcc3"/>
+				<imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/logo_flat.png"]]></imageExpression>
+			</image>
+		</band>
+	</pageHeader>
+	<detail>
+		<band height="1500" splitType="Stretch">
+			<textField>
+				<reportElement x="1" y="0" width="1149" height="20" uuid="3340166d-e746-4839-9c74-0ba3defb70e4"/>
+				<textElement textAlignment="Center"/>
+				<textFieldExpression><![CDATA[$F{description} + " from datasource: " + $F{datasource} + " rendered at: " + $F{width} + "x" + $F{height} + " px"]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="1" y="20" width="1148" height="30" isRemoveLineWhenBlank="true" uuid="6787cacd-e1f3-48a2-af7b-6c7bcb0d97f6">
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<printWhenExpression><![CDATA[$F{rowTitle}.length()>0]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font size="16" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{rowTitle}]]></textFieldExpression>
+			</textField>
+			<image>
+				<reportElement stretchType="RelativeToBandHeight" x="1" y="50" width="1148" height="1449" uuid="6d3caa20-5995-424f-893c-fcb1c220be6f">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<imageExpression><![CDATA[new java.io.ByteArrayInputStream((byte[])$F{png})]]></imageExpression>
+			</image>
+		</band>
+	</detail>
+	<columnFooter>
+		<band splitType="Stretch"/>
+	</columnFooter>
+	<pageFooter>
+		<band height="25" splitType="Stretch">
+			<frame>
+				<reportElement mode="Opaque" x="1" y="1" width="1148" height="24" uuid="10dfd2c7-7881-4dbd-b1f2-b2b550d2f003"/>
+				<textField evaluationTime="Report">
+					<reportElement x="590" y="1" width="40" height="20" uuid="f7ae35fa-8f6c-4c3e-a111-a7b868a83134"/>
+					<textElement verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+				</textField>
+				<textField>
+					<reportElement x="510" y="1" width="80" height="20" uuid="871f4010-1065-40d8-b55d-aa238d80a59d"/>
+					<textElement textAlignment="Right" verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="2" width="78" height="20" uuid="ef96d5b1-2bfc-4111-8176-6a01e0daafd8"/>
+					<textElement textAlignment="Right" verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<text><![CDATA[Rendered at:]]></text>
+				</staticText>
+				<textField>
+					<reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
+					<textElement verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
+				</textField>
+			</frame>
+		</band>
+	</pageFooter>
 </jasperReport>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-2ppp.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-2ppp.jrxml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.3.0.final using JasperReports Library version 6.3.0  -->
-<!-- 2019-07-08T15:03:09 -->
+<!-- Created with Jaspersoft Studio version 6.20.0.final using JasperReports Library version 6.20.0-2bc7ab61c56f459e8176eb05c7705e145cd400ad  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Blank_A4" pageWidth="1190" pageHeight="1684" columnWidth="1150" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="9967c600-878d-4d17-9b00-8ca2f00e9c39">
-  <property name="com.jaspersoft.studio.unit." value="pixel"/>
-  <parameter name="reportTitle" class="java.lang.String">
-    <parameterDescription><![CDATA[Report Title]]></parameterDescription>
-    <defaultValueExpression><![CDATA["Grafana Dashboard Report"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="reportDescription" class="java.lang.String">
-    <parameterDescription><![CDATA[Report Description]]></parameterDescription>
-    <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-  </parameter>
-  <parameter name="ONMS_REPORT_DIR" class="java.lang.String" isForPrompting="false">
-    <parameterDescription><![CDATA[The directory where all reports can be found]]></parameterDescription>
-    <defaultValueExpression><![CDATA["${install.dir}/etc/report-templates/"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="timezone" class="java.time.ZoneId">
-    <parameterDescription><![CDATA[Report Timezone]]></parameterDescription>
-    <defaultValueExpression><![CDATA[java.time.ZoneId.systemDefault()]]></defaultValueExpression>
-  </parameter>
-  <parameter name="startDate" class="java.util.Date">
-    <parameterDescription><![CDATA[Report Start Date]]></parameterDescription>
-    <defaultValueExpression><![CDATA[new java.util.Date(
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<parameter name="reportTitle" class="java.lang.String">
+		<parameterDescription><![CDATA[Report Title]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Grafana Dashboard Report"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="reportDescription" class="java.lang.String">
+		<parameterDescription><![CDATA[Report Description]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="ONMS_REPORT_DIR" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[The directory where all reports can be found]]></parameterDescription>
+		<defaultValueExpression><![CDATA["${install.dir}/etc/report-templates/"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="timezone" class="java.time.ZoneId">
+		<parameterDescription><![CDATA[Report Timezone]]></parameterDescription>
+		<defaultValueExpression><![CDATA[java.time.ZoneId.systemDefault()]]></defaultValueExpression>
+	</parameter>
+	<parameter name="startDate" class="java.util.Date">
+		<parameterDescription><![CDATA[Report Start Date]]></parameterDescription>
+		<defaultValueExpression><![CDATA[new java.util.Date(
 new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianCalendar().get(Calendar.MONTH), new GregorianCalendar().get(Calendar.DATE) - 1).getTimeInMillis()
 )]]></defaultValueExpression>
-  </parameter>
-  <parameter name="endDate" class="java.util.Date">
-    <parameterDescription><![CDATA[Report End Date]]></parameterDescription>
-    <defaultValueExpression><![CDATA[new java.util.Date(
+	</parameter>
+	<parameter name="endDate" class="java.util.Date">
+		<parameterDescription><![CDATA[Report End Date]]></parameterDescription>
+		<defaultValueExpression><![CDATA[new java.util.Date(
 new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianCalendar().get(Calendar.MONTH), new GregorianCalendar().get(Calendar.DATE)).getTimeInMillis()
 )]]></defaultValueExpression>
-  </parameter>
-  <parameter name="startDateTime" class="java.lang.Long" isForPrompting="false">
-    <defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{startDate}, $P{timezone})]]></defaultValueExpression>
-  </parameter>
-  <parameter name="endDateTime" class="java.lang.Long" isForPrompting="false">
-    <defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{endDate}, $P{timezone})]]></defaultValueExpression>
-  </parameter>
-  <parameter name="dateFormat" class="java.lang.String">
-    <defaultValueExpression><![CDATA["EEE dd MMM yyyy HH:mm:ss"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="GRAFANA_DASHBOARD_UID" class="java.lang.String">
-    <defaultValueExpression><![CDATA["mjkV0rkZk"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="GRAFANA_ENDPOINT_UID" class="java.lang.String">
-    <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-  </parameter>
-  <queryString language="grafana"><![CDATA[{
+	</parameter>
+	<parameter name="startDateTime" class="java.lang.Long" isForPrompting="false">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{startDate}, $P{timezone})]]></defaultValueExpression>
+	</parameter>
+	<parameter name="endDateTime" class="java.lang.Long" isForPrompting="false">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{endDate}, $P{timezone})]]></defaultValueExpression>
+	</parameter>
+	<parameter name="dateFormat" class="java.lang.String">
+		<defaultValueExpression><![CDATA["EEE dd MMM yyyy HH:mm:ss"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="GRAFANA_DASHBOARD_UID" class="java.lang.String">
+		<defaultValueExpression><![CDATA["mjkV0rkZk"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="GRAFANA_ENDPOINT_UID" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<queryString language="grafana">
+		<![CDATA[{
                         "dashboard": {
                         "uid": "$P{GRAFANA_DASHBOARD_UID}"
                         },
@@ -61,83 +61,85 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
                           "theme": "light"
                         },
                         "variables": {}
-                }]]></queryString>
-  <field name="png" class="java.lang.Object"/>
-  <field name="title" class="java.lang.String"/>
-  <field name="description" class="java.lang.String"/>
-  <field name="datasource" class="java.lang.String"/>
-  <field name="width" class="java.lang.Integer"/>
-  <field name="height" class="java.lang.Integer"/>
-  <title>
-    <band splitType="Stretch"/>
-  </title>
-  <pageHeader>
-    <band height="119" splitType="Stretch">
-      <image scaleImage="FillFrame">
-        <reportElement x="0" y="10" width="1149" height="69" uuid="b2b14931-9b7b-49fd-85ca-becf00f3b41f"/>
-        <imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/background.png"]]></imageExpression>
-      </image>
-      <rectangle>
-        <reportElement mode="Transparent" x="0" y="10" width="1149" height="69" uuid="67fa5b5c-98bb-4500-be31-b9e7c9ffd5f1"/>
-      </rectangle>
-      <textField>
-        <reportElement x="1" y="10" width="1148" height="68" uuid="2a2325ca-d32c-43ec-a930-970f17c2286c"/>
-        <textElement textAlignment="Center" verticalAlignment="Middle">
-          <font size="26"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{reportTitle}]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="7" y="89" width="702" height="20" uuid="0dad4f9e-c982-4147-8e27-5da3acdb4ced"/>
-        <textElement>
-          <font size="12"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{reportDescription}]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="500" y="89" width="210" height="20" forecolor="#000000" uuid="ac9d2b31-2a51-4768-90e9-b5a1f1698b67"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{startDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="700" y="89" width="219" height="20" forecolor="#000000" uuid="558f5fde-80e7-4515-976e-643bc23ad397"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{endDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="870" y="89" width="300" height="20" forecolor="#000000" uuid="d4f139e5-6af9-44fa-bb50-eca765c5b6f3"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{timezone} + " " + org.opennms.netmgt.jasper.helper.TimezoneHelper.getUtcOffset($P{timezone}, $P{startDate})]]></textFieldExpression>
-      </textField>
-      <staticText>
-        <reportElement x="470" y="89" width="34" height="20" uuid="30cb5bcf-d0b2-48cd-940e-f6bef7bcc753">
-          <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-          <property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-        </reportElement>
-        <textElement verticalAlignment="Middle">
-          <font size="12"/>
-        </textElement>
-        <text><![CDATA[Start:]]></text>
-      </staticText>
-      <staticText>
-        <reportElement x="670" y="89" width="30" height="20" uuid="4bcd92a9-04e0-4706-b6dc-02ab02356f40"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12"/>
-        </textElement>
-        <text><![CDATA[End:]]></text>
-      </staticText>
-      <image hAlign="Center" vAlign="Middle">
-        <reportElement x="10" y="12" width="197" height="65" uuid="84f9fb75-2b8c-4a2a-ac51-f245ae29dcc3"/>
-        <imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/logo_flat.png"]]></imageExpression>
-      </image>
-    </band>
-  </pageHeader>
+                }]]>
+	</queryString>
+	<field name="png" class="java.lang.Object"/>
+	<field name="title" class="java.lang.String"/>
+	<field name="description" class="java.lang.String"/>
+	<field name="datasource" class="java.lang.String"/>
+	<field name="width" class="java.lang.Integer"/>
+	<field name="height" class="java.lang.Integer"/>
+	<field name="rowTitle" class="java.lang.String"/>
+	<title>
+		<band splitType="Stretch"/>
+	</title>
+	<pageHeader>
+		<band height="119" splitType="Stretch">
+			<image scaleImage="FillFrame">
+				<reportElement x="0" y="10" width="1149" height="69" uuid="b2b14931-9b7b-49fd-85ca-becf00f3b41f"/>
+				<imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/background.png"]]></imageExpression>
+			</image>
+			<rectangle>
+				<reportElement mode="Transparent" x="0" y="10" width="1149" height="69" uuid="67fa5b5c-98bb-4500-be31-b9e7c9ffd5f1"/>
+			</rectangle>
+			<textField>
+				<reportElement x="1" y="10" width="1148" height="68" uuid="2a2325ca-d32c-43ec-a930-970f17c2286c"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="26"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{reportTitle}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="7" y="89" width="702" height="20" uuid="0dad4f9e-c982-4147-8e27-5da3acdb4ced"/>
+				<textElement>
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{reportDescription}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="500" y="89" width="210" height="20" forecolor="#000000" uuid="ac9d2b31-2a51-4768-90e9-b5a1f1698b67"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{startDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="700" y="89" width="219" height="20" forecolor="#000000" uuid="558f5fde-80e7-4515-976e-643bc23ad397"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{endDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="870" y="89" width="300" height="20" forecolor="#000000" uuid="d4f139e5-6af9-44fa-bb50-eca765c5b6f3"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{timezone} + " " + org.opennms.netmgt.jasper.helper.TimezoneHelper.getUtcOffset($P{timezone}, $P{startDate})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="470" y="89" width="34" height="20" uuid="30cb5bcf-d0b2-48cd-940e-f6bef7bcc753">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<text><![CDATA[Start:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="670" y="89" width="30" height="20" uuid="4bcd92a9-04e0-4706-b6dc-02ab02356f40"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<text><![CDATA[End:]]></text>
+			</staticText>
+			<image hAlign="Center" vAlign="Middle">
+				<reportElement x="10" y="12" width="197" height="65" uuid="84f9fb75-2b8c-4a2a-ac51-f245ae29dcc3"/>
+				<imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/logo_flat.png"]]></imageExpression>
+			</image>
+		</band>
+	</pageHeader>
 	<detail>
 		<band height="750" splitType="Stretch">
 			<textField>
@@ -145,50 +147,62 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
 				<textElement textAlignment="Center"/>
 				<textFieldExpression><![CDATA[$F{description} + " from datasource: " + $F{datasource} + " rendered at: " + $F{width} + "x" + $F{height} + " px"]]></textFieldExpression>
 			</textField>
+			<textField>
+				<reportElement x="1" y="20" width="1148" height="30" isRemoveLineWhenBlank="true" uuid="6787cacd-e1f3-48a2-af7b-6c7bcb0d97f6">
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<printWhenExpression><![CDATA[$F{rowTitle}.length()>0]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font size="16" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{rowTitle}]]></textFieldExpression>
+			</textField>
 			<image>
-				<reportElement stretchType="RelativeToBandHeight" x="1" y="20" width="1148" height="729" uuid="6d3caa20-5995-424f-893c-fcb1c220be6f">
+				<reportElement stretchType="RelativeToBandHeight" x="1" y="50" width="1148" height="699" uuid="6d3caa20-5995-424f-893c-fcb1c220be6f">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<imageExpression><![CDATA[new java.io.ByteArrayInputStream((byte[])$F{png})]]></imageExpression>
 			</image>
 		</band>
 	</detail>
-  <columnFooter>
-    <band splitType="Stretch"/>
-  </columnFooter>
-  <pageFooter>
-    <band height="25" splitType="Stretch">
-      <frame>
-        <reportElement mode="Opaque" x="1" y="1" width="1148" height="24" uuid="10dfd2c7-7881-4dbd-b1f2-b2b550d2f003"/>
-        <textField evaluationTime="Report">
-          <reportElement x="590" y="1" width="40" height="20" uuid="f7ae35fa-8f6c-4c3e-a111-a7b868a83134"/>
-          <textElement verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
-        </textField>
-        <textField>
-          <reportElement x="510" y="1" width="80" height="20" uuid="871f4010-1065-40d8-b55d-aa238d80a59d"/>
-          <textElement textAlignment="Right" verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
-        </textField>
-        <staticText>
-          <reportElement x="0" y="2" width="78" height="20" uuid="ef96d5b1-2bfc-4111-8176-6a01e0daafd8"/>
-          <textElement textAlignment="Right" verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <text><![CDATA[Rendered at:]]></text>
-        </staticText>
-        <textField>
-          <reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
-          <textElement verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
-        </textField>
-      </frame>
-    </band>
-  </pageFooter>
+	<columnFooter>
+		<band splitType="Stretch"/>
+	</columnFooter>
+	<pageFooter>
+		<band height="25" splitType="Stretch">
+			<frame>
+				<reportElement mode="Opaque" x="1" y="1" width="1148" height="24" uuid="10dfd2c7-7881-4dbd-b1f2-b2b550d2f003"/>
+				<textField evaluationTime="Report">
+					<reportElement x="590" y="1" width="40" height="20" uuid="f7ae35fa-8f6c-4c3e-a111-a7b868a83134"/>
+					<textElement verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+				</textField>
+				<textField>
+					<reportElement x="510" y="1" width="80" height="20" uuid="871f4010-1065-40d8-b55d-aa238d80a59d"/>
+					<textElement textAlignment="Right" verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="2" width="78" height="20" uuid="ef96d5b1-2bfc-4111-8176-6a01e0daafd8"/>
+					<textElement textAlignment="Right" verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<text><![CDATA[Rendered at:]]></text>
+				</staticText>
+				<textField>
+					<reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
+					<textElement verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
+				</textField>
+			</frame>
+		</band>
+	</pageFooter>
 </jasperReport>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-4ppp.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-4ppp.jrxml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.3.0.final using JasperReports Library version 6.3.0  -->
-<!-- 2019-07-08T15:03:09 -->
+<!-- Created with Jaspersoft Studio version 6.20.0.final using JasperReports Library version 6.20.0-2bc7ab61c56f459e8176eb05c7705e145cd400ad  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Blank_A4" pageWidth="1190" pageHeight="1684" columnWidth="1150" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="9967c600-878d-4d17-9b00-8ca2f00e9c39">
-  <property name="com.jaspersoft.studio.unit." value="pixel"/>
-  <parameter name="reportTitle" class="java.lang.String">
-    <parameterDescription><![CDATA[Report Title]]></parameterDescription>
-    <defaultValueExpression><![CDATA["Grafana Dashboard Report"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="reportDescription" class="java.lang.String">
-    <parameterDescription><![CDATA[Report Description]]></parameterDescription>
-    <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-  </parameter>
-  <parameter name="ONMS_REPORT_DIR" class="java.lang.String" isForPrompting="false">
-    <parameterDescription><![CDATA[The directory where all reports can be found]]></parameterDescription>
-    <defaultValueExpression><![CDATA["${install.dir}/etc/report-templates/"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="timezone" class="java.time.ZoneId">
-    <parameterDescription><![CDATA[Report Timezone]]></parameterDescription>
-    <defaultValueExpression><![CDATA[java.time.ZoneId.systemDefault()]]></defaultValueExpression>
-  </parameter>
-  <parameter name="startDate" class="java.util.Date">
-    <parameterDescription><![CDATA[Report Start Date]]></parameterDescription>
-    <defaultValueExpression><![CDATA[new java.util.Date(
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<parameter name="reportTitle" class="java.lang.String">
+		<parameterDescription><![CDATA[Report Title]]></parameterDescription>
+		<defaultValueExpression><![CDATA["Grafana Dashboard Report"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="reportDescription" class="java.lang.String">
+		<parameterDescription><![CDATA[Report Description]]></parameterDescription>
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<parameter name="ONMS_REPORT_DIR" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[The directory where all reports can be found]]></parameterDescription>
+		<defaultValueExpression><![CDATA["${install.dir}/etc/report-templates/"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="timezone" class="java.time.ZoneId">
+		<parameterDescription><![CDATA[Report Timezone]]></parameterDescription>
+		<defaultValueExpression><![CDATA[java.time.ZoneId.systemDefault()]]></defaultValueExpression>
+	</parameter>
+	<parameter name="startDate" class="java.util.Date">
+		<parameterDescription><![CDATA[Report Start Date]]></parameterDescription>
+		<defaultValueExpression><![CDATA[new java.util.Date(
 new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianCalendar().get(Calendar.MONTH), new GregorianCalendar().get(Calendar.DATE) - 1).getTimeInMillis()
 )]]></defaultValueExpression>
-  </parameter>
-  <parameter name="endDate" class="java.util.Date">
-    <parameterDescription><![CDATA[Report End Date]]></parameterDescription>
-    <defaultValueExpression><![CDATA[new java.util.Date(
+	</parameter>
+	<parameter name="endDate" class="java.util.Date">
+		<parameterDescription><![CDATA[Report End Date]]></parameterDescription>
+		<defaultValueExpression><![CDATA[new java.util.Date(
 new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianCalendar().get(Calendar.MONTH), new GregorianCalendar().get(Calendar.DATE)).getTimeInMillis()
 )]]></defaultValueExpression>
-  </parameter>
-  <parameter name="startDateTime" class="java.lang.Long" isForPrompting="false">
-    <defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{startDate}, $P{timezone})]]></defaultValueExpression>
-  </parameter>
-  <parameter name="endDateTime" class="java.lang.Long" isForPrompting="false">
-    <defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{endDate}, $P{timezone})]]></defaultValueExpression>
-  </parameter>
-  <parameter name="dateFormat" class="java.lang.String">
-    <defaultValueExpression><![CDATA["EEE dd MMM yyyy HH:mm:ss"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="GRAFANA_DASHBOARD_UID" class="java.lang.String">
-    <defaultValueExpression><![CDATA["mjkV0rkZk"]]></defaultValueExpression>
-  </parameter>
-  <parameter name="GRAFANA_ENDPOINT_UID" class="java.lang.String">
-    <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
-  </parameter>
-  <queryString language="grafana"><![CDATA[{
+	</parameter>
+	<parameter name="startDateTime" class="java.lang.Long" isForPrompting="false">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{startDate}, $P{timezone})]]></defaultValueExpression>
+	</parameter>
+	<parameter name="endDateTime" class="java.lang.Long" isForPrompting="false">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.getRezonedEpoch($P{endDate}, $P{timezone})]]></defaultValueExpression>
+	</parameter>
+	<parameter name="dateFormat" class="java.lang.String">
+		<defaultValueExpression><![CDATA["EEE dd MMM yyyy HH:mm:ss"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="GRAFANA_DASHBOARD_UID" class="java.lang.String">
+		<defaultValueExpression><![CDATA["mjkV0rkZk"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="GRAFANA_ENDPOINT_UID" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
+	<queryString language="grafana">
+		<![CDATA[{
                         "dashboard": {
                         "uid": "$P{GRAFANA_DASHBOARD_UID}"
                         },
@@ -61,83 +61,85 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
                           "theme": "light"
                         },
                         "variables": {}
-                }]]></queryString>
-  <field name="png" class="java.lang.Object"/>
-  <field name="title" class="java.lang.String"/>
-  <field name="description" class="java.lang.String"/>
-  <field name="datasource" class="java.lang.String"/>
-  <field name="width" class="java.lang.Integer"/>
-  <field name="height" class="java.lang.Integer"/>
-  <title>
-    <band splitType="Stretch"/>
-  </title>
-  <pageHeader>
-    <band height="119" splitType="Stretch">
-      <image scaleImage="FillFrame">
-        <reportElement x="0" y="10" width="1149" height="69" uuid="b2b14931-9b7b-49fd-85ca-becf00f3b41f"/>
-        <imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/background.png"]]></imageExpression>
-      </image>
-      <rectangle>
-        <reportElement mode="Transparent" x="0" y="10" width="1149" height="69" uuid="67fa5b5c-98bb-4500-be31-b9e7c9ffd5f1"/>
-      </rectangle>
-      <textField>
-        <reportElement x="1" y="10" width="1148" height="68" uuid="2a2325ca-d32c-43ec-a930-970f17c2286c"/>
-        <textElement textAlignment="Center" verticalAlignment="Middle">
-          <font size="26"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{reportTitle}]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="7" y="89" width="702" height="20" uuid="0dad4f9e-c982-4147-8e27-5da3acdb4ced"/>
-        <textElement>
-          <font size="12"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{reportDescription}]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="500" y="89" width="210" height="20" forecolor="#000000" uuid="ac9d2b31-2a51-4768-90e9-b5a1f1698b67"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{startDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="700" y="89" width="219" height="20" forecolor="#000000" uuid="558f5fde-80e7-4515-976e-643bc23ad397"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{endDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
-      </textField>
-      <textField>
-        <reportElement x="870" y="89" width="300" height="20" forecolor="#000000" uuid="d4f139e5-6af9-44fa-bb50-eca765c5b6f3"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12" isBold="false"/>
-        </textElement>
-        <textFieldExpression><![CDATA[$P{timezone} + " " + org.opennms.netmgt.jasper.helper.TimezoneHelper.getUtcOffset($P{timezone}, $P{startDate})]]></textFieldExpression>
-      </textField>
-      <staticText>
-        <reportElement x="470" y="89" width="34" height="20" uuid="30cb5bcf-d0b2-48cd-940e-f6bef7bcc753">
-          <property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-          <property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-        </reportElement>
-        <textElement verticalAlignment="Middle">
-          <font size="12"/>
-        </textElement>
-        <text><![CDATA[Start:]]></text>
-      </staticText>
-      <staticText>
-        <reportElement x="670" y="89" width="30" height="20" uuid="4bcd92a9-04e0-4706-b6dc-02ab02356f40"/>
-        <textElement verticalAlignment="Middle">
-          <font size="12"/>
-        </textElement>
-        <text><![CDATA[End:]]></text>
-      </staticText>
-      <image hAlign="Center" vAlign="Middle">
-        <reportElement x="10" y="12" width="197" height="65" uuid="84f9fb75-2b8c-4a2a-ac51-f245ae29dcc3"/>
-        <imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/logo_flat.png"]]></imageExpression>
-      </image>
-    </band>
-  </pageHeader>
+                }]]>
+	</queryString>
+	<field name="png" class="java.lang.Object"/>
+	<field name="title" class="java.lang.String"/>
+	<field name="description" class="java.lang.String"/>
+	<field name="datasource" class="java.lang.String"/>
+	<field name="width" class="java.lang.Integer"/>
+	<field name="height" class="java.lang.Integer"/>
+	<field name="rowTitle" class="java.lang.String"/>
+	<title>
+		<band splitType="Stretch"/>
+	</title>
+	<pageHeader>
+		<band height="119" splitType="Stretch">
+			<image scaleImage="FillFrame">
+				<reportElement x="0" y="10" width="1149" height="69" uuid="b2b14931-9b7b-49fd-85ca-becf00f3b41f"/>
+				<imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/background.png"]]></imageExpression>
+			</image>
+			<rectangle>
+				<reportElement mode="Transparent" x="0" y="10" width="1149" height="69" uuid="67fa5b5c-98bb-4500-be31-b9e7c9ffd5f1"/>
+			</rectangle>
+			<textField>
+				<reportElement x="1" y="10" width="1148" height="68" uuid="2a2325ca-d32c-43ec-a930-970f17c2286c"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="26"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{reportTitle}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="7" y="89" width="702" height="20" uuid="0dad4f9e-c982-4147-8e27-5da3acdb4ced"/>
+				<textElement>
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{reportDescription}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="500" y="89" width="210" height="20" forecolor="#000000" uuid="ac9d2b31-2a51-4768-90e9-b5a1f1698b67"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{startDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="700" y="89" width="219" height="20" forecolor="#000000" uuid="558f5fde-80e7-4515-976e-643bc23ad397"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{endDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="870" y="89" width="300" height="20" forecolor="#000000" uuid="d4f139e5-6af9-44fa-bb50-eca765c5b6f3"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{timezone} + " " + org.opennms.netmgt.jasper.helper.TimezoneHelper.getUtcOffset($P{timezone}, $P{startDate})]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="470" y="89" width="34" height="20" uuid="30cb5bcf-d0b2-48cd-940e-f6bef7bcc753">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<text><![CDATA[Start:]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="670" y="89" width="30" height="20" uuid="4bcd92a9-04e0-4706-b6dc-02ab02356f40"/>
+				<textElement verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<text><![CDATA[End:]]></text>
+			</staticText>
+			<image hAlign="Center" vAlign="Middle">
+				<reportElement x="10" y="12" width="197" height="65" uuid="84f9fb75-2b8c-4a2a-ac51-f245ae29dcc3"/>
+				<imageExpression><![CDATA[$P{ONMS_REPORT_DIR} + "assets/images/logo_flat.png"]]></imageExpression>
+			</image>
+		</band>
+	</pageHeader>
 	<detail>
 		<band height="375" splitType="Stretch">
 			<textField>
@@ -145,50 +147,62 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
 				<textElement textAlignment="Center"/>
 				<textFieldExpression><![CDATA[$F{description} + " from datasource: " + $F{datasource} + " rendered at: " + $F{width} + "x" + $F{height} + " px"]]></textFieldExpression>
 			</textField>
+			<textField>
+				<reportElement x="1" y="20" width="1148" height="30" isRemoveLineWhenBlank="true" uuid="6787cacd-e1f3-48a2-af7b-6c7bcb0d97f6">
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<printWhenExpression><![CDATA[$F{rowTitle}.length()>0]]></printWhenExpression>
+				</reportElement>
+				<textElement textAlignment="Left" verticalAlignment="Middle">
+					<font size="16" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{rowTitle}]]></textFieldExpression>
+			</textField>
 			<image>
-				<reportElement stretchType="RelativeToBandHeight" x="1" y="20" width="1148" height="354" uuid="6d3caa20-5995-424f-893c-fcb1c220be6f">
+				<reportElement stretchType="RelativeToBandHeight" x="1" y="50" width="1148" height="324" uuid="6d3caa20-5995-424f-893c-fcb1c220be6f">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<imageExpression><![CDATA[new java.io.ByteArrayInputStream((byte[])$F{png})]]></imageExpression>
 			</image>
 		</band>
 	</detail>
-  <columnFooter>
-    <band splitType="Stretch"/>
-  </columnFooter>
-  <pageFooter>
-    <band height="25" splitType="Stretch">
-      <frame>
-        <reportElement mode="Opaque" x="1" y="1" width="1148" height="24" uuid="10dfd2c7-7881-4dbd-b1f2-b2b550d2f003"/>
-        <textField evaluationTime="Report">
-          <reportElement x="590" y="1" width="40" height="20" uuid="f7ae35fa-8f6c-4c3e-a111-a7b868a83134"/>
-          <textElement verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
-        </textField>
-        <textField>
-          <reportElement x="510" y="1" width="80" height="20" uuid="871f4010-1065-40d8-b55d-aa238d80a59d"/>
-          <textElement textAlignment="Right" verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
-        </textField>
-        <staticText>
-          <reportElement x="0" y="2" width="78" height="20" uuid="ef96d5b1-2bfc-4111-8176-6a01e0daafd8"/>
-          <textElement textAlignment="Right" verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <text><![CDATA[Rendered at:]]></text>
-        </staticText>
-        <textField>
-          <reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
-          <textElement verticalAlignment="Middle">
-            <font size="10" isBold="false"/>
-          </textElement>
-          <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
-        </textField>
-      </frame>
-    </band>
-  </pageFooter>
+	<columnFooter>
+		<band splitType="Stretch"/>
+	</columnFooter>
+	<pageFooter>
+		<band height="25" splitType="Stretch">
+			<frame>
+				<reportElement mode="Opaque" x="1" y="1" width="1148" height="24" uuid="10dfd2c7-7881-4dbd-b1f2-b2b550d2f003"/>
+				<textField evaluationTime="Report">
+					<reportElement x="590" y="1" width="40" height="20" uuid="f7ae35fa-8f6c-4c3e-a111-a7b868a83134"/>
+					<textElement verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+				</textField>
+				<textField>
+					<reportElement x="510" y="1" width="80" height="20" uuid="871f4010-1065-40d8-b55d-aa238d80a59d"/>
+					<textElement textAlignment="Right" verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
+				</textField>
+				<staticText>
+					<reportElement x="0" y="2" width="78" height="20" uuid="ef96d5b1-2bfc-4111-8176-6a01e0daafd8"/>
+					<textElement textAlignment="Right" verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<text><![CDATA[Rendered at:]]></text>
+				</staticText>
+				<textField>
+					<reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
+					<textElement verticalAlignment="Middle">
+						<font size="10" isBold="false"/>
+					</textElement>
+					<textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
+				</textField>
+			</frame>
+		</band>
+	</pageFooter>
 </jasperReport>


### PR DESCRIPTION
Modified grafana jasper report templates and grafana jasper datasource  to print panels type row.

Added a new field **rowTitlte** to each grafana report template (.jrxml) and setup some rules, when the there is no row panel content it will remove the textField element from the report (see image)

<img width="1286" alt="Screen Shot 2022-11-04 at 7 52 20 AM" src="https://user-images.githubusercontent.com/3297292/199967046-09b3b536-1a0c-482b-9863-8ca8f92d68ab.png">

Test report

<img width="1466" alt="Screen Shot 2022-11-04 at 7 59 22 AM" src="https://user-images.githubusercontent.com/3297292/199967770-402ad102-0d42-4953-b1b2-d57d7a636050.png">

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14885

