### PR TITLE
NMS-15001: Use service locator key in poller client

### DIFF
--- a/features/api-layer/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -142,10 +142,6 @@
     <argument ref="dataCollectionConfigDao"/>
   </bean>
 
-  <bean id="pollerConfExtensionManager" class="org.opennms.features.apilayer.config.PollerConfExtensionManager">
-    <argument ref="pollerConfig"/>
-  </bean>
-
   <reference-list interface="org.opennms.integration.api.v1.config.datacollection.SnmpCollectionExtension" availability="optional">
     <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="snmpCollectionExtensionManager" />
   </reference-list>
@@ -170,6 +166,21 @@
     </service-properties>
   </service>
 
+  <!-- Poller Config Extension -->
+  <bean id="pollerConfExtensionManager" class="org.opennms.features.apilayer.config.PollerConfExtensionManager">
+    <argument ref="pollerConfig"/>
+    <argument ref="eventForwarder"/>
+  </bean>
+
+  <reference-list interface="org.opennms.integration.api.v1.config.poller.PollerConfigurationExtension" availability="optional">
+    <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="pollerConfExtensionManager" />
+  </reference-list>
+
+  <service ref="pollerConfExtensionManager" interface="org.opennms.core.config.api.ConfigurationProvider" >
+    <service-properties>
+      <entry key="registration.export" value="true"/>
+    </service-properties>
+  </service>
 
   <!-- Resource Graph Properties Extension -->
   <bean id="graphPropertiesExtensionManager" class="org.opennms.features.apilayer.config.GraphPropertiesExtensionManager">

--- a/features/api-layer/core/src/test/java/org/opennms/features/apilayer/config/PollerConfExtensionManagerTest.java
+++ b/features/api-layer/core/src/test/java/org/opennms/features/apilayer/config/PollerConfExtensionManagerTest.java
@@ -49,6 +49,7 @@ import org.opennms.integration.api.v1.config.poller.Service;
 import org.opennms.integration.api.xml.ClasspathPollerConfigurationLoader;
 import org.opennms.netmgt.config.PollerConfigManager;
 import org.opennms.netmgt.config.poller.ExcludeRange;
+import org.opennms.netmgt.events.api.EventForwarder;
 
 public class PollerConfExtensionManagerTest {
 
@@ -66,7 +67,7 @@ public class PollerConfExtensionManagerTest {
     @Test
     public void callbackCalled() {
         PollerConfigManager objectToNotify = mock(PollerConfigManager.class);
-        PollerConfExtensionManager instance = new PollerConfExtensionManager(objectToNotify);
+        PollerConfExtensionManager instance = new PollerConfExtensionManager(objectToNotify, mock(EventForwarder.class));
         instance.onBind(pollerConfiguration1, null);
         verify(objectToNotify, times(1)).setExternalData(any(), any());
         instance.onBind(pollerConfiguration2, null);
@@ -76,7 +77,7 @@ public class PollerConfExtensionManagerTest {
     @Test
     public void dataMatches() {
         PollerConfigManager objectToNotify = mock(PollerConfigManager.class);
-        PollerConfExtensionManager instance = new PollerConfExtensionManager(objectToNotify);
+        PollerConfExtensionManager instance = new PollerConfExtensionManager(objectToNotify, mock(EventForwarder.class));
         instance.onBind(pollerConfiguration1, null);
         instance.onBind(pollerConfiguration2, null);
 

--- a/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
+++ b/features/device-config/service/src/main/java/org/opennms/features/deviceconfig/service/impl/DeviceConfigServiceImpl.java
@@ -36,6 +36,7 @@ import java.net.UnknownHostException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +60,7 @@ import org.opennms.netmgt.poller.MonitoredService;
 import org.opennms.netmgt.poller.PollerResponse;
 import org.opennms.netmgt.poller.ServiceMonitor;
 import org.opennms.netmgt.poller.ServiceMonitorAdaptor;
+import org.opennms.netmgt.poller.ServiceMonitorLocator;
 import org.opennms.netmgt.poller.support.SimpleMonitoredService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,13 +137,9 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
                 .flatMap(svc -> pollerConfig.findService(InetAddressUtils.str(svc.getIpAddress()), svc.getServiceName()).stream())
 
                 // Filter for the device config monitor
-                .filter(match -> {
-                    ServiceMonitor serviceMonitor = pollerConfig.getServiceMonitor(match.service.getName());
-                    if (serviceMonitor != null) {
-                        return serviceMonitor.getClass().getCanonicalName().equals(DEVICE_CONFIG_SERVICE_CLASS_NAME);
-                    }
-                    return false;
-                })
+                .filter(match -> pollerConfig.getServiceMonitorLocator(match.service.getName())
+                                             .map(loc -> Objects.equals(loc.getServiceLocatorKey(), DEVICE_CONFIG_SERVICE_CLASS_NAME))
+                                             .orElse(false))
 
                 // Resolve the parameters
                 .map(match -> {
@@ -182,7 +180,8 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
         final var match = getPollerConfig().findService(ipAddress, serviceName)
                 .orElseThrow(IllegalArgumentException::new);
 
-        final var monitor = getPollerConfig().getServiceMonitor(match.service.getName());
+        final var monitor = getPollerConfig().getServiceMonitorLocator(match.service.getName())
+                .orElseThrow(IllegalArgumentException::new);
 
         final AbstractMap.SimpleImmutableEntry<Boolean, MonitoredService> boundServicePair = sessionUtils.withReadOnlyTransaction(() -> {
             final OnmsIpInterface ipInterface = findMatchingInterface(ipAddress, location, serviceName);
@@ -215,7 +214,7 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
             return locationAwarePollerClient.poll()
                     .withService(service)
                     .withAdaptor(serviceMonitorAdaptor)
-                    .withMonitor(monitor)
+                    .withMonitorLocator(monitor)
                     .withPatternVariables(match.patternVariables)
                     .withAttributes(match.service.getParameterMap())
                     .withAttribute(DeviceConfigConstants.TRIGGERED_POLL, "true")
@@ -224,7 +223,7 @@ public class DeviceConfigServiceImpl implements DeviceConfigService {
             // No persistence of config.
             return locationAwarePollerClient.poll()
                     .withService(service)
-                    .withMonitor(monitor)
+                    .withMonitorLocator(monitor)
                     .withPatternVariables(match.patternVariables)
                     .withAttributes(match.service.getParameterMap())
                     .withAttribute(DeviceConfigConstants.TRIGGERED_POLL, "true")

--- a/features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePollJob.java
+++ b/features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePollJob.java
@@ -71,7 +71,7 @@ public class PerspectivePollJob implements Job {
         backend.getLocationAwarePollerClient().poll()
                 .withService(svc.getMonitoredService())
                 .withTimeToLive(svc.getServiceConfig().getInterval())
-                .withMonitor(svc.getServiceMonitor())
+                .withMonitorLocator(svc.getServiceMonitorLocator())
                 .withAttributes(svc.getServiceConfig().getParameterMap())
                 .withPatternVariables(svc.getPatternVariables())
                 .execute()

--- a/features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePolledService.java
+++ b/features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePolledService.java
@@ -38,6 +38,7 @@ import org.opennms.netmgt.config.poller.Service;
 import org.opennms.netmgt.poller.MonitoredService;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.ServiceMonitor;
+import org.opennms.netmgt.poller.ServiceMonitorLocator;
 import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
 
@@ -57,7 +58,7 @@ public class PerspectivePolledService {
 
     private final Package.ServiceMatch serviceMatch;
 
-    private final ServiceMonitor serviceMonitor;
+    private final ServiceMonitorLocator serviceMonitorLocator;
 
     private final String perspectiveLocation;
     private final String residentLocation;
@@ -78,7 +79,7 @@ public class PerspectivePolledService {
                                     final String nodeLabel,
                                     final Package pkg,
                                     final Package.ServiceMatch serviceMatch,
-                                    final ServiceMonitor serviceMonitor,
+                                    final ServiceMonitorLocator serviceMonitorLocator,
                                     final String perspectiveLocation,
                                     final String residentLocation,
                                     final RrdRepository rrdRepository,
@@ -91,7 +92,7 @@ public class PerspectivePolledService {
         this.nodeLabel = Objects.requireNonNull(nodeLabel);
         this.pkg = Objects.requireNonNull(pkg);
         this.serviceMatch = Objects.requireNonNull(serviceMatch);
-        this.serviceMonitor = Objects.requireNonNull(serviceMonitor);
+        this.serviceMonitorLocator = Objects.requireNonNull(serviceMonitorLocator);
         this.perspectiveLocation = Objects.requireNonNull(perspectiveLocation);
         this.residentLocation = Objects.requireNonNull(residentLocation);
         this.rrdRepository = rrdRepository;
@@ -177,8 +178,8 @@ public class PerspectivePolledService {
         return this.serviceMatch.patternVariables;
     }
 
-    public ServiceMonitor getServiceMonitor() {
-        return serviceMonitor;
+    public ServiceMonitorLocator getServiceMonitorLocator() {
+        return serviceMonitorLocator;
     }
 
     public MonitoredService getMonitoredService() {
@@ -209,7 +210,7 @@ public class PerspectivePolledService {
                           .add("serviceName", this.serviceName)
                           .add("pkg", this.pkg)
                           .add("serviceMatch", this.serviceMatch)
-                          .add("serviceMonitor", this.serviceMonitor)
+                          .add("serviceMonitorLocator", this.serviceMonitorLocator)
                           .add("monitoredService", this.monitoredService)
                           .add("perspectiveLocation", this.perspectiveLocation)
                           .toString();
@@ -229,13 +230,13 @@ public class PerspectivePolledService {
                Objects.equals(this.serviceName, that.serviceName) &&
                Objects.equals(this.pkg, that.pkg) &&
                Objects.equals(this.serviceMatch, that.serviceMatch) &&
-               Objects.equals(this.serviceMonitor, that.serviceMonitor) &&
+               Objects.equals(this.serviceMonitorLocator, that.serviceMonitorLocator) &&
                Objects.equals(this.monitoredService, that.monitoredService) &&
                Objects.equals(this.perspectiveLocation, that.perspectiveLocation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.nodeId, this.ipAddress, this.serviceName, this.pkg, this.serviceMatch, this.serviceMonitor, this.monitoredService, this.perspectiveLocation);
+        return Objects.hash(this.nodeId, this.ipAddress, this.serviceName, this.pkg, this.serviceMatch, this.serviceMonitorLocator, this.monitoredService, this.perspectiveLocation);
     }
 }

--- a/features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerd.java
+++ b/features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerd.java
@@ -79,6 +79,7 @@ import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.netmgt.poller.LocationAwarePollerClient;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.ServiceMonitor;
+import org.opennms.netmgt.poller.ServiceMonitorLocator;
 import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.threshd.api.ThresholdInitializationException;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
@@ -216,8 +217,8 @@ public class PerspectivePollerd implements SpringServiceDaemon, PerspectiveServi
         }
 
         // Find the monitor implementation for the service name
-        final ServiceMonitor serviceMonitor = this.pollerConfig.getServiceMonitor(serviceMatch.get().service.getName());
-        if (serviceMonitor == null) {
+        final Optional<ServiceMonitorLocator> serviceMonitorLocator = this.pollerConfig.getServiceMonitorLocator(serviceMatch.get().service.getName());
+        if (!serviceMonitorLocator.isPresent()) {
             return;
         }
 
@@ -252,7 +253,7 @@ public class PerspectivePollerd implements SpringServiceDaemon, PerspectiveServi
                                                                                                node.getLabel(),
                                                                                                pkg,
                                                                                                serviceMatch.get(),
-                                                                                               serviceMonitor,
+                                                                                               serviceMonitorLocator.get(),
                                                                                                servicePerspective.getPerspectiveLocation(),
                                                                                                node.getLocation().getLocationName(),
                                                                                                rrdRepository.orElse(null),

--- a/features/perspectivepoller/src/test/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerdIT.java
+++ b/features/perspectivepoller/src/test/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerdIT.java
@@ -261,7 +261,6 @@ public class PerspectivePollerdIT implements InitializingBean, TemporaryDatabase
 
         final Package pkg = PollerConfigFactory.getInstance().getPackage("foo1");
         final Package.ServiceMatch serviceMatch = pkg.findService("ICMP").get();
-        final ServiceMonitor svcMon = PollerConfigFactory.getInstance().getServiceMonitor("ICMP");
 
         final int nodeId = this.node1icmp.getNodeId();
         final InetAddress ipAddress = this.node1icmp.getIpAddress();
@@ -309,14 +308,6 @@ public class PerspectivePollerdIT implements InitializingBean, TemporaryDatabase
     @Test
     public void testCloseOutageOnUnschedule() throws Exception {
         this.perspectivePollerd.start();
-
-        final Package pkg = PollerConfigFactory.getInstance().getPackage("foo1");
-        final Package.ServiceMatch serviceMatch = pkg.findService("ICMP").get();
-        final ServiceMonitor svcMon = PollerConfigFactory.getInstance().getServiceMonitor("ICMP");
-
-        final int nodeId = this.node1icmp.getNodeId();
-        final InetAddress ipAddress = this.node1icmp.getIpAddress();
-        final String location = this.node1icmp.getIpInterface().getNode().getLocation().getLocationName();
 
         final PerspectivePolledService perspectivePolledService = findPerspectivePolledService(this.node1icmp, "RDU");
         await().atMost(5, TimeUnit.SECONDS).until(() -> this.databasePopulator.getOutageDao().currentOutageForServiceFromPerspective(this.node1icmp, this.databasePopulator.getLocRDU()), is(nullValue()));
@@ -601,10 +592,6 @@ public class PerspectivePollerdIT implements InitializingBean, TemporaryDatabase
         // load the thresholds.xml and thresd-configuration.xml configuration
         this.thresholdingDao.overrideConfig(getClass().getResourceAsStream("/thresholds.xml"));
         this.threshdDao.overrideConfig(getClass().getResourceAsStream("/threshd-configuration.xml"));
-
-        final Package pkg = PollerConfigFactory.getInstance().getPackage("foo1");
-        final Package.ServiceMatch serviceMatch = pkg.findService("ICMP").get();
-        final ServiceMonitor svcMon = PollerConfigFactory.getInstance().getServiceMonitor("ICMP");
 
         final PerspectivePolledService perspectivePolledService = findPerspectivePolledService(this.node1icmp, "RDU");
 

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollerRequestBuilder.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollerRequestBuilder.java
@@ -29,9 +29,7 @@
 package org.opennms.netmgt.poller;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
 
 public interface PollerRequestBuilder {
 
@@ -39,7 +37,7 @@ public interface PollerRequestBuilder {
 
     PollerRequestBuilder withSystemId(String systemId);
 
-    PollerRequestBuilder withMonitor(ServiceMonitor serviceMonitor);
+    PollerRequestBuilder withMonitorLocator(ServiceMonitorLocator serviceMonitorLocator);
 
     PollerRequestBuilder withMonitorClassName(String className);
 

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/ServiceMonitorLocator.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/ServiceMonitorLocator.java
@@ -28,8 +28,6 @@
 
 package org.opennms.netmgt.poller;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * <p>ServiceMonitorLocator interface.</p>
  *
@@ -57,6 +55,6 @@ public interface ServiceMonitorLocator {
      *
      * @return a {@link org.opennms.netmgt.poller.ServiceMonitor} object.
      */
-    CompletableFuture<ServiceMonitor> getServiceMonitor(ServiceMonitorRegistry registry);
+    ServiceMonitor getServiceMonitor(ServiceMonitorRegistry registry);
 
 }

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/ServiceMonitorRegistry.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/ServiceMonitorRegistry.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.poller;
 
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Used to enumerate and retrieve available {@link ServiceMonitor} implementations.
@@ -38,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface ServiceMonitorRegistry {
 
-    CompletableFuture<ServiceMonitor> getMonitorFutureByClassName(String className);
+    ServiceMonitor getMonitorByClassName(String className);
 
     Set<String> getMonitorClassNames();
 

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/support/DefaultServiceMonitorRegistry.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/support/DefaultServiceMonitorRegistry.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.opennms.netmgt.poller.ServiceMonitor;
 import org.opennms.netmgt.poller.ServiceMonitorRegistry;
@@ -68,7 +67,7 @@ public class DefaultServiceMonitorRegistry implements ServiceMonitorRegistry {
 
     private static final ServiceLoader<ServiceMonitor> s_serviceMonitorLoader = ServiceLoader.load(ServiceMonitor.class);
 
-    private final Map<String, CompletableFuture<ServiceMonitor>> m_monitorsByClassName = new HashMap<>();
+    private final Map<String, ServiceMonitor> m_monitorsByClassName = new HashMap<>();
 
     public DefaultServiceMonitorRegistry() {
         for (ServiceMonitor serviceMonitor : s_serviceMonitorLoader) {
@@ -88,12 +87,7 @@ public class DefaultServiceMonitorRegistry implements ServiceMonitorRegistry {
                         serviceMonitor, properties);
                 return;
             }
-            CompletableFuture<ServiceMonitor> future = m_monitorsByClassName.get(className);
-            if(future == null) {
-                future = new CompletableFuture<>();
-                m_monitorsByClassName.put(className, future);
-            }
-            future.complete(serviceMonitor);
+            m_monitorsByClassName.put(className, serviceMonitor);
         }
     }
 
@@ -112,13 +106,8 @@ public class DefaultServiceMonitorRegistry implements ServiceMonitorRegistry {
     }
     
     @Override
-    public synchronized CompletableFuture<ServiceMonitor> getMonitorFutureByClassName(String className) {
-        CompletableFuture<ServiceMonitor> future = m_monitorsByClassName.get(className);
-        if(future == null) {
-            future = new CompletableFuture<>();
-            m_monitorsByClassName.put(className, future);
-        }
-        return future;
+    public synchronized ServiceMonitor getMonitorByClassName(String className) {
+        return m_monitorsByClassName.get(className);
     }
 
     @Override

--- a/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerClientRpcModule.java
+++ b/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerClientRpcModule.java
@@ -63,7 +63,7 @@ public class PollerClientRpcModule extends AbstractXmlRpcModule<PollerRequestDTO
     @Override
     public CompletableFuture<PollerResponseDTO> execute(PollerRequestDTO request) {
         final String className = request.getClassName();
-        final ServiceMonitor monitor = serviceMonitorRegistry.getMonitorFutureByClassName(className).getNow(null);
+        final ServiceMonitor monitor = serviceMonitorRegistry.getMonitorByClassName(className);
         if (monitor == null) {
             return CompletableFuture.completedFuture(new PollerResponseDTO(PollStatus.unknown("No monitor found with class name '" + className + "'.")));
         }

--- a/features/poller/shell/src/main/java/org/opennms/netmgt/poller/shell/Poll.java
+++ b/features/poller/shell/src/main/java/org/opennms/netmgt/poller/shell/Poll.java
@@ -70,6 +70,7 @@ import org.opennms.netmgt.poller.MonitoredService;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.PollerResponse;
 import org.opennms.netmgt.poller.ServiceMonitor;
+import org.opennms.netmgt.poller.ServiceMonitorLocator;
 import org.opennms.netmgt.poller.support.SimpleMonitoredService;
 
 @Command(scope = "opennms", name = "poll", description = "Used to invoke a monitor against a host at a specific location, or to test a service monitor definition from a given poller package.")
@@ -252,13 +253,13 @@ public class Poll implements Action {
             return null;
         }
 
-        final ServiceMonitor monitor = pollerConfig.getServiceMonitor(service.get().service.getName());
-        if (monitor == null) {
+        final Optional<ServiceMonitorLocator> serviceMonitorLocator = pollerConfig.getServiceMonitorLocator(service.get().service.getName());
+        if (!serviceMonitorLocator.isPresent()) {
             System.err.printf("Error: Service %s doesn't have a monitor class defined%n", serviceName);
             return null;
         }
 
-        return monitor.getClass().getName();
+        return serviceMonitorLocator.get().getServiceLocatorKey();
     }
 
     private Map<String, Object> retrieveParameters(final InetAddress ipAddress, final String packageName, final String serviceName) throws Exception {

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DefaultServiceMonitorLocator.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DefaultServiceMonitorLocator.java
@@ -105,7 +105,7 @@ public class DefaultServiceMonitorLocator implements ServiceMonitorLocator, Seri
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("serviceName", this.m_serviceClass)
+                          .add("serviceName", this.m_serviceName)
                           .add("serviceClass", this.m_serviceClass)
                           .toString();
     }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DefaultServiceMonitorLocator.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DefaultServiceMonitorLocator.java
@@ -35,11 +35,13 @@
 package org.opennms.netmgt.config;
 
 import java.io.Serializable;
-import java.util.concurrent.CompletableFuture;
+import java.util.Objects;
 
 import org.opennms.netmgt.poller.ServiceMonitor;
 import org.opennms.netmgt.poller.ServiceMonitorLocator;
 import org.opennms.netmgt.poller.ServiceMonitorRegistry;
+
+import com.google.common.base.MoreObjects;
 
 public class DefaultServiceMonitorLocator implements ServiceMonitorLocator, Serializable {
 
@@ -58,8 +60,8 @@ public class DefaultServiceMonitorLocator implements ServiceMonitorLocator, Seri
     }
 
     @Override
-    public CompletableFuture<ServiceMonitor> getServiceMonitor(ServiceMonitorRegistry registry) {
-        return registry.getMonitorFutureByClassName(m_serviceClass);
+    public ServiceMonitor getServiceMonitor(ServiceMonitorRegistry registry) {
+        return registry.getMonitorByClassName(m_serviceClass);
     }
 
     /**
@@ -82,4 +84,29 @@ public class DefaultServiceMonitorLocator implements ServiceMonitorLocator, Seri
         return m_serviceClass;
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultServiceMonitorLocator)) {
+            return false;
+        }
+        final DefaultServiceMonitorLocator that = (DefaultServiceMonitorLocator) o;
+        return Objects.equals(this.m_serviceName, that.m_serviceName) &&
+               Objects.equals(this.m_serviceClass, that.m_serviceClass);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.m_serviceName, this.m_serviceClass);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("serviceName", this.m_serviceClass)
+                          .add("serviceClass", this.m_serviceClass)
+                          .toString();
+    }
 }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfig.java
@@ -295,8 +295,6 @@ public interface PollerConfig extends PathOutageConfig {
 
     public List<Package> getPackages();
 
-    List<Monitor> getConfiguredMonitors();
-
     /**
      * Find the {@link Package} containing the service selected for the given IP.
      * @param ipAddr the address to select the package for
@@ -345,14 +343,6 @@ public interface PollerConfig extends PathOutageConfig {
      * @return a {@link org.opennms.netmgt.config.poller.Package} object.
      */
     public Package getPackage(String pkgName);
-    
-    /**
-     * <p>getServiceSelectorForPackage</p>
-     *
-     * @param pkg a {@link org.opennms.netmgt.config.poller.Package} object.
-     * @return a {@link org.opennms.netmgt.model.ServiceSelector} object.
-     */
-    public ServiceSelector getServiceSelectorForPackage(Package pkg);
 
     /**
      * <p>getThreads</p>
@@ -363,13 +353,7 @@ public interface PollerConfig extends PathOutageConfig {
 
     public Set<String> getServiceMonitorNames();
 
-    /**
-     * <p>getServiceMonitor</p>
-     *
-     * @param svcName a {@link java.lang.String} object.
-     * @return a {@link org.opennms.netmgt.poller.ServiceMonitor} object.
-     */
-    public ServiceMonitor getServiceMonitor(String svcName);
+    public Optional<ServiceMonitorLocator> getServiceMonitorLocator(String svcName);
     
     /**
      * <p>update</p>
@@ -392,14 +376,6 @@ public interface PollerConfig extends PathOutageConfig {
      * @param pkg a {@link org.opennms.netmgt.config.poller.Package} object.
      */
     void addPackage(Package pkg);
-    
-    /**
-     * <p>addMonitor</p>
-     *
-     * @param svcName a {@link java.lang.String} object.
-     * @param className a {@link java.lang.String} object.
-     */
-    void addMonitor(String svcName, String className);
 
     /**
      * <p>getLocalConfiguration</p>
@@ -426,7 +402,7 @@ public interface PollerConfig extends PathOutageConfig {
 
     ServiceMonitorRegistry getServiceMonitorRegistry();
 
-    default void setExternalData(List<Package> externalPackages, List<Monitor> externalMonitors) {};
+    void setExternalData(List<Package> externalPackages, List<Monitor> externalMonitors);
 
     /**
      * <p>getReadLock</p>

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
@@ -1139,7 +1139,7 @@ abstract public class PollerConfigManager implements PollerConfig  {
         
         for (final ServiceMonitorLocator locator : locators) {
             final var monitor = locator.getServiceMonitor(s_serviceMonitorRegistry);
-            if(monitor == null) {
+            if (monitor == null) {
                 LOG.warn("The monitor with class {} not available yet, if the feature is installed correctly it will be available later.", locator.getServiceName());
             }
         }

--- a/opennms-services/src/test/java/org/opennms/netmgt/config/PollerConfigWithPSMIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/config/PollerConfigWithPSMIT.java
@@ -51,6 +51,7 @@ import org.opennms.netmgt.config.poller.Service;
 import org.opennms.netmgt.mock.MockNetwork;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.ServiceMonitor;
+import org.opennms.netmgt.poller.ServiceMonitorLocator;
 import org.opennms.netmgt.poller.mock.MockMonitoredService;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -109,7 +110,8 @@ public class PollerConfigWithPSMIT {
         PollerConfigFactory factory = new PollerConfigFactory(0, is);
         PollerConfigFactory.setInstance(factory);        
         IOUtils.closeQuietly(is);
-        ServiceMonitor monitor = PollerConfigFactory.getInstance().getServiceMonitor("MQ_API_DirectRte_v2");
+        ServiceMonitor monitor = PollerConfigFactory.getInstance().getServiceMonitorLocator("MQ_API_DirectRte_v2").orElseThrow()
+                                                    .getServiceMonitor(factory.getServiceMonitorRegistry());
         Assert.assertNotNull(monitor);
         Package pkg = PollerConfigFactory.getInstance().getPackage("MapQuest");
         Assert.assertNotNull(pkg);

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/MockNetworkTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/MockNetworkTest.java
@@ -424,7 +424,7 @@ public class MockNetworkTest extends TestCase {
         m_pollerConfig.setPollInterval("HTTP", 750L);
         m_pollerConfig.setPollerThreads(5);
         m_pollerConfig.setCriticalService("YAHOO");
-        PollerConfig pollerConfig = m_pollerConfig;
+        MockPollerConfig pollerConfig = m_pollerConfig;
 
         // test the nodeOutageProcessing setting works
         assertTrue(pollerConfig.isNodeOutageProcessingEnabled());

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/MockPollerConfig.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/MockPollerConfig.java
@@ -39,9 +39,12 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.Vector;
+import java.util.concurrent.CompletableFuture;
 
 import org.opennms.netmgt.config.BasicScheduleUtils;
 import org.opennms.netmgt.config.PollerConfig;
@@ -57,18 +60,16 @@ import org.opennms.netmgt.config.poller.outages.Node;
 import org.opennms.netmgt.config.poller.outages.Outage;
 import org.opennms.netmgt.config.poller.outages.Time;
 import org.opennms.netmgt.model.OnmsMonitoredService;
-import org.opennms.netmgt.model.ServiceSelector;
 import org.opennms.netmgt.poller.ServiceMonitor;
 import org.opennms.netmgt.poller.ServiceMonitorLocator;
 import org.opennms.netmgt.poller.ServiceMonitorRegistry;
-import org.opennms.netmgt.poller.support.DefaultServiceMonitorRegistry;
 import org.springframework.core.io.ByteArrayResource;
 
 import com.google.common.collect.Maps;
 
 public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements PollerConfig {
 
-    private final ServiceMonitorRegistry m_serviceMonitorRegistry = new DefaultServiceMonitorRegistry();
+    private final MockServiceMonitorRegistry m_serviceMonitorRegistry = new MockServiceMonitorRegistry();
 
     private String m_criticalSvcName;
 
@@ -78,7 +79,7 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
 
     private Vector<Package> m_pkgs = new Vector<>();
 
-    private Map<String, ServiceMonitor> m_svcMonitors = new TreeMap<String, ServiceMonitor>();
+    private Map<String, ServiceMonitorLocator> m_svcMonitorLocators = new TreeMap<>();
 
     private int m_threads = 1;
 
@@ -232,11 +233,6 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
         addScheduledOutage(m_currentPkg, outageName, dayOfWeek, beginTime, endTime, ipAddr);
     }
 
-
-    public void addService(String name, ServiceMonitor monitor) {
-        addService(name, m_defaultPollInterval, monitor);
-    }
-
     public void addService(String name, long interval, ServiceMonitor monitor) {
         Service service = findService(m_currentPkg, name);
         if (service == null) {
@@ -250,8 +246,30 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
     }
 
     private void addServiceMonitor(String name, ServiceMonitor monitor) {
-        if (!hasServiceMonitor(name))
-            m_svcMonitors.put(name, monitor);
+        if (m_svcMonitorLocators.containsKey(name)) {
+            return;
+        }
+
+        final var key = String.format("%s:%s", monitor.getClass().getCanonicalName(), name);
+
+        m_serviceMonitorRegistry.monitors.put(key, monitor);
+
+        m_svcMonitorLocators.put(name, new ServiceMonitorLocator() {
+            @Override
+            public String getServiceName() {
+                return name;
+            }
+
+            @Override
+            public String getServiceLocatorKey() {
+                return key;
+            }
+
+            @Override
+            public ServiceMonitor getServiceMonitor(final ServiceMonitorRegistry registry) {
+                return registry.getMonitorByClassName(this.getServiceLocatorKey());
+            }
+        });
     }
 
     public void addService(MockService svc) {
@@ -272,12 +290,6 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
     }
 
     @Override
-    public void addMonitor(String svcName, String className) {
-        addServiceMonitor(svcName, new MockMonitor(m_network, svcName));
-
-    }
-
-    @Override
     public Enumeration<Package> enumeratePackage() {
         return m_pkgs.elements();
     }
@@ -285,11 +297,6 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
     @Override
     public List<Package> getPackages() {
         return m_pkgs;
-    }
-
-    @Override
-    public List<Monitor> getConfiguredMonitors() {
-        return Collections.emptyList();
     }
 
     private Service findService(Package pkg, String svcName) {
@@ -330,9 +337,13 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
         return m_rraLists.get(pkg);
     }
 
-    @Override
     public ServiceMonitor getServiceMonitor(String svcName) {
-        return m_svcMonitors.get(svcName);
+        return Objects.requireNonNull(m_svcMonitorLocators.get(svcName).getServiceMonitor(m_serviceMonitorRegistry));
+    }
+
+    @Override
+    public Optional<ServiceMonitorLocator> getServiceMonitorLocator(final String svcName) {
+        return Optional.ofNullable(m_svcMonitorLocators.get(svcName));
     }
 
     @Override
@@ -505,6 +516,10 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
         m_currentSvc.addParameter(param);
     }
 
+    public void reset() {
+        this.m_pkgs.clear();
+    }
+
     @Override
     public void addPackage(final Package pkg) {
         m_pkgs.add(pkg);
@@ -550,11 +565,6 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
         return Collections.emptyList();
     }
 
-    @Override
-    public ServiceSelector getServiceSelectorForPackage(final Package pkg) {
-        return null;
-    }
-
     public void saveResponseTimeData(final String locationMonitor, final OnmsMonitoredService monSvc, final double responseTime, final Package pkg) {
         throw new UnsupportedOperationException("not yet implemented");
 
@@ -583,5 +593,31 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
     @Override
     public ServiceMonitorRegistry getServiceMonitorRegistry() {
         return m_serviceMonitorRegistry;
+    }
+
+    @Override
+    public void setExternalData(final List<Package> externalPackages, final List<Monitor> externalMonitors) {
+        throw new UnsupportedOperationException("MockPollerConfig.setExternalData is not yet implemented");
+    }
+
+    private  static class MockServiceMonitorRegistry implements ServiceMonitorRegistry {
+
+        public final Map<String, ServiceMonitor> monitors = Maps.newHashMap();
+
+        @Override
+        public ServiceMonitor getMonitorByClassName(final String className) {
+            return this.monitors.get(className);
+        }
+
+        @Override
+        public Set<String> getMonitorClassNames() {
+            return this.monitors.keySet();
+        }
+
+        @SuppressWarnings({ "rawtypes" })
+        public synchronized void onBind(ServiceMonitor serviceMonitor, Map properties) { }
+
+        @SuppressWarnings({ "rawtypes" })
+        public synchronized void onUnbind(ServiceMonitor serviceMonitor, Map properties) { }
     }
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
@@ -120,6 +120,8 @@ import com.google.common.collect.Sets;
         "classpath:/META-INF/opennms/applicationContext-rpc-client-mock.xml",
         "classpath:/META-INF/opennms/applicationContext-rpc-poller.xml",
 
+        "classpath:/META-INF/opennms/applicationContext-serviceMonitorRegistry.xml",
+
         // Override the default QueryManager with the DAO version
         "classpath:/META-INF/opennms/applicationContext-pollerdTest.xml",
         "classpath:/META-INF/opennms/applicationContext-test-deviceConfig.xml"
@@ -133,10 +135,12 @@ public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
 
     private Poller m_poller;
 
+    @Autowired
     private MockNetwork m_network;
 
     private MockDatabase m_db;
 
+    @Autowired
     private MockPollerConfig m_pollerConfig;
 
     private boolean m_daemonsStarted = false;
@@ -176,7 +180,6 @@ public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
         MockUtil.println("------------ Begin Test  --------------------------");
         MockLogAppender.setupLogging();
 
-        m_network = new MockNetwork();
         m_network.setCriticalService("ICMP");
         m_network.addNode(1, "Router");
         m_network.addInterface("192.168.1.1");
@@ -212,7 +215,6 @@ public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
         m_db.populate(m_network);
         DataSourceFactory.setInstance(m_db);
 
-        m_pollerConfig = new MockPollerConfig(m_network);
         m_pollerConfig.setNextOutageIdSql(m_db.getNextOutageIdStatement());
         m_pollerConfig.setNodeOutageProcessingEnabled(true);
         m_pollerConfig.setCriticalService("ICMP");

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
@@ -47,6 +47,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.db.DataSourceFactory;
+import org.opennms.core.mate.api.EntityScopeProvider;
+import org.opennms.core.rpc.mock.MockEntityScopeProvider;
+import org.opennms.core.rpc.utils.RpcTargetHelper;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.MockDatabase;
@@ -55,6 +58,7 @@ import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.utils.Querier;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.eventd.AbstractEventUtil;
@@ -76,6 +80,7 @@ import org.opennms.netmgt.mock.PollAnticipator;
 import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
+import org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl;
 import org.opennms.netmgt.poller.pollables.PollableNetwork;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.JUnitConfigurationEnvironment;
@@ -100,6 +105,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath:/META-INF/opennms/applicationContext-rpc-client-mock.xml",
         "classpath:/META-INF/opennms/applicationContext-rpc-poller.xml",
 
+		"classpath:/META-INF/opennms/applicationContext-serviceMonitorRegistry.xml",
+
         // Override the default QueryManager with the DAO version
         "classpath:/META-INF/opennms/applicationContext-pollerdTest.xml",
 		"classpath:/META-INF/opennms/applicationContext-test-deviceConfig.xml"
@@ -112,10 +119,12 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
 
 	private Poller m_poller;
 
+	@Autowired
 	private MockNetwork m_network;
 
 	private MockDatabase m_db;
 
+	@Autowired
 	private MockPollerConfig m_pollerConfig;
 
 	@Autowired
@@ -138,7 +147,7 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
 	private TransactionTemplate m_transactionTemplate;
 
 	@Autowired
-	private LocationAwarePollerClient m_locationAwarePollerClient;
+	private LocationAwarePollerClientImpl m_locationAwarePollerClient;
 
 	private LocationAwarePingClient m_locationAwarePingClient;
 
@@ -160,7 +169,6 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
 		MockUtil.println("------------ Begin Test  --------------------------");
 		MockLogAppender.setupLogging();
 
-		m_network = new MockNetwork();
 		m_network.setCriticalService("ICMP");
 		m_network.addNode(1, "Router");
 		m_network.addInterface("192.168.1.1");
@@ -193,7 +201,6 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
 		m_db.populate(m_network);
 		DataSourceFactory.setInstance(m_db);
 
-		m_pollerConfig = new MockPollerConfig(m_network);
 		m_pollerConfig.setNextOutageIdSql(m_db.getNextOutageIdStatement());
 		m_pollerConfig.setNodeOutageProcessingEnabled(true);
 		m_pollerConfig.setCriticalService("ICMP");

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerRpcTimeoutIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerRpcTimeoutIT.java
@@ -211,7 +211,8 @@ public class PollerRpcTimeoutIT implements TemporaryDatabaseAware<MockDatabase> 
         IOUtils.closeQuietly(is);
 
         // Sanity check the config
-        ServiceMonitor monitor = PollerConfigFactory.getInstance().getServiceMonitor("HTTP");
+        ServiceMonitor monitor = PollerConfigFactory.getInstance().getServiceMonitorLocator("HTTP").orElseThrow()
+                .getServiceMonitor(PollerConfigFactory.getInstance().getServiceMonitorRegistry());
         Assert.assertNotNull(monitor);
         Package pkg = PollerConfigFactory.getInstance().getPackage("PollerRpcTimeoutIT");
         Assert.assertNotNull(pkg);

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PollablesIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PollablesIT.java
@@ -122,6 +122,8 @@ public class PollablesIT {
 
     private PollableNetwork m_network;
     private MockPollContext m_pollContext;
+
+    @Autowired
     private MockNetwork m_mockNetwork;
     private MockDatabase m_db;
     private MockEventIpcManager m_eventMgr;
@@ -155,6 +157,8 @@ public class PollablesIT {
     private PollableService pDot4Smtp;
     private PollableService pDot4Http;
     private OutageAnticipator m_outageAnticipator;
+
+    @Autowired
     private MockPollerConfig m_pollerConfig;
 
     private MockScheduler m_scheduler;
@@ -176,7 +180,6 @@ public class PollablesIT {
 
         MockLogAppender.setupLogging();
 
-        m_mockNetwork = new MockNetwork();
         m_mockNetwork.addNode(1, "Router");
         m_mockNetwork.addInterface("192.168.1.1");
         m_mockNetwork.addService("ICMP");
@@ -214,7 +217,7 @@ public class PollablesIT {
         m_pollContext.setEventMgr(m_eventMgr);
         m_pollContext.setMockNetwork(m_mockNetwork);
 
-        m_pollerConfig = new MockPollerConfig(m_mockNetwork);
+        m_pollerConfig.reset();
         m_pollerConfig.setNodeOutageProcessingEnabled(true);
         m_pollerConfig.setCriticalService("ICMP");
         m_pollerConfig.addPackage("TestPackage");

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-serviceMonitorRegistry.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-serviceMonitorRegistry.xml
@@ -4,7 +4,14 @@
   xsi:schemaLocation="
   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
 ">
-    
-    <bean id="serviceMonitorRegistry" class="org.opennms.netmgt.poller.support.DefaultServiceMonitorRegistry" />
+    <bean id="mockNetwork" class="org.opennms.netmgt.mock.MockNetwork" primary="true" />
 
+    <bean id="mockPollerConfig" class="org.opennms.netmgt.mock.MockPollerConfig" primary="true" >
+        <constructor-arg ref="mockNetwork"/>
+    </bean>
+
+    <bean id="serviceMonitorRegistry" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" primary="true" >
+        <property name="targetObject" ref="mockPollerConfig"/>
+        <property name="targetMethod" value="getServiceMonitorRegistry"/>
+    </bean>
 </beans>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/service.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/service.jsp
@@ -58,6 +58,7 @@
 <%@ page import="org.opennms.core.mate.api.Scope" %>
 <%@ page import="org.opennms.core.utils.InetAddressUtils" %>
 <%@ page import="org.opennms.core.mate.api.MapScope" %>
+<%@ page import="org.opennms.netmgt.poller.ServiceMonitorLocator" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -95,8 +96,8 @@
             pageContext.setAttribute("pollerPattern", serviceMatch.service.getPattern());
             pageContext.setAttribute("patternVariables", serviceMatch.patternVariables);
 
-            ServiceMonitor monitor = pollerCfgFactory.getServiceMonitor(serviceMatch.service.getName());
-            pageContext.setAttribute("monitorClass", monitor == null ? "N/A" : monitor.getClass().getName());
+            Optional<ServiceMonitorLocator> monitor = pollerCfgFactory.getServiceMonitorLocator(serviceMatch.service.getName());
+            pageContext.setAttribute("monitorClass", monitor.isEmpty() ? "N/A" : monitor.get().getServiceLocatorKey());
 
             pageContext.setAttribute("interval", serviceMatch.service.getInterval());
 


### PR DESCRIPTION
The lookup of the service monitor implementation can not be done by class name, as there are delegate implementaions like the one used for OIA pollers. Therefor the pollers are now addressed by service locators only. This uses the registered poller class name, which can differ from the actual class in case of delegates. Thus allowing to find the correct implementations in the service monitor registry.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15001

