### PR TITLE
NMS-14996: Ensure Multiple Plugins Work

### DIFF
--- a/ui/src/components/Plugin/utils.ts
+++ b/ui/src/components/Plugin/utils.ts
@@ -1,10 +1,11 @@
 const externalComponent = (url: string) => {
   try {
+    // this is the extensionId part of the url
     const name = (
       url
         .split('/')
-        .reverse()[0]
-        .match(/^(.*?)\.es/) as any[]
+        .reverse()[1]
+        .match(/^([^?]+)/) as any[]
     )[1]
 
     if (window[name]) {

--- a/ui/src/components/Plugin/utils.ts
+++ b/ui/src/components/Plugin/utils.ts
@@ -1,12 +1,32 @@
+const isLegacyPluginUrl = (extensionId: string, moduleFileName: string) => {
+  if (moduleFileName == 'uiextension' &&
+     (extensionId === 'cloudUiExtension' || extensionId === 'uiextension' || extensionId === 'uiExtension')) {
+    return true
+  }
+
+  return false
+}
+
 const externalComponent = (url: string) => {
   try {
     // this is the extensionId part of the url
-    const name = (
+    // should be used in the future when all plugins have unique extensionIds
+    const extensionId = (
       url
         .split('/')
         .reverse()[1]
         .match(/^([^?]+)/) as any[]
     )[1]
+
+    // for compatibility with legacy plugins
+    const moduleFileName = (
+      url
+        .split('/')
+        .reverse()[0]
+        .match(/^(.*?)\.es/) as any[]
+    )[1]
+
+    const name = isLegacyPluginUrl(extensionId, moduleFileName) ? moduleFileName : extensionId
 
     if (window[name]) {
       return new Promise((resolve) => {

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp, h } from 'vue'
+import { RouteRecordRaw } from 'vue-router'
 import App from './App.vue'
 import router from './router'
 import store from './store'
@@ -80,6 +81,25 @@ const plugins = await API.getPlugins()
 
 for (const plugin of plugins) {
   const js = getJSPath(baseUrl, plugin.extensionId, plugin.resourceRootPath, plugin.moduleFileName)
+
+  // add this plugin to routes
+  // - route 'name' is 'Plugin-pluginName'. Plugins must add their routes as children of this named route
+  // - route 'path' has the Plugin extensionId as part of the segment rather than as a parameter,
+  //   so it will only match the uniquely-named plugin
+  const routeRecord : RouteRecordRaw =
+    {
+      path: `/plugins/${plugin.extensionId}/:resourceRootPath/:moduleFileName`,
+      name: `Plugin-${plugin.extensionId}`,
+      props: route => ({
+        extensionId: plugin.extensionId,
+        resourceRootPath: route.params.resourceRootPath,
+        moduleFileName: route.params.moduleFileName
+      }),
+      component: () => import('@/containers/Plugin.vue')
+    }
+
+  router.addRoute(routeRecord)
+
   await externalComponent(js)
 }
 

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -21,12 +21,6 @@ const router = createRouter({
       component: Home
     },
     {
-      path: '/plugins/:extensionId/:resourceRootPath/:moduleFileName',
-      name: 'Plugin',
-      props: true,
-      component: () => import('@/containers/Plugin.vue')
-    },
-    {
       path: '/file-editor',
       name: 'FileEditor',
       component: FileEditor,

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
+import { Plugin } from '@/types'
 import DeviceConfigBackup from '@/containers/DeviceConfigBackup.vue'
 import Home from '@/containers/Home.vue'
 import FileEditor from '@/containers/FileEditor.vue'
@@ -12,6 +13,26 @@ const { adminRole, filesystemEditorRole, dcbRole, rolesAreLoaded } = useRole()
 const { showSnackBar } = useSnackbar()
 const { startSpinner, stopSpinner } = useSpinner()
 
+// for backward compatibility with legacy OpenNMS plugins
+// should eventually be removed when plugins are compliant with new schema
+const isLegacyPlugin = (plugin: Plugin) => {
+  if (plugin.extensionClass &&
+      (plugin.extensionClass === 'org.opennms.plugins.cloud.ui.CloudUiExtension' ||
+       plugin.menuEntry === 'Cloud Services') &&
+       plugin.moduleFileName === 'uiextension.es.js') {
+    return true
+  }
+
+  if (plugin.extensionClass &&
+      (plugin.extensionClass === 'org.opennms.alec.ui.UIExtension' ||
+       plugin.menuEntry === 'ALEC') &&
+       plugin.moduleFileName === 'uiextension.es.js') {
+    return true
+  }
+
+  return false
+}
+
 const router = createRouter({
   history: createWebHashHistory('/opennms/ui'),
   routes: [
@@ -19,6 +40,14 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: Home
+    },
+    {
+      // for compatibility with legacy plugins
+      // should be removed when all plugins have unique 'extensionId' and follow new pattern
+      path: '/plugins/:extensionId/:resourceRootPath/:moduleFileName',
+      name: 'Plugin',
+      props: true,
+      component: () => import('@/containers/Plugin.vue')
     },
     {
       path: '/file-editor',
@@ -143,3 +172,4 @@ const router = createRouter({
 router.beforeEach(() => startSpinner())
 router.afterEach(() => stopSpinner())
 export default router
+export { isLegacyPlugin }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -461,6 +461,7 @@ export interface Expression {
 }
 
 export interface Plugin {
+  extensionClass?: string
   extensionId: string
   menuEntry: string
   moduleFileName: string


### PR DESCRIPTION
Plugins / UI Extensions did not work properly if more than one plugin was installed in OpenNMS at a time. This PR, in conjunction with PRs for ALEC and Cloud plugins, will allow all plugins to work when multiple ones are installed.

- Plugins get `window.VRouter` which is the Vue Router object used in OpenNMS Vue UI, then add their own routes to it. However, they added their routes as children of the 'Plugins' named route. Basically whichever plugin was installed first would have their routes 'win' vs. any subsequently installed plugin. In this PR, Horizon dynamically adds unique parent routes for each installed plugins on startup and plugins should be updated to add their routes under their specific parent route

- Plugin components get stored in `window[pluginId]`, but currently plugins may have the same ID which was based on plugin `moduleFileName` instead of `extensionId`. This PR will get component data out of `window[plugin.extensionId]`, so that multiple plugins are stored separately

- Plugins should have unique `extensionId` parameters in their bundle blueprint metadata for routing and component storage to work properly when multiple plugins are installed. To make things easier, `extensionId` and the filename portion of `moduleFileName` should be the same.

- Code has been added to detect if a 'legacy' plugin is installed, and then uses the 'old' behavior. This allows current ALEC and Cloud plugins (only) to work properly if they are the only UI plugin installed (current Horizon 30/31.0 behavior). Ideally this code (and the 'Plugin' route) should be eventually removed when all plugins have been updated to new pattern. Any other legacy plugins may not work.

- This only affects plugins with a UI component. Non-UI plugins (e.g. cortex) don't have any effect on this issue. 

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14996

