### PR TITLE
NMS-7775: Add lldpRemLocalPortNum in LldpLink Table

### DIFF
--- a/core/schema/src/main/liquibase/32.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/32.0.0/changelog.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet runOnChange="false" author="rssntn67" id="32.0.0-lldplink">
+        <dropIndex tableName="lldplink" indexName="lldplink_pk_idx"/>
+        <renameColumn tableName="lldplink" oldColumnName="lldplocalportnum" newColumnName="lldpremindex"/>
+        <addColumn tableName="lldplink">
+            <column name="lldpremlocalportnum" type="integer" defaultValue="1">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addUniqueConstraint tableName="lldplink" columnNames="nodeid,lldpremlocalportnum,lldpremindex" constraintName="lldplink_pk_idx"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/core/schema/src/main/liquibase/changelog.xml
+++ b/core/schema/src/main/liquibase/changelog.xml
@@ -97,6 +97,7 @@
 	<include file="29.0.4/changelog.xml"/>
 	<include file="30.0.0/changelog.xml"/>
 	<include file="30.0.2/changelog.xml"/>
+	<include file="32.0.0/changelog.xml"/>
 
 	<include file="stored-procedures/getManagePercentAvailIntfWindow.xml" />
 	<include file="stored-procedures/getManagePercentAvailNodeWindow.xml" />

--- a/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpLocPortGetter.java
+++ b/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpLocPortGetter.java
@@ -65,7 +65,7 @@ public class LldpLocPortGetter extends SnmpGetter {
         LldpLink lldplink = row.getLldpLink();
         if (val == null) {
             LOG.debug("getLldpLink: cannot find local instance for lldp local port number {}",
-                     lldplink.getLldpLocalPortNum());
+                     lldplink.getLldpRemLocalPortNum());
             LOG.debug("getLldpLink: setting default not found Values: portidtype \"InterfaceAlias\", portid=\"Not Found On lldpLocPortTable\"");
             lldplink.setLldpPortIdSubType(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACEALIAS);
             lldplink.setLldpPortId("\"Not Found On lldpLocPortTable\"");
@@ -75,7 +75,7 @@ public class LldpLocPortGetter extends SnmpGetter {
 
         if (val.get(0) == null || val.get(0).isError() || !val.get(0).isNumeric()) {
             LOG.debug("getLldpLink: port id subtype is null or invalid for lldp local port number {}",
-                     lldplink.getLldpLocalPortNum());
+                     lldplink.getLldpRemLocalPortNum());
             LOG.debug("getLldpLink: setting default not found Values: portidtype \"InterfaceAlias\"");
             lldplink.setLldpPortIdSubType(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACEALIAS);
         } else {
@@ -83,7 +83,7 @@ public class LldpLocPortGetter extends SnmpGetter {
         }
         if (val.get(1) == null || val.get(1).isError()) {
             LOG.debug("getLldpLink: port id is null for lldp local port number {}",
-                     lldplink.getLldpLocalPortNum());
+                     lldplink.getLldpRemLocalPortNum());
             LOG.debug("get: setting default not found Values: portid=\"Not Found On lldpLocPortTable\"");
             lldplink.setLldpPortId("\"Not Found On lldpLocPortTable\"");
         } else {

--- a/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpRemTableTracker.java
+++ b/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpRemTableTracker.java
@@ -209,7 +209,8 @@ public class LldpRemTableTracker extends TableTracker {
 	    public LldpLink getLldpLink() {
 
             LldpLink lldpLink = new LldpLink();
-            lldpLink.setLldpLocalPortNum(getLldpRemIndex());
+            lldpLink.setLldpRemLocalPortNum(getLldpRemLocalPortNum());
+            lldpLink.setLldpRemIndex(getLldpRemIndex());
             lldpLink.setLldpRemChassisId(LldpLocalGroupTracker.decodeLldpChassisId(getLldpRemChassisId() , getLldpRemChassisidSubtype()));
             lldpLink.setLldpRemChassisIdSubType(LldpChassisIdSubType.get(getLldpRemChassisidSubtype()));
             lldpLink.setLldpRemSysname(getLldpRemSysname());

--- a/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/TimeTetraLldpLocPortGetter.java
+++ b/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/TimeTetraLldpLocPortGetter.java
@@ -64,9 +64,9 @@ public class TimeTetraLldpLocPortGetter extends SnmpGetter {
         List<SnmpValue> val = get(lldpLink.getLldpPortIfindex(),timeTetraLldpRemRow.getTmnxLldpRemLocalDestMACAddress());
 
         if (val == null ) {
-            LOG.debug("getLldpLink: cannot find local instance for lldp ifindex {} and local port number {}",
+            LOG.debug("getLldpLink: cannot find local instance for lldp ifindex {} and TmnxLldpRemLocalDestMACAddress {}",
                     lldpLink.getLldpPortIfindex(),
-                    lldpLink.getLldpLocalPortNum());
+                    timeTetraLldpRemRow.getTmnxLldpRemLocalDestMACAddress());
             LOG.debug("getLldpLink: setting default not found Values: portidtype \"InterfaceAlias\", portid=\"Not Found On lldpLocPortTable\"");
             lldpLink.setLldpPortIdSubType(LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACEALIAS);
             lldpLink.setLldpPortId("\"Not Found On lldpLocPortTable\"");
@@ -75,18 +75,18 @@ public class TimeTetraLldpLocPortGetter extends SnmpGetter {
         }
 
         if (val.get(0) == null || val.get(0).isError() || !val.get(0).isNumeric()) {
-            LOG.debug("getLldpLink: port id subtype is null or invalid for lldp ifindex {} and local port number {}",
+            LOG.debug("getLldpLink: port id subtype is null or invalid for lldp ifindex {} and TmnxLldpRemLocalDestMACAddress {}",
                     lldpLink.getLldpPortIfindex(),
-                    lldpLink.getLldpLocalPortNum());
+                    timeTetraLldpRemRow.getTmnxLldpRemLocalDestMACAddress());
             LOG.debug("get: setting default not found Values: portidtype \"InterfaceAlias\"");
             lldpLink.setLldpPortIdSubType(LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACEALIAS);
         } else {
             lldpLink.setLldpPortIdSubType(LldpUtils.LldpPortIdSubType.get(val.get(0).toInt()));
         }
         if (val.get(1) == null || val.get(1).isError()) {
-            LOG.debug("getLldpLink: port id is null for lldp ifindex {} and local port number {}",
+            LOG.debug("getLldpLink: port id is null for lldp ifindex {} and TmnxLldpRemLocalDestMACAddress {}",
                     lldpLink.getLldpPortIfindex(),
-                    lldpLink.getLldpLocalPortNum());
+                    timeTetraLldpRemRow.getTmnxLldpRemLocalDestMACAddress());
             LOG.debug("getLldpLink: setting default not found Values: portid=\"Not Found On lldpLocPortTable\"");
             lldpLink.setLldpPortId("\"Not Found On lldpLocPortTable\"");
         } else {

--- a/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/TimeTetraLldpRemTableTracker.java
+++ b/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/snmp/TimeTetraLldpRemTableTracker.java
@@ -104,7 +104,7 @@ public class TimeTetraLldpRemTableTracker extends TableTracker {
 		}
 
 		public Integer getLldpLocalPortNum() {return getInstance().toString().hashCode();}
-	    public Integer getLldpRemLocalPortNum() {
+	    public Integer getLldpRemIndex() {
 	    	return getInstance().getSubIdAt(3);
 	    }
         public Integer getTmnxLldpRemLocalDestMACAddress() {
@@ -144,7 +144,8 @@ public class TimeTetraLldpRemTableTracker extends TableTracker {
 	    public LldpLink getLldpLink() {
 
             LldpLink lldpLink = new LldpLink();
-            lldpLink.setLldpLocalPortNum(getLldpLocalPortNum());
+            lldpLink.setLldpRemLocalPortNum(getIfindex()*31+getTmnxLldpRemLocalDestMACAddress());
+            lldpLink.setLldpRemIndex(getLldpRemIndex());
             lldpLink.setLldpPortIfindex(getIfindex());
             lldpLink.setLldpRemChassisId(LldpLocalGroupTracker.decodeLldpChassisId(getLldpRemChassisId(), getLldpRemChassisidSubtype()));
             lldpLink.setLldpRemChassisIdSubType(LldpChassisIdSubType.get(getLldpRemChassisidSubtype()));
@@ -153,8 +154,8 @@ public class TimeTetraLldpRemTableTracker extends TableTracker {
             lldpLink.setLldpRemPortIdSubType(LldpPortIdSubType.get(getLldpRemPortidSubtype()));
             lldpLink.setLldpRemPortDescr(getLldpRemPortDescr());
 
-            LOG.debug( "getLldpLink: local port num: {}, ifindex: {}, TmnxLldpRemLocalDestMACAddress: {}, identifier: {}, chassis subtype: {}, \n rem sysname: {}, rem port: {}, rem port subtype: {}",
-                       lldpLink.getLldpLocalPortNum(),
+            LOG.debug( "getLldpLink: Rem Index: {}, ifindex: {}, TmnxLldpRemLocalDestMACAddress: {}, identifier: {}, chassis subtype: {}, \n rem sysname: {}, rem port: {}, rem port subtype: {}",
+                       lldpLink.getLldpRemIndex(),
                        lldpLink.getLldpPortIfindex(),
                         getTmnxLldpRemLocalDestMACAddress(),
                        lldpLink.getLldpRemChassisId(),

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -37,7 +37,6 @@ import org.opennms.enlinkd.generator.protocol.bridge.BridgeBuilder;
 import org.opennms.enlinkd.generator.protocol.bridge.BridgeBuilderContext;
 import org.opennms.enlinkd.generator.util.InetAddressGenerator;
 import org.opennms.enlinkd.generator.util.MacAddressGenerator;
-import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.model.OnmsNode;
 
 /**
@@ -61,7 +60,7 @@ import org.opennms.netmgt.model.OnmsNode;
  *
  * If more than 10 nodes are requested then the tree repeats itself with bridge5 as the root node of the new subtree.
  */
-public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
+public class BridgeProtocol extends Protocol {
 
     /* this is the vlan id for all the bridgebridgelinks and bridgemaclinks */
     private final static int VLAN_ID = 1;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/CdpProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/CdpProtocol.java
@@ -42,12 +42,9 @@ import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.OspfElement;
 import org.opennms.netmgt.model.OnmsNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class CdpProtocol extends Protocol<CdpElement> {
-    private final static Logger LOG = LoggerFactory.getLogger(CdpProtocol.class);
-    private TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.cdp;
+public class CdpProtocol extends Protocol {
+    private final TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.cdp;
 
     public CdpProtocol(TopologySettings topologySettings, TopologyContext context) {
         super(topologySettings, context);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/IsIsProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/IsIsProtocol.java
@@ -40,12 +40,9 @@ import org.opennms.enlinkd.generator.topology.PairGenerator;
 import org.opennms.netmgt.enlinkd.model.IsIsElement;
 import org.opennms.netmgt.enlinkd.model.IsIsLink;
 import org.opennms.netmgt.model.OnmsNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class IsIsProtocol extends Protocol<IsIsElement> {
-    private final static Logger LOG = LoggerFactory.getLogger(IsIsProtocol.class);
-    private TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.isis;
+public class IsIsProtocol extends Protocol {
+    private final TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.isis;
 
     public IsIsProtocol(TopologySettings topologySettings, TopologyContext context) {
         super(topologySettings, context);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/LldpProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/LldpProtocol.java
@@ -129,7 +129,8 @@ public class LldpProtocol extends Protocol<LldpElement> {
 
         // static attributes:
         link.setLldpRemChassisIdSubType(LldpUtils.LldpChassisIdSubType.LLDP_CHASSISID_SUBTYPE_CHASSISCOMPONENT); // shouldn't be relevant for match => set it fixed
-        link.setLldpLocalPortNum(123);
+        link.setLldpRemIndex(123);
+        link.setLldpRemLocalPortNum(456);
         link.setLldpLinkLastPollTime(new Date());
         link.setLldpPortDescr("lldpportdescr");
         link.setLldpRemSysname("lldpRemSysname");

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/LldpProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/LldpProtocol.java
@@ -31,6 +31,7 @@ package org.opennms.enlinkd.generator.protocol;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -42,12 +43,10 @@ import org.opennms.enlinkd.generator.topology.PairGenerator;
 import org.opennms.netmgt.enlinkd.model.LldpElement;
 import org.opennms.netmgt.enlinkd.model.LldpLink;
 import org.opennms.netmgt.model.OnmsNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class LldpProtocol extends Protocol<LldpElement> {
-    private final static Logger LOG = LoggerFactory.getLogger(IsIsProtocol.class);
-    private TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.lldp;
+public class LldpProtocol extends Protocol {
+    private final TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.lldp;
+    private final Random ifindexRandomGenerator = new Random();
 
     public LldpProtocol(TopologySettings topologySettings, TopologyContext context) {
         super(topologySettings, context);
@@ -129,8 +128,8 @@ public class LldpProtocol extends Protocol<LldpElement> {
 
         // static attributes:
         link.setLldpRemChassisIdSubType(LldpUtils.LldpChassisIdSubType.LLDP_CHASSISID_SUBTYPE_CHASSISCOMPONENT); // shouldn't be relevant for match => set it fixed
-        link.setLldpRemIndex(123);
-        link.setLldpRemLocalPortNum(456);
+        link.setLldpRemLocalPortNum(ifindexRandomGenerator.nextInt(100000));
+        link.setLldpRemIndex(ifindexRandomGenerator.nextInt(100000));
         link.setLldpLinkLastPollTime(new Date());
         link.setLldpPortDescr("lldpportdescr");
         link.setLldpRemSysname("lldpRemSysname");

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/OspfProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/OspfProtocol.java
@@ -39,13 +39,12 @@ import org.opennms.enlinkd.generator.TopologyGenerator;
 import org.opennms.enlinkd.generator.TopologySettings;
 import org.opennms.enlinkd.generator.topology.PairGenerator;
 import org.opennms.enlinkd.generator.util.InetAddressGenerator;
-import org.opennms.netmgt.enlinkd.model.OspfElement;
 import org.opennms.netmgt.enlinkd.model.OspfLink;
 import org.opennms.netmgt.model.OnmsNode;
 
-public class OspfProtocol extends Protocol<OspfElement> {
-    private TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.ospf;
-    private InetAddressGenerator inetAddressCreator = new InetAddressGenerator();
+public class OspfProtocol extends Protocol {
+    private final TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.ospf;
+    private final InetAddressGenerator inetAddressCreator = new InetAddressGenerator();
 
     public OspfProtocol(TopologySettings topologySettings, TopologyContext context) {
         super(topologySettings, context);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
@@ -51,7 +51,7 @@ import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 
-public abstract class Protocol<Element> {
+public abstract class Protocol {
 
     final TopologySettings topologySettings;
     final TopologyContext context;
@@ -151,7 +151,7 @@ public abstract class Protocol<Element> {
         onmsSnmpInterface.setIfOperStatus(7);
         onmsSnmpInterface.setLastCapsdPoll(new Date());
         onmsSnmpInterface.setLastSnmpPoll(new Date());
-        nodeIfIndexes.computeIfAbsent(node.getId(), key -> ifIndex);
+        nodeIfIndexes.putIfAbsent(node.getId(), ifIndex);
 
         return onmsSnmpInterface;
     }
@@ -170,7 +170,7 @@ public abstract class Protocol<Element> {
         ip.setId(snmp.getId());
         ip.setSnmpInterface(snmp);
         ip.setIpLastCapsdPoll(new Date());
-        ip.setNode(Optional.ofNullable(snmp).map(OnmsSnmpInterface::getNode).orElse(null));
+        ip.setNode(Optional.of(snmp).map(OnmsSnmpInterface::getNode).orElse(null));
         ip.setIpAddress(inetAddress);
         return ip;
     }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/UserDefinedProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/UserDefinedProtocol.java
@@ -39,9 +39,9 @@ import org.opennms.enlinkd.generator.topology.PairGenerator;
 import org.opennms.netmgt.enlinkd.model.UserDefinedLink;
 import org.opennms.netmgt.model.OnmsNode;
 
-public class UserDefinedProtocol extends Protocol<UserDefinedLink> {
+public class UserDefinedProtocol extends Protocol {
     public static final String OWNER = TopologyGenerator.class.getCanonicalName();
-    private TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.userdefined;
+    private final TopologyGenerator.Protocol protocol = TopologyGenerator.Protocol.userdefined;
 
     public UserDefinedProtocol(TopologySettings topologySettings, TopologyContext context) {
         super(topologySettings, context);

--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/LldpLink.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/LldpLink.java
@@ -66,7 +66,8 @@ public class LldpLink implements Serializable {
 	private OnmsNode m_node;
 	
 	private LldpPortIdSubType m_lldpPortIdSubType;
-	private Integer m_lldpLocalPortNum;
+	private Integer m_lldpRemLocalPortNum;
+	private Integer m_lldpRemIndex;
 	private Integer m_lldpPortIfindex;
 	private String m_lldpPortId;
 	private String m_lldpPortDescr;
@@ -83,11 +84,12 @@ public class LldpLink implements Serializable {
 	public LldpLink() {
 	}
 
-    public LldpLink(OnmsNode node, Integer localPortNum, Integer portIfIndex, String portId,
+    public LldpLink(OnmsNode node, Integer lldpRemIndex, Integer lldpRemLocalPortNum, Integer portIfIndex, String portId,
                     String portDescr, LldpPortIdSubType portIdSubType, String remChassisId, String remSysname, LldpChassisIdSubType remChassisIdSubType,
                     String remPortId, LldpPortIdSubType remPortIdSubType, String remPortDescr) {
         setNode(node);
-        setLldpLocalPortNum(localPortNum);
+        setLldpRemIndex(lldpRemIndex);
+		setLldpRemLocalPortNum(lldpRemLocalPortNum);
         setLldpPortIfindex(portIfIndex);
         setLldpPortId(portId);
         setLldpPortDescr(portDescr);
@@ -126,16 +128,23 @@ public class LldpLink implements Serializable {
 		m_node = node;
 	}
 
-    @Column(name="lldpLocalPortNum", nullable = false)
-	public Integer getLldpLocalPortNum() {
-		return m_lldpLocalPortNum;
+    @Column(name="lldpRemLocalPortNum", nullable = false)
+	public Integer getLldpRemLocalPortNum() {
+		return m_lldpRemLocalPortNum;
 	}
 
-	public void setLldpLocalPortNum(Integer lldpLocalPortNum) {
-		m_lldpLocalPortNum = lldpLocalPortNum;
+	public void setLldpRemLocalPortNum(Integer lldpRemLocalPortNum) {
+		m_lldpRemLocalPortNum = lldpRemLocalPortNum;
 	}
 
+	@Column(name="lldpRemIndex", nullable = false)
+	public Integer getLldpRemIndex() {
+		return m_lldpRemIndex;
+	}
 
+	public void setLldpRemIndex(Integer lldpRemIndex) {
+		m_lldpRemIndex = lldpRemIndex;
+	}
 
     @Column(name="lldpPortIdSubType", nullable = false)
     @Type(type="org.opennms.netmgt.enlinkd.model.LldpPortIdSubTypeUserType")
@@ -298,8 +307,10 @@ public class LldpLink implements Serializable {
 
 		return "lldplink: nodeid:[" +
 				getNode().getId() +
-				"]. portnum:[ " +
-				getLldpLocalPortNum() +
+				"]. remLocalPortNum:[ " +
+				getLldpRemLocalPortNum() +
+				"]. remIndex:[ " +
+				getLldpRemIndex() +
 				"], ifindex:[" +
 				getLldpPortIfindex() +
 				"], port type/id:[" +

--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/LldpLinkDao.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/LldpLinkDao.java
@@ -36,9 +36,9 @@ import org.opennms.netmgt.model.OnmsNode;
 
 public interface LldpLinkDao extends LinkDao<LldpLink, Integer> {
 
-    LldpLink get(OnmsNode node, Integer lldpLocalPortNum);
+    LldpLink get(OnmsNode node, Integer lldpRemLocalPortNum, Integer lldpRemIndex);
 
-    LldpLink get(Integer nodeId, Integer lldpLocalPortNum);
+    LldpLink get(Integer nodeId, Integer lldpRemLocalPortNum, Integer lldpRemIndex);
 
     List<LldpLink> findLinksForIds(List<Integer> ids);
 

--- a/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/LldpLinkDaoHibernate.java
+++ b/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/LldpLinkDaoHibernate.java
@@ -55,16 +55,17 @@ public class LldpLinkDaoHibernate extends AbstractDaoHibernate<LldpLink, Integer
 
     /** {@inheritDoc} */
     @Override
-    public LldpLink get(OnmsNode node, Integer lldpLocalPortNum) {
-        return findUnique("from LldpLink as lldpLink where lldpLink.node = ? and lldpLink.lldpLocalPortNum = ?", node, lldpLocalPortNum);
+    public LldpLink get(OnmsNode node, Integer lldpRemLocalPortNum, Integer lldpRemIndex) {
+        return findUnique("from LldpLink as lldpLink where lldpLink.node = ? and lldpLink.lldpRemLocalPortNum = ? and lldpRemIndex = ?", node, lldpRemLocalPortNum, lldpRemIndex);
     }
 
     /** {@inheritDoc} */
     @Override
-    public LldpLink get(Integer nodeId, Integer lldpLocalPortNum) {
+    public LldpLink get(Integer nodeId, Integer lldpRemLocalPortNum, Integer lldpRemIndex) {
         Assert.notNull(nodeId, "nodeId cannot be null");
-        Assert.notNull(lldpLocalPortNum, "lldpLocalPortNum cannot be null");
-        return findUnique("from LldpLink as lldpLink where lldpLink.node.id = ? and lldpLink.lldpLocalPortNum = ?", nodeId, lldpLocalPortNum);
+        Assert.notNull(lldpRemLocalPortNum, "lldpRemLocalPortNum cannot be null");
+        Assert.notNull(lldpRemIndex, "lldpRemIndex cannot be null");
+        return findUnique("from LldpLink as lldpLink where lldpLink.node.id = ? and lldpLink.lldpRemLocalPortNum = ? and lldpLink.lldpRemIndex = ?", nodeId, lldpRemLocalPortNum, lldpRemIndex);
     }
     
     /** {@inheritDoc} */

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/LldpTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/LldpTopologyServiceImpl.java
@@ -107,7 +107,7 @@ public class LldpTopologyServiceImpl extends TopologyServiceImpl implements Lldp
 
             @Override
             protected LldpLink query() {
-                return m_dao.get(nodeId, saveMe.getLldpLocalPortNum());
+                return m_dao.get(nodeId, saveMe.getLldpRemLocalPortNum(), saveMe.getLldpRemIndex());
             }
 
             @Override

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdSnmpIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdSnmpIT.java
@@ -64,11 +64,11 @@ import static org.opennms.netmgt.nb.Nms13923NetworkBuilder.srv005_NAME;
 import static org.opennms.netmgt.nb.Nms13923NetworkBuilder.srv005_IP;
 import static org.opennms.netmgt.nb.Nms13923NetworkBuilder.srv005_RESOURCE;
 import static org.opennms.netmgt.nb.Nms13923NetworkBuilder.srv005_LLDP_ID;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_NAME;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_IP;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_RESOURCE;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_LLDP_ID;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_GB05_MAC;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_NAME;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_IP;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_RESOURCE;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_LLDP_ID;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_GB05_MAC;
 import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER1_NAME;
 import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER1_IP;
 import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER1_RESOURCE;
@@ -83,9 +83,9 @@ import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER3_RESOURCE;
 import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER3_ETHER1_MAC;
 import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER3_ETHER2_MAC;
 import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER3_ETHER3_MAC;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_HOST3_LLDP_ID;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_HOST4_LLDP_ID;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_HOST5_LLDP_ID;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.HOST3_LLDP_ID;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.HOST4_LLDP_ID;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.HOST5_LLDP_ID;
 
 
 
@@ -668,7 +668,7 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
                 LldpLink link = row.getLldpLink();
                 assertNotNull(link);
                 assertNotNull(row.getTmnxLldpRemLocalDestMACAddress());
-                assertNotNull(link.getLldpLocalPortNum());
+                assertNotNull(link.getLldpRemIndex());
                 assertNotNull(link.getLldpPortIfindex());
                 links01.add(row);
                 assertEquals(LldpChassisIdSubType.LLDP_CHASSISID_SUBTYPE_MACADDRESS, link.getLldpRemChassisIdSubType());
@@ -683,7 +683,7 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
                 LldpLink link = row.getLldpLink();
                 assertNotNull(link);
                 assertNotNull(row.getTmnxLldpRemLocalDestMACAddress());
-                assertNotNull(link.getLldpLocalPortNum());
+                assertNotNull(link.getLldpRemIndex());
                 assertNotNull(link.getLldpPortIfindex());
                 links02.add(row);
                 assertEquals(LldpChassisIdSubType.LLDP_CHASSISID_SUBTYPE_MACADDRESS, link.getLldpRemChassisIdSubType());
@@ -729,16 +729,16 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
             assertNotEquals("\"Not Found On lldpLocPortTable\"",updated.getLldpPortId());
             assertEquals(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_LOCAL, updated.getLldpPortIdSubType());
             assertNotEquals("",updated.getLldpPortDescr());
-            LOG.warn("01 {} ifindex {}",updated.getLldpLocalPortNum(),updated.getLldpPortIfindex());
-            LOG.warn("01 {} portid {}",updated.getLldpLocalPortNum(),updated.getLldpPortId());
-            LOG.warn("01 {} port subtype {}",updated.getLldpLocalPortNum(),updated.getLldpPortIdSubType());
-            LOG.warn("01 {} portdescr {}",updated.getLldpLocalPortNum(),updated.getLldpPortDescr());
-            LOG.warn("01 {} rem chassisId {}",updated.getLldpLocalPortNum(),updated.getLldpRemChassisId());
-            LOG.warn("01 {} rem chassisId subtype {}",updated.getLldpLocalPortNum(),updated.getLldpRemChassisIdSubType());
-            LOG.warn("01 {} rem sysname {}",updated.getLldpLocalPortNum(),updated.getLldpRemSysname());
-            LOG.warn("01 {} rem portid {}",updated.getLldpLocalPortNum(),updated.getLldpRemPortId());
-            LOG.warn("01 {} rem port subtype {}",updated.getLldpLocalPortNum(),updated.getLldpRemPortIdSubType());
-            LOG.warn("01 {} rem portdescr {}",updated.getLldpLocalPortNum(),updated.getLldpRemPortDescr());
+            LOG.warn("01 {} ifindex {}",updated.getLldpRemIndex(),updated.getLldpPortIfindex());
+            LOG.warn("01 {} portid {}",updated.getLldpRemIndex(),updated.getLldpPortId());
+            LOG.warn("01 {} port subtype {}",updated.getLldpRemIndex(),updated.getLldpPortIdSubType());
+            LOG.warn("01 {} portdescr {}",updated.getLldpRemIndex(),updated.getLldpPortDescr());
+            LOG.warn("01 {} rem chassisId {}",updated.getLldpRemIndex(),updated.getLldpRemChassisId());
+            LOG.warn("01 {} rem chassisId subtype {}",updated.getLldpRemIndex(),updated.getLldpRemChassisIdSubType());
+            LOG.warn("01 {} rem sysname {}",updated.getLldpRemIndex(),updated.getLldpRemSysname());
+            LOG.warn("01 {} rem portid {}",updated.getLldpRemIndex(),updated.getLldpRemPortId());
+            LOG.warn("01 {} rem port subtype {}",updated.getLldpRemIndex(),updated.getLldpRemPortIdSubType());
+            LOG.warn("01 {} rem portdescr {}",updated.getLldpRemIndex(),updated.getLldpRemPortDescr());
         }
 
         for (TimeTetraLldpRemTableTracker.TimeTetraLldpRemRow timeTetraLldpLink02 : links02) {
@@ -752,16 +752,16 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
             assertNotEquals("\"Not Found On lldpLocPortTable\"",updated.getLldpPortId());
             assertEquals(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_LOCAL, updated.getLldpPortIdSubType());
             assertNotEquals("",updated.getLldpPortDescr());
-            LOG.warn("02 {} ifindex {}",updated.getLldpLocalPortNum(),updated.getLldpPortIfindex());
-            LOG.warn("02 {} portid {}",updated.getLldpLocalPortNum(),updated.getLldpPortId());
-            LOG.warn("02 {} port subtype {}",updated.getLldpLocalPortNum(),updated.getLldpPortIdSubType());
-            LOG.warn("02 {} portdescr {}",updated.getLldpLocalPortNum(),updated.getLldpPortDescr());
-            LOG.warn("02 {} rem chassisId {}",updated.getLldpLocalPortNum(),updated.getLldpRemChassisId());
-            LOG.warn("02 {} rem chassisId subtype {}",updated.getLldpLocalPortNum(),updated.getLldpRemChassisIdSubType());
-            LOG.warn("02 {} rem sysname {}",updated.getLldpLocalPortNum(),updated.getLldpRemSysname());
-            LOG.warn("02 {} rem portid {}",updated.getLldpLocalPortNum(),updated.getLldpRemPortId());
-            LOG.warn("02 {} rem port subtype {}",updated.getLldpLocalPortNum(),updated.getLldpRemPortIdSubType());
-            LOG.warn("02 {} rem portdescr {}",updated.getLldpLocalPortNum(),updated.getLldpRemPortDescr());
+            LOG.warn("02 {} ifindex {}",updated.getLldpRemIndex(),updated.getLldpPortIfindex());
+            LOG.warn("02 {} portid {}",updated.getLldpRemIndex(),updated.getLldpPortId());
+            LOG.warn("02 {} port subtype {}",updated.getLldpRemIndex(),updated.getLldpPortIdSubType());
+            LOG.warn("02 {} portdescr {}",updated.getLldpRemIndex(),updated.getLldpPortDescr());
+            LOG.warn("02 {} rem chassisId {}",updated.getLldpRemIndex(),updated.getLldpRemChassisId());
+            LOG.warn("02 {} rem chassisId subtype {}",updated.getLldpRemIndex(),updated.getLldpRemChassisIdSubType());
+            LOG.warn("02 {} rem sysname {}",updated.getLldpRemIndex(),updated.getLldpRemSysname());
+            LOG.warn("02 {} rem portid {}",updated.getLldpRemIndex(),updated.getLldpRemPortId());
+            LOG.warn("02 {} rem port subtype {}",updated.getLldpRemIndex(),updated.getLldpRemPortIdSubType());
+            LOG.warn("02 {} rem portdescr {}",updated.getLldpRemIndex(),updated.getLldpRemPortDescr());
 
         }
 
@@ -820,20 +820,19 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
             public void processLldpRemRow(final TimeTetraLldpRemRow row) {
                 assertEquals(6, row.getColumnCount());
                 assertNotNull(row.getTmnxLldpRemLocalDestMACAddress());
-                assertNotNull(row.getLldpRemLocalPortNum());
+                assertNotNull(row.getLldpRemIndex());
                 assertNotNull(row.getIfindex());
                 assertNotNull(row.getLldpLocalPortNum());
                 LldpLink link = row.getLldpLink();
                 assertNotNull(link);
-                assertNotNull(link.getLldpLocalPortNum());
+                assertNotNull(link.getLldpRemIndex());
                 assertNotNull(link.getLldpPortIfindex());
-                assertNotNull(link.getLldpLocalPortNum());
                 assertNotNull(link.getLldpPortIfindex());
-                if (!links05.containsKey(link.getLldpLocalPortNum())) {
-                    links05.put(link.getLldpLocalPortNum(),new ArrayList<>());
+                if (!links05.containsKey(31*link.getLldpRemLocalPortNum()+link.getLldpRemIndex())) {
+                    links05.put(31*link.getLldpRemLocalPortNum()+link.getLldpRemIndex(),new ArrayList<>());
                 }
                 LldpLink updated = ttlldpLocPort05.getLldpLink(row);
-                links05.get(link.getLldpLocalPortNum()).add(updated);
+                links05.get(31*link.getLldpRemLocalPortNum()+link.getLldpRemIndex()).add(updated);
             }
         };
         try {
@@ -872,13 +871,13 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
      */
     @Test
     @JUnitSnmpAgents(value={
-            @JUnitSnmpAgent(host=MKT_CISCO_SW01_IP, port=161, resource=MKT_CISCO_SW01_RESOURCE)
+            @JUnitSnmpAgent(host= CISCO_SW01_IP, port=161, resource= CISCO_SW01_RESOURCE)
     })
     public void testCiscoHomeLldpWalk() throws Exception {
-        LOG.info(MKT_CISCO_SW01_IP);
+        LOG.info(CISCO_SW01_IP);
         String trackerName00 = "lldpLocalGroup00";
 
-        SnmpAgentConfig  config00 = SnmpPeerFactory.getInstance().getAgentConfig(InetAddress.getByName(MKT_CISCO_SW01_IP));
+        SnmpAgentConfig  config00 = SnmpPeerFactory.getInstance().getAgentConfig(InetAddress.getByName(CISCO_SW01_IP));
         LldpLocalGroupTracker lldpLocalGroup00 = new LldpLocalGroupTracker();
         try {
             m_client.walk(config00,lldpLocalGroup00)
@@ -890,9 +889,9 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
             LOG.info("run: collection interrupted, exiting {}",e.getMessage());
         }
 
-        assertEquals(MKT_CISCO_SW01_LLDP_ID,lldpLocalGroup00.getLldpElement().getLldpChassisId());
+        assertEquals(CISCO_SW01_LLDP_ID,lldpLocalGroup00.getLldpElement().getLldpChassisId());
         assertEquals(LldpChassisIdSubType.LLDP_CHASSISID_SUBTYPE_MACADDRESS, lldpLocalGroup00.getLldpElement().getLldpChassisIdSubType());
-        assertEquals(MKT_CISCO_SW01_NAME, lldpLocalGroup00.getLldpElement().getLldpSysname());
+        assertEquals(CISCO_SW01_NAME, lldpLocalGroup00.getLldpElement().getLldpSysname());
 
         final List<LldpRemTableTracker.LldpRemRow> links00 = new ArrayList<>();
 
@@ -921,7 +920,7 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
         links00.stream().filter(row -> row.getLldpRemSysname().equals(MKTROUTER1_NAME))
                 .forEach(row -> {
                     LldpLink link = lldpLocPortGetter.getLldpLink(row);
-                    assertEquals(73, link.getLldpLocalPortNum().intValue());
+                    assertEquals(73, link.getLldpRemIndex().intValue());
                     assertEquals("gi5", link.getLldpPortId());
                     assertEquals("GigabitEthernet5", link.getLldpPortDescr());
                     assertEquals(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACENAME, link.getLldpPortIdSubType());
@@ -934,7 +933,7 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
         links00.stream().filter(row -> row.getLldpRemSysname().equals(MKTROUTER2_NAME))
                 .forEach(row -> {
                     LldpLink link = lldpLocPortGetter.getLldpLink(row);
-                    assertEquals(74, link.getLldpLocalPortNum().intValue());
+                    assertEquals(74, link.getLldpRemIndex().intValue());
                     assertEquals("gi5", link.getLldpPortId());
                     assertEquals("GigabitEthernet5", link.getLldpPortDescr());
                     assertEquals(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACENAME, link.getLldpPortIdSubType());
@@ -1032,13 +1031,13 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
                 assertEquals(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACENAME, link.getLldpPortIdSubType());
                 assertEquals(LldpChassisIdSubType.LLDP_CHASSISID_SUBTYPE_MACADDRESS, link.getLldpRemChassisIdSubType());
                 assertEquals("",link.getLldpRemPortDescr());
-                switch(link.getLldpLocalPortNum()) {
+                switch(link.getLldpRemIndex()) {
                     case 1:
                         assertEquals("gi5", link.getLldpRemPortId());
-                        assertEquals(MKT_CISCO_SW01_NAME, link.getLldpRemSysname());
+                        assertEquals(CISCO_SW01_NAME, link.getLldpRemSysname());
                         //this is a clear violation of LLDP-MIB implementation by Mikrotik
-                        assertNotEquals(MKT_CISCO_SW01_LLDP_ID, link.getLldpRemChassisId());
-                        assertEquals(MKT_CISCO_SW01_GB05_MAC,link.getLldpRemChassisId());
+                        assertNotEquals(CISCO_SW01_LLDP_ID, link.getLldpRemChassisId());
+                        assertEquals(CISCO_SW01_GB05_MAC,link.getLldpRemChassisId());
                         break;
                     case 2:
                         assertEquals("ether1", link.getLldpRemPortId());
@@ -1048,17 +1047,17 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
                     case 3:
                         assertEquals("ens160", link.getLldpRemPortId());
                         assertEquals("elastic-01", link.getLldpRemSysname());
-                        assertEquals(MKT_HOST3_LLDP_ID, link.getLldpRemChassisId());
+                        assertEquals(HOST3_LLDP_ID, link.getLldpRemChassisId());
                         break;
                     case 4:
                         assertEquals("vmx1", link.getLldpRemPortId());
                         assertEquals("opn-fw-01.clab.labmonkeys.tech", link.getLldpRemSysname());
-                        assertEquals(MKT_HOST4_LLDP_ID, link.getLldpRemChassisId());
+                        assertEquals(HOST4_LLDP_ID, link.getLldpRemChassisId());
                         break;
                     case 5:
                         assertEquals("ens160", link.getLldpRemPortId());
                         assertEquals("onms-hzn", link.getLldpRemSysname());
-                        assertEquals(MKT_HOST5_LLDP_ID, link.getLldpRemChassisId());
+                        assertEquals(HOST5_LLDP_ID, link.getLldpRemChassisId());
                         break;
                     default:
                         fail();
@@ -1160,7 +1159,7 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
             assertEquals(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACENAME, link.getLldpPortIdSubType());
             assertEquals(LldpChassisIdSubType.LLDP_CHASSISID_SUBTYPE_MACADDRESS, link.getLldpRemChassisIdSubType());
             assertEquals("", link.getLldpRemPortDescr());
-            switch(link.getLldpLocalPortNum()) {
+            switch(link.getLldpRemIndex()) {
                 case 1:
                     assertEquals("ether1", link.getLldpRemPortId());
                     assertEquals(MKTROUTER1_NAME, link.getLldpRemSysname());
@@ -1169,23 +1168,23 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
                 case 2:
                     assertEquals("ens160", link.getLldpRemPortId());
                     assertEquals("elastic-01", link.getLldpRemSysname());
-                    assertEquals(MKT_HOST3_LLDP_ID, link.getLldpRemChassisId());
+                    assertEquals(HOST3_LLDP_ID, link.getLldpRemChassisId());
                     break;
                 case 3:
                     assertEquals("vmx1", link.getLldpRemPortId());
                     assertEquals("opn-fw-01.clab.labmonkeys.tech", link.getLldpRemSysname());
-                    assertEquals(MKT_HOST4_LLDP_ID, link.getLldpRemChassisId());
+                    assertEquals(HOST4_LLDP_ID, link.getLldpRemChassisId());
                     break;
                 case 4:
                     assertEquals("ens160", link.getLldpRemPortId());
                     assertEquals("onms-hzn", link.getLldpRemSysname());
-                    assertEquals(MKT_HOST5_LLDP_ID, link.getLldpRemChassisId());
+                    assertEquals(HOST5_LLDP_ID, link.getLldpRemChassisId());
                     break;
                 case 5:
                     assertEquals("gi5",link.getLldpRemPortId());
-                    assertEquals(MKT_CISCO_SW01_NAME, link.getLldpRemSysname());
-                    assertNotEquals(MKT_CISCO_SW01_LLDP_ID, link.getLldpRemChassisId());
-                    assertEquals(MKT_CISCO_SW01_GB05_MAC, link.getLldpRemChassisId());
+                    assertEquals(CISCO_SW01_NAME, link.getLldpRemSysname());
+                    assertNotEquals(CISCO_SW01_LLDP_ID, link.getLldpRemChassisId());
+                    assertEquals(CISCO_SW01_GB05_MAC, link.getLldpRemChassisId());
                     break;
                 default:
                     fail();
@@ -1413,7 +1412,8 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
         for (LldpRemTableTracker.LldpRemRow row : links) {
             assertNotNull(row);
             LldpLink link = row.getLldpLink();
-            assertNotNull(link.getLldpLocalPortNum());
+            assertNotNull(link.getLldpRemIndex());
+            assertNotNull(link.getLldpRemLocalPortNum());
             assertNull(link.getLldpPortId());
             assertNull(link.getLldpPortIdSubType());
             assertNull(link.getLldpPortDescr());
@@ -1443,7 +1443,8 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
         		assertEquals(6, row.getColumnCount());
         		LldpLink link = row.getLldpLink();
 
-        		System.err.println("local port number: " + row.getLldpRemLocalPortNum());
+        		System.err.println("rem local port number: " + row.getLldpRemLocalPortNum());
+                System.err.println("rem local index: " + row.getLldpRemIndex());
         		System.err.println("remote chassis: " + link.getLldpRemChassisId());
         		System.err.println("remote chassis type: " + LldpChassisIdSubType.getTypeString(link.getLldpRemChassisIdSubType().getValue()));
         		assertEquals(LldpChassisIdSubType.LLDP_CHASSISID_SUBTYPE_MACADDRESS, link.getLldpRemChassisIdSubType());

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms13637EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms13637EnIT.java
@@ -52,10 +52,10 @@ import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER2_IP;
 import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER2_RESOURCE;
 import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKTROUTER2_ETHER1_MAC;
 
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_NAME;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_IP;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_RESOURCE;
-import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.MKT_CISCO_SW01_LLDP_ID;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_NAME;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_IP;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_RESOURCE;
+import static org.opennms.netmgt.nb.Nms13637NetworkBuilder.CISCO_SW01_LLDP_ID;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -71,7 +71,7 @@ public class Nms13637EnIT extends EnLinkdBuilderITCase {
     @JUnitSnmpAgents(value={
             @JUnitSnmpAgent(host=MKTROUTER1_IP, port=161, resource=MKTROUTER1_RESOURCE),
             @JUnitSnmpAgent(host=MKTROUTER2_IP, port=161, resource=MKTROUTER2_RESOURCE),
-            @JUnitSnmpAgent(host=MKT_CISCO_SW01_IP, port=161, resource=MKT_CISCO_SW01_RESOURCE)
+            @JUnitSnmpAgent(host= CISCO_SW01_IP, port=161, resource= CISCO_SW01_RESOURCE)
     })
 
     public void testLldpLinks() {
@@ -93,7 +93,7 @@ public class Nms13637EnIT extends EnLinkdBuilderITCase {
         assertFalse(m_linkdConfig.useBridgeDiscovery());
         assertFalse(m_linkdConfig.useIsisDiscovery());
 
-        final OnmsNode ciscohomesw = m_nodeDao.findByForeignId("linkd", MKT_CISCO_SW01_NAME);
+        final OnmsNode ciscohomesw = m_nodeDao.findByForeignId("linkd", CISCO_SW01_NAME);
         final OnmsNode router1 = m_nodeDao.findByForeignId("linkd", MKTROUTER1_NAME);
         final OnmsNode router2 = m_nodeDao.findByForeignId("linkd", MKTROUTER2_NAME);
 
@@ -131,7 +131,7 @@ public class Nms13637EnIT extends EnLinkdBuilderITCase {
                     break;
                 case "sw01-office":
                     assertEquals(ciscohomesw.getId().intValue(), node.getNode().getId().intValue());
-                    assertEquals(MKT_CISCO_SW01_LLDP_ID, node.getLldpChassisId());
+                    assertEquals(CISCO_SW01_LLDP_ID, node.getLldpChassisId());
                     ek++;
                     break;
                 default:
@@ -153,7 +153,7 @@ public class Nms13637EnIT extends EnLinkdBuilderITCase {
                 Assert.assertEquals("", link.getLldpRemPortDescr());
             } else {
                 Assert.assertEquals(ciscohomesw.getId().intValue(), link.getNode().getId().intValue());
-                switch (link.getLldpLocalPortNum()) {
+                switch (link.getLldpRemIndex()) {
                     case 9:
                     case 73:
                     case 74:

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms17216EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms17216EnIT.java
@@ -230,7 +230,7 @@ public class Nms17216EnIT extends EnLinkdBuilderITCase {
                 case SWITCH1_NAME:
                     assertEquals(SWITCH2_LLDP_CHASSISID, link.getLldpRemChassisId());
                     assertEquals(SWITCH2_NAME,link.getLldpRemSysname());
-                    switch (link.getLldpLocalPortNum()) {
+                    switch (link.getLldpRemIndex()) {
                         case 4:
                             assertEquals(10109,link.getLldpPortIfindex().intValue());
                             assertEquals(SWITCH1_IF_IFNAME_MAP.get(10109), link.getLldpPortId());
@@ -265,7 +265,7 @@ public class Nms17216EnIT extends EnLinkdBuilderITCase {
                     }
                     break;
                 case SWITCH2_NAME:
-                    switch (link.getLldpLocalPortNum()) {
+                    switch (link.getLldpRemIndex()) {
                         case 4:
                             assertEquals(SWITCH1_LLDP_CHASSISID, link.getLldpRemChassisId());
                             assertEquals(SWITCH1_NAME,link.getLldpRemSysname());
@@ -328,7 +328,7 @@ public class Nms17216EnIT extends EnLinkdBuilderITCase {
                 case SWITCH3_NAME:
                     assertEquals(SWITCH2_LLDP_CHASSISID, link.getLldpRemChassisId());
                     assertEquals(SWITCH2_NAME,link.getLldpRemSysname());
-                    switch (link.getLldpLocalPortNum()) {
+                    switch (link.getLldpRemIndex()) {
                         case 1:
                             assertEquals(10019,link.getLldpPortIfindex().intValue());
                             assertEquals(SWITCH3_IF_IFNAME_MAP.get(10019), link.getLldpPortId());

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms7563EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms7563EnIT.java
@@ -117,7 +117,8 @@ public class Nms7563EnIT extends EnLinkdBuilderITCase {
         for (LldpLink link: m_lldpLinkDao.findAll()) {
             assertNotNull(link);
             printLldpLink(link);
-            assertEquals(1, link.getLldpLocalPortNum().intValue());
+            assertEquals(8, link.getLldpRemLocalPortNum().intValue());
+            assertEquals(1, link.getLldpRemIndex().intValue());
             assertEquals(10008,link.getLldpPortIfindex().intValue());
             assertEquals(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACENAME,link.getLldpPortIdSubType());
             assertEquals("Fa0/8",link.getLldpPortId());
@@ -177,7 +178,8 @@ public class Nms7563EnIT extends EnLinkdBuilderITCase {
         for (LldpLink link: m_lldpLinkDao.findAll()) {
             assertNotNull(link);
             printLldpLink(link);
-            assertEquals(1, link.getLldpLocalPortNum().intValue());
+            assertEquals(1, link.getLldpRemIndex().intValue());
+            assertEquals(2, link.getLldpRemLocalPortNum().intValue());
             assertEquals(2,link.getLldpPortIfindex().intValue());
             assertEquals(LldpPortIdSubType.LLDP_PORTID_SUBTYPE_MACADDRESS,link.getLldpPortIdSubType());
             assertEquals(HOMESERVER_IF_MAC_MAP.get(2),link.getLldpPortId());

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms8000EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms8000EnIT.java
@@ -272,7 +272,8 @@ public class Nms8000EnIT extends EnLinkdBuilderITCase {
         reverseLink.setId(-link.getId());
         reverseLink.setNode(sourcenode);
         
-        reverseLink.setLldpLocalPortNum(0);
+        reverseLink.setLldpRemLocalPortNum(0);
+        reverseLink.setLldpRemIndex(0);
         reverseLink.setLldpPortId(link.getLldpRemPortId());
         reverseLink.setLldpPortIdSubType(link.getLldpRemPortIdSubType());
         reverseLink.setLldpPortDescr(link.getLldpRemPortDescr());

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/nb/Nms13637NetworkBuilder.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/nb/Nms13637NetworkBuilder.java
@@ -63,16 +63,16 @@ public class Nms13637NetworkBuilder extends NmsNetworkBuilder {
     public static final String MKTROUTER3_ETHER2_MAC =    "00 50 56 82 04 D6".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
     public static final String MKTROUTER3_ETHER3_MAC =    "00 50 56 82 7D A0".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
 
-    public static final String MKT_CISCO_SW01_SYSOID=".1.3.6.1.4.1.9.6.1.95.10.3";
-    public static final String MKT_CISCO_SW01_NAME="sw01-office";
-    public static final String MKT_CISCO_SW01_IP="192.168.178.30";
-    public static final String MKT_CISCO_SW01_RESOURCE="classpath:/linkd/nms13637/sw01-office-walk.txt";
-    public static final String MKT_CISCO_SW01_LLDP_ID=    "5C 71 0D 26 AC 3E".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
-    public static final String MKT_CISCO_SW01_GB05_MAC=    "5C 71 0D 26 AC 43".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
+    public static final String CISCO_SW01_SYSOID =".1.3.6.1.4.1.9.6.1.95.10.3";
+    public static final String CISCO_SW01_NAME ="sw01-office";
+    public static final String CISCO_SW01_IP ="192.168.178.30";
+    public static final String CISCO_SW01_RESOURCE ="classpath:/linkd/nms13637/sw01-office-walk.txt";
+    public static final String CISCO_SW01_LLDP_ID =    "5C 71 0D 26 AC 3E".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
+    public static final String CISCO_SW01_GB05_MAC =    "5C 71 0D 26 AC 43".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
 
-    public static final String MKT_HOST3_LLDP_ID="00 50 56 82 23 35".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
-    public static final String MKT_HOST4_LLDP_ID="00 50 56 82 20 E2".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
-    public static final String MKT_HOST5_LLDP_ID="00 50 56 82 62 AB".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
+    public static final String HOST3_LLDP_ID ="00 50 56 82 23 35".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
+    public static final String HOST4_LLDP_ID ="00 50 56 82 20 E2".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
+    public static final String HOST5_LLDP_ID ="00 50 56 82 62 AB".replaceAll("\\s+","").toLowerCase(Locale.ROOT);
 
 
     public static final Map<InetAddress,Integer> MKTROUTER1_IP_IF_MAP =  new HashMap<>();
@@ -96,12 +96,12 @@ public class Nms13637NetworkBuilder extends NmsNetworkBuilder {
     public static final Map<Integer,String>      MKTROUTER3_IF_MAC_MAP = new HashMap<>();
     public static final Map<Integer,String>      MKTROUTER3_IF_IFALIAS_MAP = new HashMap<>();
 
-    public static final Map<InetAddress,Integer> MKT_CISCO_SW01_IP_IF_MAP =  new HashMap<>();
-    public static final Map<InetAddress,InetAddress> MKT_CISCO_SW01_IP_MK_MAP =  new HashMap<>();
-    public static final Map<Integer,String>      MKT_CISCO_SW01_IF_IFNAME_MAP = new HashMap<>();
-    public static final Map<Integer,String>      MKT_CISCO_SW01_IF_IFDESCR_MAP = new HashMap<>();
-    public static final Map<Integer,String>      MKT_CISCO_SW01_IF_MAC_MAP = new HashMap<>();
-    public static final Map<Integer,String>      MKT_CISCO_SW01_IF_IFALIAS_MAP = new HashMap<>();
+    public static final Map<InetAddress,Integer> CISCO_SW01_IP_IF_MAP =  new HashMap<>();
+    public static final Map<InetAddress,InetAddress> CISCO_SW01_IP_MK_MAP =  new HashMap<>();
+    public static final Map<Integer,String>      CISCO_SW01_IF_IFNAME_MAP = new HashMap<>();
+    public static final Map<Integer,String>      CISCO_SW01_IF_IFDESCR_MAP = new HashMap<>();
+    public static final Map<Integer,String>      CISCO_SW01_IF_MAC_MAP = new HashMap<>();
+    public static final Map<Integer,String>      CISCO_SW01_IF_IFALIAS_MAP = new HashMap<>();
 
 
     static {
@@ -127,55 +127,55 @@ public class Nms13637NetworkBuilder extends NmsNetworkBuilder {
         MKTROUTER3_IF_MAC_MAP.put(1, MKTROUTER2_ETHER1_MAC);
         MKTROUTER3_IF_IFALIAS_MAP.put(1, "");
 
-        MKT_CISCO_SW01_IP_IF_MAP.put(InetAddressUtils.addr(MKT_CISCO_SW01_IP),7000);
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(7000, "loopback1");
-        MKT_CISCO_SW01_IF_MAC_MAP.put(7000, "5C 71 0D 26 AC 3E".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(7000, "loopback1");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(7000, "");
+        CISCO_SW01_IP_IF_MAP.put(InetAddressUtils.addr(CISCO_SW01_IP),7000);
+        CISCO_SW01_IF_IFDESCR_MAP.put(7000, "loopback1");
+        CISCO_SW01_IF_MAC_MAP.put(7000, "5C 71 0D 26 AC 3E".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_IFNAME_MAP.put(7000, "loopback1");
+        CISCO_SW01_IF_IFALIAS_MAP.put(7000, "");
 
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(1, "GigabitEthernet1");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(2, "GigabitEthernet2");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(3, "GigabitEthernet3");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(4, "GigabitEthernet4");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(5, "GigabitEthernet5");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(6, "GigabitEthernet6");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(7, "GigabitEthernet7");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(8, "GigabitEthernet8");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(9, "GigabitEthernet9");
-        MKT_CISCO_SW01_IF_IFDESCR_MAP.put(10, "GigabitEthernet10");
+        CISCO_SW01_IF_IFDESCR_MAP.put(1, "GigabitEthernet1");
+        CISCO_SW01_IF_IFDESCR_MAP.put(2, "GigabitEthernet2");
+        CISCO_SW01_IF_IFDESCR_MAP.put(3, "GigabitEthernet3");
+        CISCO_SW01_IF_IFDESCR_MAP.put(4, "GigabitEthernet4");
+        CISCO_SW01_IF_IFDESCR_MAP.put(5, "GigabitEthernet5");
+        CISCO_SW01_IF_IFDESCR_MAP.put(6, "GigabitEthernet6");
+        CISCO_SW01_IF_IFDESCR_MAP.put(7, "GigabitEthernet7");
+        CISCO_SW01_IF_IFDESCR_MAP.put(8, "GigabitEthernet8");
+        CISCO_SW01_IF_IFDESCR_MAP.put(9, "GigabitEthernet9");
+        CISCO_SW01_IF_IFDESCR_MAP.put(10, "GigabitEthernet10");
 
-        MKT_CISCO_SW01_IF_MAC_MAP.put(1, "5C 71 0D 26 AC 3F".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_MAC_MAP.put(2, "5C 71 0D 26 AC 40".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_MAC_MAP.put(3, "5C 71 0D 26 AC 41".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_MAC_MAP.put(4, "5C 71 0D 26 AC 42".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_MAC_MAP.put(5, MKT_CISCO_SW01_GB05_MAC);
-        MKT_CISCO_SW01_IF_MAC_MAP.put(6, "5C 71 0D 26 AC 44".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_MAC_MAP.put(7, "5C 71 0D 26 AC 45".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_MAC_MAP.put(8, "5C 71 0D 26 AC 46".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_MAC_MAP.put(9, "5C 71 0D 26 AC 47".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
-        MKT_CISCO_SW01_IF_MAC_MAP.put(10, "5C 71 0D 26 AC 48".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(1, "5C 71 0D 26 AC 3F".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(2, "5C 71 0D 26 AC 40".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(3, "5C 71 0D 26 AC 41".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(4, "5C 71 0D 26 AC 42".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(5, CISCO_SW01_GB05_MAC);
+        CISCO_SW01_IF_MAC_MAP.put(6, "5C 71 0D 26 AC 44".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(7, "5C 71 0D 26 AC 45".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(8, "5C 71 0D 26 AC 46".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(9, "5C 71 0D 26 AC 47".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
+        CISCO_SW01_IF_MAC_MAP.put(10, "5C 71 0D 26 AC 48".replaceAll("\\s+","").toLowerCase(Locale.ROOT));
 
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(1, "gi1");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(2, "gi2");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(3, "gi3");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(4, "gi4");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(5, "gi5");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(6, "gi6");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(7, "gi7");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(8, "gi8");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(9, "gi9");
-        MKT_CISCO_SW01_IF_IFNAME_MAP.put(10, "gi10");
+        CISCO_SW01_IF_IFNAME_MAP.put(1, "gi1");
+        CISCO_SW01_IF_IFNAME_MAP.put(2, "gi2");
+        CISCO_SW01_IF_IFNAME_MAP.put(3, "gi3");
+        CISCO_SW01_IF_IFNAME_MAP.put(4, "gi4");
+        CISCO_SW01_IF_IFNAME_MAP.put(5, "gi5");
+        CISCO_SW01_IF_IFNAME_MAP.put(6, "gi6");
+        CISCO_SW01_IF_IFNAME_MAP.put(7, "gi7");
+        CISCO_SW01_IF_IFNAME_MAP.put(8, "gi8");
+        CISCO_SW01_IF_IFNAME_MAP.put(9, "gi9");
+        CISCO_SW01_IF_IFNAME_MAP.put(10, "gi10");
 
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(1, "");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(2, "Powerline Office");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(3, "");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(4, "Brother DCP-9022CDW");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(5, "ESX Management");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(6, "VMware ESX");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(7, "dinky");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(8, "fritz.box");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(9, "");
-        MKT_CISCO_SW01_IF_IFALIAS_MAP.put(10, "");
+        CISCO_SW01_IF_IFALIAS_MAP.put(1, "");
+        CISCO_SW01_IF_IFALIAS_MAP.put(2, "Powerline Office");
+        CISCO_SW01_IF_IFALIAS_MAP.put(3, "");
+        CISCO_SW01_IF_IFALIAS_MAP.put(4, "Brother DCP-9022CDW");
+        CISCO_SW01_IF_IFALIAS_MAP.put(5, "ESX Management");
+        CISCO_SW01_IF_IFALIAS_MAP.put(6, "VMware ESX");
+        CISCO_SW01_IF_IFALIAS_MAP.put(7, "dinky");
+        CISCO_SW01_IF_IFALIAS_MAP.put(8, "fritz.box");
+        CISCO_SW01_IF_IFALIAS_MAP.put(9, "");
+        CISCO_SW01_IF_IFALIAS_MAP.put(10, "");
 
 
     } catch (Exception ignored) {
@@ -199,8 +199,8 @@ public class Nms13637NetworkBuilder extends NmsNetworkBuilder {
     }
 
     public OnmsNode getCiscoHomeSw() {
-        return getNode(MKT_CISCO_SW01_NAME, MKT_CISCO_SW01_SYSOID, MKT_CISCO_SW01_IP, MKT_CISCO_SW01_IP_IF_MAP, MKT_CISCO_SW01_IF_IFNAME_MAP,
-                MKT_CISCO_SW01_IF_MAC_MAP,MKT_CISCO_SW01_IF_IFDESCR_MAP,MKT_CISCO_SW01_IF_IFALIAS_MAP, MKT_CISCO_SW01_IP_MK_MAP);
+        return getNode(CISCO_SW01_NAME, CISCO_SW01_SYSOID, CISCO_SW01_IP, CISCO_SW01_IP_IF_MAP, CISCO_SW01_IF_IFNAME_MAP,
+                CISCO_SW01_IF_MAC_MAP,CISCO_SW01_IF_IFDESCR_MAP,CISCO_SW01_IF_IFALIAS_MAP, CISCO_SW01_IP_MK_MAP);
     }
 
 }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdMockDataPopulator.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdMockDataPopulator.java
@@ -337,7 +337,7 @@ public class EnhancedLinkdMockDataPopulator {
     }
 
     private LldpLink createLldpLink(OnmsNode node, String nodePortId, String nodePortDescr, int portIfIndex, int localPortNum, LldpPortIdSubType portIdSubType, LldpElement remLldpElement, String node2PortDescr, String node2PortId) {
-        return new LldpLink(node, localPortNum, portIfIndex, nodePortId, nodePortDescr,
+        return new LldpLink(node, localPortNum, portIfIndex, portIfIndex, nodePortId, nodePortDescr,
                 portIdSubType, remLldpElement.getLldpChassisId(), remLldpElement.getLldpSysname(), remLldpElement.getLldpChassisIdSubType(),
                 node2PortId, LldpPortIdSubType.LLDP_PORTID_SUBTYPE_LOCAL, node2PortDescr);
     }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -52,7 +52,6 @@ import org.opennms.features.topology.api.topo.Edge;
 import org.opennms.features.topology.api.topo.EdgeRef;
 import org.opennms.features.topology.api.topo.Vertex;
 import org.opennms.features.topology.api.topo.VertexRef;
-import org.opennms.features.topology.api.topo.DefaultTopologyProviderInfo;
 import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
 import org.opennms.netmgt.enlinkd.BridgeOnmsTopologyUpdater;
 import org.opennms.netmgt.enlinkd.CdpOnmsTopologyUpdater;
@@ -87,9 +86,6 @@ public class LinkdTopologyProviderTestIT {
     GenericPersistenceAccessor genericPersistenceAccessor;
 
     @Autowired
-    LinkdTopologyFactory linkdTopologyFactory;
-
-    @Autowired
     TopologyEntityCache entityCache;
     
     @Autowired
@@ -119,7 +115,7 @@ public class LinkdTopologyProviderTestIT {
     private TopologyGenerator generator;
 
     @Autowired
-    private LinkdTopologyProvider linkdTopologyProvider;
+    LinkdTopologyProvider linkdTopologyProvider;
 
     @BeforeTransaction
     public void setUp() {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeLinkRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeLinkRestServiceIT.java
@@ -373,7 +373,8 @@ public class NodeLinkRestServiceIT extends AbstractSpringJerseyRestTestCase {
         LldpLink link = new LldpLink();
         link.setId(11);
         link.setNode(node);
-        link.setLldpLocalPortNum(123);
+        link.setLldpRemIndex(123);
+        link.setLldpRemLocalPortNum(1234);
         link.setLldpPortId("1234");
         link.setLldpPortIdSubType(LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACEALIAS);
         link.setLldpPortDescr("portDescr");


### PR DESCRIPTION

    Renamed LldpPortNum to be LldpRemIndex and
    added lldpRemPortNum to Lldplink table
    Reworked Snmp Class correlated and changed
    the LldpLinkDao classes to use a new index
    primary key nodeid, lldpremportnum, lldpremindex

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-7775

