### PR TITLE
NMS-14743  Rework NMS0123EnIT test

### DIFF
--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/LldpTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/LldpTopologyServiceImpl.java
@@ -179,62 +179,70 @@ public class LldpTopologyServiceImpl extends TopologyServiceImpl implements Lldp
 
     @Override
     public List<TopologyConnection<LldpLinkTopologyEntity, LldpLinkTopologyEntity>> match() {
-        
-            List<TopologyConnection<LldpLinkTopologyEntity, LldpLinkTopologyEntity>> results = new ArrayList<>();
 
             Map<Integer, LldpElementTopologyEntity> nodelldpelementidMap = getTopologyEntityCache().getLldpElementTopologyEntities().stream()
                     .collect(Collectors.toMap(LldpElementTopologyEntity::getNodeId, lldpelem -> lldpelem));
-            
-            List<LldpLinkTopologyEntity> allLinks = getTopologyEntityCache().getLldpLinkTopologyEntities();
+            List<LldpLinkTopologyEntity> lldpLinks = getTopologyEntityCache().getLldpLinkTopologyEntities();
             // 1.) create mapping
-            Map<CompositeKey, LldpLinkTopologyEntity> targetLinkMap = new HashMap<>();
-            for(LldpLinkTopologyEntity targetLink : allLinks){
+            Map<CompositeKey, LldpLinkTopologyEntity> lldpLinkCompositeKeyMap = new HashMap<>();
+            List<LldpLinkTopologyEntity> goodLldpLinks = new ArrayList<>();
+            for(LldpLinkTopologyEntity lldpLink : lldpLinks){
+                if (lldpLink.getLldpPortIfindex() == -1 ) {
+                    CompositeKey elementarKeyA = new CompositeKey(
+                            lldpLink.getLldpRemChassisId(),
+                            nodelldpelementidMap.get(lldpLink.getNodeId()).getLldpChassisId(),
+                            lldpLink.getLldpRemPortId(),
+                            lldpLink.getLldpRemPortIdSubType());
+                    CompositeKey elementarKeyB = new CompositeKey(
+                            lldpLink.getLldpRemChassisId(),
+                            nodelldpelementidMap.get(lldpLink.getNodeId()).getLldpChassisId(),
+                            lldpLink.getLldpRemPortDescr());
+                    lldpLinkCompositeKeyMap.put(elementarKeyA,lldpLink);
+                    lldpLinkCompositeKeyMap.put(elementarKeyB,lldpLink);
+                    continue;
+                }
+                goodLldpLinks.add(lldpLink);
                 CompositeKey key = new CompositeKey(
-                        targetLink.getLldpRemChassisId(),
-                        nodelldpelementidMap.get(targetLink.getNodeId()).getLldpChassisId(),
-                        targetLink.getLldpPortId(),
-                        targetLink.getLldpPortIdSubType(),
-                        targetLink.getLldpRemPortId(),
-                        targetLink.getLldpRemPortIdSubType());
-                targetLinkMap.put(key, targetLink);
+                        lldpLink.getLldpRemChassisId(),
+                        nodelldpelementidMap.get(lldpLink.getNodeId()).getLldpChassisId(),
+                        lldpLink.getLldpPortId(),
+                        lldpLink.getLldpPortIdSubType(),
+                        lldpLink.getLldpRemPortId(),
+                        lldpLink.getLldpRemPortIdSubType());
+                lldpLinkCompositeKeyMap.put(key, lldpLink);
                 CompositeKey descrkey = new CompositeKey(
-                        targetLink.getLldpRemChassisId(),
-                        nodelldpelementidMap.get(targetLink.getNodeId()).getLldpChassisId(),
-                        targetLink.getLldpPortDescr(),
-                        targetLink.getLldpRemPortDescr());
-                targetLinkMap.put(descrkey,targetLink);
+                        lldpLink.getLldpRemChassisId(),
+                        nodelldpelementidMap.get(lldpLink.getNodeId()).getLldpChassisId(),
+                        lldpLink.getLldpPortDescr(),
+                        lldpLink.getLldpRemPortDescr());
+                lldpLinkCompositeKeyMap.put(descrkey,lldpLink);
                 CompositeKey sysnameKey = new CompositeKey(
-                    targetLink.getLldpRemSysname(),
-                    nodelldpelementidMap.get(targetLink.getNodeId()).getLldpSysname(),
-                    targetLink.getLldpPortId(),
-                    targetLink.getLldpPortIdSubType(),
-                    targetLink.getLldpRemPortId(),
-                    targetLink.getLldpRemPortIdSubType()
+                    lldpLink.getLldpRemSysname(),
+                    nodelldpelementidMap.get(lldpLink.getNodeId()).getLldpSysname(),
+                    lldpLink.getLldpPortId(),
+                    lldpLink.getLldpPortIdSubType(),
+                    lldpLink.getLldpRemPortId(),
+                    lldpLink.getLldpRemPortIdSubType()
                 );
-                targetLinkMap.put(sysnameKey,targetLink);
+                lldpLinkCompositeKeyMap.put(sysnameKey,lldpLink);
             }
 
             // 2.) iterate
-            Set<Integer> parsed = new HashSet<>();
-            for (LldpLinkTopologyEntity sourceLink : allLinks) {
+        Set<Integer> parsed = new HashSet<>();
+        List<TopologyConnection<LldpLinkTopologyEntity, LldpLinkTopologyEntity>> results = new ArrayList<>();
+
+        for (LldpLinkTopologyEntity sourceLink : goodLldpLinks) {
                 if (parsed.contains(sourceLink.getId())) {
                     continue;
                 }
-                String sourceLldpChassisId = nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpChassisId();
-                if (sourceLldpChassisId.equals(sourceLink.getLldpRemChassisId())) {
-                    LOG.debug("getLldpLinks: self link not adding source: {}",sourceLink);
-                    parsed.add(sourceLink.getId());
-                    continue;
-                }
-                String sourceLldpSysname = nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpSysname();
-                if (sourceLldpSysname.equals(sourceLink.getLldpRemSysname())) {
-                    LOG.debug("getLldpLinks: self link not adding source: {}",sourceLink);
-                    parsed.add(sourceLink.getId());
+
+                if (nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpChassisId().equals(sourceLink.getLldpRemChassisId())
+                   || nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpSysname().equals(sourceLink.getLldpRemSysname())) {
+                    LOG.info("match: self link, skipping:{}",sourceLink);
                     continue;
                 }
 
-                LOG.info("getLldpLinks: checking target for source: {}", sourceLink);
-
+                String compositeKeyExplained="composite key: default";
                 CompositeKey key = new CompositeKey(
                         nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpChassisId(),
                         sourceLink.getLldpRemChassisId(),
@@ -242,18 +250,18 @@ public class LldpTopologyServiceImpl extends TopologyServiceImpl implements Lldp
                         sourceLink.getLldpRemPortIdSubType(),
                         sourceLink.getLldpPortId(),
                         sourceLink.getLldpPortIdSubType());
-                LldpLinkTopologyEntity targetLink = targetLinkMap.get(key);
+                LldpLinkTopologyEntity targetLink = lldpLinkCompositeKeyMap.get(key);
                 if (targetLink == null) {
-                    LOG.debug("getLldpLinks: cannot found target using default key for source: '{}'", sourceLink.getId());
+                    compositeKeyExplained="composite key: port description";
                     CompositeKey descrkey = new CompositeKey(
                             nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpChassisId(),
                             sourceLink.getLldpRemChassisId(),
                             sourceLink.getLldpRemPortDescr(),
                             sourceLink.getLldpPortDescr());
-                    targetLink = targetLinkMap.get(descrkey);
+                    targetLink = lldpLinkCompositeKeyMap.get(descrkey);
                 }
                 if (targetLink == null) {
-                    LOG.debug("getLldpLinks: cannot found target using descr key for source: '{}'", sourceLink.getId());
+                    compositeKeyExplained="composite key: sysname";
                     CompositeKey sysnamekey = new CompositeKey(
                             nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpSysname(),
                             sourceLink.getLldpRemSysname(),
@@ -261,14 +269,31 @@ public class LldpTopologyServiceImpl extends TopologyServiceImpl implements Lldp
                             sourceLink.getLldpRemPortIdSubType(),
                             sourceLink.getLldpPortId(),
                             sourceLink.getLldpPortIdSubType());
-                    targetLink = targetLinkMap.get(sysnamekey);
+                    targetLink = lldpLinkCompositeKeyMap.get(sysnamekey);
                 }
                 if (targetLink == null) {
-                    LOG.debug("getLldpLinks: cannot found target using sysname key for source: '{}'", sourceLink.getId());
+                    compositeKeyExplained="composite key: elementary with port id";
+                    CompositeKey elementaryA = new CompositeKey(
+                            nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpChassisId(),
+                            sourceLink.getLldpRemChassisId(),
+                            sourceLink.getLldpPortId(),
+                            sourceLink.getLldpPortIdSubType());
+                    targetLink = lldpLinkCompositeKeyMap.get(elementaryA);
+                }
+                if (targetLink == null) {
+                    compositeKeyExplained="composite key: elementary with port descr";
+                    CompositeKey elementaryB = new CompositeKey(
+                            nodelldpelementidMap.get(sourceLink.getNodeId()).getLldpChassisId(),
+                            sourceLink.getLldpRemChassisId(),
+                            sourceLink.getLldpPortDescr());
+                    targetLink = lldpLinkCompositeKeyMap.get(elementaryB);
+                }
+                if (targetLink == null) {
+                    LOG.info("match: cannot found target for lldplink:{}", sourceLink);
                     continue;
                 }
 
-                LOG.info("getLldpLinks: source: '{}' found target: {}", sourceLink.getId(), targetLink);
+                LOG.info("match: {}, source:{}, target:{}", compositeKeyExplained, sourceLink, targetLink);
 
                 parsed.add(sourceLink.getId());
                 parsed.add(targetLink.getId());

--- a/features/enlinkd/service/impl/src/test/java/org/opennms/netmgt/enlinkd/service/ServiceTest.java
+++ b/features/enlinkd/service/impl/src/test/java/org/opennms/netmgt/enlinkd/service/ServiceTest.java
@@ -156,7 +156,7 @@ public class ServiceTest {
         createLldpElement(35,nodes.get(5), "match2.2", "host35"));
 
         lldpLinks = Arrays.asList(
-           createLldpLink(0, nodes.get(0), "nomatch1", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_PORTCOMPONENT,  "nomatch2", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_PORTCOMPONENT, "nomatch3","host0"),
+            createLldpLink(0, nodes.get(0), "nomatch1", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_PORTCOMPONENT,  "nomatch2", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_PORTCOMPONENT, "nomatch3","host0"),
             createLldpLink(1, nodes.get(1), "match1.5", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACENAME,  "match1.3", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_MACADDRESS, "match1.2","host1"),
             createLldpLink(2, nodes.get(2), "nomatch4", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_PORTCOMPONENT,  "nomatch5", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_PORTCOMPONENT, "nomatch6","host2"),
             createLldpLink(3, nodes.get(3), "match1.3", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_MACADDRESS,  "match1.5", LldpUtils.LldpPortIdSubType.LLDP_PORTID_SUBTYPE_INTERFACENAME, "match1.1","host3"),
@@ -189,8 +189,6 @@ public class ServiceTest {
         List<TopologyConnection<IsIsLinkTopologyEntity, IsIsLinkTopologyEntity>> matchedLinks = isisTopologyService.match();
         assertMatching(isisLinks, matchedLinks);
 
-        verify(topologyEntityCache, atLeastOnce()).getCdpElementTopologyEntities();
-        verify(topologyEntityCache, atLeastOnce()).getCdpLinkTopologyEntities();
         verify(topologyEntityCache, atLeastOnce()).getIsIsElementTopologyEntities();
         verify(topologyEntityCache, atLeastOnce()).getIsIsLinkTopologyEntities();
     }
@@ -214,9 +212,6 @@ public class ServiceTest {
         // 4 and 5 will match
         List<TopologyConnection<OspfLinkTopologyEntity, OspfLinkTopologyEntity>> matchedLinks = ospfTopologyService.match();
         assertMatching(ospfLinks, matchedLinks);
-
-        verify(topologyEntityCache, atLeastOnce()).getCdpElementTopologyEntities();
-        verify(topologyEntityCache, atLeastOnce()).getCdpLinkTopologyEntities();
         verify(topologyEntityCache, atLeastOnce()).getOspfLinkTopologyEntities();
     }
 
@@ -227,9 +222,6 @@ public class ServiceTest {
         // 4 and 5 will match
         List<TopologyConnection<LldpLinkTopologyEntity, LldpLinkTopologyEntity>> matchedLinks = lldpTopologyService.match();
         assertMatching(lldpLinks, matchedLinks);
-
-        verify(topologyEntityCache, atLeastOnce()).getCdpElementTopologyEntities();
-        verify(topologyEntityCache, atLeastOnce()).getCdpLinkTopologyEntities();
         verify(topologyEntityCache, atLeastOnce()).getLldpElementTopologyEntities();
         verify(topologyEntityCache, atLeastOnce()).getLldpLinkTopologyEntities();
     }
@@ -251,7 +243,7 @@ public class ServiceTest {
 
     private LldpLinkTopologyEntity createLldpLink(int id, OnmsNode node, String portId, LldpUtils.LldpPortIdSubType portIdSubType
             , String remotePortId, LldpUtils.LldpPortIdSubType remotePortIdSubType, String remoteChassisId, String remoteSysname) {
-        return new LldpLinkTopologyEntity(id, node.getId(), remoteChassisId, remoteSysname, remotePortId, remotePortIdSubType, "dwscr", portId, portIdSubType, "dwscr", -1);
+        return new LldpLinkTopologyEntity(id, node.getId(), remoteChassisId, remoteSysname, remotePortId, remotePortIdSubType, "dwscr", portId, portIdSubType, "dwscr", 100);
     }
 
     private OspfLinkTopologyEntity createOspfLink(int id, OnmsNode node, InetAddress ipAddress, InetAddress remoteAddress) {

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms0123EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms0123EnIT.java
@@ -29,10 +29,9 @@
 package org.opennms.netmgt.enlinkd;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-
 import static org.opennms.netmgt.nb.Nms0123NetworkBuilder.ITPN0111_IP;
 import static org.opennms.netmgt.nb.Nms0123NetworkBuilder.ITPN0111_NAME;
 import static org.opennms.netmgt.nb.Nms0123NetworkBuilder.ITPN0111_SNMP_RESOURCE;
@@ -58,13 +57,10 @@ import static org.opennms.netmgt.nb.Nms0123NetworkBuilder.ITPN0202_IP;
 import static org.opennms.netmgt.nb.Nms0123NetworkBuilder.ITPN0202_NAME;
 import static org.opennms.netmgt.nb.Nms0123NetworkBuilder.ITPN0202_SNMP_RESOURCE;
 
-import java.util.List;
-
 import org.junit.Test;
 import org.opennms.core.test.snmp.annotations.JUnitSnmpAgent;
 import org.opennms.core.test.snmp.annotations.JUnitSnmpAgents;
 import org.opennms.netmgt.enlinkd.model.LldpElement;
-import org.opennms.netmgt.enlinkd.model.LldpLink;
 import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.nb.Nms0123NetworkBuilder;
@@ -73,6 +69,7 @@ import org.opennms.netmgt.topologies.service.api.OnmsTopology;
 public class Nms0123EnIT extends EnLinkdBuilderITCase {
 
     Nms0123NetworkBuilder builder = new Nms0123NetworkBuilder();
+
     /*
      *  itpn0111 -- itpn0112 --. itpn0113 -- itpn0202 -- itpn0123
      *     |                                     |
@@ -161,10 +158,7 @@ public class Nms0123EnIT extends EnLinkdBuilderITCase {
         assertNotNull(topology);
         printOnmsTopology(topology);
         assertEquals(8,topology.getVertices().size());
-//        assertEquals(8,topology.getEdges().size());
-        //FIXME should be 8
-        assertEquals(4,topology.getEdges().size());
-
+        assertEquals(8,topology.getEdges().size());
     }
 
 }


### PR DESCRIPTION
Added a match in lldp for when ifindex is -1
ifindex -1 means that there is a failure getting the localportdata

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14743

