### PR TITLE
NMS-14778: RRD persistence with default configs in our Horizon OCI points to wrong libjrrd2.so

### DIFF
--- a/opennms-container/horizon/container-fs/confd/templates/timeseries.properties.tpl
+++ b/opennms-container/horizon/container-fs/confd/templates/timeseries.properties.tpl
@@ -7,4 +7,4 @@ org.opennms.rrd.storeByForeignSource={{getv "/opennms/rrd/storebyforeignsource" 
 org.opennms.timeseries.strategy={{getv "/opennms/timeseries/strategy" "rrd"}}
 org.opennms.rrd.interfaceJar={{getv "/opennms/rrd/interfacejar" "/usr/share/java/jrrd2.jar"}}
 org.opennms.rrd.strategyClass={{getv "/opennms/rrd/strategyclass" "org.opennms.netmgt.rrd.rrdtool.MultithreadedJniRrdStrategy"}}
-opennms.library.jrrd2={{getv "/opennms/library/jrrd2" "/usr/lib64/libjrrd2.so"}}
+opennms.library.jrrd2={{getv "/opennms/library/jrrd2" "/usr/lib/jni/libjrrd2.so"}}

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -388,7 +388,7 @@ public class OpenNMSContainer extends GenericContainer implements KarafContainer
             // Use jrrd2
             props.put("org.opennms.rrd.strategyClass", "org.opennms.netmgt.rrd.rrdtool.MultithreadedJniRrdStrategy");
             props.put("org.opennms.rrd.interfaceJar", "/usr/share/java/jrrd2.jar");
-            props.put("opennms.library.jrrd2", "/usr/lib64/libjrrd2.so");
+            props.put("opennms.library.jrrd2", "/usr/lib/jni/libjrrd2.so");
         } else if (TimeSeriesStrategy.NEWTS.equals(model.getTimeSeriesStrategy())) {
             // Use Newts
             props.put("org.opennms.timeseries.strategy", "newts");


### PR DESCRIPTION
### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14778

