### PR TITLE
NMS-15005: Display Admin Icons in Menubar for more items

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/controller/NavBarController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/NavBarController.java
@@ -28,6 +28,13 @@
 
 package org.opennms.web.controller;
 
+import com.google.common.collect.ImmutableSet;
+import freemarker.ext.beans.StringModel;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateExceptionHandler;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -42,18 +49,16 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.opennms.core.time.CentralizedDateTimeFormat;
 import org.opennms.netmgt.config.NotifdConfigFactory;
 import org.opennms.web.api.Authentication;
-import org.opennms.web.navigate.MenuContext;
 import org.opennms.web.api.MenuProvider;
 import org.opennms.web.api.OnmsHeaderProvider;
 import org.opennms.web.navigate.DefaultMenuEntry;
 import org.opennms.web.navigate.DisplayStatus;
+import org.opennms.web.navigate.MenuContext;
 import org.opennms.web.navigate.MenuEntry;
 import org.opennms.web.navigate.NavBarEntry;
 import org.opennms.web.navigate.NavBarModel;
@@ -63,13 +68,6 @@ import org.springframework.util.Assert;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
 import org.springframework.web.servlet.view.AbstractView;
-
-import freemarker.ext.beans.StringModel;
-import freemarker.template.Configuration;
-import freemarker.template.Template;
-import freemarker.template.TemplateExceptionHandler;
-import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModelException;
 
 /**
  * This controller uses Freemarker to render the view.
@@ -256,7 +254,15 @@ public class NavBarController extends AbstractController implements Initializing
         }
     }
 
+    /**
+     * Method used to determine whether an Admin icon should be displayed next to a menu entry.
+     */
     public static class IsAdminLinkEntryMethod implements TemplateMethodModelEx {
+        private static final ImmutableSet<String> ADMIN_ROLES = ImmutableSet.of(
+            Authentication.ROLE_ADMIN,
+            Authentication.ROLE_FILESYSTEM_EDITOR
+        );
+
         public IsAdminLinkEntryMethod () {
         }
 
@@ -276,7 +282,7 @@ public class NavBarController extends AbstractController implements Initializing
 
                     return Arrays.stream(roleEntry.getRoles().split(","))
                         .map(String::trim)
-                        .anyMatch(s -> s.toUpperCase(Locale.ROOT).equals(Authentication.ROLE_ADMIN));
+                        .anyMatch(s -> ADMIN_ROLES.contains(s.toUpperCase(Locale.ROOT)));
                 }
             } else {
                 throw new TemplateModelException("Wrong arguments");

--- a/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -352,10 +352,11 @@
                                 <property name="locationMatch" value="configurationManagement"/>
                                 <property name="roles" value="ROLE_ADMIN,ROLE_REST,ROLE_DEVICE_CONFIG_BACKUP"/>
                             </bean>
-                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                            <bean class="org.opennms.web.navigate.RoleBasedNavBarEntry">
                                 <property name="name" value="External Requisitions"/>
                                 <property name="url" value="ui/index.html#/configuration"/>
                                 <property name="locationMatch" value="configurationManagement"/>
+                                <property name="roles" value="ROLE_ADMIN"/>
                             </bean>
                             <bean class="org.opennms.web.navigate.RoleBasedNavBarEntry">
                                 <property name="name" value="File Editor"/>

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -68,7 +68,18 @@ const router = createRouter({
     {
       path: '/configuration',
       name: 'Configuration',
-      component: () => import('@/containers/ProvisionDConfig.vue')
+      component: () => import('@/containers/ProvisionDConfig.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'No role access to external requisitions.' })
+            router.push(from.path)
+          }
+        }
+
+        if (rolesAreLoaded.value) checkRoles()
+        else whenever(rolesAreLoaded, () => checkRoles())
+      }
     },
     {
       path: '/logs',


### PR DESCRIPTION
Display Admin "cogs" icon in Menubar for several additional items:

- File Editor - we now display admin icons for items having either `ROLE_ADMIN` or `ROLE_FILESYSTEM_EDITOR`
- External Requisition - added `ROLE_ADMIN`, user must now have this to access this page or see on menu

### External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15005

