### PR TITLE
NMS-15134: Default to direction 'unknown' when the direction field is not present

### DIFF
--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
@@ -64,6 +64,7 @@ public class IpFixMessageBuilder implements MessageBuilder {
     @Override
     public FlowMessage.Builder buildMessage(final Iterable<Value<?>> values, final RecordEnrichment enrichment) {
         final FlowMessage.Builder builder = FlowMessage.newBuilder();
+        builder.setDirection(Direction.UNKNOWN);
 
         Long exportTime = null;
         Long octetDeltaCount = null;

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
@@ -61,6 +61,7 @@ public class Netflow9MessageBuilder implements MessageBuilder {
     @Override
     public FlowMessage.Builder buildMessage(final Iterable<Value<?>> values, final RecordEnrichment enrichment) {
         final FlowMessage.Builder builder = FlowMessage.newBuilder();
+        builder.setDirection(Direction.UNKNOWN);
 
         InetAddress ipv4DstAddress = null;
         InetAddress ipv6DstAddress = null;
@@ -78,7 +79,7 @@ public class Netflow9MessageBuilder implements MessageBuilder {
         Long dstVlan = null;
         Long flowActiveTimeout = this.flowActiveTimeoutFallback;
         Long flowInActiveTimeout = this.flowInactiveTimeoutFallback;
-        Long sysUpTime = null;
+        Long sysUpTime = 0L;
         Long unixSecs = null;
         Long firstSwitched = null;
         Long lastSwitched = null;

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpfixMessageBuilderTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpfixMessageBuilderTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.netflow.parser.transport;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.RecordEnrichment;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.Direction;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
+
+public class IpfixMessageBuilderTest {
+
+    /**
+     * Validate that the direction on the flow message is set to UNKNOWN if there is no value present
+     */
+    @Test
+    public void verifyDefaultDirectionIsUnknown() {
+        RecordEnrichment recordEnrichment = mock(RecordEnrichment.class);
+        IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
+        FlowMessage.Builder builder = ipFixMessageBuilder.buildMessage(Collections.emptyList(), recordEnrichment);
+        assertThat(builder.getDirection(), equalTo(Direction.UNKNOWN));
+    }
+}

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilderTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilderTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.netflow.parser.transport;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.RecordEnrichment;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.Direction;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
+
+public class Netflow9MessageBuilderTest {
+
+    /**
+     * Validate that the direction on the flow message is set to UNKNOWN if there is no value present
+     */
+    @Test
+    public void verifyDefaultDirectionIsUnknown() {
+        RecordEnrichment recordEnrichment = mock(RecordEnrichment.class);
+        Netflow9MessageBuilder nf9MessageBuilder = new Netflow9MessageBuilder();
+        FlowMessage.Builder builder = nf9MessageBuilder.buildMessage(Collections.emptyList(), recordEnrichment);
+        assertThat(builder.getDirection(), equalTo(Direction.UNKNOWN));
+    }
+}


### PR DESCRIPTION
JIRA: https://opennms.atlassian.net/browse/NMS-15134

This allows for bidirectional flows to work properly when the exporter does not include the field.

Tested with a RB5009 on MikroTik RouterOS 7.6.