### PR TITLE
fix(doc): Remove <pre /> tag around trapd configuration

### DIFF
--- a/docs/modules/reference/pages/daemons/daemon-config-files/trapd.adoc
+++ b/docs/modules/reference/pages/daemons/daemon-config-files/trapd.adoc
@@ -61,12 +61,11 @@ Note that for V3, you must specify the SNMPv3 credentials used to authenticate a
 
 [source, xml]
 ----
-<pre>
 <trapd-configuration snmp-trap-port="162" new-suspect-on-trap="true">
   <snmpv3-user security-name="opennms" auth-passphrase="0p3nNMSv3" auth-protocol="MD5"
       privacy-passphrase="0p3nNMSv3" privacy-protocol="DES"/>
   <snmpv3-user security-name="sample-name" auth-passphrase="secret" auth-protocol="MD5"
       privacy-passphrase="super-secret" privacy-protocol="DES"/>
 </trapd-configuration>
-</pre>
 ----
+


### PR DESCRIPTION
The `<pre />`  tag is not part of the configuration and was used in our Wiki to format it as a code block with a mono-spaced font.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?



