### PR TITLE
Fix copy/paste error in trapd daemon docs

### DIFF
--- a/docs/modules/reference/pages/daemons/daemon-config-files/trapd.adoc
+++ b/docs/modules/reference/pages/daemons/daemon-config-files/trapd.adoc
@@ -61,12 +61,10 @@ Note that for V3, you must specify the SNMPv3 credentials used to authenticate a
 
 [source, xml]
 ----
-<pre>
 <trapd-configuration snmp-trap-port="162" new-suspect-on-trap="true">
   <snmpv3-user security-name="opennms" auth-passphrase="0p3nNMSv3" auth-protocol="MD5"
       privacy-passphrase="0p3nNMSv3" privacy-protocol="DES"/>
   <snmpv3-user security-name="sample-name" auth-passphrase="secret" auth-protocol="MD5"
       privacy-passphrase="super-secret" privacy-protocol="DES"/>
 </trapd-configuration>
-</pre>
 ----


### PR DESCRIPTION
Remove `<pre>` tags that shouldn't be there

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* JIRA (Issue Tracker): No Jira

