### PR TITLE
NMS-15149: Fix Vue menubar items obscured by GeoMap

### DIFF
--- a/ui/src/components/Map/SeverityFilter.vue
+++ b/ui/src/components/Map/SeverityFilter.vue
@@ -38,7 +38,8 @@ const onSeveritySelect = () => store.dispatch('mapModule/setSelectedSeverity', s
   width: 250px;
   right: 60px;
   top: 80px;
-  z-index: var($zindex-tooltip);
+  /* z-index needs to be below $zindex-fixed (1030) which is the z-index of the FeatherAppBar component */
+  z-index: var($zindex-sticky);
   .feather-input-wrapper {
     background: var($primary-text-on-color);
     border: 2px solid var($secondary);


### PR DESCRIPTION
Vue MenuBar dropdown items were being obscured by the `SeverityIndex` component of the GeoMap.

Changed `SeverityIndex` z-index to be `$zindex-sticky` which is just below `$zindex-fixed` which is the z-index of the `FeatherAppBar` (container of MenuBar).

### External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15149

