### PR TITLE
NMS-14910: Smoke test navigating to new Vue UI page

### DIFF
--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -140,6 +140,12 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         clickMenuItemWithIcon(helpMenuName, "About", "opennms/about/index.jsp");
         findElementByXpath("//div[@class='card-header']/span[text()='Version Details']");
 
+        // Navigation to new Vue UI page from legacy menubar
+        frontPage();
+        clickMenuItemWithIcon("nav-Info-top", "Device Configs", "opennms/ui/index.html#/device-config-backup");
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("app")));
+        findElementByXpath("//div[@id='app']//span[text()='Device Configuration']");
+
         Unreliables.retryUntilSuccess(60, TimeUnit.SECONDS, () -> {
             frontPage();
             Thread.sleep(200);


### PR DESCRIPTION
Adding a smoke test which navigates from the legacy menubar to one of the new(er) Vue UI pages.

### External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/NMS-14910

