### PR TITLE
NMS-15161: fix missing timeseries API on Sentinel

### DIFF
--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -94,7 +94,7 @@
     </feature>
 
     <feature name="sentinel-telemetry" description="OpenNMS :: Sentinel :: Telemetry" version="${project.version}">
-        <feature>sentinel-persistence</feature>
+        <feature>sentinel-timeseries-api</feature>
 
         <feature version="${netty4Version}">netty4</feature>
         <feature>dropwizard-metrics</feature>
@@ -259,7 +259,7 @@
              version="${project.version}">
         <feature>opennms-jsonstore-shell</feature>
         <feature>sentinel-kvstore-api</feature>
-        <feature>sentinel-persistence</feature>
+        <feature>sentinel-timeseries-api</feature>
         <bundle dependency="true">mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.postgres-shared/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.json.postgres/${project.version}</bundle>
     </feature>
@@ -301,7 +301,7 @@
 
     <feature name="sentinel-api-layer" version="${project.version}" description="Sentinel :: API Layer">
         <feature version="${opennmsApiVersion}">opennms-integration-api</feature>
-        <feature>sentinel-persistence</feature>
+        <feature>sentinel-timeseries-api</feature>
         <feature>opennms-provisioning</feature>
         <feature>opennms-situation-feedback-api</feature>
         <feature>scv-api</feature>


### PR DESCRIPTION
### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15161

