### PR TITLE
Cleanup some GenericContainer warnings

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/CassandraContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/CassandraContainer.java
@@ -33,7 +33,7 @@ import org.testcontainers.containers.Network;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
 
-public class CassandraContainer extends org.testcontainers.containers.CassandraContainer {
+public class CassandraContainer extends org.testcontainers.containers.CassandraContainer<CassandraContainer> {
 
     public CassandraContainer() {
         // Reduce JVM heap to 512m

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/CassandraContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/CassandraContainer.java
@@ -31,8 +31,6 @@ package org.opennms.smoketest.containers;
 import org.opennms.smoketest.utils.TestContainerUtils;
 import org.testcontainers.containers.Network;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
-
 public class CassandraContainer extends org.testcontainers.containers.CassandraContainer<CassandraContainer> {
 
     public CassandraContainer() {
@@ -40,9 +38,6 @@ public class CassandraContainer extends org.testcontainers.containers.CassandraC
         withEnv("JVM_OPTS", "-Xms512m -Xmx512m")
                 .withNetwork(Network.SHARED)
                 .withNetworkAliases(OpenNMSContainer.CASSANDRA_ALIAS)
-                .withCreateContainerCmdModifier(cmd -> {
-                    final CreateContainerCmd createCmd = (CreateContainerCmd)cmd;
-                    TestContainerUtils.setGlobalMemAndCpuLimits(createCmd);
-                });
+                .withCreateContainerCmdModifier(TestContainerUtils::setGlobalMemAndCpuLimits);
     }
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/JaegerContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/JaegerContainer.java
@@ -47,20 +47,30 @@ import org.testcontainers.lifecycle.TestDescription;
 import org.testcontainers.lifecycle.TestLifecycleAware;
 
 public class JaegerContainer extends GenericContainer<JaegerContainer> implements TestLifecycleAware {
+    public static final String ALIAS = "jaeger";
+    public static final int WEB_PORT = 16686;
+    public static final int THRIFT_HTTP_PORT = 14268;
     public static final String IMAGE = "jaegertracing/all-in-one:1.39";
-    private static final String ALIAS = "jaeger";
     private static final Logger LOG = LoggerFactory.getLogger(JaegerContainer.class);
 
     public JaegerContainer() {
         super(IMAGE);
         withNetwork(Network.SHARED);
         withNetworkAliases(ALIAS);
-        withExposedPorts(16686);
+        withExposedPorts(WEB_PORT);
     }
 
     public URL getURL(String path) throws MalformedURLException {
         Objects.requireNonNull(path);
-        return new URL("http://" + getHost() + ":" + getMappedPort(16686).toString() + path);
+        return new URL("http://" + getHost() + ":" + getMappedPort(WEB_PORT).toString() + path);
+    }
+
+    /**
+     * Gets the Thrift HTTP URL.
+     * @return String suitable to pass to JAEGER_ENDPOINT
+     */
+    public static String getThriftHttpURL() {
+        return String.format("http://%s:%d/api/traces", ALIAS, THRIFT_HTTP_PORT);
     }
 
     @Override

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/KarafContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/KarafContainer.java
@@ -33,7 +33,7 @@ import java.net.InetSocketAddress;
 import org.opennms.smoketest.utils.SshClient;
 import org.testcontainers.containers.Container;
 
-public interface KarafContainer extends Container {
+public interface KarafContainer<T extends Container<T>> extends Container<T> {
 
     /**
      * Create a new SSH client connected to the Karaf shell in this container.

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/KarafContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/KarafContainer.java
@@ -38,7 +38,7 @@ import org.opennms.smoketest.utils.SshClient;
 import org.testcontainers.containers.Container;
 import org.testcontainers.utility.MountableFile;
 
-public interface KarafContainer<T extends Container<T>> extends Container<T> {
+public interface KarafContainer<T extends KarafContainer<T>> extends Container<T> {
 
     /**
      * Create a new SSH client connected to the Karaf shell in this container.

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/KarafContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/KarafContainer.java
@@ -28,10 +28,15 @@
 
 package org.opennms.smoketest.containers;
 
-import java.net.InetSocketAddress;
+import static org.junit.Assert.assertTrue;
 
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+
+import org.opennms.smoketest.utils.KarafShell;
 import org.opennms.smoketest.utils.SshClient;
 import org.testcontainers.containers.Container;
+import org.testcontainers.utility.MountableFile;
 
 public interface KarafContainer<T extends Container<T>> extends Container<T> {
 
@@ -48,4 +53,59 @@ public interface KarafContainer<T extends Container<T>> extends Container<T> {
      * @return an InetSocketAddress usable for connecting to the Karaf shell.
      */
     InetSocketAddress getSshAddress();
+
+    /**
+     * Returns the path to the Karaf home directory.
+     *
+     * @return the path to the Karaf home directory
+     */
+    Path getKarafHomeDirectory();
+
+    /**
+     * Returns the path to the Karaf hot deploy directory. KARs installed in this directory will be
+     * deployed automatically without needing to run "kar:install".
+     *
+     * @return the path to the Karaf hot deploy directory
+     */
+    default Path getKarafHotDeployDirectory() {
+        return getKarafHomeDirectory().resolve("deploy");
+    }
+
+    /**
+     * Copy KAR file from the host system to the Karaf hot deploy directory in the container,
+     * verify that the feature is available, optionally run pre-install configuration commands,
+     * and finally install the feature, ensuring there are no errors in the output.
+     *
+     * @param feature the name of the Karaf feature
+     * @param kar the KAR file on the local host system to copy to the container
+     * @param preInstallConfig pre-install configuration commands
+     */
+    default void installFeature(String feature, Path kar, String... preInstallConfig) {
+        copyFileToContainer(MountableFile.forHostPath(kar), getKarafHotDeployDirectory().resolve(kar.getFileName()).toString());
+
+        installFeature(feature, preInstallConfig);
+    }
+
+    /**
+     * Verify that a Karaf feature is available, optionally run pre-install configuration commands,
+     * and finally install the feature, ensuring there are no errors in the output.
+     *
+     * @param feature the name of the Karaf feature
+     * @param preInstallConfig pre-install configuration commands
+     */
+    default void installFeature(String feature, String... preInstallConfig) {
+        var karafShell = new KarafShell(getSshAddress());
+
+        karafShell.runCommand("feature:list | grep " + feature,
+                output -> output.contains(feature),false);
+
+        for (var line : preInstallConfig) {
+            assertTrue(karafShell.runCommandOnce(line,
+                    output -> !output.toLowerCase().contains("error"), false));
+        }
+
+        // Note that the feature name doesn't always match the KAR name
+        assertTrue(karafShell.runCommandOnce("feature:install " + feature,
+                output -> !output.toLowerCase().contains("error"), false));
+    }
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -71,7 +71,6 @@ import org.testcontainers.lifecycle.TestDescription;
 import org.testcontainers.lifecycle.TestLifecycleAware;
 import org.testcontainers.utility.MountableFile;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.base.Strings;
 
 public class MinionContainer extends GenericContainer<MinionContainer> implements KarafContainer<MinionContainer>, TestLifecycleAware {
@@ -122,8 +121,7 @@ public class MinionContainer extends GenericContainer<MinionContainer> implement
         };
 
         withExposedPorts(tcpPorts)
-                .withCreateContainerCmdModifier(cmd -> {
-                    final CreateContainerCmd createCmd = (CreateContainerCmd)cmd;
+                .withCreateContainerCmdModifier(createCmd -> {
                     TestContainerUtils.setGlobalMemAndCpuLimits(createCmd);
                     TestContainerUtils.exposePortsAsUdp(createCmd, udpPorts);
                 })

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -247,12 +247,20 @@ public class MinionContainer extends GenericContainer<MinionContainer> implement
         return new InetSocketAddress(getContainerIpAddress(), TestContainerUtils.getMappedUdpPort(this, MINION_SYSLOG_PORT));
     }
 
+    @Override
     public InetSocketAddress getSshAddress() {
         return new InetSocketAddress(getContainerIpAddress(), getMappedPort(MINION_SSH_PORT));
     }
 
+    @Override
     public SshClient ssh() {
         return new SshClient(getSshAddress(), OpenNMSContainer.ADMIN_USER, OpenNMSContainer.ADMIN_PASSWORD);
+    }
+
+
+    @Override
+    public Path getKarafHomeDirectory() {
+        return Path.of("/opt/minion");
     }
 
     public URL getWebUrl() {

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -214,7 +214,7 @@ public class MinionContainer extends GenericContainer<MinionContainer> implement
             String jaeger = "{\n" +
                     "\t\"system\": {\n" +
                     "\t\t\"properties\": {\n" +
-                    "\t\t\t\"JAEGER_ENDPOINT\": \"http://jaeger:14268/api/traces\"\n" +
+                    "\t\t\t\"JAEGER_ENDPOINT\": \"" + JaegerContainer.getThriftHttpURL() + "\"\n" +
                     "\t\t}\n" +
                     "\t}\n" +
                     "}";

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -74,7 +74,7 @@ import org.testcontainers.utility.MountableFile;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.base.Strings;
 
-public class MinionContainer extends GenericContainer implements KarafContainer, TestLifecycleAware {
+public class MinionContainer extends GenericContainer<MinionContainer> implements KarafContainer<MinionContainer>, TestLifecycleAware {
     private static final Logger LOG = LoggerFactory.getLogger(MinionContainer.class);
     private static final int MINION_DEBUG_PORT = 5005;
     private static final int MINION_SYSLOG_PORT = 1514;

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
@@ -36,11 +36,14 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-public class MockCloudContainer extends org.testcontainers.containers.GenericContainer<MockCloudContainer> {
+import com.google.common.base.Joiner;
+
+public class MockCloudContainer extends GenericContainer<MockCloudContainer> {
     public static final String ALIAS = "cloudMock";
     public static final int PORT = 9003;
 
@@ -64,20 +67,17 @@ public class MockCloudContainer extends org.testcontainers.containers.GenericCon
     }
 
     public static String createConfig() throws IOException {
-        return format("config:edit org.opennms.plugins.cloud%n"
-                        + "property-set pas.tls.host %s%n"
-                        + "property-set pas.tls.port %s%n"
-                        + "property-set pas.tls.security TLS%n"
-                        + "property-set pas.mtls.host %s%n"
-                        + "property-set pas.mtls.port %s%n"
-                        + "property-set pas.mtls.security MTLS%n"
-                        + "property-set grpc.truststore \"%s\"%n"
-                        + "config:update",
-                ALIAS,
-                PORT,
-                ALIAS,
-                PORT,
-                classpathFileToString("/cert/horizon/servertruststore.pem")
-        );
+        return Joiner.on('\n').join(new String[] {
+                "config:edit org.opennms.plugins.cloud",
+                String.format("property-set pas.tls.host %s", ALIAS),
+                String.format("property-set pas.tls.port %s", PORT),
+                "property-set pas.tls.security TLS",
+                String.format("property-set pas.mtls.host %s", ALIAS),
+                String.format("property-set pas.mtls.port %s", PORT),
+                "property-set pas.mtls.security MTLS",
+                String.format("property-set grpc.truststore \"%s\"",
+                        classpathFileToString("/cert/horizon/servertruststore.pem")),
+                "config:update",
+        });
     }
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest.containers;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+public class MockCloudContainer extends org.testcontainers.containers.GenericContainer<MockCloudContainer> {
+    public static final String ALIAS = "cloudMock";
+    public static final int PORT = 9003;
+
+    private static final Path CLOUD_MOCK_PATH_HOST = Path.of("target/cloud-mock-with-dependencies/org.opennms.plugins.cloud-mock-with-dependencies.jar");
+    private static final Path CLOUD_MOCK_PATH_CONTAINER = Path.of("/").resolve(CLOUD_MOCK_PATH_HOST.getFileName());
+    private static final String CLOUD_MOCK_MAIN = "org.opennms.plugins.cloud.ittest.MockCloudMain";
+    public MockCloudContainer() {
+        super(DockerImageName.parse("opennms/deploy-base:jre-2.0.6.b165"));
+        withCopyFileToContainer(MountableFile.forHostPath(CLOUD_MOCK_PATH_HOST), CLOUD_MOCK_PATH_CONTAINER.toString())
+                .withCommand("/usr/bin/java", "-cp", CLOUD_MOCK_PATH_CONTAINER.toString(), CLOUD_MOCK_MAIN)
+                .withExposedPorts(PORT)
+                .withNetwork(Network.SHARED)
+                .withNetworkAliases(ALIAS);
+    }
+
+    public static String classpathFileToString(final String fileInClasspath) throws IOException {
+        URL url = new URL(format("jar:file:%s!%s", CLOUD_MOCK_PATH_HOST, fileInClasspath));
+        try (InputStream inputStream = url.openStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    public static String createConfig() throws IOException {
+        return format("config:edit org.opennms.plugins.cloud%n"
+                        + "property-set pas.tls.host %s%n"
+                        + "property-set pas.tls.port %s%n"
+                        + "property-set pas.tls.security TLS%n"
+                        + "property-set pas.mtls.host %s%n"
+                        + "property-set pas.mtls.port %s%n"
+                        + "property-set pas.mtls.security MTLS%n"
+                        + "property-set grpc.truststore \"%s\"%n"
+                        + "config:update",
+                ALIAS,
+                PORT,
+                ALIAS,
+                PORT,
+                classpathFileToString("/cert/horizon/servertruststore.pem")
+        );
+    }
+}

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -95,7 +95,7 @@ import com.google.common.collect.ImmutableMap;
  * @author jwhite
  */
 @SuppressWarnings("java:S2068")
-public class OpenNMSContainer extends GenericContainer implements KarafContainer, TestLifecycleAware {
+public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> implements KarafContainer<OpenNMSContainer>, TestLifecycleAware {
     public static final String ALIAS = "opennms";
     public static final String DB_ALIAS = "db";
     public static final String KAFKA_ALIAS = "kafka";

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -80,7 +80,6 @@ import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.lifecycle.TestDescription;
 import org.testcontainers.lifecycle.TestLifecycleAware;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.google.common.collect.ImmutableMap;
 
@@ -184,8 +183,7 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
         }
 
         withExposedPorts(exposedPorts)
-                .withCreateContainerCmdModifier(cmd -> {
-                    final CreateContainerCmd createCmd = (CreateContainerCmd)cmd;
+                .withCreateContainerCmdModifier(createCmd -> {
                     TestContainerUtils.setGlobalMemAndCpuLimits(createCmd);
                     // The framework doesn't support exposing UDP ports directly, so we use this hook to map some of the exposed ports to UDP
                     TestContainerUtils.exposePortsAsUdp(createCmd, exposedUdpPorts);

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -385,7 +385,7 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
 
         if (model.isJaegerEnabled()) {
             props.put("org.opennms.core.tracer", "jaeger");
-            props.put("JAEGER_ENDPOINT", "http://jaeger:14268/api/traces");
+            props.put("JAEGER_ENDPOINT", JaegerContainer.getThriftHttpURL());
         }
 
         // output Karaf logs to the console to help in debugging intermittent container startup failures

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/PostgreSQLContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/PostgreSQLContainer.java
@@ -45,7 +45,6 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.TestDescription;
 import org.testcontainers.lifecycle.TestLifecycleAware;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -69,10 +68,7 @@ public class PostgreSQLContainer extends org.testcontainers.containers.PostgreSQ
         super("postgres:10.7-alpine");
         withNetwork(Network.SHARED)
                 .withNetworkAliases(OpenNMSContainer.DB_ALIAS)
-                .withCreateContainerCmdModifier(cmd -> {
-                    final CreateContainerCmd createCmd = (CreateContainerCmd)cmd;
-                    TestContainerUtils.setGlobalMemAndCpuLimits(createCmd);
-                });
+                .withCreateContainerCmdModifier(TestContainerUtils::setGlobalMemAndCpuLimits);
     }
 
     @Override

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/PostgreSQLContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/PostgreSQLContainer.java
@@ -50,7 +50,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
-public class PostgreSQLContainer extends org.testcontainers.containers.PostgreSQLContainer implements TestLifecycleAware {
+public class PostgreSQLContainer extends org.testcontainers.containers.PostgreSQLContainer<PostgreSQLContainer> implements TestLifecycleAware {
     private static final Logger LOG = LoggerFactory.getLogger(PostgreSQLContainer.class);
 
     private LoadingCache<Integer, HibernateDaoFactory> daoFactoryCache = CacheBuilder.newBuilder()

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -80,7 +80,7 @@ import org.testcontainers.utility.MountableFile;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.collect.ImmutableMap;
 
-public class SentinelContainer extends GenericContainer implements KarafContainer, TestLifecycleAware {
+public class SentinelContainer extends GenericContainer<SentinelContainer> implements KarafContainer<SentinelContainer>, TestLifecycleAware {
     private static final Logger LOG = LoggerFactory.getLogger(SentinelContainer.class);
     private static final int SENTINEL_DEBUG_PORT = 5005;
     private static final int SENTINEL_SSH_PORT = 8301;

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -77,7 +77,6 @@ import org.testcontainers.lifecycle.TestDescription;
 import org.testcontainers.lifecycle.TestLifecycleAware;
 import org.testcontainers.utility.MountableFile;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.collect.ImmutableMap;
 
 public class SentinelContainer extends GenericContainer<SentinelContainer> implements KarafContainer<SentinelContainer>, TestLifecycleAware {
@@ -120,10 +119,7 @@ public class SentinelContainer extends GenericContainer<SentinelContainer> imple
                 .withNetworkAliases(ALIAS)
                 .withCommand("-f")
                 .waitingFor(new WaitForSentinel(this))
-                .withCreateContainerCmdModifier(cmd -> {
-                    final CreateContainerCmd createCmd = (CreateContainerCmd)cmd;
-                    TestContainerUtils.setGlobalMemAndCpuLimits(createCmd);
-                })
+                .withCreateContainerCmdModifier(TestContainerUtils::setGlobalMemAndCpuLimits)
                 .addFileSystemBind(overlay.toString(),
                         "/opt/sentinel-overlay", BindMode.READ_ONLY, SelinuxContext.SINGLE);
 
@@ -286,7 +282,7 @@ public class SentinelContainer extends GenericContainer<SentinelContainer> imple
 
     /**
      * Workaround exception details that are lost from waitUntilReady due to
-     * https://github.com/testcontainers/testcontainers-java/pull/6167
+     * <a href="https://github.com/testcontainers/testcontainers-java/pull/6167">this issue</a>.
      */
     @Override
     protected void doStart() {

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -257,6 +257,7 @@ public class SentinelContainer extends GenericContainer<SentinelContainer> imple
         return props;
     }
 
+    @Override
     public InetSocketAddress getSshAddress() {
         return new InetSocketAddress(getContainerIpAddress(), getMappedPort(SENTINEL_SSH_PORT));
     }
@@ -264,6 +265,11 @@ public class SentinelContainer extends GenericContainer<SentinelContainer> imple
     @Override
     public SshClient ssh() {
         return new SshClient(getSshAddress(), OpenNMSContainer.ADMIN_USER, OpenNMSContainer.ADMIN_PASSWORD);
+    }
+
+    @Override
+    public Path getKarafHomeDirectory() {
+        return Path.of("/opt/sentinel");
     }
 
     public URL getWebUrl() {

--- a/smoke-test/src/test/java/org/opennms/smoketest/OpenNMSCloudPluginIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/OpenNMSCloudPluginIT.java
@@ -28,125 +28,70 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static java.lang.String.format;
+import static org.awaitility.Awaitility.await;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Duration;
-import java.util.stream.Collectors;
 
 import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.opennms.smoketest.containers.MockCloudContainer;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.KarafShellUtils;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.MountableFile;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
-
+/*
+ * Enforce ordering based on name so that the OpenNMS test runs before Sentinel.
+ * The sentinel plugin requires a successful installation of the core plugin first.
+ * Reason: The core plugin does the configuration and puts the certificates into the database via KV Store.
+ * The Sentinel Plugin needs those certificates. The reason it was implemented that way:
+ * The user needs to configure only one plugin.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class OpenNMSCloudPluginIT {
 
-    private static final String PATH_TO_FILE = "target/plugin-cloud-assembly/org.opennms.plugins.cloud-assembly.kar";
-    private static final String PATH_TO_CLOUD_MOCK = "target/cloud-mock-with-dependencies/org.opennms.plugins.cloud-mock-with-dependencies.jar";
-    private static final String CONTAINER_PATH = "/usr/share/opennms/deploy/";
-    private static final String CLOUD_MOCK_JAR_NAME = "org.opennms.plugins.cloud-mock-with-dependencies.jar";
-    private static final String CLOUD_MOCK_MAIN = "org.opennms.plugins.cloud.ittest.MockCloudMain";
-    private static final String KAR_FILE_NAME = "org.opennms.plugins.cloud-assembly.kar";
+    private static final Path CLOUD_KAR_PATH_HOST = Path.of("target/plugin-cloud-assembly/org.opennms.plugins.cloud-assembly.kar");
 
     @ClassRule
     public static OpenNMSStack stack = OpenNMSStack.SENTINEL;
 
     @ClassRule
-    public static GenericContainer mockCloudContainer = new GenericContainer(DockerImageName.parse("opennms/deploy-base:jre-2.0.6.b165"))
-            .withCreateContainerCmdModifier(cmd -> {
-                final CreateContainerCmd createCmd = (CreateContainerCmd) cmd;
-                createCmd.withEntrypoint("/bin/bash");
-                createCmd.withName("cloudMock");
-            }).withCopyFileToContainer(MountableFile.forHostPath(PATH_TO_CLOUD_MOCK), format("%s%s", CONTAINER_PATH, CLOUD_MOCK_JAR_NAME))
-            .withCommand("-c", format("java -cp %s%s %s", CONTAINER_PATH, CLOUD_MOCK_JAR_NAME, CLOUD_MOCK_MAIN)).withExposedPorts(9003)
-            .withNetwork(stack.opennms().getNetwork())
-            .withNetworkAliases("cloudMock");
+    public static MockCloudContainer mockCloudContainer = new MockCloudContainer();
 
     @Test
-    public void installCloudPlugin() throws Exception {
-        /* The sentinel plugin requires a successful installation of the core plugin first.
-           Reason: The core plugin does the configuration and puts the certificates into the database via KV Store.
-           The Sentinel Plugin needs those certificates. The reason it was implemented that way:
-           The user needs to configure only one plugin.
-        */
-        installCloudPluginInOpennmsMustBeSuccessful();
-        installCloudPluginInSentinelMustBeSuccessful();
-    }
-
     public void installCloudPluginInOpennmsMustBeSuccessful() throws Exception {
         // Given
-        stack.opennms().copyFileToContainer(MountableFile.forHostPath(PATH_TO_FILE), format("%s%s", CONTAINER_PATH, KAR_FILE_NAME));
-        String config = createConfig();
+        stack.opennms().installFeature("opennms-plugin-cloud-core", CLOUD_KAR_PATH_HOST, MockCloudContainer.createConfig());
 
         // When
         KarafShellUtils.withKarafShell(stack.opennms().getSshAddress(), Duration.ofMinutes(3), streams -> {
-            streams.stdin.println(config);
-            streams.stdin.println("feature:install opennms-plugin-cloud-core");
             streams.stdin.println("feature:list | grep opennms-plugin-cloud-core");
-            await().atMost(com.jayway.awaitility.Duration.ONE_MINUTE).until(() -> streams.stdout.getLines().stream().anyMatch(line -> line.contains("Started")));
+            await().atMost(Duration.ofMinutes(1)).until(() -> streams.stdout.getLines().stream().anyMatch(line -> line.contains("Started")));
             streams.stdin.println("opennms-cloud:init key");
-            await().atMost(com.jayway.awaitility.Duration.ONE_MINUTE).until(() ->
+            await().atMost(Duration.ofMinutes(1)).until(() ->
                     String.join("\n", streams.stdout.getLines()).contains("Initialization of cloud plugin in OPENNMS was successful"));
             return true;
         });
     }
 
-
+    @Test
     public void installCloudPluginInSentinelMustBeSuccessful() throws Exception {
         // Given
-        stack.sentinel().copyFileToContainer(MountableFile.forHostPath(PATH_TO_FILE), format("%s%s", CONTAINER_PATH, KAR_FILE_NAME));
-        String config = createConfig();
+        stack.sentinel().installFeature("opennms-plugin-cloud-sentinel", CLOUD_KAR_PATH_HOST, MockCloudContainer.createConfig());
 
         // When
         KarafShellUtils.withKarafShell(stack.sentinel().getSshAddress(), Duration.ofMinutes(3), streams -> {
-            streams.stdin.println(config);
-            streams.stdin.printf("kar:install file:%s%s%n", CONTAINER_PATH, KAR_FILE_NAME);
-            streams.stdin.println("feature:install opennms-plugin-cloud-sentinel");
             streams.stdin.println("feature:list | grep opennms-plugin-cloud-sentinel");
-            await().atMost(com.jayway.awaitility.Duration.ONE_MINUTE).until(() -> streams.stdout.getLines().stream().anyMatch(line -> line.contains("Started")));
-            await().atMost(com.jayway.awaitility.Duration.ONE_MINUTE).until(() ->
+            await().atMost(Duration.ofMinutes(1)).until(() -> streams.stdout.getLines().stream().anyMatch(line -> line.contains("Started")));
+            await().atMost(Duration.ofMinutes(1)).until(() ->
             {
                 streams.stdin.println("opennms-cloud:init key");
                 return streams.stdout.getLines().stream().anyMatch(line -> line.contains("Initialization of cloud plugin in SENTINEL was successful."));
             });
-            await().atMost(com.jayway.awaitility.Duration.ONE_MINUTE).until(() ->
+            await().atMost(Duration.ofMinutes(1)).until(() ->
                     String.join("\n", streams.stdout.getLines()).contains("Initialization of cloud plugin in SENTINEL was successful."));
             return true;
         });
     }
-
-    private String createConfig() throws IOException {
-        return format("config:edit org.opennms.plugins.cloud%n"
-                        + "property-set pas.tls.host %s%n"
-                        + "property-set pas.tls.port %s%n"
-                        + "property-set pas.tls.security TLS%n"
-                        + "property-set pas.mtls.host %s%n"
-                        + "property-set pas.mtls.port %s%n"
-                        + "property-set pas.mtls.security MTLS%n"
-                        + "property-set grpc.truststore \"%s\"%n"
-                        + "config:update",
-                "cloudMock",
-                9003,
-                "cloudMock",
-                9003,
-                classpathFileToString("/cert/horizon/servertruststore.pem")
-        );
-    }
-
-    public static String classpathFileToString(final String fileInClasspath) throws IOException {
-        URL url = new URL(format("jar:file:%s!%s", PATH_TO_CLOUD_MOCK, fileInClasspath));
-        try (InputStream inputStream = url.openStream()) {
-            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-        }
-    }
-
 }


### PR DESCRIPTION
### Changes

This just cleans up some warnings I came across in our container classes that extend GenericContainers. It seemed easy to fix (which was *almost* true), so I cleaned them up.

The [MockCloudContainer](https://github.com/OpenNMS/opennms/pull/5678/commits/49df9f862bae8277ad15445367a0c63f1f769918) change wasn't something I expected to do, but it let me eliminate the last case of a raw type of GenericContainer being used. And overall, I like the change (I hope others agree, :grin:).

While moving MockCloudContainer into its own class, I noticed some duplication with installing KAR features, which led me to [Move installFeature into KarafContainer.](https://github.com/OpenNMS/opennms/pull/5678/commits/c2ae9e962d5f645411d013694033910333247b35) 

I also deduplicated the Jaeger Thrift HTTP while I was waiting for tests to run. :)

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}

