### PR TITLE
Jaeger smoke test fixes

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/JaegerContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/JaegerContainer.java
@@ -30,12 +30,15 @@ package org.opennms.smoketest.containers;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
+import org.opennms.core.utils.SystemInfoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -69,9 +72,11 @@ public class JaegerContainer extends GenericContainer<JaegerContainer> implement
         // This can take a few seconds, so we only do it on failures
         if (failed) {
             try {
-                Path output = Paths.get("target", "logs", prefix, ALIAS, "opennms-traces.json");
-                FileUtils.copyURLToFile(getURL("/api/traces?service=OpenNMS"), output.toFile());
-                LOG.info("Jaeger trace JSON: {}", output.toUri());
+                Path opennms = Paths.get("target", "logs", prefix, ALIAS, "opennms-traces.json");
+                FileUtils.copyURLToFile(getURL("/api/traces?service=" +
+                        URLEncoder.encode(SystemInfoUtils.getInstanceId(), Charset.defaultCharset())),
+                        opennms.toFile());
+                LOG.info("OpenNMS Jaeger trace JSON: {}", opennms.toUri());
             } catch (Exception e) {
                 System.err.println("Received exception while trying to save all Jaeger traces");
                 e.printStackTrace(System.err);

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/JaegerContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/JaegerContainer.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest.containers;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.TestDescription;
+import org.testcontainers.lifecycle.TestLifecycleAware;
+
+public class JaegerContainer extends GenericContainer<JaegerContainer> implements TestLifecycleAware {
+    public static final String IMAGE = "jaegertracing/all-in-one:1.39";
+    private static final String ALIAS = "jaeger";
+    private static final Logger LOG = LoggerFactory.getLogger(JaegerContainer.class);
+
+    public JaegerContainer() {
+        super(IMAGE);
+        withNetwork(Network.SHARED);
+        withNetworkAliases(ALIAS);
+        withExposedPorts(16686);
+    }
+
+    public URL getURL(String path) throws MalformedURLException {
+        Objects.requireNonNull(path);
+        return new URL("http://" + getHost() + ":" + getMappedPort(16686).toString() + path);
+    }
+
+    @Override
+    public void afterTest(final TestDescription description, final Optional<Throwable> throwable) {
+        retainLogsIfNeeded(description.getFilesystemFriendlyName(), !throwable.isPresent());
+    }
+
+    private void retainLogsIfNeeded(String prefix, boolean failed) {
+        // This can take a few seconds, so we only do it on failures
+        if (failed) {
+            try {
+                Path output = Paths.get("target", "logs", prefix, ALIAS, "opennms-traces.json");
+                FileUtils.copyURLToFile(getURL("/api/traces?service=OpenNMS"), output.toFile());
+                LOG.info("Jaeger trace JSON: {}", output.toUri());
+            } catch (Exception e) {
+                System.err.println("Received exception while trying to save all Jaeger traces");
+                e.printStackTrace(System.err);
+            }
+        }
+    }
+}

--- a/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSStack.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSStack.java
@@ -38,12 +38,12 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.opennms.smoketest.containers.CassandraContainer;
 import org.opennms.smoketest.containers.ElasticsearchContainer;
+import org.opennms.smoketest.containers.JaegerContainer;
 import org.opennms.smoketest.containers.LocalOpenNMS;
 import org.opennms.smoketest.containers.MinionContainer;
 import org.opennms.smoketest.containers.OpenNMSContainer;
 import org.opennms.smoketest.containers.PostgreSQLContainer;
 import org.opennms.smoketest.containers.SentinelContainer;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
@@ -101,7 +101,7 @@ public final class OpenNMSStack implements TestRule {
 
     private final PostgreSQLContainer postgreSQLContainer;
 
-    private final GenericContainer jaegerContainer;
+    private final JaegerContainer jaegerContainer;
 
     private final OpenNMSContainer opennmsContainer;
 
@@ -136,10 +136,7 @@ public final class OpenNMSStack implements TestRule {
         RuleChain chain = RuleChain.outerRule(postgreSQLContainer);
 
         if (model.isJaegerEnabled()) {
-            jaegerContainer = new GenericContainer("jaegertracing/all-in-one:1.39")
-                    .withNetwork(Network.SHARED)
-                    .withNetworkAliases("jaeger")
-                    .withExposedPorts(16686);
+            jaegerContainer = new JaegerContainer();
             chain = chain.around(jaegerContainer);
         } else {
             jaegerContainer = null;
@@ -222,7 +219,7 @@ public final class OpenNMSStack implements TestRule {
         return sentinelContainers.get(index);
     }
 
-    public GenericContainer jaeger() {
+    public JaegerContainer jaeger() {
         if (jaegerContainer == null) {
             throw new IllegalStateException("Jaeger container is not enabled in this stack.");
         }

--- a/smoke-test/src/test/java/org/opennms/smoketest/JaegerTracingIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/JaegerTracingIT.java
@@ -41,6 +41,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.opennms.core.utils.SystemInfoUtils;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
 
@@ -79,7 +80,7 @@ public class JaegerTracingIT {
                 .until(
                         () -> {
                             given().accept(ContentType.JSON)
-                                    .param("service", "OpenNMS")
+                                    .param("service", SystemInfoUtils.getInstanceId())
                                     .param("operation", "trapd.listener.config")
                                     .param("limit", 1)
                                     .get("/traces")
@@ -103,7 +104,7 @@ public class JaegerTracingIT {
                         givenWithFailureDetails((spec) -> {
                             spec
                                     .accept(ContentType.JSON)
-                                    .param("service", "OpenNMS")
+                                    .param("service", SystemInfoUtils.getInstanceId())
                                     .param("operation", "Echo")
                                     .param("limit", 1)
                                     .get("/traces")


### PR DESCRIPTION
Ben noticed when doing builds that the JaegerTracingIT smoke test failed if the system name wasn't OpenNMS. This fixes that and also adds some previous refactoring to pull the Jaeger container into its own JaegerContainer class.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15267

