### PR TITLE
Fix integration test reports

### DIFF
--- a/.circleci/main/commands/executions/run-integration-tests.yml
+++ b/.circleci/main/commands/executions/run-integration-tests.yml
@@ -35,8 +35,8 @@ commands:
           when: always
           command: |
             mkdir -p ~/test-results/junit
-            find . -type f -regex ".*/target/.*-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
-            find . -type f -regex ".*/target/.*-reports-[0-9]+/.*dump.*" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*-reports/.*dump.*" -exec cp {} ~/test-results/junit/ \;
       - run:
           name: Gather tests
           when: always

--- a/.circleci/main/commands/executions/run-smoke-tests.yml
+++ b/.circleci/main/commands/executions/run-smoke-tests.yml
@@ -49,8 +49,8 @@ commands:
           when: always
           command: |
             mkdir -p ~/test-results/junit
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
-            find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*-reports/.*dump.*" -exec cp {} ~/test-results/junit/ \;
             mkdir -p ~/test-artifacts/recordings
             cp -R ~/project/smoke-test/target/*.{flv,mp4} ~/test-artifacts/recordings || true
             cp -R ~/project/smoke-test/target/screenshots ~/test-artifacts/ || true


### PR DESCRIPTION
### ~~Not sure why it stopped working~~ Figured it out

We stopped setting reportsDirectory to
`${project.build.directory}/surefire-reports-${ci.instance} in`
https://github.com/OpenNMS/opennms/commit/9d229346a2a891f3cf89ee7df42011309d01c305 and let is go back to the default. The smoke-test project wasn't affected because it doesn't inherit from the top-level pom.xml.

It is working in the latest build of foundation-2021: https://app.circleci.com/pipelines/github/OpenNMS/opennms/26734/workflows/a3b52ddf-6122-4def-ad76-3aec00854c11/jobs/213699/tests

But it isn't working in foundation-2022 (nor foundation-2023 or release-31.x or develop): https://app.circleci.com/pipelines/github/OpenNMS/opennms/26712/workflows/cee6672b-37c6-4000-b66e-0aecb6076e77/jobs/213483/tests

Gather test results output:
```
#!/bin/bash -eo pipefail
mkdir -p ~/test-results/junit
find . -type f -regex ".*/target/.*-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
find . -type f -regex ".*/target/.*-reports-[0-9]+/.*dump.*" -exec cp {} ~/test-results/junit/ \;

CircleCI received exit code 0
```
-- https://app.circleci.com/pipelines/github/OpenNMS/opennms/26712/workflows/cee6672b-37c6-4000-b66e-0aecb6076e77/jobs/213483/steps?invite=true#step-105-6

Uploading test results output:
```
Found no test results, skipping
```
-- https://app.circleci.com/pipelines/github/OpenNMS/opennms/26712/workflows/cee6672b-37c6-4000-b66e-0aecb6076e77/jobs/213483/steps?invite=true#step-108-1

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15271

