### PR TITLE
NMS-15275: Add step to verify the main.yml file in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,22 +36,18 @@ commands:
               ssh-keyscan -p 443 ssh.github.com >> ~/.ssh/known_hosts
               chmod 600 ~/.ssh/known_hosts
               git clone --depth 20 "${CIRCLE_REPOSITORY_URL}" --branch "${CIRCLE_BRANCH}" .
-  pack-config:
-    description: "Pack the dynamic config in .circleci/main/"
+  verify-config:
+    description: "Verify generated main.yml file"
     steps:
       - run:
-          name: Pack Dynamic Config
+          name: Verify Dynamic Config
           command: |
             CIRCLE_BIN_DIR="$HOME/.local/bin"
             mkdir -p "$CIRCLE_BIN_DIR"
             export PATH="$CIRCLE_BIN_DIR:$PATH"
             curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | DESTDIR="$CIRCLE_BIN_DIR" bash
             "$CIRCLE_BIN_DIR/circleci" version
-            "$CIRCLE_BIN_DIR/circleci" config pack /tmp/.circleci/main --skip-update-check > /tmp/.circleci/main.yml || exit 1
             "$CIRCLE_BIN_DIR/circleci" config validate --skip-update-check /tmp/.circleci/main.yml || exit 1
-      - store_artifacts:
-          path: .circleci/main.yml
-          destination: main.yml
 
 workflows:
   coverage:
@@ -193,6 +189,7 @@ jobs:
       - run:
           name: Generate Main YAML file
           command: python3 .circleci/pyscripts/generate_main.py 
+      - verify-config
       - store_artifacts:
           path: /tmp/pipeline-parameters.json
           destination: pipeline-parameters.json


### PR DESCRIPTION
Add a step to `trigger-path-filtering` to verify the generated 'main.yml' file

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15275

