### PR TITLE
NMS-15196: bump xstream version to 1.4.20

### DIFF
--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -89,6 +89,8 @@
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
+
+                        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1</bundle>
                     </installedBundles>
                     <libraries>
                         <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.11.0_1;type:=endorsed;export:=true;delegate:=true</library>

--- a/container/karaf/src/main/filtered-resources/etc/overrides.properties
+++ b/container/karaf/src/main/filtered-resources/etc/overrides.properties
@@ -5,3 +5,4 @@ mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}
 mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
+mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -103,6 +103,8 @@
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
 
                         <bundle>mvn:org.apache.felix/org.apache.felix.http.bridge/${felixBridgeVersion}</bundle>
+
+                        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1</bundle>
                     </installedBundles>
                     <libraries>
                         <!-- OPENNMS: Add JNA bundles to prevent jline from refreshing (KARAF-5251) -->

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -5,3 +5,4 @@ mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}
 mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
+mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1

--- a/opennms-full-assembly/src/assembly/components/osgi.xml
+++ b/opennms-full-assembly/src/assembly/components/osgi.xml
@@ -8,6 +8,10 @@
       <filtered>false</filtered>
       <outputDirectory>system</outputDirectory>
       <directory>target/opennms-repo</directory>
+      <excludes>
+        <exclude>**/*xstream*/1.4.8_1</exclude>
+        <exclude>**/*xstream*/1.4.8_1/*</exclude>
+      </excludes>
     </fileSet>
   </fileSets>
 </component>

--- a/pom.xml
+++ b/pom.xml
@@ -1786,6 +1786,7 @@
     <xercesVersion>2.9.1</xercesVersion>
     <xmlApisVersion>99.99.99-exclude-provided-by-jdk11-and-up</xmlApisVersion>
     <xmlApisExtVersion>1.3.04</xmlApisExtVersion>
+    <xstreamVersion>1.4.20</xstreamVersion>
     <wsdl4jVersion>1.6.3</wsdl4jVersion>
     <wsmanVersion>1.2.3</wsmanVersion>
     <zookeeperVersion>3.4.14</zookeeperVersion>
@@ -3657,6 +3658,16 @@
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
         <version>${caffeineVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>${xstreamVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>org.apache.servicemix.bundles.xstream</artifactId>
+        <version>${xstreamVersion}_1</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>


### PR DESCRIPTION
This PR bumps xstream to the latest version.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15196
