### PR TITLE
NMS-15197: update jasypt to 1.9.3

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -479,7 +479,7 @@
         <feature>opennms-rrd-api</feature>
         <feature>opennms-snmp</feature>
         <bundle dependency="true">wrap:mvn:com.googlecode.concurrent-locks/concurrent-locks/1.0.0</bundle>
-        <bundle dependency="true">wrap:mvn:org.jasypt/jasypt/1.9.0</bundle>
+        <bundle dependency="true">wrap:mvn:org.jasypt/jasypt/${jasyptVersion}</bundle>
         <bundle>mvn:org.opennms/opennms-config/${project.version}</bundle>
     </feature>
     <feature name="opennms-kafka" version="${project.version}" description="OpenNMS :: Features :: Kafka">

--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -89,6 +89,9 @@
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
+
+                        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1</bundle>
+                        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1</bundle>
                     </installedBundles>
                     <libraries>
                         <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.11.0_1;type:=endorsed;export:=true;delegate:=true</library>

--- a/container/karaf/src/main/filtered-resources/etc/overrides.properties
+++ b/container/karaf/src/main/filtered-resources/etc/overrides.properties
@@ -5,3 +5,5 @@ mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}
 mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
+mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1
+mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -103,6 +103,9 @@
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
 
                         <bundle>mvn:org.apache.felix/org.apache.felix.http.bridge/${felixBridgeVersion}</bundle>
+
+                        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1</bundle>
+                        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1</bundle>
                     </installedBundles>
                     <libraries>
                         <!-- OPENNMS: Add JNA bundles to prevent jline from refreshing (KARAF-5251) -->

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -5,3 +5,5 @@ mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}
 mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
+mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1
+mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1

--- a/dependencies/jasypt/pom.xml
+++ b/dependencies/jasypt/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.jasypt</groupId>
       <artifactId>jasypt</artifactId>
-      <version>1.9.0</version>
+      <version>${jasyptVersion}</version>
     </dependency>
   </dependencies>
 </project>

--- a/opennms-full-assembly/src/assembly/components/osgi.xml
+++ b/opennms-full-assembly/src/assembly/components/osgi.xml
@@ -8,6 +8,10 @@
       <filtered>false</filtered>
       <outputDirectory>system</outputDirectory>
       <directory>target/opennms-repo</directory>
+      <excludes>
+        <exclude>**/org.apache.servicemix.bundles.jasypt*/1.9.2_1</exclude>
+        <exclude>**/org.apache.servicemix.bundles.jasypt*/1.9.2_1/*</exclude>
+      </excludes>
     </fileSet>
   </fileSets>
 </component>

--- a/pom.xml
+++ b/pom.xml
@@ -1694,6 +1694,7 @@
     <jacocoVersion>0.8.8</jacocoVersion>
     <jasperreportsVersion>6.3.0</jasperreportsVersion>
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
+    <jasyptVersion>1.9.3</jasyptVersion>
     <!-- this should match what's in Karaf's lib/jdk9plus directory -->
     <jaxbRuntimeVersion>2.3.3</jaxbRuntimeVersion>
     <!-- this should match what's in Karaf's lib/jdk9plus directory -->
@@ -2842,6 +2843,16 @@
         <artifactId>jasypt-dependencies</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.jasypt</groupId>
+        <artifactId>jasypt</artifactId>
+        <version>${jasyptVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>org.apache.servicemix.bundles.jasypt</artifactId>
+        <version>${jasyptVersion}_1</version>
       </dependency>
       <dependency>
         <groupId>org.opennms.dependencies</groupId>


### PR DESCRIPTION
This PR bumps our included jasypt to the latest version.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15197

