### PR TITLE
NMS-15194: update quartz to 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1700,6 +1700,7 @@
     <jakartaXmlBindVersion>2.3.3</jakartaXmlBindVersion>
     <!-- this should match what's in Karaf's lib/jdk9plus directory -->
     <javaxAnnotationApiVersion>1.3.1</javaxAnnotationApiVersion>
+    <jbossLoggingVersion>3.5.0.Final</jbossLoggingVersion>
     <jcifsVersion>2.1.6</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
     <jettyVersion>9.4.44.v20210927</jettyVersion>
@@ -1760,7 +1761,7 @@
     <opentracingVersion>0.31.0</opentracingVersion>
     <jeagertracingVersion>0.34.0</jeagertracingVersion>
     <lz4JavaVersion>1.7.1</lz4JavaVersion>
-    <quartzVersion>2.2.3</quartzVersion>
+    <quartzVersion>2.3.2</quartzVersion>
     <rancidApiVersion>2.0.0</rancidApiVersion>
     <rateLimitedLoggerVersion>2.0.1</rateLimitedLoggerVersion>
     <resilience4jVersion>0.17.0</resilience4jVersion>
@@ -4126,6 +4127,11 @@
             <artifactId>standard</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>${jbossLoggingVersion}</version>
       </dependency>
       <!--
 


### PR DESCRIPTION
This PR bumps quartz to version 2.3.2

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15194