### PR TITLE
NMS-15192: bump jboss-logging to 3.5.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1700,6 +1700,7 @@
     <jakartaXmlBindVersion>2.3.3</jakartaXmlBindVersion>
     <!-- this should match what's in Karaf's lib/jdk9plus directory -->
     <javaxAnnotationApiVersion>1.3.1</javaxAnnotationApiVersion>
+    <jbossLoggingVersion>3.5.0.Final</jbossLoggingVersion>
     <jcifsVersion>2.1.6</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
     <jettyVersion>9.4.44.v20210927</jettyVersion>
@@ -4285,6 +4286,11 @@
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>${hibernateValidatorVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>${jbossLoggingVersion}</version>
       </dependency>
       <!-- this should match what's in Karaf's lib/jdk9plus directory -->
       <dependency>


### PR DESCRIPTION
This PR bumps our jboss-logging dependency to 3.5.0.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15192

