### PR TITLE
NMS-15200: use forked jsch, move to latest version

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -847,14 +847,13 @@
         <feature version="${guavaOsgiVersion}">guava</feature>
         <feature>joda-time</feature>
         <feature>opennms-core-web</feature>
-        <bundle>wrap:mvn:com.jcraft/jsch/0.1.51</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.oro/2.0.8_6</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ezmorph/1.0.6_1</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.json-lib/2.4_1</bundle>
         <bundle dependency="true">mvn:org.codehaus.jackson/jackson-core-asl/${jacksonVersion}</bundle>
         <bundle dependency="true">mvn:org.codehaus.jackson/jackson-mapper-asl/${jacksonVersion}</bundle>
         <bundle dependency="true">mvn:org.codehaus.jackson/jackson-xc/${jacksonVersion}</bundle>
-        <bundle dependency="true">wrap:mvn:com.jcraft/jsch/0.1.51</bundle>
+        <bundle dependency="true">wrap:mvn:com.github.mwiede/jsch/${jschVersion}</bundle>
         <bundle dependency="true">wrap:mvn:org.jsoup/jsoup/${jsoupVersion}</bundle>
         <bundle>mvn:org.opennms.protocols/org.opennms.protocols.xml/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.api/${project.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -1718,6 +1718,7 @@
     <jrrdVersion>1.1.0</jrrdVersion>
     <jrrd2Version>2.0.3</jrrd2Version>
     <jrubyVersion>9.2.6.0</jrubyVersion>
+    <jschVersion>0.2.6</jschVersion>
     <jsonVersion>20171018</jsonVersion>
     <jsonPatchVersion>1.13</jsonPatchVersion>
     <jsoupVersion>1.7.2</jsoupVersion>
@@ -4489,9 +4490,9 @@
         <version>${servletApiVersion}</version>
       </dependency>
       <dependency>
-        <groupId>com.jcraft</groupId>
+        <groupId>com.github.mwiede</groupId>
         <artifactId>jsch</artifactId>
-        <version>0.1.51</version>
+        <version>${jschVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/protocols/xml/pom.xml
+++ b/protocols/xml/pom.xml
@@ -133,7 +133,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
     </dependency>
     <dependency>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -610,9 +610,9 @@
       <version>1.11.3</version>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.55</version>
+      <version>0.2.6</version>
     </dependency>
     <dependency>
       <groupId>com.hubspot.jinjava</groupId>


### PR DESCRIPTION
The original JSCH is abandoned, this PR changes to the maintained fork, and uses the latest version.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15200

