### PR TITLE
NMS-15202: update proton-j to 0.34.0

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -8,11 +8,16 @@
     <repository>mvn:org.apache.activemq/activemq-karaf/${activemqVersion}/xml/features</repository>
     <repository>mvn:org.opennms.integration.api/karaf-features/${opennmsApiVersion}/xml</repository>
     <repository>mvn:com.eclipsesource.jaxrs/features/${osgiJaxRsVersion}/xml/features</repository>
-    <feature name="opennms-amqp-event-forwarder" version="${project.version}" description="OpenNMS :: Features :: AMQP :: Event Forwarder">
+    <feature name="opennms-camel-amqp" version="${project.version}" description="OpenNMS :: Features :: AMQP :: Camel Wrapper">
+        <!-- start this early so camel-amqp doesn't use its old version -->
+        <bundle start-level="75">mvn:org.apache.qpid/proton-j/0.34.0</bundle>
         <feature>camel-core</feature>
         <feature>camel-blueprint</feature>
         <feature>camel-http</feature>
         <feature>camel-amqp</feature>
+    </feature>
+    <feature name="opennms-amqp-event-forwarder" version="${project.version}" description="OpenNMS :: Features :: AMQP :: Event Forwarder">
+        <feature>opennms-camel-amqp</feature>
         <feature version="${guavaOsgiVersion}">guava</feature>
         <feature>opennms-core-camel</feature>
         <feature>opennms-dao-api</feature>
@@ -20,10 +25,7 @@
         <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.event-forwarder/${project.version}</bundle>
     </feature>
     <feature name="opennms-amqp-event-receiver" version="${project.version}" description="OpenNMS :: Features :: AMQP :: Event Receiver">
-        <feature>camel-core</feature>
-        <feature>camel-blueprint</feature>
-        <feature>camel-http</feature>
-        <feature>camel-amqp</feature>
+        <feature>opennms-camel-amqp</feature>
         <feature version="${guavaOsgiVersion}">guava</feature>
         <feature>opennms-core-camel</feature>
         <feature>opennms-dao-api</feature>
@@ -31,10 +33,7 @@
         <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.event-receiver/${project.version}</bundle>
     </feature>
     <feature name="opennms-amqp-alarm-northbounder" version="${project.version}" description="OpenNMS :: Features :: AMQP :: Alarm Northbounder">
-        <feature>camel-core</feature>
-        <feature>camel-blueprint</feature>
-        <feature>camel-http</feature>
-        <feature>camel-amqp</feature>
+        <feature>opennms-camel-amqp</feature>
         <feature>opennms-core-camel</feature>
         <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.alarm-northbounder/${project.version}</bundle>

--- a/container/karaf/src/main/filtered-resources/etc/overrides.properties
+++ b/container/karaf/src/main/filtered-resources/etc/overrides.properties
@@ -5,3 +5,4 @@ mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}
 mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
+mvn:org.apache.qpid/proton-j/0.34.0

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -5,3 +5,4 @@ mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}
 mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}
 mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}
+mvn:org.apache.qpid/proton-j/0.34.0

--- a/opennms-full-assembly/src/assembly/components/osgi.xml
+++ b/opennms-full-assembly/src/assembly/components/osgi.xml
@@ -8,6 +8,10 @@
       <filtered>false</filtered>
       <outputDirectory>system</outputDirectory>
       <directory>target/opennms-repo</directory>
+      <excludes>
+        <exclude>**/proton-j/0.14.0</exclude>
+        <exclude>**/proton-j/0.14.0/*</exclude>
+      </excludes>
     </fileSet>
   </fileSets>
 </component>


### PR DESCRIPTION
This PR bumps proton-j to the latest 0.x version.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15202
