### PR TITLE
NMS-15205: update xmlgraphics-commons and fix fop dependencies

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -47,23 +47,23 @@
         <bundle>wrap:mvn:com.atomikos/transactions-jdbc/${atomikosVersion}</bundle>
     </feature>
     <feature name="batik" version="${batikVersion}" description="Apache :: XML Graphics :: Batik">
-        <bundle>wrap:mvn:xalan/xalan/${xalanVersion}</bundle>
-        <bundle>wrap:mvn:xalan/serializer/${xalanVersion}</bundle>
-        <bundle>wrap:mvn:xml-apis/xml-apis-ext/1.3.04</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-anim/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-awt-util/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-bridge/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-css/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-dom/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-ext/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-gvt/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-parser/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-script/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svggen/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svg-dom/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-transcoder/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-util/${batikVersion}</bundle>
-        <bundle>wrap:mvn:org.apache.xmlgraphics/batik-xml/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:xalan/xalan/${xalanVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:xalan/serializer/${xalanVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:xml-apis/xml-apis-ext/1.3.04</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-anim/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-awt-util/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-bridge/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-css/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-dom/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-ext/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-gvt/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-parser/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-script/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-svggen/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-svg-dom/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-transcoder/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-util/${batikVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-xml/${batikVersion}</bundle>
     </feature>
     <feature name="bcprov" version="${bouncyCastleVersion}" description="Legion of the Bouncy Castle :: Java Cryptography APIs">
         <bundle>wrap:mvn:org.bouncycastle/bcprov-jdk15on/${bouncyCastleVersion}</bundle>
@@ -139,7 +139,9 @@
         <bundle>mvn:io.dropwizard.metrics/metrics-core/${dropwizardMetricsVersion}</bundle>
     </feature>
     <feature name="fop" version="${fopVersion}" description="Apache :: XML Graphics :: FOP">
-        <bundle>wrap:mvn:org.apache.xmlgraphics/fop/${fopVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/fop/${fopVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/xmlgraphics-commons/${xmlgraphicsCommonsVersion}</bundle>
+        <feature>batik</feature>
     </feature>
     <feature name="gemini-blueprint" version="${eclipseGeminiVersion}" description="Eclipse :: Gemini Blueprint">
         <feature version="[4.2,4.3)">spring</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -1786,6 +1786,7 @@
     <xercesVersion>2.9.1</xercesVersion>
     <xmlApisVersion>99.99.99-exclude-provided-by-jdk11-and-up</xmlApisVersion>
     <xmlApisExtVersion>1.3.04</xmlApisExtVersion>
+    <xmlgraphicsCommonsVersion>2.8</xmlgraphicsCommonsVersion>
     <wsdl4jVersion>1.6.3</wsdl4jVersion>
     <wsmanVersion>1.2.3</wsmanVersion>
     <zookeeperVersion>3.4.14</zookeeperVersion>
@@ -3631,6 +3632,11 @@
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-util</artifactId>
         <version>${batikVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>xmlgraphics-commons</artifactId>
+        <version>${xmlgraphicsCommonsVersion}</version>
       </dependency>
       <dependency>
         <groupId>bsf</groupId>


### PR DESCRIPTION
This PR bumps `xmlgraphics-commons` to the latest version.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15205
