### PR TITLE
NMS-15198: bump jdom2 to 2.0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1702,6 +1702,7 @@
     <javaxAnnotationApiVersion>1.3.1</javaxAnnotationApiVersion>
     <jcifsVersion>2.1.6</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
+    <jdom2Version>2.0.6.1</jdom2Version>
     <jettyVersion>9.4.44.v20210927</jettyVersion>
     <jestVersion>5.3.4</jestVersion>
     <jestGsonVersion>2.9.1</jestGsonVersion>
@@ -4391,6 +4392,11 @@
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>${dropwizardMetricsVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jdom</groupId>
+        <artifactId>jdom2</artifactId>
+        <version>${jdom2Version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
This PR bumps jdom2 to the latest version.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15198