### PR TITLE
NMS-15201: bump protobuf to latest 3.16.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1741,7 +1741,7 @@
     <paxLoggingVersion>2.0.14</paxLoggingVersion>
     <paxSwissboxVersion>1.8.3</paxSwissboxVersion>
     <paxWebVersion>7.3.16</paxWebVersion>
-    <protobufVersion>3.16.1</protobufVersion>
+    <protobufVersion>3.16.3</protobufVersion>
     <protobuf2Version>2.6.1</protobuf2Version>
     <postgresqlVersion>42.4.3</postgresqlVersion>
     <powermockVersion>2.0.9</powermockVersion>


### PR DESCRIPTION
Not knowing how it would affect things, I only bumped to the latest 3.16.x, rather than the latest 3.x, since 3.16.3 was sufficient to avoid known CVEs.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15201
