### PR TITLE
NMS-15074: bump junit4 to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4587,7 +4587,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <version>4.13.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1728,7 +1728,7 @@
     <jsoupVersion>1.7.2</jsoupVersion>
     <jsonlibVersion>2.4</jsonlibVersion>
     <jsonlibBundleVersion>2.4_1</jsonlibBundleVersion>
-    <junitVintageEngineVersion>5.6.2</junitVintageEngineVersion>
+    <junitVintageEngineVersion>5.6.3</junitVintageEngineVersion>
     <karafVersion>4.3.2</karafVersion>
     <kafkaBundleVersion>2.8.2_1</kafkaBundleVersion>
     <kafkaVersion>2.8.0</kafkaVersion>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -361,7 +361,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>


### PR DESCRIPTION
This PR bumps our junit to the latest 4.x.
We have had problems in the past doing this, but I suspect it was because of the "vintage engine" thing I fixed in the second commit.

I have rebased to remove the commit before merging so I don't create a bunch of churn, but [the previous build](https://app.circleci.com/pipelines/github/OpenNMS/opennms/26942/workflows/2f6c25bd-46cb-4d6e-973c-f8610e94e12a) touched every single test and went green.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15074