### PR TITLE
NMS-15199: bump jettison transient feature dep to 1.4.1

### DIFF
--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -189,6 +189,8 @@
     <feature>opennms-health-rest</feature>
     <feature version="${cxfVersion}">cxf-core</feature>
     <feature version="${cxfVersion}">cxf-jaxrs</feature>
+    <!-- early start-level to override jettison version in 3rd-party feature files -->
+    <bundle start-level="30">mvn:org.codehaus.jettison/jettison/${jettisonVersion}</bundle>
     <bundle>mvn:org.opennms.features.minion/minion-rest-service/${project.version}</bundle>
   </feature>
 

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -788,6 +788,8 @@
     <feature name="tsrm-troubleticketer" version="${project.version}" description="OpenNMS :: Features :: Ticketing :: Tivoli Service Request Manager (TSRM)">
         <feature version="${cxfVersion}">cxf-jaxws</feature>
         <feature>javax.servlet</feature>
+        <!-- early start-level to override jettison version in 3rd-party feature files -->
+        <bundle start-level="30">mvn:org.codehaus.jettison/jettison/${jettisonVersion}</bundle>
         <bundle>mvn:org.opennms.features.ticketing/org.opennms.features.ticketing.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features/opennms-integration-tsrm/${project.version}</bundle>
     </feature>
@@ -816,6 +818,8 @@
         <feature>opennms-poller-monitors-core</feature>
         <feature>opennms-provisioning-api</feature>
         <feature>opennms-dao-api</feature>
+        <!-- early start-level to override jettison version in 3rd-party feature files -->
+        <bundle start-level="30">mvn:org.codehaus.jettison/jettison/${jettisonVersion}</bundle>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2/${servicemixSpecsVersion}</bundle>
         <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/${servicemixSpecsVersion}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.11.0_1</bundle>

--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -93,6 +93,7 @@
                         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1</bundle>
                         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1</bundle>
                         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1</bundle>
+                        <bundle>mvn:org.codehaus.jettison/jettison/${jettisonVersion}</bundle>
                         <bundle>mvn:org.scala-lang/scala-library/${scala11LibraryVersion}</bundle>
                     </installedBundles>
                     <libraries>

--- a/container/karaf/src/main/filtered-resources/etc/overrides.properties
+++ b/container/karaf/src/main/filtered-resources/etc/overrides.properties
@@ -9,4 +9,5 @@ mvn:org.apache.qpid/proton-j/0.34.0
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1
+mvn:org.codehaus.jettison/jettison/${jettisonVersion}
 mvn:org.scala-lang/scala-library/${scala11LibraryVersion}

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -102,13 +102,13 @@
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
                         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
 
-                        <bundle>mvn:org.scala-lang/scala-library/${scala11LibraryVersion}</bundle>
-
-                        <bundle>mvn:org.apache.felix/org.apache.felix.http.bridge/${felixBridgeVersion}</bundle>
-
                         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1</bundle>
                         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1</bundle>
                         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1</bundle>
+                        <bundle>mvn:org.codehaus.jettison/jettison/${jettisonVersion}</bundle>
+                        <bundle>mvn:org.scala-lang/scala-library/${scala11LibraryVersion}</bundle>
+
+                        <bundle>mvn:org.apache.felix/org.apache.felix.http.bridge/${felixBridgeVersion}</bundle>
                     </installedBundles>
                     <libraries>
                         <!-- OPENNMS: Add JNA bundles to prevent jline from refreshing (KARAF-5251) -->

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -9,4 +9,5 @@ mvn:org.apache.qpid/proton-j/0.34.0
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1
+mvn:org.codehaus.jettison/jettison/${jettisonVersion}
 mvn:org.scala-lang/scala-library/${scala11LibraryVersion}

--- a/features/minion/repository/src/assembly/repo.xml
+++ b/features/minion/repository/src/assembly/repo.xml
@@ -10,6 +10,10 @@
       <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <directoryMode>0755</directoryMode>
+      <excludes>
+        <exclude>**/jettison/1.3.*</exclude>
+        <exclude>**/jettison/1.3.*/*</exclude>
+      </excludes>
     </fileSet>
   </fileSets>
 </assembly>

--- a/opennms-full-assembly/src/assembly/components/osgi.xml
+++ b/opennms-full-assembly/src/assembly/components/osgi.xml
@@ -11,6 +11,8 @@
       <excludes>
         <exclude>**/*jasypt*/1.9.2_1</exclude>
         <exclude>**/*jasypt*/1.9.2_1/*</exclude>
+        <exclude>**/jettison/1.3.*</exclude>
+        <exclude>**/jettison/1.3.*/*</exclude>
         <exclude>**/proton-j/0.14.0</exclude>
         <exclude>**/proton-j/0.14.0/*</exclude>
         <exclude>**/scala-library/2.11.0</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -1705,6 +1705,7 @@
     <jbossLoggingVersion>3.5.0.Final</jbossLoggingVersion>
     <jcifsVersion>2.1.6</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
+    <jettisonVersion>1.4.1</jettisonVersion>
     <jettyVersion>9.4.44.v20210927</jettyVersion>
     <jestVersion>5.3.4</jestVersion>
     <jestGsonVersion>2.9.1</jestGsonVersion>


### PR DESCRIPTION
This PR updates jettison to 1.4.1. 1.5.3 is technically out but bumping it makes overriding things more complicated.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15199
