### PR TITLE
NMS-15204: bump velocity to 2.3

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1194,10 +1194,11 @@
     <feature name="jmxconfiggenerator" version="${project.version}" description="OpenNMS JMX Configuration Generator">
         <feature version="${guavaOsgiVersion}">guava</feature>
         <feature>commons-io</feature>
+        <feature>commons-lang3</feature>
         <bundle>mvn:org.opennms.features/jmxconfiggenerator/${project.version}</bundle>
         <bundle>wrap:mvn:args4j/args4j/${args4jVersion}</bundle>
         <bundle>wrap:mvn:org.jvnet.opendmk/jmxremote_optional/${jmxremote.optional.version}</bundle>
-        <bundle>mvn:org.apache.velocity/velocity/1.7</bundle>
+        <bundle>mvn:org.apache.velocity/velocity-engine-core/${velocityVersion}</bundle>
         <bundle>mvn:org.opennms.features/org.opennms.features.name-cutter/${project.version}</bundle>
     </feature>
     <feature name="vaadin-jmxconfiggenerator" version="${project.version}" description="OpenNMS :: Features :: JMX Config Generator :: Web UI">

--- a/container/karaf/src/main/filtered-resources/etc/custom.properties
+++ b/container/karaf/src/main/filtered-resources/etc/custom.properties
@@ -353,33 +353,25 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         org.apache.http.impl.client.cache.ehcache;version=${httpclientVersion},\
         org.apache.http.impl.client.cache.memcached;version=${httpclientVersion},\
         org.apache.http.osgi.services;version=${httpclientVersion},\
-        org.apache.velocity,\
-        org.apache.velocity.anakia,\
-        org.apache.velocity.app,\
-        org.apache.velocity.app.event,\
-        org.apache.velocity.app.event.implement,\
-        org.apache.velocity.app.tools,\
-        org.apache.velocity.context,\
-        org.apache.velocity.convert,\
-        org.apache.velocity.exception,\
-        org.apache.velocity.io,\
-        org.apache.velocity.runtime,\
-        org.apache.velocity.runtime.defaults,\
-        org.apache.velocity.runtime.directive,\
-        org.apache.velocity.runtime.log,\
-        org.apache.velocity.runtime.parser,\
-        org.apache.velocity.runtime.parser.node,\
-        org.apache.velocity.runtime.resource,\
-        org.apache.velocity.runtime.resource.loader,\
-        org.apache.velocity.runtime.resource.util,\
-        org.apache.velocity.runtime.visitor,\
-        org.apache.velocity.servlet,\
-        org.apache.velocity.texen,\
-        org.apache.velocity.texen.ant,\
-        org.apache.velocity.texen.defaults,\
-        org.apache.velocity.texen.util,\
-        org.apache.velocity.util,\
-        org.apache.velocity.util.introspection,\
+        org.apache.velocity;version=${velocityVersion},\
+        org.apache.velocity.app;version=${velocityVersion},\
+        org.apache.velocity.app.event;version=${velocityVersion},\
+        org.apache.velocity.app.event.implement;version=${velocityVersion},\
+        org.apache.velocity.context;version=${velocityVersion},\
+        org.apache.velocity.exception;version=${velocityVersion},\
+        org.apache.velocity.io;version=${velocityVersion},\
+        org.apache.velocity.runtime;version=${velocityVersion},\
+        org.apache.velocity.runtime.directive;version=${velocityVersion},\
+        org.apache.velocity.runtime.directive.contrib;version=${velocityVersion},\
+        org.apache.velocity.runtime.parser;version=${velocityVersion},\
+        org.apache.velocity.runtime.parser.node;version=${velocityVersion},\
+        org.apache.velocity.runtime.resource;version=${velocityVersion},\
+        org.apache.velocity.runtime.resource.loader;version=${velocityVersion},\
+        org.apache.velocity.runtime.resource.util;version=${velocityVersion},\
+        org.apache.velocity.runtime.visitor;version=${velocityVersion},\
+        org.apache.velocity.shaded.commons.io;version=${velocityVersion},\
+        org.apache.velocity.util;version=${velocityVersion},\
+        org.apache.velocity.util.introspection;version=${velocityVersion},\
         org.dom4j;version=${dom4jVersion},\
         org.dom4j.bean;version=${dom4jVersion},\
         org.dom4j.datatype;version=${dom4jVersion},\

--- a/dependencies/activemq/pom.xml
+++ b/dependencies/activemq/pom.xml
@@ -17,6 +17,11 @@
       <version>${activemqVersion}</version>
       <scope>compile</scope>
       <exclusions>
+        <!-- Exclude org.apache.velocity:velocity as the 2.x version is at org.apache.velocity:velocity-engine-core -->
+        <exclusion>
+          <groupId>org.apache.velocity</groupId>
+          <artifactId>velocity</artifactId>
+        </exclusion>
         <!-- Exclude all Felix, Karaf, Jetty, and Pax dependencies since they are part of the OSGi container -->
         <exclusion>
           <groupId>org.apache.aries.blueprint</groupId>
@@ -138,93 +143,10 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!--
-      This is causing problems when building the Remote Poller JNLP since it is a
-      compile dependency on an XML artifact. Exclude it for now since we cannot
-      load ActiveMQ inside Karaf right now because of Spring version conflicts
-      anyway.
-
     <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-karaf</artifactId>
-      <version>${activemqVersion}</version>
-      <type>xml</type>
-      <classifier>features</classifier>
-      <exclusions>
-        <!- - Exclude all Felix, Karaf, Jetty, and Pax dependencies since they are part of the OSGi container - ->
-        <exclusion>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>org.apache.felix.framework</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>org.apache.felix.bundlerepository</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.karaf.shell</groupId>
-          <artifactId>org.apache.karaf.shell.console</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-websocket</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.jetty.aggregate</groupId>
-          <artifactId>jetty-all</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.jetty.aggregate</groupId>
-          <artifactId>jetty-all-server</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ops4j.pax.logging</groupId>
-          <artifactId>pax-logging-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ops4j.pax.logging</groupId>
-          <artifactId>pax-logging-service</artifactId>
-        </exclusion>
-        <!- - Exclude all logging APIs since they are provided by the container - ->
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <!- - Exclude legacy Spring artifacts - ->
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-asm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-beans</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-expression</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>org.springframework.asm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>org.springframework.context</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>org.springframework.expression</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.apache.velocity</groupId>
+      <artifactId>velocity-engine-core</artifactId>
     </dependency>
-    -->
     <dependency>
       <groupId>org.opennms.dependencies</groupId>
       <artifactId>jackson1-dependencies</artifactId>

--- a/features/jmx-config-generator/pom.xml
+++ b/features/jmx-config-generator/pom.xml
@@ -14,10 +14,6 @@
     <name>OpenNMS :: Features :: JMX Config Generator</name>
     <url>http://www.opennms.org</url>
 
-    <properties>
-        <velocity.version>1.7</velocity.version>
-    </properties>
-
     <build>
         <resources>
             <resource>
@@ -93,8 +89,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-            <version>${velocity.version}</version>
+            <artifactId>velocity-engine-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/features/jmx-config-generator/src/main/filtered/features.xml
+++ b/features/jmx-config-generator/src/main/filtered/features.xml
@@ -6,7 +6,8 @@
         <bundle>mvn:org.opennms.features/jmxconfiggenerator/${project.version}</bundle>
         <bundle>wrap:mvn:args4j/args4j/${args4jVersion}</bundle>
         <bundle>wrap:mvn:org.jvnet.opendmk/jmxremote_optional/${jmxremote.optional.version}</bundle>
-        <bundle>mvn:org.apache.velocity/velocity/${velocity.version}</bundle>
+        <bundle>mvn:org.apache.velocity/velocity-engine-core/${velocityVersion}</bundle>
+        <bundle>mvn:org.slf4j/slf4j-api/${slf4jVersion}</bundle>
         <bundle>mvn:org.opennms.features/org.opennms.features.name-cutter/${project.version}</bundle>
     </feature>
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -1138,6 +1138,7 @@
                    <exclude>javax.xml.bind:jaxb-api</exclude>        <!-- use: jaxb-dependencies -->
                    <exclude>jdom:jdom</exclude>                      <!-- use: org.apache.servicemix.bundles.jdom -->
                    <exclude>log4j:log4j</exclude>                    <!-- use: log4j2 -->
+                   <exclude>org.apache.velocity:velocity</exclude>   <!-- use: org.apache.velocity:velocity-engine-core -->
                    <exclude>org.springframework:*</exclude>          <!-- use: org.apache.servicemix.bundles.spring-* -->
                  </excludes>
                </bannedDependencies>
@@ -1646,7 +1647,7 @@
     <commonsJxpathVersion>1.3</commonsJxpathVersion>
     <commonsIoVersion>2.8.0</commonsIoVersion>
     <commonsLangVersion>2.6</commonsLangVersion>
-    <commonsLang3Version>3.4</commonsLang3Version>
+    <commonsLang3Version>3.12.0</commonsLang3Version>
     <commonsMath3Version>3.5</commonsMath3Version>
     <commonsNetVersion>3.9.0</commonsNetVersion>
     <commonsValidatorVersion>1.6</commonsValidatorVersion>
@@ -1788,6 +1789,7 @@
     <tape2Version>2.0.0-beta1</tape2Version>
     <trackerVersion>0.7</trackerVersion>
     <twitter4jVersion>3.0.6</twitter4jVersion>
+    <velocityVersion>2.3</velocityVersion>
     <xalanVersion>2.7.2</xalanVersion>
     <xercesVersion>2.9.1</xercesVersion>
     <xmlApisVersion>99.99.99-exclude-provided-by-jdk11-and-up</xmlApisVersion>
@@ -4941,6 +4943,11 @@
         <groupId>com.ximpleware</groupId>
         <artifactId>vtd-xml</artifactId>
         <version>2.11</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.velocity</groupId>
+        <artifactId>velocity-engine-core</artifactId>
+        <version>${velocityVersion}</version>
       </dependency>
       <dependency>
         <groupId>wsdl4j</groupId>

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019-2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -150,7 +150,7 @@ public class OpenNMSContainer extends GenericContainer implements KarafContainer
                 .mapToInt(Map.Entry::getValue)
                 .toArray();
 
-        String javaOpts = "-Xms2048m -Xmx2048m -Djava.security.egd=file:/dev/./urandom -javaagent:/opt/opennms/agent/jacoco-agent.jar=output=none,jmx=true";
+        String javaOpts = "-Xms2048m -Xmx2048m -Djava.security.egd=file:/dev/./urandom -javaagent:/opt/opennms/agent/jacoco-agent.jar=output=none,jmx=true,excludes=org.drools.*";
         if (profile.isJvmDebuggingEnabled()) {
             javaOpts += String.format("-agentlib:jdwp=transport=dt_socket,server=y,address=*:%d,suspend=n", OPENNMS_DEBUG_PORT);
         }


### PR DESCRIPTION
This PR bumps our embedded Velocity template engine to 2.3.

2.x is technically incompatible with 1.x, but the JMX config generator builds fine with 2.3.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15204
