### PR TITLE
NMS-15317: bump kafka to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1728,8 +1728,8 @@
     <jsonlibBundleVersion>2.4_1</jsonlibBundleVersion>
     <junitVintageEngineVersion>5.6.2</junitVintageEngineVersion>
     <karafVersion>4.3.6</karafVersion>
-    <kafkaBundleVersion>3.2.0_1</kafkaBundleVersion>
-    <kafkaVersion>3.2.0</kafkaVersion>
+    <kafkaBundleVersion>3.3.1_1</kafkaBundleVersion>
+    <kafkaVersion>3.3.1</kafkaVersion>
     <kotlinVersion>1.4.10</kotlinVersion>
     <liquibaseVersion>3.6.3</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>


### PR DESCRIPTION
This PR bumps the Kafka version to 3.3 to resolve an [issue with rebalancing](https://issues.apache.org/jira/browse/KAFKA-14024).

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15317
