### PR TITLE
NMS-15326: do not refresh bundles when features get installed

### DIFF
--- a/container/extender/pom.xml
+++ b/container/extender/pom.xml
@@ -60,5 +60,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.core.health</groupId>
+            <artifactId>org.opennms.core.health.api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/container/extender/src/main/java/org/opennms/karaf/extender/KarafExtender.java
+++ b/container/extender/src/main/java/org/opennms/karaf/extender/KarafExtender.java
@@ -54,11 +54,15 @@ import java.util.stream.Collectors;
 import org.apache.karaf.features.FeaturesService;
 import org.apache.karaf.features.FeaturesService.Option;
 import org.apache.karaf.kar.KarService;
+import org.opennms.core.health.api.DefaultPassiveHealthCheck;
+import org.opennms.core.health.api.Response;
+import org.opennms.core.health.api.Status;
 import org.ops4j.pax.url.mvn.MavenResolver;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 
 import com.google.common.collect.Lists;
 
@@ -87,21 +91,26 @@ public class KarafExtender {
     private MavenResolver m_mavenResolver;
     private FeaturesService m_featuresService;
     private KarService m_karService;
+    private DefaultPassiveHealthCheck m_defaultPassiveHealthCheck;
 
     private Thread m_installThread;
     private Thread m_karDependencyInstallThread;
+    private ExtenderStatus m_extenderStatus = new ExtenderStatus();
 
     public void init() throws InterruptedException {
         Objects.requireNonNull(m_configurationAdmin, "configurationAdmin");
         Objects.requireNonNull(m_mavenResolver, "mavenResolver");
         Objects.requireNonNull(m_featuresService, "featuresService");
         Objects.requireNonNull(m_karService, "karService");
+        Objects.requireNonNull(m_defaultPassiveHealthCheck, "healthCheckResponseCache");
+
+        m_defaultPassiveHealthCheck.setResponse(new Response(Status.Starting), false);
 
         List<Repository> repositories;
         try {
             repositories = getRepositories();
         } catch (IOException e) {
-            LOG.error("Failed to retrieve the list of repositories. Aborting.", e);
+            m_extenderStatus.error("Failed to retrieve the list of repositories. Aborting", e);
             return;
         }
 
@@ -112,7 +121,7 @@ public class KarafExtender {
         try {
             featuresBoot.addAll(getFeaturesBoot());
         } catch (IOException e) {
-            LOG.error("Failed to retrieve the list of features to boot. Aborting.", e);
+            m_extenderStatus.error("Failed to retrieve the list of features to boot. Aborting", e);
             return;
         }
 
@@ -143,7 +152,7 @@ public class KarafExtender {
                     config.update(props);
                 }
             } catch (IOException e) {
-                LOG.error("Failed to update the list of Maven repositories to '{}'. Aborting.",
+                m_extenderStatus.error("Failed to update the list of Maven repositories to '{}'. Aborting",
                         mavenRepos, e);
                 return;
             }
@@ -164,7 +173,7 @@ public class KarafExtender {
                         LOG.info("Adding feature repository: {}", featureUri);
                         m_featuresService.addRepository(featureUri);
                     } catch (Exception e) {
-                        LOG.error("Failed to add feature repository '{}'. Skipping.", featureUri, e);
+                        m_extenderStatus.error("Failed to add feature repository '{}'. Skipping", featureUri, e);
                     }
                 }
             }
@@ -190,14 +199,16 @@ public class KarafExtender {
                 try {
                     LOG.info("Installing features: {}", featuresToInstall);
                     m_featuresService.installFeatures(featuresToInstall, EnumSet.noneOf(Option.class));
+                    m_extenderStatus.featuresDone(String.format("%s non-KAR features installed", featuresToInstall.size()));
                 } catch (Exception e) {
-                    LOG.error("Failed to install one or more features.", e);
+                    m_extenderStatus.error("Failed to install one or more features", e);
                 }
             });
             m_installThread.setName("Karaf-Extender-Feature-Install");
             m_installThread.start();
         } else {
             LOG.debug("No features to install.");
+            m_extenderStatus.featuresDone("");
         }
 
 
@@ -206,12 +217,13 @@ public class KarafExtender {
                 .collect(Collectors.toList());
         if (!featuresWithKarDependencies.isEmpty()) {
             final KarDependencyHandler karDependencyHandler = new KarDependencyHandler(featuresWithKarDependencies,
-                    m_karService, m_featuresService);
+                    m_karService, m_featuresService, m_extenderStatus);
             m_karDependencyInstallThread = new Thread(karDependencyHandler);
             m_karDependencyInstallThread.setName("Karaf-Extender-Feature-Install-For-Kars");
             m_karDependencyInstallThread.start();
         } else {
             LOG.debug("No features with dependencies on .kar files to install.");
+            m_extenderStatus.karsDone("");
         }
     }
 
@@ -262,7 +274,7 @@ public class KarafExtender {
                 }
                 repositories.add(new Repository(repositoryPath, featureUris, featuresBoot));
             } catch (URISyntaxException e) {
-                LOG.error("Failed to generate one or more feature URIs for repository {}. Skipping.",
+                m_extenderStatus.error("Failed to generate one or more feature URIs for repository {}. Skipping",
                         repositoryPath, e);
             }
         }
@@ -415,4 +427,67 @@ public class KarafExtender {
         m_karService = karService;
     }
 
+    public void setDefaultPassiveHealthCheck(DefaultPassiveHealthCheck defaultPassiveHealthCheck) {
+        m_defaultPassiveHealthCheck = defaultPassiveHealthCheck;
+    }
+
+    public class ExtenderStatus {
+        private String featuresToInstallDone = null;
+        private String karDependencyInstallDone = null;
+
+        public void info(String messagePattern, Object... argArray) {
+            LOG.info(messagePattern, argArray);
+            setResponse(Status.Starting, messagePattern, argArray);
+        }
+
+        public void warn(String messagePattern, Object... argArray) {
+            LOG.warn(messagePattern, argArray);
+            setResponse(Status.Starting, messagePattern, argArray);
+        }
+
+        public void error(String messagePattern, Object... argArray) {
+            LOG.error(messagePattern, argArray);
+            setResponse(Status.Failure, messagePattern, argArray);
+        }
+
+        private void setResponse(Status status, String messagePattern, Object[] argArray) {
+            var formattingTuple = MessageFormatter.arrayFormat(messagePattern, argArray);
+            var failureMessage = new StringBuffer(formattingTuple.getMessage());
+            var throwable = formattingTuple.getThrowable();
+            if (throwable != null) {
+                failureMessage.append(": ");
+                failureMessage.append(throwable.getMessage());
+            }
+            m_defaultPassiveHealthCheck.setResponse(new Response(status, failureMessage.toString()), false);
+        }
+
+        public void featuresDone(String message) {
+            featuresToInstallDone = Objects.requireNonNull(message);
+            areWeCompletelyDone();
+        }
+
+        public void karsDone(String message) {
+            karDependencyInstallDone = Objects.requireNonNull(message);
+            areWeCompletelyDone();
+        }
+
+        private void areWeCompletelyDone() {
+            if (featuresToInstallDone != null && karDependencyInstallDone != null) {
+                StringBuffer message = new StringBuffer();
+                if (!featuresToInstallDone.isEmpty()) {
+                    message.append(featuresToInstallDone);
+                    message.append(". ");
+                }
+                if (!karDependencyInstallDone.isEmpty()) {
+                    message.append(karDependencyInstallDone);
+                    message.append(". ");
+                }
+                if (message.length() > 0) {
+                    m_defaultPassiveHealthCheck.setResponse(new Response(Status.Success, message.toString()), false);
+                } else {
+                    m_defaultPassiveHealthCheck.setResponse(new Response(Status.Success), false);
+                }
+            }
+        }
+    }
 }

--- a/container/extender/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/container/extender/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,10 +10,32 @@
     <reference id="featuresService" interface="org.apache.karaf.features.FeaturesService"/>
     <reference id="karService" interface="org.apache.karaf.kar.KarService"/>
 
+    <bean id="karafExtenderHealthCheck" class="org.opennms.core.health.api.DefaultPassiveHealthCheck">
+        <argument value="Karaf extender"/>
+        <argument>
+            <list>
+                <value>local</value>
+                <value>passive</value>
+            </list>
+        </argument>
+        <argument value="Unknown"/>
+    </bean>
+
     <bean id="controller" class="org.opennms.karaf.extender.KarafExtender" init-method="init" destroy-method="destroy">
         <property name="configurationAdmin" ref="configurationAdmin" />
         <property name="mavenResolver" ref="mavenResolver" />
         <property name="featuresService" ref="featuresService" />
         <property name="karService" ref="karService" />
+        <property name="defaultPassiveHealthCheck" ref="karafExtenderHealthCheck" />
     </bean>
+
+    <service ref="karafExtenderHealthCheck">
+        <interfaces>
+            <value>org.opennms.core.health.api.HealthCheck</value>
+            <value>org.opennms.core.health.api.HealthCheckResponseCache</value>
+        </interfaces>
+        <service-properties>
+            <entry key="alias" value="opennms.karafExtenderHealthCheck"/>
+        </service-properties>
+    </service>
 </blueprint>

--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -24,6 +24,10 @@
         <bundle dependency="true">mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}</bundle>
     </feature>
 
+    <feature name="commons-lang3" version="${commonsLang3Version}" description="Apache :: commons-lang3">
+        <bundle>mvn:org.apache.commons/commons-lang3/${commonsLang3Version}</bundle>
+    </feature>
+
     <feature name="guava" version="${guavaOsgiVersion}" description="Google :: Guava">
         <feature prerequisite="true">wrap</feature>
         <bundle start-level="30" dependency="true">mvn:com.google.guava/guava/${guavaVersion}</bundle>
@@ -91,5 +95,11 @@
         <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/1.70</bundle>
         <bundle start-level="30">mvn:org.bouncycastle/bcpkix-jdk15on/1.70</bundle>
         <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.ssh/${karafVersion}</bundle>
+    </feature>
+
+    <feature name="health-api" version="${project.version}" description="Health API">
+        <feature version="${commonsLang3Version}">commons-lang3</feature>
+        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
+        <bundle dependency="true">mvn:io.vavr/vavr/0.10.0</bundle>
     </feature>
 </features>

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -189,9 +189,7 @@
     </feature>
 
     <feature name="minion-health-check" version="${project.version}" description="Minion :: Health Check">
-        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
-        <bundle dependency="true">mvn:io.vavr/vavr/0.10.0</bundle>
-        <feature>commons-lang3</feature>
+        <feature>health-api</feature>
         <bundle>mvn:org.opennms.features.minion/health-check/${project.version}</bundle>
     </feature>
 

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -131,9 +131,7 @@
     <feature name="commons-lang" version="${commonsLangVersion}" description="Apache :: commons-lang">
         <bundle>mvn:commons-lang/commons-lang/${commonsLangVersion}</bundle>
     </feature>
-    <feature name="commons-lang3" version="${commonsLang3Version}" description="Apache :: commons-lang3">
-        <bundle>mvn:org.apache.commons/commons-lang3/${commonsLang3Version}</bundle>
-    </feature>
+    <!-- commons-lang3 is in features-core.xml -->
     <feature name="commons-net" version="${commonsNetVersion}" description="Apache :: commons-net">
         <bundle>mvn:commons-net/commons-net/${commonsNetVersion}</bundle>
     </feature>

--- a/container/features/src/main/resources/karaf-extensions.xml
+++ b/container/features/src/main/resources/karaf-extensions.xml
@@ -4,6 +4,7 @@
 
     <feature name="karaf-extender" description="Karaf Extender" version="${project.version}">
         <feature version="${guavaOsgiVersion}" prerequisite="true">guava</feature>
+        <feature version="${project.version}">health-api</feature>
         <bundle>mvn:org.opennms.container/extender/${project.version}</bundle>
     </feature>
 </features>

--- a/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -150,6 +150,11 @@ featuresBoot = ( \
 featuresBootAsynchronous=false
 
 #
+# Define if the feature service automatically refreshes bundles
+#
+autoRefresh=false
+
+#
 # Service requirements enforcement
 #
 # By default, the feature resolver checks the service requirements/capabilities of

--- a/container/shared/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/container/shared/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -77,6 +77,11 @@ featuresBoot = \
 featuresBootAsynchronous=false
 
 #
+# Define if the feature service automatically refreshes bundles
+#
+autoRefresh=false
+
+#
 # Service requirements enforcement
 #
 # By default, the feature resolver checks the service requirements/capabilities of

--- a/core/soa/src/main/java/org/opennms/core/soa/lookup/BlockingServiceLookup.java
+++ b/core/soa/src/main/java/org/opennms/core/soa/lookup/BlockingServiceLookup.java
@@ -71,7 +71,7 @@ public class BlockingServiceLookup<C, F> implements ServiceLookup<C, F> {
             try {
                 Thread.sleep(this.lookupDelayMs);
             } catch (InterruptedException e) {
-                LOG.error("Interrupted while waiting for service with search criteria " + criteria + " to become available in the service registry. Aborting.");
+                LOG.error("Interrupted while waiting for service with search criteria '{}' to become available in the service registry. Aborting.", criteria);
                 return null;
             }
             service = delegate.lookup(criteria, filter);
@@ -81,6 +81,7 @@ public class BlockingServiceLookup<C, F> implements ServiceLookup<C, F> {
         }
 
         // Couldn't find a service within the defined time
+        LOG.error("Timed out while waiting for service with search criteria '{}' to become available in the service registry. Aborting.", criteria);
         return null;
     }
 

--- a/core/soa/src/main/java/org/opennms/core/soa/lookup/ServiceLookupBuilder.java
+++ b/core/soa/src/main/java/org/opennms/core/soa/lookup/ServiceLookupBuilder.java
@@ -39,7 +39,7 @@ public class ServiceLookupBuilder<C, F> {
 
 public static final long GRACE_PERIOD_MS = SystemProperties.getLong("org.opennms.core.soa.lookup.gracePeriodMs", TimeUnit.MINUTES.toMillis(5));
 
-    public static final long WAIT_PERIOD_MS = SystemProperties.getLong("org.opennms.core.soa.lookup.gracePeriodMs", TimeUnit.MINUTES.toMillis(1));
+    public static final long WAIT_PERIOD_MS = SystemProperties.getLong("org.opennms.core.soa.lookup.waitPeriodMs", TimeUnit.MINUTES.toMillis(1));
 
     public static final long LOOKUP_DELAY_MS = SystemProperties.getLong("org.opennms.core.soa.lookup.lookupDelayMs", TimeUnit.SECONDS.toMillis(5));
 
@@ -54,7 +54,7 @@ public static final long GRACE_PERIOD_MS = SystemProperties.getLong("org.opennms
     }
 
     public ServiceLookupBuilder blocking() {
-        return blocking(GRACE_PERIOD_MS, LOOKUP_DELAY_MS, GRACE_PERIOD_MS);
+        return blocking(GRACE_PERIOD_MS, LOOKUP_DELAY_MS, WAIT_PERIOD_MS);
     }
 
     public ServiceLookupBuilder blocking(long gracePeriodInMs, long sleepTimeInMs, long waitTimeMs) {

--- a/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -75,6 +75,11 @@ featuresBoot = \
 featuresBootAsynchronous=false
 
 #
+# Define if the feature service automatically refreshes bundles
+#
+autoRefresh=false
+
+#
 # Service requirements enforcement
 #
 # By default, the feature resolver checks the service requirements/capabilities of

--- a/features/minion/runInPlace.sh
+++ b/features/minion/runInPlace.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-set -e
 
-test -d repository || (echo "This command must be ran from the features/minion directory" && exit 1)
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "${MYDIR}"
+test -d repository || (echo "No 'repository' directory in $(pwd) -- are we in the right place (which is container/minion if you are curious)?" && exit 1)
 
 # Inclue the bundled Maven in the $PATH
-MYDIR=$(dirname "$0")
-MYDIR=$(cd "$MYDIR"; pwd)
 PATH="$MYDIR/../..:$MYDIR/../../bin:$MYDIR/../../maven/bin:$PATH"
 CONTAINERDIR="${MYDIR}/../container/minion"
 JAVA_OPTS="-Xmx2g"
@@ -190,9 +192,12 @@ NUM_INSTANCES=1
 DETACHED=0
 SUDO=0
 
-while [ "$1" != "" ]; do
+while [ $# -gt 0 ]; do
     case $1 in
         -n | --num-instances )  shift
+                                if [ $# -lt 1 ] ; then
+                                    echo "Must specify argument to -n | --num-instances"; exit 1
+                                fi
                                 NUM_INSTANCES=$1
                                 ;;
         -d | --detached )       DETACHED=1

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/KarafContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/KarafContainer.java
@@ -32,9 +32,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 import org.opennms.smoketest.utils.KarafShell;
 import org.opennms.smoketest.utils.SshClient;
+import org.opennms.smoketest.utils.TestContainerUtils;
 import org.testcontainers.containers.Container;
 import org.testcontainers.utility.MountableFile;
 
@@ -107,5 +109,22 @@ public interface KarafContainer<T extends KarafContainer<T>> extends Container<T
         // Note that the feature name doesn't always match the KAR name
         assertTrue(karafShell.runCommandOnce("feature:install " + feature,
                 output -> !output.toLowerCase().contains("error"), false));
+    }
+
+    default void assertNoKarafDestroy(Path karafLogFile) {
+        final var karafLogs = TestContainerUtils.getFileFromContainerAsString(this, karafLogFile);
+        final var lines = karafLogs.split("[\r\n]+");
+
+        final var regex = Pattern.compile("Destroying container");
+        final var matches = new StringBuffer();
+        for (final var line : lines) {
+            if (regex.matcher(line).find()) {
+                matches.append(line + "\n");
+            }
+        }
+
+        if (matches.length() > 0) {
+            throw new AssertionError("Found 'Destroying container' messages in karaf.log:\n" + matches);
+        }
     }
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -372,7 +372,6 @@ public class MinionContainer extends GenericContainer<MinionContainer> implement
         Path targetLogFolder = Paths.get("target", "logs", prefix, "minion");
         DevDebugUtils.clearLogs(targetLogFolder);
 
-        LOG.info("Gathering thread dump...");
         var threadDump = DevDebugUtils.gatherThreadDump(this, targetLogFolder, null);
 
         LOG.info("Gathering logs...");

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -356,6 +356,8 @@ public class MinionContainer extends GenericContainer<MinionContainer> implement
                     .ignoreExceptionsMatching((e) -> { return e.getCause() != null && e.getCause() instanceof SocketException; })
                     .until(client::getProbeHealthResponse, containsString(client.getProbeSuccessMessage()));
             LOG.info("Health check passed.");
+
+            container.assertNoKarafDestroy(Paths.get("/opt", ALIAS, "data", "log", "karaf.log"));
         }
     }
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -213,9 +213,18 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
                 .withNetwork(Network.SHARED)
                 .withNetworkAliases(ALIAS)
                 .withCommand(containerCommand)
-                .waitingFor(Objects.requireNonNull(profile.getWaitStrategy()).apply(this))
-                .addFileSystemBind(overlay.toString(),
+                .waitingFor(Objects.requireNonNull(profile.getWaitStrategy()).apply(this));
+
+        addFileSystemBind(overlay.toString(),
                         "/opt/opennms-overlay", BindMode.READ_ONLY, SelinuxContext.SINGLE);
+
+        for (var installFeature : profile.getInstallFeatures().entrySet()) {
+            if (installFeature.getValue() != null) {
+                addFileSystemBind(installFeature.getValue().toString(),
+                        "/opt/opennms/deploy/" + installFeature.getValue().getFileName(),
+                        BindMode.READ_ONLY, SelinuxContext.SINGLE);
+            }
+        }
 
         // Help make development/debugging easier
         DevDebugUtils.setupMavenRepoBind(this, "/root/.m2/repository");
@@ -397,6 +406,11 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
 
     public List<String> getFeaturesOnBoot() {
         final List<String> featuresOnBoot = new ArrayList<>();
+
+        for (var installFeature : profile.getInstallFeatures().entrySet()) {
+            featuresOnBoot.add(installFeature.getKey());
+        }
+
         if(IpcStrategy.GRPC.equals(model.getIpcStrategy())) {
             featuresOnBoot.add("opennms-core-ipc-grpc-server");
         }

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -33,7 +33,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.opennms.smoketest.utils.KarafShellUtils.awaitHealthCheckSucceeded;
 import static org.opennms.smoketest.utils.OverlayUtils.writeFeaturesBoot;
 import static org.opennms.smoketest.utils.OverlayUtils.writeProps;
 
@@ -67,6 +66,7 @@ import org.opennms.smoketest.utils.DevDebugUtils;
 import org.opennms.smoketest.utils.KarafShellUtils;
 import org.opennms.smoketest.utils.OverlayUtils;
 import org.opennms.smoketest.utils.RestClient;
+import org.opennms.smoketest.utils.RestHealthClient;
 import org.opennms.smoketest.utils.SshClient;
 import org.opennms.smoketest.utils.TestContainerUtils;
 import org.slf4j.Logger;
@@ -339,6 +339,10 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
         }
     }
 
+    public URL getWebUrl() {
+        return getBaseUrlExternal();
+    }
+
     public RestClient getRestClient() {
         try {
             return new RestClient(new URL(getBaseUrlExternal() + "opennms"));
@@ -540,7 +544,13 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
             // Defer the health-check until the system has completely started
             // in order to give all the health checks a chance to load.
             LOG.info("Waiting for OpenNMS health check...");
-            awaitHealthCheckSucceeded(container);
+            RestHealthClient client = new RestHealthClient(container.getWebUrl(), Optional.of(ALIAS));
+            await("waiting for good health check probe")
+                    .atMost(5, MINUTES)
+                    .pollInterval(10, SECONDS)
+                    .failFast("container is no longer running", () -> !container.isRunning())
+                    .ignoreExceptionsMatching((e) -> { return e.getCause() != null && e.getCause() instanceof SocketException; })
+                    .until(client::getProbeHealthResponse, containsString(client.getProbeSuccessMessage()));
             LOG.info("Health check passed.");
 
             container.assertNoKarafDestroy(Paths.get("/opt", ALIAS, "logs", "karaf.log"));

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -537,15 +537,11 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
                             containsString("Starter: Startup complete"));
             LOG.info("OpenNMS has started.");
 
-            // Defer the health-check (if we do run it) until the system has completely started
+            // Defer the health-check until the system has completely started
             // in order to give all the health checks a chance to load.
-            // Only wait for the health-check if Elasticsearch is enabled, since it's
-            // currently required to pass.
-            if (container.getModel().isElasticsearchEnabled()) {
-                LOG.info("Waiting for OpenNMS health check...");
-                awaitHealthCheckSucceeded(container);
-                LOG.info("Health check passed.");
-            }
+            LOG.info("Waiting for OpenNMS health check...");
+            awaitHealthCheckSucceeded(container);
+            LOG.info("Health check passed.");
 
             container.assertNoKarafDestroy(Paths.get("/opt", ALIAS, "logs", "karaf.log"));
         }

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -532,7 +532,10 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
                 awaitHealthCheckSucceeded(container);
                 LOG.info("Health check passed.");
             }
+
+            container.assertNoKarafDestroy(Paths.get("/opt", ALIAS, "logs", "karaf.log"));
         }
+
     }
 
     public int getGeneratedUserId() {

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -594,8 +594,7 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
         DevDebugUtils.clearLogs(targetLogFolder);
 
         LOG.info("Gathering thread dump...");
-        final var threadDump = DevDebugUtils.gatherThreadDump(this,
-                targetLogFolder, CONTAINER_LOG_DIR.resolve("output.log"));
+        final var threadDump = DevDebugUtils.gatherThreadDump(this, targetLogFolder, null);
 
         LOG.info("Gathering logs...");
         DevDebugUtils.copyLogs(this,

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -139,7 +139,7 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
     private final OpenNMSProfile profile;
     private final Path overlay;
     private int generatedUserId = -1;
-    private boolean afterTestCalled = false;
+    private Exception afterTestCalled = null;
     private Exception waitUntilReadyException = null;
 
     public OpenNMSContainer(StackModel model, OpenNMSProfile profile) {
@@ -564,11 +564,13 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
 
     @Override
     public void afterTest(final TestDescription description, final Optional<Throwable> throwable) {
-        if (afterTestCalled) {
-            LOG.warn("afterTest has already been called, not running on subsequent calls");
+        var pid = ProcessHandle.current().pid();
+        if (afterTestCalled != null) {
+            LOG.warn("afterTest has already been called, not running on subsequent calls. My PID {}.", pid, new Exception("exception placeholder for stacktrace -- subsequent call location of afterTest"));
+            LOG.warn("original call location of afterTest", afterTestCalled);
             return;
         }
-        afterTestCalled = true;
+        afterTestCalled = new Exception("exception placeholder for stacktrace -- original call location of afterTest; PID: " + pid);
         if (COLLECT_COVERAGE) {
             KarafShellUtils.saveCoverage(this, description.getFilesystemFriendlyName(), ALIAS);
         }

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -596,7 +596,6 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
         Path targetLogFolder = Paths.get("target", "logs", prefix, ALIAS);
         DevDebugUtils.clearLogs(targetLogFolder);
 
-        LOG.info("Gathering thread dump...");
         final var threadDump = DevDebugUtils.gatherThreadDump(this, targetLogFolder, null);
 
         LOG.info("Gathering logs...");

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -586,6 +586,7 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
                 "manager.log",
                 "poller.log",
                 "provisiond.log",
+                "telemetryd.log",
                 "trapd.log",
                 "web.log"
         );

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -352,7 +352,6 @@ public class SentinelContainer extends GenericContainer<SentinelContainer> imple
         Path targetLogFolder = Paths.get("target", "logs", prefix, ALIAS);
         DevDebugUtils.clearLogs(targetLogFolder);
 
-        LOG.info("Gathering thread dump...");
         var threadDump = DevDebugUtils.gatherThreadDump(this, targetLogFolder, null);
 
         LOG.info("Gathering logs...");

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -336,6 +336,8 @@ public class SentinelContainer extends GenericContainer<SentinelContainer> imple
                     .ignoreExceptionsMatching((e) -> { return e.getCause() != null && e.getCause() instanceof SocketException; })
                     .until(client::getProbeHealthResponse, containsString(client.getProbeSuccessMessage()));
             LOG.info("Health check passed.");
+
+            container.assertNoKarafDestroy(Paths.get("/opt", ALIAS, "data", "log", "karaf.log"));
         }
     }
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSProfile.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSProfile.java
@@ -179,10 +179,10 @@ public class OpenNMSProfile {
         public Builder withInstallFeature(final String feature) {
             return withInstallFeature(feature, null, null);
         }
-        public Builder withInstallFeature(final String feature, final Path karFile) {
-            return withInstallFeature(feature, karFile, null);
+        public Builder withInstallFeature(final String feature, final String waitForKar) {
+            return withInstallFeature(feature, waitForKar, null);
         }
-        public Builder withInstallFeature(final String feature, final Path karFile, final String waitForKar) {
+        public Builder withInstallFeature(final String feature, final String waitForKar, final Path karFile) {
             if (waitForKar != null) {
                 installFeatures.put(String.format("%s wait-for-kar=%s", feature, waitForKar), karFile);
             } else {

--- a/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSStack.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSStack.java
@@ -31,6 +31,7 @@ package org.opennms.smoketest.stacks;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
@@ -68,11 +69,7 @@ public final class OpenNMSStack implements TestRule {
      */
     public static final OpenNMSStack NONE = new OpenNMSStack();
 
-	public static final OpenNMSStack MINIMAL = OpenNMSStack.withModel(StackModel.newBuilder()
-			.withOpenNMS(OpenNMSProfile.newBuilder()
-					.withFile("empty-discovery-configuration.xml", "etc/discovery-configuration.xml")
-					.build())
-			.build());
+	public static final OpenNMSStack MINIMAL = minimal();
 
 	public static final OpenNMSStack MINIMAL_WITH_DEFAULT_LOCALHOST = OpenNMSStack.withModel(StackModel.newBuilder().build());
 
@@ -114,6 +111,20 @@ public final class OpenNMSStack implements TestRule {
     private final List<MinionContainer> minionContainers;
 
     private final List<SentinelContainer> sentinelContainers;
+
+    public static OpenNMSStack minimal(Consumer<OpenNMSProfile.Builder>... with) {
+        var builder = OpenNMSProfile.newBuilder();
+
+        builder.withFile("empty-discovery-configuration.xml", "etc/discovery-configuration.xml");
+
+        for (var w : with) {
+            w.accept(builder);
+        }
+
+        return OpenNMSStack.withModel(StackModel.newBuilder()
+                .withOpenNMS(builder.build())
+                .build());
+    }
 
     /**
      * Create an empty OpenNMS stack for testing with locally-installed components outside of Docker.

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/DevDebugUtils.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/DevDebugUtils.java
@@ -133,6 +133,8 @@ public class DevDebugUtils {
      * @return path to thread dump file if one was stored, null otherwise.
      */
     public static Path gatherThreadDump(Container container, Path targetLogFolder, Path outputLog) {
+        LOG.info("Gathering thread dump...");
+
         if (!container.isRunning()) {
             LOG.warn("gatherThreadDump can only be used on a running container. Container [{}] is not running",
                     container.getDockerImageName());

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/DevDebugUtils.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/DevDebugUtils.java
@@ -139,12 +139,21 @@ public class DevDebugUtils {
             return null;
         }
 
+        LOG.info("kill -3 -1 ...");
         try {
-            LIMITER.callWithTimeout(() -> {
-                LOG.info("kill -3 -1");
-                container.execInContainer("kill", "-3", "1");
-                return null;
-            }, 1, TimeUnit.MINUTES);
+            // We've been having tests hang, and I suspect it's in this code.
+            // The LIMITER interrupts the thread running the callable, but I
+            // suspect the command isn't reacting to the interrupt.
+            await("send kill to process in container")
+                    .atMost(Duration.ofSeconds(65))
+                    .untilAsserted(
+                        () ->
+                            LIMITER.callWithTimeout(() -> {
+                                LOG.info("kill -3 -1");
+                                container.execInContainer("kill", "-3", "1");
+                                return null;
+                            }, 1, TimeUnit.MINUTES)
+                    );
         } catch (Exception e) {
             LOG.warn("Sending SIGQUIT to JVM in container failed. Thread dump may not be available.", e);
         }
@@ -156,6 +165,7 @@ public class DevDebugUtils {
             threadDumpCallable = container::getLogs;
         }
 
+        LOG.info("waiting for thread dump to complete ...");
         try {
             await("waiting for thread dump to complete")
                     .atMost(Duration.ofSeconds(5))

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/KarafShell.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/KarafShell.java
@@ -31,6 +31,7 @@ package org.opennms.smoketest.utils;
 import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
 
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
@@ -155,5 +156,11 @@ public class KarafShell {
         Objects.requireNonNull(function);
         runCommand(null, function);
         return this;
+    }
+
+    public void checkFeature(String feature, String regex) {
+        assertTrue(String.format("feature '%s' is expected to be installed in state matching regex '%s'", feature, regex),
+                runCommandOnce("feature:list | grep " + feature,
+                        output -> output.matches("(?ms).*?\\|\\s*(" + regex + ")\\s*\\|.*"), false));
     }
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/KarafShell.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/KarafShell.java
@@ -28,13 +28,13 @@
 
 package org.opennms.smoketest.utils;
 
-import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertTrue;
+import static org.awaitility.Awaitility.await;
 
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -158,9 +158,12 @@ public class KarafShell {
         return this;
     }
 
-    public void checkFeature(String feature, String regex) {
-        assertTrue(String.format("feature '%s' is expected to be installed in state matching regex '%s'", feature, regex),
-                runCommandOnce("feature:list | grep " + feature,
-                        output -> output.matches("(?ms).*?\\|\\s*(" + regex + ")\\s*\\|.*"), false));
+    public void checkFeature(String feature, String regex, Duration wait) {
+        await(String.format("waiting for feature %s state to match regex '%s'", feature, regex))
+                .atMost(wait)
+                .until(() ->
+                        runCommandOnce("feature:list | grep " + feature,
+                                output -> output.matches("(?ms).*?\\|\\s*(" + regex + ")\\s*\\|.*"), false)
+                );
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/BrokenWebappIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/BrokenWebappIT.java
@@ -40,24 +40,18 @@ import java.nio.file.Path;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opennms.smoketest.containers.OpenNMSContainer;
-import org.opennms.smoketest.stacks.OpenNMSProfile;
 import org.opennms.smoketest.stacks.OpenNMSStack;
-import org.opennms.smoketest.stacks.StackModel;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
 
 public class BrokenWebappIT {
     @ClassRule
-    public static final OpenNMSStack BROKEN_WEBAPP = OpenNMSStack.withModel(StackModel.newBuilder()
-            .withOpenNMS(OpenNMSProfile.newBuilder()
-                    .withFile("empty-discovery-configuration.xml", "etc/discovery-configuration.xml")
-                    .withFile(getBrokenLdapXml(), "jetty-webapps/opennms/WEB-INF/spring-security.d/ldap.xml")
-                    .withWaitStrategy(c -> new AbstractWaitStrategy() {
+    public static final OpenNMSStack BROKEN_WEBAPP = OpenNMSStack.minimal(
+            b -> b.withFile(getBrokenLdapXml(), "jetty-webapps/opennms/WEB-INF/spring-security.d/ldap.xml"),
+            b -> b.withWaitStrategy(c -> new AbstractWaitStrategy() {
                         @Override
                         protected void waitUntilReady() {
                         }
-                    })
-                    .build())
-            .build());
+                    }));
 
     public static URL getBrokenLdapXml() {
         try {

--- a/smoke-test/src/test/java/org/opennms/smoketest/CortexTssPluginIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/CortexTssPluginIT.java
@@ -31,6 +31,7 @@ package org.opennms.smoketest;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -40,7 +41,6 @@ import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.KarafShell;
 import org.opennms.smoketest.utils.KarafShellUtils;
 
-@org.junit.experimental.categories.Category(org.opennms.smoketest.junit.FlakyTests.class)
 public class CortexTssPluginIT {
     public static final String CORTEX_PLUGIN_RELEASE = "https://github.com/OpenNMS/opennms-cortex-tss-plugin/releases/download/v2.0.1/opennms-cortex-tss-plugin.kar";
     public static final Path CORTEX_PLUGIN_KAR = Path.of("target", "opennms-cortex-tss-plugin.kar");
@@ -72,6 +72,6 @@ public class CortexTssPluginIT {
 
     @Test
     public void everythingHappy() throws Exception {
-        karafShell.checkFeature("opennms-plugins-cortex-tss", "Started");
+        karafShell.checkFeature("opennms-plugins-cortex-tss", "Started", Duration.ofSeconds(30));
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/CortexTssPluginIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/CortexTssPluginIT.java
@@ -29,11 +29,8 @@
 package org.opennms.smoketest;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Path;
 import java.time.Duration;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -42,25 +39,10 @@ import org.opennms.smoketest.utils.KarafShell;
 import org.opennms.smoketest.utils.KarafShellUtils;
 
 public class CortexTssPluginIT {
-    public static final String CORTEX_PLUGIN_RELEASE = "https://github.com/OpenNMS/opennms-cortex-tss-plugin/releases/download/v2.0.1/opennms-cortex-tss-plugin.kar";
-    public static final Path CORTEX_PLUGIN_KAR = Path.of("target", "opennms-cortex-tss-plugin.kar");
-
     @ClassRule
     public static OpenNMSStack stack = OpenNMSStack.minimal(
-            b -> b.withInstallFeature("opennms-plugins-cortex-tss", CortexTssPluginIT.downloadPlugin(),
-                    "opennms-cortex-tss-plugin")
+            b -> b.withInstallFeature("opennms-plugins-cortex-tss", "opennms-cortex-tss-plugin")
     );
-
-    protected static Path downloadPlugin() {
-        if (!CortexTssPluginIT.CORTEX_PLUGIN_KAR.toFile().exists()) {
-            try {
-                FileUtils.copyURLToFile(new URL(CortexTssPluginIT.CORTEX_PLUGIN_RELEASE), CortexTssPluginIT.CORTEX_PLUGIN_KAR.toFile());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return CortexTssPluginIT.CORTEX_PLUGIN_KAR;
-    }
 
     protected KarafShell karafShell = new KarafShell(stack.opennms().getSshAddress());
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/CortexTssTimeseriesPluginIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/CortexTssTimeseriesPluginIT.java
@@ -41,9 +41,8 @@ import org.opennms.smoketest.utils.KarafShellUtils;
 public class CortexTssTimeseriesPluginIT {
     @ClassRule
     public static OpenNMSStack stack = OpenNMSStack.minimal(
-            b -> b.withInstallFeature("opennms-plugins-cortex-tss", CortexTssPluginIT.downloadPlugin(),
-                    "opennms-cortex-tss-plugin"),
-            b -> b.withInstallFeature("opennms-timeseries-api")
+            b -> b.withInstallFeature("opennms-timeseries-api"),
+            b -> b.withInstallFeature("opennms-plugins-cortex-tss", "opennms-cortex-tss-plugin")
     );
 
     protected KarafShell karafShell = new KarafShell(stack.opennms().getSshAddress());

--- a/smoke-test/src/test/java/org/opennms/smoketest/CortexTssTimeseriesPluginIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/CortexTssTimeseriesPluginIT.java
@@ -28,46 +28,35 @@
 
 package org.opennms.smoketest;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
-import java.net.URL;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.KarafShell;
 import org.opennms.smoketest.utils.KarafShellUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @org.junit.experimental.categories.Category(org.opennms.smoketest.junit.FlakyTests.class)
 public class CortexTssTimeseriesPluginIT {
-
-    private static final Logger LOG = LoggerFactory.getLogger(CortexTssTimeseriesPluginIT.class);
-
     @ClassRule
-    public static OpenNMSStack stack = OpenNMSStack.MINIMAL;
+    public static OpenNMSStack stack = OpenNMSStack.minimal(
+            b -> b.withInstallFeature("opennms-plugins-cortex-tss", CortexTssPluginIT.downloadPlugin(),
+                    "opennms-cortex-tss-plugin"),
+            b -> b.withInstallFeature("opennms-timeseries-api")
+    );
 
-    private KarafShell karafShell = new KarafShell(stack.opennms().getSshAddress());
+    protected KarafShell karafShell = new KarafShell(stack.opennms().getSshAddress());
 
     @Before
     public void setUp() throws IOException, InterruptedException {
-        if (!CortexTssPluginIT.CORTEX_PLUGIN_KAR.toFile().exists()) {
-            FileUtils.copyURLToFile(new URL(CortexTssPluginIT.CORTEX_PLUGIN_RELEASE), CortexTssPluginIT.CORTEX_PLUGIN_KAR.toFile());
-        }
-
         // Make sure the Karaf shell is healthy before we start
         KarafShellUtils.awaitHealthCheckSucceeded(stack.opennms());
     }
 
     @Test
-    public void canLoadTimeseriesFeatureWithCortex() throws Exception {
-        stack.opennms().installFeature("opennms-plugins-cortex-tss", CortexTssPluginIT.CORTEX_PLUGIN_KAR);
-        assertTrue(karafShell.runCommandOnce("feature:install opennms-timeseries-api", output -> !output.toLowerCase().contains("error"), false));
-
-        KarafShellUtils.testHealthCheckSucceeded(stack.opennms().getSshAddress());
+    public void everythingHappy() throws Exception {
+        karafShell.checkFeature("opennms-plugins-cortex-tss", "Started");
+        karafShell.checkFeature("opennms-timeseries-api", "Started|Uninstalled"); // NMS-15329
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/CortexTssTimeseriesPluginIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/CortexTssTimeseriesPluginIT.java
@@ -29,6 +29,7 @@
 package org.opennms.smoketest;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -37,7 +38,6 @@ import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.KarafShell;
 import org.opennms.smoketest.utils.KarafShellUtils;
 
-@org.junit.experimental.categories.Category(org.opennms.smoketest.junit.FlakyTests.class)
 public class CortexTssTimeseriesPluginIT {
     @ClassRule
     public static OpenNMSStack stack = OpenNMSStack.minimal(
@@ -56,7 +56,7 @@ public class CortexTssTimeseriesPluginIT {
 
     @Test
     public void everythingHappy() throws Exception {
-        karafShell.checkFeature("opennms-plugins-cortex-tss", "Started");
-        karafShell.checkFeature("opennms-timeseries-api", "Started|Uninstalled"); // NMS-15329
+        karafShell.checkFeature("opennms-timeseries-api", "Started|Uninstalled", Duration.ofSeconds(30)); // NMS-15329
+        karafShell.checkFeature("opennms-plugins-cortex-tss", "Started", Duration.ofSeconds(30));
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionRestIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionRestIT.java
@@ -89,7 +89,7 @@ public class MinionRestIT {
                 .statusCode(200);
 
         LOG.info("testing /minion/rest/health?tag=local .........");
-        List<String> localDescriptions = Arrays.asList("Verifying installed bundles", "Retrieving NodeDao", "DNS Lookups (Netty)");
+        List<String> localDescriptions = Arrays.asList("Verifying installed bundles", "Retrieving NodeDao", "DNS Lookups (Netty)", "Karaf extender");
         List<String> descriptions = given().get("/minion/rest/health?tag=local")
                 .then()
                 .log().ifStatusCodeIsEqualTo(200)
@@ -100,7 +100,9 @@ public class MinionRestIT {
                 .jsonPath().getList("responses.description",String.class);
 
         LOG.info("descriptions in tag 'local' is: {}", Arrays.toString(descriptions.toArray()));
-        descriptions.stream().forEach(d-> Assert.assertTrue(localDescriptions.contains(d) || d.contains("Verifying Listener")));
+        descriptions.stream().forEach(d-> Assert.assertTrue(
+                String.format("Service health description '%s' must be in %s or contain '%s'", d, localDescriptions, "Verifying Listener"),
+                localDescriptions.contains(d) || d.contains("Verifying Listener")));
 
         LOG.info("testing /minion/rest/health/probe?tag=local  .......");
         given().get("/minion/rest/health/probe?tag=local")

--- a/src/assembly/source.xml
+++ b/src/assembly/source.xml
@@ -20,6 +20,7 @@
         <exclude>**/.settings/**/*</exclude>
         <exclude>**/.DS_Store</exclude>
         <exclude>**/.idea</exclude>
+        <exclude>**/*.iml</exclude>
         <exclude>**/target</exclude>
         <exclude>**/target/**/*</exclude>
       </excludes>


### PR DESCRIPTION
This unfortunately includes a number of things, but it is all in support of preventing for Karaf bundle refreshes at startup which leads to issues like http://issues.opennms.org/browse/NMS-15326.

## Breakdown of changes

This is best reviewed commit-by-commit, and I've organized them in the groups listed below.

### Service lookup fixes/tweaks

* [BlockingServiceLookup: Log an error if we timed out waiting for a ser…](https://github.com/OpenNMS/opennms/pull/5748/commits/a194b1f9a298ff15514e20b26489760b8db9ad6f) 
* [ServiceLookupBuilder: Fix what appear to be cut-n-paste errors in wai…](https://github.com/OpenNMS/opennms/pull/5748/commits/e646dddbfbee09683cb147f8b4888d64d71f7dbc) 

### Add smoke-test check to for Karaf bundles getting destroyed at startup

* [smoke-test: Fail if we see 'Destroy container' in the karaf log](https://github.com/OpenNMS/opennms/pull/5748/commits/323026ccadc5794b3b5c482e832b7c3e6be8feb8)

### Add support for installing features at boot time of OpenNMSContainer

Note: Without this change, and features starting to use it, the 'Destroy container' check above will happen *before* plugins are loaded. The Cortex plugin checks are changed a few sections down.

* [smoke-test: OpenNMSProfile.withInstallFeature (new): install a featur…](https://github.com/OpenNMS/opennms/pull/5748/commits/2a17d3b572133059584019503aa338c1df6488b7) 

### Make sure we wait Karaf to fully come up

Otherwise, we might miss things getting destroyed late during startup.

* [smoke-test: OpenNMSContainer: Always wait for OpenNMS health check](https://github.com/OpenNMS/opennms/pull/5748/commits/c05ebf9a0b760e370f4e6280b0d66312e38c0732) 
* [smoke-test: OpenNMSContainer: Use the same RestHealthClient as Minion…](https://github.com/OpenNMS/opennms/pull/5748/commits/4bed6411e5a36df7e80ea53ee681acc664714ad2)

### Tweak the Cortex plugin checks to install at boot time and use the plugins in the container

This is our test for https://opennms.atlassian.net/browse/NMS-15326 since it reliably triggers it. Plus some infrastructure to support the changes.

* [smoke-test: OpenNMSStack.minimal (new): Simplify tweaking a MINIMAL d…](https://github.com/OpenNMS/opennms/pull/5748/commits/c68061583ce7ed1ab85e42c2f5364d33221a24a7) 
* [smoke-test: KarafShell.checkFeature (new): ensure feature is in expec…](https://github.com/OpenNMS/opennms/pull/5748/commits/8aa49787a44a1e8f87b0be6cf1eb84d074c22e34) 
* [smoke-test: Simplify CortexTss*PluginIT tests with minimal() and chec…](https://github.com/OpenNMS/opennms/pull/5748/commits/60526135cc1df7683eaeaffbe0ed9163d8e718d3) 
* [NMS-15413: fix for CortexTSS tests flapping with retries](https://github.com/OpenNMS/opennms/pull/5748/commits/c890811b2243cf5a3bcf8b2d2fe2eb3454aa69f4) 
* [Use local Cortex plugin in the container instead of downloading from …](https://github.com/OpenNMS/opennms/pull/5748/commits/edb7154dde7de0cf263282aad487442c2b3b815c) 

### Fixes for smaller issues and some debugging for issues that are still being chased down

* [NMS-15387: Fix for errantly committed code looking for output.log](https://github.com/OpenNMS/opennms/pull/5748/commits/65aed88d556777a18c4fa5536a5ddf720c91efd9)
* [Debugging: try to see why DevDebugUtils.gatherThreadDump sometimes ha…](https://github.com/OpenNMS/opennms/pull/5748/commits/f2ec8711bef871ad80bcc782d90fa1411f3082ff) 
* [Debugging: also grab telemetryd.log log file in OpenNMSContainer](https://github.com/OpenNMS/opennms/pull/5748/commits/3179ec5cf2eb19a97ccd68fdb40b7ee6c83de2bd) 
* [Debugging: Try to see why afterTest is getting called multiple times](https://github.com/OpenNMS/opennms/pull/5748/commits/65dd0527877c3c4a3a772ef43d180d66736543e8) 
* [DevDebugUtils.gatherThreadDump and friends: A little refactoring, for…](https://github.com/OpenNMS/opennms/pull/5748/commits/6c7ab117b6bf4e30bfd217cba0ae374e02433867) 

### Pull in karaf-extender health check

This is from #5758 which was only merged to `develop` at this point. Without this change, our smoke test change that looks for 'Destroy container' might not catch issues from plugins that are loaded in `featuresBoot.d`.

* [DefaultPassiveHealthCheck: optionally allow a Response to never expire](https://github.com/OpenNMS/opennms/pull/5748/commits/187e84782f329cf9baaa57e992f2a79bd8cdbd79)
* [Make health-api a feature so it can be used by karaf-extender](https://github.com/OpenNMS/opennms/pull/5748/commits/33146a8e73a507d5d177345689d1ef39a0654ad9)
* [Add a (passive) HealthCheck to the KarafExtender](https://github.com/OpenNMS/opennms/pull/5748/commits/45742ff6b0bf34fd83cb6add348610d6ee99cfdc)
* [Allow minion runInPlace.sh to be run from anywhere!](https://github.com/OpenNMS/opennms/pull/5748/commits/f7043b812c1db73a1b084c6dfbf366fd75ee795f)

### The one that actually matters: use autoRefresh=false in Karaf

This is the change from #3829 that wasn't merged previously due to test issues.

This is the commit that actually matters. All of the other changes are supporting smoke tests that validate this change (well, and some bug fixes/debugging changes/refactoring along the way).

* [NMS-13268: do not refresh bundles when features get installed](https://github.com/OpenNMS/opennms/pull/5748/commits/8b31381ec8da35f578172faa202bcfb044f2d80c)



### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15326

