### PR TITLE
fixes and improvements for docker_gc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,19 +127,16 @@ jobs:
           command: |
             wget https://github.com/docker/hub-tool/releases/download/v0.4.5/hub-tool-linux-amd64.tar.gz
             tar -xzf hub-tool-linux-amd64.tar.gz
-            apk update
-            apk add expect
-            expect_commands="
-            spawn hub-tool/hub-tool login ${DOCKERHUB_LOGIN}
-            expect 'Password:'
-            send \"${DOCKERHUB_PASS}\n\"
-            interact"
-            expect -c "${expect_commands//
-            /;}"
-            GC_LIST=$( hub-tool/hub-tool tag ls opennms/horizon | ( grep feature || true ) | ( grep inactive || true ) | cut -d" " -f1 )
-            for image in $GC_LIST; do
-              echo "Delete image $image"
-              ( yes || true ) | hub-tool/hub-tool tag rm $image
+            cd hub-tool
+            DOCKERHUB_AUTH_HASH="$(echo -n "${DOCKERHUB_LOGIN}:${DOCKERHUB_PASS}" | base64)"
+            echo "{ \"auths\": { \"hub-tool\": { \"auth\": \"${DOCKERHUB_AUTH_HASH}\" } } }" > config.json
+            export DOCKER_CONFIG="$(pwd)"
+            for HUB_REPO in horizon minion sentinel meridian-minion; do
+              GC_LIST=$( ./hub-tool tag ls "opennms/${HUB_REPO}" | ( grep -E '^[^:][^:]*:(feature|jira|dependabot)' || true ) | ( grep inactive || true ) | cut -d" " -f1 )
+              for image in $GC_LIST; do
+                echo "Delete image $image"
+                ( yes || true ) | ./hub-tool tag rm $image
+              done
             done
 
   trigger-coverage:


### PR DESCRIPTION
This PR fixes the `docker_gc` automation to do a number of things:

1. write a `config.json` docker file to avoid having to deal with multiple levels of escaping around doing `expect` commands
2. add `minion`, `sentinel`, and `meridian-minion` to the list of images that can be cleaned up
3. add `jira` and `dependabot` to the list of branch types to clean up (also: increase strictness of _where_ these keywords get matched)