### PR TITLE
Feature: add a KarafExtender health check

### DIFF
--- a/container/extender/pom.xml
+++ b/container/extender/pom.xml
@@ -60,5 +60,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.core.health</groupId>
+            <artifactId>org.opennms.core.health.api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/container/extender/src/main/java/org/opennms/karaf/extender/KarafExtender.java
+++ b/container/extender/src/main/java/org/opennms/karaf/extender/KarafExtender.java
@@ -54,11 +54,15 @@ import java.util.stream.Collectors;
 import org.apache.karaf.features.FeaturesService;
 import org.apache.karaf.features.FeaturesService.Option;
 import org.apache.karaf.kar.KarService;
+import org.opennms.core.health.api.DefaultPassiveHealthCheck;
+import org.opennms.core.health.api.Response;
+import org.opennms.core.health.api.Status;
 import org.ops4j.pax.url.mvn.MavenResolver;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 
 import com.google.common.collect.Lists;
 
@@ -87,21 +91,26 @@ public class KarafExtender {
     private MavenResolver m_mavenResolver;
     private FeaturesService m_featuresService;
     private KarService m_karService;
+    private DefaultPassiveHealthCheck m_defaultPassiveHealthCheck;
 
     private Thread m_installThread;
     private Thread m_karDependencyInstallThread;
+    private ExtenderStatus m_extenderStatus = new ExtenderStatus();
 
     public void init() throws InterruptedException {
         Objects.requireNonNull(m_configurationAdmin, "configurationAdmin");
         Objects.requireNonNull(m_mavenResolver, "mavenResolver");
         Objects.requireNonNull(m_featuresService, "featuresService");
         Objects.requireNonNull(m_karService, "karService");
+        Objects.requireNonNull(m_defaultPassiveHealthCheck, "healthCheckResponseCache");
+
+        m_defaultPassiveHealthCheck.setResponse(new Response(Status.Starting), false);
 
         List<Repository> repositories;
         try {
             repositories = getRepositories();
         } catch (IOException e) {
-            LOG.error("Failed to retrieve the list of repositories. Aborting.", e);
+            m_extenderStatus.error("Failed to retrieve the list of repositories. Aborting", e);
             return;
         }
 
@@ -112,7 +121,7 @@ public class KarafExtender {
         try {
             featuresBoot.addAll(getFeaturesBoot());
         } catch (IOException e) {
-            LOG.error("Failed to retrieve the list of features to boot. Aborting.", e);
+            m_extenderStatus.error("Failed to retrieve the list of features to boot. Aborting", e);
             return;
         }
 
@@ -143,7 +152,7 @@ public class KarafExtender {
                     config.update(props);
                 }
             } catch (IOException e) {
-                LOG.error("Failed to update the list of Maven repositories to '{}'. Aborting.",
+                m_extenderStatus.error("Failed to update the list of Maven repositories to '{}'. Aborting",
                         mavenRepos, e);
                 return;
             }
@@ -164,7 +173,7 @@ public class KarafExtender {
                         LOG.info("Adding feature repository: {}", featureUri);
                         m_featuresService.addRepository(featureUri);
                     } catch (Exception e) {
-                        LOG.error("Failed to add feature repository '{}'. Skipping.", featureUri, e);
+                        m_extenderStatus.error("Failed to add feature repository '{}'. Skipping", featureUri, e);
                     }
                 }
             }
@@ -190,14 +199,16 @@ public class KarafExtender {
                 try {
                     LOG.info("Installing features: {}", featuresToInstall);
                     m_featuresService.installFeatures(featuresToInstall, EnumSet.noneOf(Option.class));
+                    m_extenderStatus.featuresDone(String.format("%s non-KAR features installed", featuresToInstall.size()));
                 } catch (Exception e) {
-                    LOG.error("Failed to install one or more features.", e);
+                    m_extenderStatus.error("Failed to install one or more features", e);
                 }
             });
             m_installThread.setName("Karaf-Extender-Feature-Install");
             m_installThread.start();
         } else {
             LOG.debug("No features to install.");
+            m_extenderStatus.featuresDone("");
         }
 
 
@@ -206,12 +217,13 @@ public class KarafExtender {
                 .collect(Collectors.toList());
         if (!featuresWithKarDependencies.isEmpty()) {
             final KarDependencyHandler karDependencyHandler = new KarDependencyHandler(featuresWithKarDependencies,
-                    m_karService, m_featuresService);
+                    m_karService, m_featuresService, m_extenderStatus);
             m_karDependencyInstallThread = new Thread(karDependencyHandler);
             m_karDependencyInstallThread.setName("Karaf-Extender-Feature-Install-For-Kars");
             m_karDependencyInstallThread.start();
         } else {
             LOG.debug("No features with dependencies on .kar files to install.");
+            m_extenderStatus.karsDone("");
         }
     }
 
@@ -262,7 +274,7 @@ public class KarafExtender {
                 }
                 repositories.add(new Repository(repositoryPath, featureUris, featuresBoot));
             } catch (URISyntaxException e) {
-                LOG.error("Failed to generate one or more feature URIs for repository {}. Skipping.",
+                m_extenderStatus.error("Failed to generate one or more feature URIs for repository {}. Skipping",
                         repositoryPath, e);
             }
         }
@@ -415,4 +427,67 @@ public class KarafExtender {
         m_karService = karService;
     }
 
+    public void setDefaultPassiveHealthCheck(DefaultPassiveHealthCheck defaultPassiveHealthCheck) {
+        m_defaultPassiveHealthCheck = defaultPassiveHealthCheck;
+    }
+
+    public class ExtenderStatus {
+        private String featuresToInstallDone = null;
+        private String karDependencyInstallDone = null;
+
+        public void info(String messagePattern, Object... argArray) {
+            LOG.info(messagePattern, argArray);
+            setResponse(Status.Starting, messagePattern, argArray);
+        }
+
+        public void warn(String messagePattern, Object... argArray) {
+            LOG.warn(messagePattern, argArray);
+            setResponse(Status.Starting, messagePattern, argArray);
+        }
+
+        public void error(String messagePattern, Object... argArray) {
+            LOG.error(messagePattern, argArray);
+            setResponse(Status.Failure, messagePattern, argArray);
+        }
+
+        private void setResponse(Status status, String messagePattern, Object[] argArray) {
+            var formattingTuple = MessageFormatter.arrayFormat(messagePattern, argArray);
+            var failureMessage = new StringBuffer(formattingTuple.getMessage());
+            var throwable = formattingTuple.getThrowable();
+            if (throwable != null) {
+                failureMessage.append(": ");
+                failureMessage.append(throwable.getMessage());
+            }
+            m_defaultPassiveHealthCheck.setResponse(new Response(status, failureMessage.toString()), false);
+        }
+
+        public void featuresDone(String message) {
+            featuresToInstallDone = Objects.requireNonNull(message);
+            areWeCompletelyDone();
+        }
+
+        public void karsDone(String message) {
+            karDependencyInstallDone = Objects.requireNonNull(message);
+            areWeCompletelyDone();
+        }
+
+        private void areWeCompletelyDone() {
+            if (featuresToInstallDone != null && karDependencyInstallDone != null) {
+                StringBuffer message = new StringBuffer();
+                if (!featuresToInstallDone.isEmpty()) {
+                    message.append(featuresToInstallDone);
+                    message.append(". ");
+                }
+                if (!karDependencyInstallDone.isEmpty()) {
+                    message.append(karDependencyInstallDone);
+                    message.append(". ");
+                }
+                if (message.length() > 0) {
+                    m_defaultPassiveHealthCheck.setResponse(new Response(Status.Success, message.toString()), false);
+                } else {
+                    m_defaultPassiveHealthCheck.setResponse(new Response(Status.Success), false);
+                }
+            }
+        }
+    }
 }

--- a/container/extender/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/container/extender/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,10 +10,32 @@
     <reference id="featuresService" interface="org.apache.karaf.features.FeaturesService"/>
     <reference id="karService" interface="org.apache.karaf.kar.KarService"/>
 
+    <bean id="karafExtenderHealthCheck" class="org.opennms.core.health.api.DefaultPassiveHealthCheck">
+        <argument value="Karaf extender"/>
+        <argument>
+            <list>
+                <value>local</value>
+                <value>passive</value>
+            </list>
+        </argument>
+        <argument value="Unknown"/>
+    </bean>
+
     <bean id="controller" class="org.opennms.karaf.extender.KarafExtender" init-method="init" destroy-method="destroy">
         <property name="configurationAdmin" ref="configurationAdmin" />
         <property name="mavenResolver" ref="mavenResolver" />
         <property name="featuresService" ref="featuresService" />
         <property name="karService" ref="karService" />
+        <property name="defaultPassiveHealthCheck" ref="karafExtenderHealthCheck" />
     </bean>
+
+    <service ref="karafExtenderHealthCheck">
+        <interfaces>
+            <value>org.opennms.core.health.api.HealthCheck</value>
+            <value>org.opennms.core.health.api.HealthCheckResponseCache</value>
+        </interfaces>
+        <service-properties>
+            <entry key="alias" value="opennms.karafExtenderHealthCheck"/>
+        </service-properties>
+    </service>
 </blueprint>

--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -24,6 +24,10 @@
         <bundle dependency="true">mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}</bundle>
     </feature>
 
+    <feature name="commons-lang3" version="${commonsLang3Version}" description="Apache :: commons-lang3">
+        <bundle>mvn:org.apache.commons/commons-lang3/${commonsLang3Version}</bundle>
+    </feature>
+
     <feature name="guava" version="${guavaOsgiVersion}" description="Google :: Guava">
         <feature prerequisite="true">wrap</feature>
         <bundle start-level="30" dependency="true">mvn:com.google.guava/guava/${guavaVersion}</bundle>
@@ -91,5 +95,11 @@
         <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/1.70</bundle>
         <bundle start-level="30">mvn:org.bouncycastle/bcpkix-jdk15on/1.70</bundle>
         <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.ssh/${karafVersion}</bundle>
+    </feature>
+
+    <feature name="health-api" version="${project.version}" description="Health API">
+        <feature version="${commonsLang3Version}">commons-lang3</feature>
+        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
+        <bundle dependency="true">mvn:io.vavr/vavr/0.10.0</bundle>
     </feature>
 </features>

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -189,9 +189,7 @@
     </feature>
 
     <feature name="minion-health-check" version="${project.version}" description="Minion :: Health Check">
-        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
-        <bundle dependency="true">mvn:io.vavr/vavr/0.10.0</bundle>
-        <feature>commons-lang3</feature>
+        <feature>health-api</feature>
         <bundle>mvn:org.opennms.features.minion/health-check/${project.version}</bundle>
     </feature>
 

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -130,9 +130,7 @@
     <feature name="commons-lang" version="${commonsLangVersion}" description="Apache :: commons-lang">
         <bundle>mvn:commons-lang/commons-lang/${commonsLangVersion}</bundle>
     </feature>
-    <feature name="commons-lang3" version="${commonsLang3Version}" description="Apache :: commons-lang3">
-        <bundle>mvn:org.apache.commons/commons-lang3/${commonsLang3Version}</bundle>
-    </feature>
+    <!-- commons-lang3 is in features-core.xml -->
     <feature name="commons-net" version="${commonsNetVersion}" description="Apache :: commons-net">
         <bundle>mvn:commons-net/commons-net/${commonsNetVersion}</bundle>
     </feature>

--- a/container/features/src/main/resources/karaf-extensions.xml
+++ b/container/features/src/main/resources/karaf-extensions.xml
@@ -4,6 +4,7 @@
 
     <feature name="karaf-extender" description="Karaf Extender" version="${project.version}">
         <feature version="${guavaOsgiVersion}" prerequisite="true">guava</feature>
+        <feature version="${project.version}">health-api</feature>
         <bundle>mvn:org.opennms.container/extender/${project.version}</bundle>
     </feature>
 </features>

--- a/features/minion/runInPlace.sh
+++ b/features/minion/runInPlace.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-set -e
 
-test -d repository || (echo "This command must be ran from the features/minion directory" && exit 1)
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "${MYDIR}"
+
+test -d repository || (echo "No 'repository' directory in $(pwd) -- are we in the right place (which is container/minion if you are curious)?" && exit 1)
 
 # Inclue the bundled Maven in the $PATH
-MYDIR=$(dirname "$0")
-MYDIR=$(cd "$MYDIR"; pwd)
 export PATH="$MYDIR/../..:$MYDIR/../../bin:$MYDIR/../../maven/bin:$PATH"
 export CONTAINERDIR="${MYDIR}/../container/minion"
 
@@ -187,9 +190,12 @@ NUM_INSTANCES=1
 DETACHED=0
 SUDO=0
 
-while [ "$1" != "" ]; do
+while [ $# -gt 0 ]; do
     case $1 in
         -n | --num-instances )  shift
+                                if [ $# -lt 1 ] ; then
+                                    echo "Must specify argument to -n | --num-instances"; exit 1
+                                fi
                                 NUM_INSTANCES=$1
                                 ;;
         -d | --detached )       DETACHED=1

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionRestIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionRestIT.java
@@ -89,7 +89,7 @@ public class MinionRestIT {
                 .statusCode(200);
 
         LOG.info("testing /minion/rest/health?tag=local .........");
-        List<String> localDescriptions = Arrays.asList("Verifying installed bundles", "Retrieving NodeDao", "DNS Lookups (Netty)");
+        List<String> localDescriptions = Arrays.asList("Verifying installed bundles", "Retrieving NodeDao", "DNS Lookups (Netty)", "Karaf extender");
         List<String> descriptions = given().get("/minion/rest/health?tag=local")
                 .then()
                 .log().ifStatusCodeIsEqualTo(200)
@@ -100,7 +100,9 @@ public class MinionRestIT {
                 .jsonPath().getList("responses.description",String.class);
 
         LOG.info("descriptions in tag 'local' is: {}", Arrays.toString(descriptions.toArray()));
-        descriptions.stream().forEach(d-> Assert.assertTrue(localDescriptions.contains(d) || d.contains("Verifying Listener")));
+        descriptions.stream().forEach(d-> Assert.assertTrue(
+                String.format("Service health description '%s' must be in %s or contain '%s'", d, localDescriptions, "Verifying Listener"),
+                localDescriptions.contains(d) || d.contains("Verifying Listener")));
 
         LOG.info("testing /minion/rest/health/probe?tag=local  .......");
         given().get("/minion/rest/health/probe?tag=local")


### PR DESCRIPTION
### Example output

With this in featuresBoot.d:
```
opennms@onms-core-0:~$ cat etc/featuresBoot.d/*
opennms-plugins-cortex-tss wait-for-kar=opennms-cortex-tss-plugin
opennms-timeseries-api
```

```
admin@opennms()> health-check
Command not found: health-check
admin@opennms()> health-check
Verifying the health of the container

Karaf extender                [ Starting ] => Installing features: [opennms-plugins-cortex-tss]
Verifying installed bundles   [ Failure  ] => Bundle 79 is resolved, but not active

=> Oh no, something is wrong
admin@opennms()> health-check
Verifying the health of the container

Karaf extender                [ Starting ] => Installing features: [opennms-plugins-cortex-tss]
Verifying installed bundles   [ Success  ]

=> Oh no, something is wrong

... snip ...

admin@opennms()> health-check
Verifying the health of the container

Karaf extender                [ Starting ] => Installing features: [opennms-plugins-cortex-tss]
Verifying installed bundles   [ Success  ]

=> Oh no, something is wrong
admin@opennms()> health-check
Verifying the health of the container

Karaf extender                [ Starting ] => Installing features: [opennms-plugins-cortex-tss]
Verifying installed bundles   [ Starting ] => Bundle 79 is not yet started

=> Oh no, something is wrong
admin@opennms()> health-check
Verifying the health of the container

Karaf extender                [ Success  ] => 1 features installed. 1 KAR features installed.
Verifying installed bundles   [ Success  ]

=> Everything is awesome
admin@opennms()> health-check
Verifying the health of the container

Karaf extender                [ Success  ] => 1 features installed. 1 KAR features installed.
Verifying installed bundles   [ Success  ]

=> Everything is awesome
admin@opennms()>
```

### External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15351

