### PR TITLE
NMS-15347: Fix wording for regular Requisition empty state

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/requisitions.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/requisitions.html
@@ -68,8 +68,8 @@
     <!-- No Requisitions -->
     <div class="jumbotron" ng-show="loaded && requisitionsData.requisitions.length == 0">
       <div class="container">
-        <h1>There are no external requisitions</h1>
-        <p>Click the 'Add External Requisition' button, to add some.</p>
+        <h1>There are no requisitions</h1>
+        <p>Click the 'Add Requisition' button, to add some.</p>
       </div>
     </div>
 


### PR DESCRIPTION
When there are no requisitions, fix wording to state "There are no requisitions", instead of "There are no external requisitions", and fix 'help' wording as well.

### External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15347
