### PR TITLE
NMS-15341: cosign image and SBOM signing and attestation

### DIFF
--- a/.circleci/build-triggers.override.json
+++ b/.circleci/build-triggers.override.json
@@ -1,0 +1,14 @@
+{
+    "build-deploy": false,
+    "coverage": false,
+    "docs": false,
+    "ui": false,
+    "integration": false,
+    "smoke": false,
+    "smoke-flaky": false,
+    "rpms": false,
+    "debs": false,
+    "oci": false,
+    "build-publish": false,
+    "experimental": true
+}

--- a/.circleci/main/commands/oci/oci.yml
+++ b/.circleci/main/commands/oci/oci.yml
@@ -10,9 +10,9 @@ commands:
           name: restore OCI files matching "<< parameters.match >>"
           command: |
             if [ -n "<< parameters.match >>" ]; then
-              download-artifacts.pl --include-failed --workflow="${CIRCLE_WORKFLOW_ID}" --match="<< parameters.match >>" oci "${CIRCLE_BRANCH}" /tmp/oci-artifacts
+              download-artifacts.pl --include-failed --ci --token="${CIRCLE_TOKEN}" --workflow="${CIRCLE_WORKFLOW_ID}" --match="<< parameters.match >>" oci "${CIRCLE_BRANCH}" /tmp/oci-artifacts
             else
-              download-artifacts.pl --include-failed --workflow="${CIRCLE_WORKFLOW_ID}" oci "${CIRCLE_BRANCH}" /tmp/oci-artifacts
+              download-artifacts.pl --include-failed --ci --token="${CIRCLE_TOKEN}" --workflow="${CIRCLE_WORKFLOW_ID}" oci "${CIRCLE_BRANCH}" /tmp/oci-artifacts
             fi
 
             cd /tmp/oci-artifacts
@@ -59,7 +59,7 @@ commands:
       - download-download-artifacts
       - run:
           name: download tarball dependency to << parameters.tarball_path >>
-          command: download-artifacts.pl --include-failed --workflow="${CIRCLE_WORKFLOW_ID}" --match="<< parameters.tarball_match >>" tar.gz "${CIRCLE_BRANCH}" "$(pwd)/<< parameters.tarball_path >>"
+          command: download-artifacts.pl --include-failed --ci --token="${CIRCLE_TOKEN}" --workflow="${CIRCLE_WORKFLOW_ID}" --match="<< parameters.tarball_match >>" tar.gz "${CIRCLE_BRANCH}" "$(pwd)/<< parameters.tarball_path >>"
       - run:
           name: build << parameters.container_name >>=<< parameters.architecture >> container image
           command: |

--- a/.circleci/main/commands/oci/oci.yml
+++ b/.circleci/main/commands/oci/oci.yml
@@ -81,3 +81,30 @@ commands:
       - store_artifacts:
           path: ~/project/opennms-container/<< parameters.container_dir >>/images/
           destination: /
+
+  generate-sbom:
+    parameters:
+      container_dir:
+        type: string
+    steps:
+      - run:
+          name: install Syft
+          command: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "${HOME}/bin"
+      - run:
+          name: generate SBOM
+          command: |
+            cd ~/project/opennms-container/"<< parameters.container_dir >>"/images/
+            if [ -z "$(ls *.oci 2>/dev/null)" ]; then
+              echo 'ERROR: no *.oci files found in opennms-container/<< parameters.container_dir >>/images/'
+              exit 1
+            fi
+
+            mkdir -p /tmp/sboms
+            for IMAGE_FILE in *.oci; do
+              IMAGE_ROOT="$(echo "${IMAGE_FILE}" | sed -e 's,\.oci$,,')"
+              syft packages "docker-archive:${IMAGE_FILE}" -o cyclonedx --quiet >"/tmp/sboms/${IMAGE_ROOT}-sbom.xml"
+            done
+      - store_artifacts:
+          path: /tmp/sboms/
+          destination: /
+

--- a/.circleci/main/jobs/oci/horizon-image-single-arch-linux-amd64.yml
+++ b/.circleci/main/jobs/oci/horizon-image-single-arch-linux-amd64.yml
@@ -9,3 +9,5 @@ jobs:
           container_dir: core
           tarball_match: -core
           tarball_path: opennms-full-assembly/target/
+      - generate-sbom:
+          container_dir: core

--- a/.circleci/main/jobs/oci/horizon-image-single-arch.yml
+++ b/.circleci/main/jobs/oci/horizon-image-single-arch.yml
@@ -12,3 +12,5 @@ jobs:
           container_dir: core
           tarball_match: -core
           tarball_path: opennms-full-assembly/target/
+      - generate-sbom:
+          container_dir: core

--- a/.circleci/main/jobs/oci/minion-image-single-arch-linux-amd64.yml
+++ b/.circleci/main/jobs/oci/minion-image-single-arch-linux-amd64.yml
@@ -18,3 +18,5 @@ jobs:
       - save-artifacts:
           path: target/config-schema/
           location: minion-config-schema
+      - generate-sbom:
+          container_dir: minion

--- a/.circleci/main/jobs/oci/minion-image-single-arch.yml
+++ b/.circleci/main/jobs/oci/minion-image-single-arch.yml
@@ -12,3 +12,5 @@ jobs:
           container_dir: minion
           tarball_match: minion
           tarball_path: /opennms-assemblies/minion/target
+      - generate-sbom:
+          container_dir: minion

--- a/.circleci/main/jobs/oci/sentinel-image-single-arch-linux-amd64.yml
+++ b/.circleci/main/jobs/oci/sentinel-image-single-arch-linux-amd64.yml
@@ -9,3 +9,5 @@ jobs:
           container_dir: sentinel
           tarball_match: sentinel
           tarball_path: /opennms-assemblies/sentinel/target
+      - generate-sbom:
+          container_dir: sentinel

--- a/.circleci/main/jobs/oci/sentinel-image-single-arch.yml
+++ b/.circleci/main/jobs/oci/sentinel-image-single-arch.yml
@@ -12,3 +12,5 @@ jobs:
           container_dir: sentinel
           tarball_match: sentinel
           tarball_path: /opennms-assemblies/sentinel/target
+      - generate-sbom:
+          container_dir: sentinel

--- a/.circleci/main/jobs/publish.yml
+++ b/.circleci/main/jobs/publish.yml
@@ -25,6 +25,14 @@ jobs:
                "${TYPE}" \
                "${CIRCLE_BRANCH}" \
                /tmp/artifacts
+              download-artifacts.pl \
+                --vault-layout \
+                --include-failed \
+                --workflow="${CIRCLE_WORKFLOW_ID}" \
+                --match="sbom" \
+               xml \
+               "${CIRCLE_BRANCH}" \
+               /tmp/artifacts
             done
       - run:
           name: Import OCI Files

--- a/.circleci/main/jobs/publish.yml
+++ b/.circleci/main/jobs/publish.yml
@@ -21,6 +21,8 @@ jobs:
               download-artifacts.pl \
                 --vault-layout \
                 --include-failed \
+                --ci \
+                --token="${CIRCLE_TOKEN}" \
                 --workflow="${CIRCLE_WORKFLOW_ID}" \
                "${TYPE}" \
                "${CIRCLE_BRANCH}" \
@@ -28,6 +30,8 @@ jobs:
               download-artifacts.pl \
                 --vault-layout \
                 --include-failed \
+                --ci \
+                --token="${CIRCLE_TOKEN}" \
                 --workflow="${CIRCLE_WORKFLOW_ID}" \
                 --match="sbom" \
                xml \

--- a/.circleci/main/workflows/workflows_v2.json
+++ b/.circleci/main/workflows/workflows_v2.json
@@ -106,7 +106,7 @@
         },
         "experimental": {
             "extends": [
-                "empty"
+                "build-publish"
             ]
         }
     },
@@ -509,6 +509,7 @@
             "filters": {
                 "branches": {
                     "only": [
+                        "jira/NMS-15341-cosign-sbom",
                         "develop",
                         "/^master-.*/",
                         "/^release-.*/",

--- a/.circleci/main/workflows/workflows_v2.json
+++ b/.circleci/main/workflows/workflows_v2.json
@@ -490,6 +490,7 @@
             "context": [
                 "CircleCI",
                 "cloudsmith-publish-account",
+                "cosign-signing",
                 "docker-content-trust",
                 "docker-publish-account",
                 "azure-sp-dct"

--- a/.circleci/scripts/lib-docker.sh
+++ b/.circleci/scripts/lib-docker.sh
@@ -2,6 +2,8 @@
 
 export DOCKER_CONTENT_TRUST=1
 
+export COSIGN_VERSION="1.13.1"
+
 export KEY_FOLDER="${HOME}/.docker/trust"
 export PRIVATE_KEY_FOLDER="${KEY_FOLDER}/private"
 install -d -m 700 "${PRIVATE_KEY_FOLDER}"
@@ -15,7 +17,40 @@ echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdi
 NOTARY_AUTH="$(printf '%s:%s' "${DOCKER_USERNAME}" "${DOCKER_PASSWORD}" | base64 -w0)"
 export NOTARY_AUTH
 
-# usage: create_and_push_manifest [registry] [source-tag] [target-tag]
+configure_cosign() {
+  if [ ! -e /tmp/cosign.key ]; then
+    printf '%s' "${COSIGN_PRIVATE_KEY}" | base64 -d > /tmp/cosign.key
+  fi
+  if [ ! -x "${HOME}/bin/cosign" ]; then
+    curl -L -o "${HOME}/bin/cosign" "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64"
+    chmod 755 "${HOME}/bin/cosign"
+  fi
+}
+
+# usage: cosign_sign <docker-tag> [path-to-sbom]
+cosign_sign() {
+  local _tag="$1"
+  local _sbom="$2"
+
+  if [ -z "${_tag}" ]; then
+    echo 'you must specify a docker tag to sign!'
+    exit 1
+  fi
+  cosign sign --key /tmp/cosign.key "${_tag}"
+
+  # we won't attach an SBOM to the multi-arch tag, since their contents can be OS-dependent
+  if [ -z "${_sbom}" ] || [ ! -e "${_sbom}" ]; then
+    echo 'WARNING: sbom not set, or does not exist (this is OK when signing multi-arch tags)'
+  else
+    cosign attest --key /tmp/cosign.key --predicate "${_sbom}" "${_tag}"
+  fi
+}
+
+get_sha256() {
+  docker inspect --format='{{.RepoDigests}}' "$1" | sed -e 's,^\[,,' -e 's,\]$,,' | awk '{ print $1 }' | cut -d'@' -f2
+}
+
+# usage: create_and_push_manifest <registry> <source-tag> <target-tag>
 # ex: create_and_push_manifest docker.io "develop" "31-dev"
 create_and_push_manifest() {
   local _repo="$1"

--- a/.circleci/scripts/publish-azure.sh
+++ b/.circleci/scripts/publish-azure.sh
@@ -18,6 +18,8 @@ export DOCKER_PASSWORD="${AZURE_SP_PASSWORD}"
 # shellcheck disable=SC1091
 . "${MYDIR}/lib-docker.sh"
 
+configure_cosign
+
 printf '%s' "${AZURE_DCT_CI_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${AZURE_DCT_CI_KEY_ID}.key"
 printf '%s' "${AZURE_DCT_REPO_MINION_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${AZURE_DCT_REPO_MINION_KEY_ID}.key"
 chmod 600 "${PRIVATE_KEY_FOLDER}"/*
@@ -37,14 +39,19 @@ for TYPE in minion; do
     _arch_tag="$(printf '%s' "${_file_tag}" | sed -e "s,^${TYPE}-,,")"
 
     _push_tag="${DOCKER_BRANCH_TAG}-${_arch_tag}"
-    docker tag "${_internal_tag}" "${DOCKER_REPO}:${_push_tag}"
-    do_with_retries docker push --quiet "${DOCKER_REPO}:${_push_tag}"
+    _tagname="${DOCKER_REPO}:${_push_tag}"
+    docker tag "${_internal_tag}" "${_tagname}"
+    do_with_retries docker push --quiet "${_tagname}"
+
+    _sha256="$(get_sha256 "${_internal_tag}")"
+    cosign_sign "${DOCKER_REPO}@${_sha256}" "/tmp/artifacts/xml/${_file_tag}-sbom.xml"
   done
 
   export NOTARY_TARGETS_PASSPHRASE="${AZURE_DCT_REPO_MINION_KEY_PASSPHRASE}"
   for _publish_tag in "${DOCKER_TAGS[@]}"; do
     create_and_push_manifest "${DOCKER_REPO}" "${DOCKER_BRANCH_TAG}" "${_publish_tag}"
     do_with_retries notary -d ~/.docker/trust/ -s "https://${DOCKER_SERVER}" addhash "${DOCKER_REPO}" "${_publish_tag}" "${DOCKER_IMAGE_BYTES_SIZE}" --sha256 "${DOCKER_IMAGE_SHA_256}" --publish --verbose
+    cosign_sign "${DOCKER_REPO}@sha256:${DOCKER_IMAGE_SHA_256}"
   done
 
 done

--- a/.circleci/scripts/publish-cloudsmith.sh
+++ b/.circleci/scripts/publish-cloudsmith.sh
@@ -23,6 +23,9 @@ case "${CIRCLE_BRANCH}" in
   master-*)
     REPO="stable"
     ;;
+  *NMS-15341*)
+    REPO="foundation-2023"
+    ;;
   *)
     echo "This branch is not eligible for deployment: ${CIRCLE_BRANCH}"
     exit 0

--- a/.circleci/scripts/publish-cloudsmith.sh
+++ b/.circleci/scripts/publish-cloudsmith.sh
@@ -61,6 +61,8 @@ export DOCKER_PASSWORD="${CLOUDSMITH_API_KEY}"
 
 export DOCKER_CONTENT_TRUST=0
 
+configure_cosign
+
 for TYPE in horizon minion sentinel; do
   export DOCKER_REPO="${DOCKER_SERVER}/opennms/${REPO}/${TYPE}"
 
@@ -69,6 +71,7 @@ for TYPE in horizon minion sentinel; do
     _file_tag="$(basename "${_file}" | sed -e 's,\.oci$,,')"
     _internal_tag="opennms/${_file_tag}"
     _arch_tag="$(printf '%s' "${_file_tag}" | sed -e "s,^${TYPE}-,,")"
+
     echo "${TYPE}: tag=${_internal_tag}, arch_tag=${_arch_tag}, file=${_file}"
     for _publish_tag in "${DOCKER_TAGS[@]}"; do
       _tagname="${DOCKER_REPO}:${_publish_tag}-${_arch_tag}"
@@ -82,6 +85,9 @@ for TYPE in horizon minion sentinel; do
         do_with_retries docker push --quiet "${_tagname}"
       fi
     done
+
+    _sha256="$(get_sha256 "${_internal_tag}")"
+    cosign_sign "${DOCKER_REPO}@${_sha256}" "/tmp/artifacts/xml/${_file_tag}-sbom.xml"
   done
 
 done

--- a/.circleci/scripts/publish-dockerhub.sh
+++ b/.circleci/scripts/publish-dockerhub.sh
@@ -18,6 +18,8 @@ export DOCKER_PASSWORD="${DOCKERHUB_PASS}"
 # shellcheck disable=SC1091
 . "${MYDIR}/lib-docker.sh"
 
+configure_cosign
+
 printf '%s' "${DCT_DELEGATE_KEY}" | base64 -d > "${PRIVATE_KEY_FOLDER}/${DCT_DELEGATE_KEY_NAME}.key"
 chmod 600 "${PRIVATE_KEY_FOLDER}/${DCT_DELEGATE_KEY_NAME}.key"
 
@@ -49,14 +51,19 @@ for TYPE in horizon minion sentinel; do
     _arch_tag="$(printf '%s' "${_file_tag}" | sed -e "s,^${TYPE}-,,")"
 
     _push_tag="${DOCKER_BRANCH_TAG}-${_arch_tag}"
-    docker tag "${_internal_tag}" "${DOCKER_REPO}:${_push_tag}"
-    do_with_retries docker push --quiet "${DOCKER_REPO}:${_push_tag}"
+    _tagname="${DOCKER_REPO}:${_push_tag}"
+    docker tag "${_internal_tag}" "${_tagname}"
+    do_with_retries docker push --quiet "${_tagname}"
+
+    _sha256="$(get_sha256 "${_internal_tag}")"
+    cosign_sign "${DOCKER_REPO}@${_sha256}" "/tmp/artifacts/xml/${_file_tag}-sbom.xml"
   done
 
   export NOTARY_TARGETS_PASSPHRASE="${!_key_passphrase_variable}"
   for _publish_tag in "${DOCKER_TAGS[@]}"; do
     create_and_push_manifest "${DOCKER_REPO}" "${DOCKER_BRANCH_TAG}" "${_publish_tag}"
     do_with_retries notary -d ~/.docker/trust/ -s https://notary.docker.io addhash "${DOCKER_REPO}" "${_publish_tag}" "${DOCKER_IMAGE_BYTES_SIZE}" --sha256 "${DOCKER_IMAGE_SHA_256}" --publish --verbose
+    cosign_sign "${DOCKER_REPO}@sha256:${DOCKER_IMAGE_SHA_256}"
   done
 
 done


### PR DESCRIPTION
This PR implements docker image signing using [cosign](https://github.com/sigstore/cosign), an alternative to Docker Content Trust that supports signing other arbitrary resources including SBOMs (Software Bill-Of-Materials).

I have implemented SBOM-signing/attestation along with image signing.

Once approved, I will remove the temporary code that allowed me to publish from my branch to dockerhub and similar.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15341
