### PR TITLE
Smoke test improvements and tweaks to help developers

### DIFF
--- a/.circleci/scripts/smoke.sh
+++ b/.circleci/scripts/smoke.sh
@@ -75,4 +75,5 @@ fi
   -N \
   '-P!smoke.all' \
   "-Psmoke.$SUITE" \
+  -Pcoverage \
   install verify

--- a/.circleci/scripts/smoke.sh
+++ b/.circleci/scripts/smoke.sh
@@ -65,6 +65,7 @@ else
   IT_TESTS="$(< /tmp/this_node_it_tests paste -s -d, -)"
 fi
 
+# When we are ready to collect coverge on smoke tests, add "-Pcoverage" below
 ../compile.pl \
   -DskipTests=false \
   -DskipITs=false \
@@ -75,5 +76,4 @@ fi
   -N \
   '-P!smoke.all' \
   "-Psmoke.$SUITE" \
-  -Pcoverage \
   install verify

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -62,6 +62,9 @@ RUNJAVA_OPTIONS=""
 # when it cannot connect using the Attach API (automatically or by PID)
 JMX_URL="service:jmx:rmi:///jndi/rmi://127.0.0.1:1099/jmxrmi"
 
+# Whether to include a thread dump before we start shutting down
+THREAD_DUMP=1
+
 # Whether to enable the Pyroscope agent
 [ -z "$PYROSCOPE_AGENT_ENABLED" ] && PYROSCOPE_AGENT_ENABLED=0
 
@@ -561,7 +564,9 @@ doStop() {
 	fi
 
 	PID="$(getPid)"
-	if [ "$PID" -gt 0 ]; then
+	if [ -z "$THREAD_DUMP" ] || [ "$THREAD_DUMP" -eq 0 ]; then
+		echo "=== Skipping Complimentary Thread Dump ===" >> "$REDIRECT"
+	elif [ "$PID" -gt 0 ]; then
 		echo "=== ${install.package.description} Complimentary Thread Dump ===" >> "$REDIRECT"
 		kill -3 "$PID" >> "$REDIRECT" 2>&1
 	else

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -119,7 +119,7 @@ show_help () {
 	cat <<END
 Usage: $0 [-f] [-n] [-t] [-p] [-o] [-c timeout] [-v] [-Q] [-s] <command> [<service>]
 
-  command options: start|stop|restart|status|ssh|check|pause|resume|kill
+  command options: start|stop|restart|status|ssh|check|pause|resume|kill|restart-fast
 
   service options: all|<a service id from the etc/service-configuration.xml>
       defaults to all
@@ -1123,6 +1123,26 @@ case "$COMMAND" in
 			__opennms_cmd+=("-f")
 		fi
 		"${__opennms_cmd[@]}" "stop" && \
+		"${__opennms_cmd[@]}" "start"
+		;;
+
+	restart-fast)
+		## Kill the service and regardless of whether it was
+		## running or not, start it again.
+		__opennms_cmd=("$OPENNMS_HOME/bin/opennms");
+		if [ "$BIGTFLAG" -eq 1 ]; then
+			__opennms_cmd+=("-T")
+		fi
+		if [ "$SMALLTFLAG" -eq 1 ]; then
+			__opennms_cmd+=("-t")
+		fi
+		if [ "$NOEXECUTE" -eq 1 ]; then
+			__opennms_cmd+=("-n")
+		fi
+		if [ "$BACKGROUND" -eq 0 ]; then
+			__opennms_cmd+=("-f")
+		fi
+		"${__opennms_cmd[@]}" "kill" && \
 		"${__opennms_cmd[@]}" "start"
 		;;
 

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -87,6 +87,7 @@
             <!-- Don't specify argLine here or it will override the argLine property value -->
             <systemPropertyVariables>
               <seleniarm.version>${seleniarm.version}</seleniarm.version>
+              <coverage>${coverage}</coverage>
             </systemPropertyVariables>
             <!--
               Configure failsafe to put reports in the surefire unit test directory so that
@@ -337,6 +338,15 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>coverage</id>
+      <activation>
+        <property>
+          <name>coverage</name>
+          <value>true</value>
+        </property>
+      </activation>
     </profile>
   </profiles>
   <dependencyManagement>

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -367,22 +367,28 @@ public class MinionContainer extends GenericContainer<MinionContainer> implement
     }
 
     private void retainLogsfNeeded(String prefix, boolean succeeded) {
-        LOG.info("Triggering thread dump...");
-        DevDebugUtils.triggerThreadDump(this);
-        LOG.info("Gathering logs...");
-        copyLogs(this, prefix);
-    }
+        Path targetLogFolder = Paths.get("target", "logs", prefix, "minion");
+        DevDebugUtils.clearLogs(targetLogFolder);
 
-    private static void copyLogs(MinionContainer container, String prefix) {
+        LOG.info("Gathering thread dump...");
+        var threadDump = DevDebugUtils.gatherThreadDump(this, targetLogFolder, null);
+
+        LOG.info("Gathering logs...");
         // List of known log files we expect to find in the container
         final List<String> logFiles = Arrays.asList("karaf.log");
-        DevDebugUtils.copyLogs(container,
+        DevDebugUtils.copyLogs(this,
                 // dest
-                Paths.get("target", "logs", prefix, "minion"),
+                targetLogFolder,
                 // source folder
                 Paths.get("/opt", "minion", "data", "log"),
                 // log files
                 logFiles);
+
+        LOG.info("Log directory: {}", targetLogFolder.toUri());
+        LOG.info("Console log: {}", targetLogFolder.resolve(DevDebugUtils.CONTAINER_STDOUT_STDERR).toUri());
+        if (threadDump != null) {
+            LOG.info("Thread dump: {}", threadDump.toUri());
+        }
     }
 
     public String getId() {

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -116,7 +116,7 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
     private static final int OPENNMS_BMP_PORT = 11019;
     private static final int OPENNMS_TFTP_PORT = 6969;
 
-    private static final boolean COLLECT_COVERAGE = true;
+    private static final boolean COLLECT_COVERAGE = "true".equals(System.getProperty("coverage", "false"));
 
     private static final Map<NetworkProtocol, Integer> networkProtocolMap = ImmutableMap.<NetworkProtocol, Integer>builder()
             .put(NetworkProtocol.SSH, OPENNMS_SSH_PORT)

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/PostgreSQLContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/PostgreSQLContainer.java
@@ -29,6 +29,7 @@
 package org.opennms.smoketest.containers;
 
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Optional;
@@ -107,18 +108,16 @@ public class PostgreSQLContainer extends org.testcontainers.containers.PostgreSQ
     private void retainLogsfNeeded(String prefix, boolean succeeded) {
         if (!succeeded) {
             LOG.info("Gathering logs...");
-            copyLogs(this, prefix);
+            Path targetLogFolder = Paths.get("target", "logs", prefix, "postgresql");
+            DevDebugUtils.clearLogs(targetLogFolder);
+            DevDebugUtils.copyLogs(this,
+                    // dest
+                    targetLogFolder,
+                    // source folder
+                    Paths.get("/var", "lib", "postgresql", "data"),
+                    // no log files to copy, everything is available via the container logs
+                    Collections.emptyList());
         }
-    }
-
-    private static void copyLogs(PostgreSQLContainer container, String prefix) {
-        DevDebugUtils.copyLogs(container,
-                // dest
-                Paths.get("target", "logs", prefix, "postgresql"),
-                // source folder
-                Paths.get("/var", "lib", "postgresql", "data"),
-                // no log files to copy, everything is available via the container logs
-                Collections.emptyList());
     }
 
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/DevDebugUtils.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/DevDebugUtils.java
@@ -28,14 +28,22 @@
 
 package org.opennms.smoketest.utils;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -108,31 +116,105 @@ public class DevDebugUtils {
         }
     }
 
-    public static void triggerThreadDump(Container container) {
+    public static void clearLogs(Path targetLogFolder) {
+        // We don't want to intermix old and new log files.
+        if (Files.exists(targetLogFolder)) {
+            FileSystemUtils.deleteRecursively(targetLogFolder.toFile());
+        }
+    }
+
+    /**
+     * Gather a thread dump on the JVM process at PID 1 in the container.
+     *
+     * @param container       Container to gather a thread dump from.
+     * @param targetLogFolder if set, store the thread dump in a "threadDump.log" in this directory.
+     * @param outputLog       if set, this is the log file in the container where we expect to see the thread dump.
+     *                        If null, will use getLogs().
+     * @return path to thread dump file if one was stored, null otherwise.
+     */
+    public static Path gatherThreadDump(Container container, Path targetLogFolder, Path outputLog) {
         if (!container.isRunning()) {
-            LOG.warn("triggerThreadDump can only be used on a running container. Container [{}] is not running", container.getDockerImageName());
-            return;
+            LOG.warn("gatherThreadDump can only be used on a running container. Container [{}] is not running",
+                    container.getDockerImageName());
+            return null;
         }
 
         try {
             LIMITER.callWithTimeout(() -> {
                 LOG.info("kill -3 -1");
                 container.execInContainer("kill", "-3", "1");
-                LOG.info("Sleeping for 5 seconds to give the JVM a chance to respond...");
-                Thread.sleep(TimeUnit.SECONDS.toMillis(5));
-                LOG.info("Thread dump should be ready.");
                 return null;
             }, 1, TimeUnit.MINUTES);
         } catch (Exception e) {
             LOG.warn("Sending SIGQUIT to JVM in container failed. Thread dump may not be available.", e);
         }
+
+        final Callable<String> threadDumpCallable;
+        if (outputLog != null) {
+            threadDumpCallable = () -> TestContainerUtils.getFileFromContainerAsString(container, outputLog);
+        } else {
+            threadDumpCallable = container::getLogs;
+        }
+
+        try {
+            await("waiting for thread dump to complete")
+                    .atMost(Duration.ofSeconds(5))
+                    .failFast("container is no longer running", () -> !container.isRunning())
+                    .ignoreException(NotFoundException.class)
+                    .until(threadDumpCallable, containsString("JNI global refs")); // shows up near the end
+        } catch (Exception e) {
+            LOG.warn("Did not see thread dump in container {} within timeout",
+                    outputLog != null ? outputLog : "console logs",
+                    e);
+        }
+
+        if (targetLogFolder == null) {
+            return null;
+        }
+
+        try {
+            Files.createDirectories(targetLogFolder);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create " + targetLogFolder, e);
+        }
+
+        var targetFile = targetLogFolder.resolve("threadDump.log");
+        try {
+            // Example:
+            //
+            //     2022-11-13 16:46:30
+            //     Full thread dump OpenJDK 64-Bit Server VM (11.0.16+8-post-Ubuntu-0ubuntu122.04 mixed mode):
+            //     ...
+            //
+            //     Heap
+            //      garbage-first heap   total 2097152K, used 474813K [0x0000000080000000, 0x0000000100000000)
+            //       region size 1024K, 111 young (113664K), 20 survivors (20480K)
+            //      Metaspace       used 303094K, capacity 321939K, committed 322160K, reserved 1335296K
+            //       class space    used 31196K, capacity 35846K, committed 35916K, reserved 1048576K
+            //
+            // A few tricky things:
+            // - We optionally include the time stamp on the line before "Full thread dump".
+            // - We end our match once we see an empty line after "Heap".
+            var threadDump = threadDumpCallable.call().replaceFirst(
+                    "(?ms).*?((^[^\r\n]*$[\r\n]+)?^Full thread dump .*^Heap$.*?^$).*?",
+                    "$1"
+            );
+            try (Writer fileWriter = new OutputStreamWriter(
+                    new FileOutputStream(targetFile.toFile()), StandardCharsets.UTF_8)) {
+                fileWriter.write(
+                        "# IntelliJ IDEA users: might I suggest Code | Analyze Stack Trace or Thread Dump.\n"
+                                + "# See: https://www.jetbrains.com/help/idea/analyzing-external-stacktraces.html\n"
+                                + "\n");
+                fileWriter.write(threadDump);
+            }
+            return targetFile;
+        } catch (Exception e) {
+            LOG.warn("Could not retrieve or store thread dump in file {}", targetFile, e);
+            return null;
+        }
     }
 
     public static void copyLogs(Container container, Path targetLogFolder, Path sourceLogFolder, List<String> logFiles) {
-        // We don't want to intermix old and new log files.
-        if (Files.exists(targetLogFolder)) {
-            FileSystemUtils.deleteRecursively(targetLogFolder.toFile());
-        }
         try {
             Files.createDirectories(targetLogFolder);
         } catch (IOException e) {


### PR DESCRIPTION
- Allow thread dumps on shutdown to be disabled.
- Add "restart-fast" option to opennms script.
- Disable code coverage collection by default in smoke tests
- Speedup thread dump collection and store in its own file

### External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15387

