### PR TITLE
Move from com.jayway.awaitility (1.7.0) to org.awaitility (4.2.0)

### DIFF
--- a/core/api/pom.xml
+++ b/core/api/pom.xml
@@ -61,7 +61,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/ipc/grpc/itests/pom.xml
+++ b/core/ipc/grpc/itests/pom.xml
@@ -66,7 +66,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/ipc/grpc/itests/src/test/java/org/opennms/core/ipc/grpc/GrpcIpcRpcIT.java
+++ b/core/ipc/grpc/itests/src/test/java/org/opennms/core/ipc/grpc/GrpcIpcRpcIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.grpc;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;

--- a/core/ipc/grpc/itests/src/test/java/org/opennms/core/ipc/grpc/GrpcIpcSinkIT.java
+++ b/core/ipc/grpc/itests/src/test/java/org/opennms/core/ipc/grpc/GrpcIpcSinkIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.grpc;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/core/ipc/grpc/itests/src/test/java/org/opennms/core/ipc/grpc/GrpcTLSMutualAuthIT.java
+++ b/core/ipc/grpc/itests/src/test/java/org/opennms/core/ipc/grpc/GrpcTLSMutualAuthIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.grpc;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/core/ipc/rpc/kafka/pom.xml
+++ b/core/ipc/rpc/kafka/pom.xml
@@ -155,7 +155,7 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.jayway.awaitility</groupId>
+        <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <scope>test</scope>
       </dependency>

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaIT.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.rpc.kafka;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;

--- a/core/ipc/sink/camel/itests/pom.xml
+++ b/core/ipc/sink/camel/itests/pom.xml
@@ -97,7 +97,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/ipc/sink/camel/itests/src/test/java/org/opennms/core/ipc/sink/camel/itests/HeartbeatSinkBlueprintIT.java
+++ b/core/ipc/sink/camel/itests/src/test/java/org/opennms/core/ipc/sink/camel/itests/HeartbeatSinkBlueprintIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.camel.itests;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.equalTo;
 

--- a/core/ipc/sink/camel/itests/src/test/java/org/opennms/core/ipc/sink/camel/itests/HeartbeatSinkPerfIT.java
+++ b/core/ipc/sink/camel/itests/src/test/java/org/opennms/core/ipc/sink/camel/itests/HeartbeatSinkPerfIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.camel.itests;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.greaterThan;
 
 import java.util.ArrayList;

--- a/core/ipc/sink/common/pom.xml
+++ b/core/ipc/sink/common/pom.xml
@@ -130,7 +130,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/ipc/sink/common/src/test/java/org/opennms/core/ipc/sink/aggregation/AggregationTest.java
+++ b/core/ipc/sink/common/src/test/java/org/opennms/core/ipc/sink/aggregation/AggregationTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.aggregation;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThan;

--- a/core/ipc/sink/common/src/test/java/org/opennms/core/ipc/sink/common/AsyncDispatcherTest.java
+++ b/core/ipc/sink/common/src/test/java/org/opennms/core/ipc/sink/common/AsyncDispatcherTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.common;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -67,7 +67,7 @@ import org.opennms.core.ipc.sink.api.SinkModule;
 import org.opennms.core.ipc.sink.offheap.DispatchQueueServiceLoader;
 import org.opennms.core.ipc.sink.offheap.QueueFileOffHeapDispatchQueueFactory;
 
-import com.jayway.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.ConditionTimeoutException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AsyncDispatcherTest {

--- a/core/ipc/sink/kafka/itests/pom.xml
+++ b/core/ipc/sink/kafka/itests/pom.xml
@@ -112,7 +112,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/HeartbeatSinkIT.java
+++ b/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/HeartbeatSinkIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.kafka.itests;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;

--- a/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/HeartbeatSinkPerfIT.java
+++ b/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/HeartbeatSinkPerfIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.kafka.itests;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;

--- a/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/KafkaLargeBufferSinkIT.java
+++ b/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/KafkaLargeBufferSinkIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.kafka.itests;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;

--- a/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/offset/KafkaOffsetIT.java
+++ b/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/offset/KafkaOffsetIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.kafka.itests.offset;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.ArrayList;

--- a/core/ipc/sink/off-heap/pom.xml
+++ b/core/ipc/sink/off-heap/pom.xml
@@ -65,7 +65,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueueTest.java
+++ b/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueueTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.offheap;
 
-import com.jayway.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -57,7 +57,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;

--- a/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/QueueFileOffHeapDispatchQueueTest.java
+++ b/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/QueueFileOffHeapDispatchQueueTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.sink.offheap;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -59,7 +59,7 @@ import org.junit.rules.TemporaryFolder;
 import org.opennms.core.ipc.sink.api.DispatchQueue;
 import org.opennms.core.ipc.sink.api.WriteFailedException;
 
-import com.jayway.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.ConditionTimeoutException;
 
 public class QueueFileOffHeapDispatchQueueTest {
 

--- a/core/ipc/twin/common/pom.xml
+++ b/core/ipc/twin/common/pom.xml
@@ -158,7 +158,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/core/ipc/twin/grpc/itests/pom.xml
+++ b/core/ipc/twin/grpc/itests/pom.xml
@@ -63,7 +63,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/core/ipc/twin/jms/itests/src/test/java/org/opennms/core/ipc/twin/jms/JmsTwinIT.java
+++ b/core/ipc/twin/jms/itests/src/test/java/org/opennms/core/ipc/twin/jms/JmsTwinIT.java
@@ -63,7 +63,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;

--- a/core/ipc/twin/kafka/itests/pom.xml
+++ b/core/ipc/twin/kafka/itests/pom.xml
@@ -46,7 +46,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/core/ipc/twin/kafka/itests/src/test/java/org/opennms/core/ipc/twin/kafka/KafkaTwinIT.java
+++ b/core/ipc/twin/kafka/itests/src/test/java/org/opennms/core/ipc/twin/kafka/KafkaTwinIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.twin.kafka;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.contains;
 
 import java.util.Properties;

--- a/core/ipc/twin/memory/pom.xml
+++ b/core/ipc/twin/memory/pom.xml
@@ -49,7 +49,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/core/ipc/twin/test/pom.xml
+++ b/core/ipc/twin/test/pom.xml
@@ -48,7 +48,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/core/ipc/twin/test/src/main/java/org/opennms/core/ipc/twin/test/AbstractTwinBrokerIT.java
+++ b/core/ipc/twin/test/src/main/java/org/opennms/core/ipc/twin/test/AbstractTwinBrokerIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.ipc.twin.test;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;

--- a/core/lib/pom.xml
+++ b/core/lib/pom.xml
@@ -57,7 +57,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/lib/src/test/java/org/opennms/core/fileutils/FileUpdateWatcherTest.java
+++ b/core/lib/src/test/java/org/opennms/core/fileutils/FileUpdateWatcherTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.fileutils;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.BufferedWriter;

--- a/core/snmp/impl-snmp4j/pom.xml
+++ b/core/snmp/impl-snmp4j/pom.xml
@@ -89,7 +89,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/snmp/integration-tests/pom.xml
+++ b/core/snmp/integration-tests/pom.xml
@@ -62,7 +62,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/SnmpUtilsIT.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/SnmpUtilsIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.snmp;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/snmp4j/Snmp4jTrapReceiverIT.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/snmp4j/Snmp4jTrapReceiverIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.snmp.snmp4j;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/core/test-api/alarms/pom.xml
+++ b/core/test-api/alarms/pom.xml
@@ -74,7 +74,7 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/core/test-api/alarms/src/test/java/org/opennms/core/test/alarms/driver/ScenarioDriverIT.java
+++ b/core/test-api/alarms/src/test/java/org/opennms/core/test/alarms/driver/ScenarioDriverIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.test.alarms.driver;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;

--- a/core/test-api/kafka/pom.xml
+++ b/core/test-api/kafka/pom.xml
@@ -38,7 +38,7 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/core/test-api/kafka/src/main/java/org/opennms/core/test/kafka/JUnitKafkaServer.java
+++ b/core/test-api/kafka/src/main/java/org/opennms/core/test/kafka/JUnitKafkaServer.java
@@ -28,7 +28,7 @@
 
 package org.opennms.core.test.kafka;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;

--- a/features/alarms/history/elastic/pom.xml
+++ b/features/alarms/history/elastic/pom.xml
@@ -120,7 +120,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryBlackboxIT.java
+++ b/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryBlackboxIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.alarms.history.elastic;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;

--- a/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryRepositoryIT.java
+++ b/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryRepositoryIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.alarms.history.elastic;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,7 +57,7 @@ import org.opennms.features.jest.client.index.IndexStrategy;
 import org.opennms.features.jest.client.template.IndexSettings;
 
 import com.codahale.metrics.MetricRegistry;
-import com.jayway.awaitility.Awaitility;
+import org.awaitility.Awaitility;
 
 import io.searchbox.client.JestClient;
 

--- a/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmIndexerIT.java
+++ b/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmIndexerIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.alarms.history.elastic;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -58,7 +58,7 @@ import org.opennms.features.jest.client.index.IndexStrategy;
 import org.opennms.features.jest.client.template.IndexSettings;
 
 import com.codahale.metrics.MetricRegistry;
-import com.jayway.awaitility.Awaitility;
+import org.awaitility.Awaitility;
 
 import io.searchbox.client.JestClient;
 

--- a/features/bsm/daemon/pom.xml
+++ b/features/bsm/daemon/pom.xml
@@ -123,7 +123,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/bsm/daemon/src/test/java/org/opennms/netmgt/bsm/daemon/BsmdIT.java
+++ b/features/bsm/daemon/src/test/java/org/opennms/netmgt/bsm/daemon/BsmdIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.bsm.daemon;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;

--- a/features/collection/persistence-tcp/pom.xml
+++ b/features/collection/persistence-tcp/pom.xml
@@ -66,7 +66,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/collection/persistence-tcp/src/test/java/org/opennms/netmgt/collection/persistence/tcp/TcpOutputStrategyTest.java
+++ b/features/collection/persistence-tcp/src/test/java/org/opennms/netmgt/collection/persistence/tcp/TcpOutputStrategyTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.collection.persistence.tcp;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -78,7 +78,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.jayway.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.ConditionTimeoutException;
 
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations={

--- a/features/collection/thresholding/impl/pom.xml
+++ b/features/collection/thresholding/impl/pom.xml
@@ -214,7 +214,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdingConfigPersistenceIT.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdingConfigPersistenceIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.threshd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.TimeUnit;
 

--- a/features/distributed/coordination/common/pom.xml
+++ b/features/distributed/coordination/common/pom.xml
@@ -52,7 +52,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/features/distributed/coordination/common/src/test/java/org/opennms/features/distributed/coordination/common/ConnectionBasedDomainManagerTest.java
+++ b/features/distributed/coordination/common/src/test/java/org/opennms/features/distributed/coordination/common/ConnectionBasedDomainManagerTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.distributed.coordination.common;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;

--- a/features/distributed/coordination/zookeeper/pom.xml
+++ b/features/distributed/coordination/zookeeper/pom.xml
@@ -91,7 +91,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/features/distributed/coordination/zookeeper/src/test/java/org/opennms/features/distributed/coordination/zookeeper/ZookeeperDomainManagerIT.java
+++ b/features/distributed/coordination/zookeeper/src/test/java/org/opennms/features/distributed/coordination/zookeeper/ZookeeperDomainManagerIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.distributed.coordination.zookeeper;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -48,7 +48,7 @@ import org.junit.rules.TemporaryFolder;
 import org.opennms.features.distributed.coordination.api.DomainManager;
 import org.opennms.features.distributed.coordination.api.Role;
 
-import com.jayway.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.ConditionTimeoutException;
 
 /**
  * Integration tests for {@link ZookeeperDomainManager}.

--- a/features/distributed/coordination/zookeeper/src/test/java/org/opennms/features/distributed/coordination/zookeeper/ZookeeperDomainManagerTest.java
+++ b/features/distributed/coordination/zookeeper/src/test/java/org/opennms/features/distributed/coordination/zookeeper/ZookeeperDomainManagerTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.distributed.coordination.zookeeper;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.instanceOf;

--- a/features/distributed/kv-store/blob/in-memory/pom.xml
+++ b/features/distributed/kv-store/blob/in-memory/pom.xml
@@ -23,7 +23,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/features/distributed/kv-store/blob/in-memory/src/test/java/org/opennms/features/distributed/kvstore/blob/inmemory/InMemoryMapBlobStoreTest.java
+++ b/features/distributed/kv-store/blob/in-memory/src/test/java/org/opennms/features/distributed/kvstore/blob/inmemory/InMemoryMapBlobStoreTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.distributed.kvstore.blob.inmemory;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/features/eif-adapter/pom.xml
+++ b/features/eif-adapter/pom.xml
@@ -83,7 +83,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/eif-adapter/src/test/java/org/opennms/features/eifadapter/EifAdapterBlueprintTest.java
+++ b/features/eif-adapter/src/test/java/org/opennms/features/eifadapter/EifAdapterBlueprintTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.eifadapter;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.collect.Lists;

--- a/features/events/daemon/pom.xml
+++ b/features/events/daemon/pom.xml
@@ -118,7 +118,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImplTest.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImplTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.eventd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.opennms.core.utils.InetAddressUtils.addr;
 
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -69,7 +70,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
-import com.jayway.awaitility.Duration;
 
 /**
  * @author Seth
@@ -108,12 +108,12 @@ public class EventIpcManagerDefaultImplTest {
     public void tearDown() throws Exception {
         verifyNoMoreInteractions(m_eventHandler);
 
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertEquals("unprocessed received events", 0, m_listener.getEvents().size());
             if (m_caughtThrowable != null) {
                 throw new RuntimeException("Thread " + m_caughtThrowableThread + " threw an uncaught exception: " + m_caughtThrowable, m_caughtThrowable);
             }
-        }});
+        });
     }
 
     @Test
@@ -215,10 +215,10 @@ public class EventIpcManagerDefaultImplTest {
         m_manager.addEventListener(m_listener);
         m_manager.broadcastNow(event, false);
         
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertTrue("could not remove broadcasted event--did it make it?",
                        m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(event)));
-        }});
+        });
     }
 
     @Test
@@ -257,10 +257,10 @@ public class EventIpcManagerDefaultImplTest {
         m_manager.addEventListener(m_listener, e.getUei());
         m_manager.broadcastNow(e, false);
 
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertTrue("could not remove broadcasted event--did it make it?",
                        m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
-        }});
+        });
     }
 
     @Test
@@ -271,10 +271,10 @@ public class EventIpcManagerDefaultImplTest {
         m_manager.addEventListener(m_listener, "uei.opennms.org/");
         m_manager.broadcastNow(e, false);
 
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertTrue("could not remove broadcasted event--did it make it?",
                        m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
-        }});
+        });
     }
 
     @Test
@@ -285,10 +285,10 @@ public class EventIpcManagerDefaultImplTest {
         m_manager.addEventListener(m_listener, "uei.opennms.org/");
         m_manager.broadcastNow(e, false);
 
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertTrue("could not remove broadcasted event--did it make it?",
                        m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
-        }});
+        });
     }
 
     @Test
@@ -318,10 +318,10 @@ public class EventIpcManagerDefaultImplTest {
         m_manager.addEventListener(m_listener, "uei.opennms.org/");
         m_manager.broadcastNow(e, false);
 
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertTrue("could not remove broadcasted event--did it make it?",
                        m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
-        }});
+        });
     }
 
     @Test
@@ -431,10 +431,10 @@ public class EventIpcManagerDefaultImplTest {
         m_manager.addEventListener(m_listener, e.getUei());
         m_manager.broadcastNow(e, false);
 
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertTrue("could not remove broadcasted event--did it make it?",
                        m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
-        }});
+        });
     }
 
     @Test
@@ -446,10 +446,10 @@ public class EventIpcManagerDefaultImplTest {
         m_manager.addEventListener(m_listener);
         m_manager.broadcastNow(e, false);
 
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertTrue("could not remove broadcasted event--did it make it?",
                        m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
-        }});
+        });
     }
 
     /**
@@ -818,9 +818,9 @@ public class EventIpcManagerDefaultImplTest {
         // Wait for N threads to be locked
         lockedFuture.get();
 
-        await().atMost(Duration.ONE_SECOND).until(new Runnable() { public void run() {
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
             assertThat(locker.getNumExtraThreadsWaiting(), equalTo(0));
-        }});
+        });
 
         // Release
         locker.release();

--- a/features/events/syslog/pom.xml
+++ b/features/events/syslog/pom.xml
@@ -202,7 +202,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogSinkConsumerNewSuspectIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogSinkConsumerNewSuspectIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.syslogd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdLoadIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdLoadIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.syslogd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.opennms.core.utils.InetAddressUtils.addr;
 

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -170,7 +170,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapListenerTest.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapListenerTest.java
@@ -31,7 +31,7 @@ package org.opennms.netmgt.trapd;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import com.jayway.awaitility.Awaitility;
+import org.awaitility.Awaitility;
 import java.util.concurrent.TimeUnit;
 import org.opennms.netmgt.config.trapd.Snmpv3User;
 import org.opennms.netmgt.config.trapd.TrapdConfiguration;

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdConfigReloadIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdConfigReloadIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.trapd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.net.InetAddress;

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.trapd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdInformIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdInformIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.trapd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;

--- a/features/flows/itests/pom.xml
+++ b/features/flows/itests/pom.xml
@@ -129,7 +129,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/AggregatedFlowQueryIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/AggregatedFlowQueryIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.flows.elastic;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/BulkingIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/BulkingIT.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.jayway.awaitility.Awaitility.with;
+import static org.awaitility.Awaitility.with;
 import static java.util.concurrent.TimeUnit.*;
 import static org.junit.Assert.*;
 

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/DefaultDirectionIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/DefaultDirectionIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.flows.elastic;
 
-import static com.jayway.awaitility.Awaitility.with;
+import static org.awaitility.Awaitility.with;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.flows.elastic;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/KafkaFlowForwarderIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/KafkaFlowForwarderIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.flows.elastic;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ThresholdingIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ThresholdingIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.flows.elastic;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;

--- a/features/ifttt/pom.xml
+++ b/features/ifttt/pom.xml
@@ -109,7 +109,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/features/ifttt/src/test/java/org/opennms/features/ifttt/IfTttDaemonTest.java
+++ b/features/ifttt/src/test/java/org/opennms/features/ifttt/IfTttDaemonTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.ifttt;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/features/kafka/consumer/pom.xml
+++ b/features/kafka/consumer/pom.xml
@@ -97,7 +97,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/kafka/consumer/src/test/java/org/opennms/features/kafka/consumer/events/OpenNMSKafkaConsumerIT.java
+++ b/features/kafka/consumer/src/test/java/org/opennms/features/kafka/consumer/events/OpenNMSKafkaConsumerIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.kafka.consumer.events;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -200,7 +200,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.kafka.producer;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/collection/KafkaMetricsMaxSizeIT.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/collection/KafkaMetricsMaxSizeIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.kafka.producer.collection;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/collection/KafkaPersisterIT.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/collection/KafkaPersisterIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.kafka.producer.collection;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isOneOf;

--- a/features/minion/heartbeat/consumer/pom.xml
+++ b/features/minion/heartbeat/consumer/pom.xml
@@ -85,7 +85,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/features/minion/heartbeat/consumer/src/test/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumerIT.java
+++ b/features/minion/heartbeat/consumer/src/test/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumerIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.minion.heartbeat.consumer;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.io.IOException;

--- a/features/perspectivepoller/pom.xml
+++ b/features/perspectivepoller/pom.xml
@@ -90,7 +90,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/perspectivepoller/src/test/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerdIT.java
+++ b/features/perspectivepoller/src/test/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerdIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.perspectivepoller;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;

--- a/features/situation-feedback/elastic/pom.xml
+++ b/features/situation-feedback/elastic/pom.xml
@@ -133,7 +133,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/situation-feedback/elastic/src/test/java/org/opennms/features/situationfeedback/elastic/ElasticFeedbackRepositoryIT.java
+++ b/features/situation-feedback/elastic/src/test/java/org/opennms/features/situationfeedback/elastic/ElasticFeedbackRepositoryIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.features.situationfeedback.elastic;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 

--- a/features/situation-feedback/rest/impl/pom.xml
+++ b/features/situation-feedback/rest/impl/pom.xml
@@ -128,7 +128,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/telemetry/itests/pom.xml
+++ b/features/telemetry/itests/pom.xml
@@ -38,7 +38,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/JtiIT.java
+++ b/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/JtiIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.telemetry.itests;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertTrue;

--- a/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
+++ b/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.telemetry.itests;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;

--- a/features/telemetry/protocols/bmp/stats/pom.xml
+++ b/features/telemetry/protocols/bmp/stats/pom.xml
@@ -104,7 +104,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/telemetry/protocols/bmp/stats/src/test/java/org/opennms/netmgt/telemetry/protocols/bmp/adapter/stats/RouteInfoPersistIT.java
+++ b/features/telemetry/protocols/bmp/stats/src/test/java/org/opennms/netmgt/telemetry/protocols/bmp/adapter/stats/RouteInfoPersistIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.telemetry.protocols.bmp.adapter.stats;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 import java.net.URISyntaxException;
 import java.net.URL;

--- a/features/telemetry/protocols/netflow/parser/pom.xml
+++ b/features/telemetry/protocols/netflow/parser/pom.xml
@@ -115,7 +115,7 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IllegalFlowTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IllegalFlowTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.telemetry.protocols.netflow.parser;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 

--- a/features/telemetry/protocols/openconfig/itests/pom.xml
+++ b/features/telemetry/protocols/openconfig/itests/pom.xml
@@ -51,7 +51,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/telemetry/protocols/openconfig/itests/src/test/java/org/opennms/features/telemetry/protocols/openconfig/OpenConfigClientIT.java
+++ b/features/telemetry/protocols/openconfig/itests/src/test/java/org/opennms/features/telemetry/protocols/openconfig/OpenConfigClientIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.telemetry.protocols.openconfig;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 

--- a/features/telemetry/protocols/openconfig/itests/src/test/java/org/opennms/features/telemetry/protocols/openconfig/OpenConfigIT.java
+++ b/features/telemetry/protocols/openconfig/itests/src/test/java/org/opennms/features/telemetry/protocols/openconfig/OpenConfigIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.telemetry.protocols.openconfig;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertTrue;
 

--- a/integrations/opennms-vmware/pom.xml
+++ b/integrations/opennms-vmware/pom.xml
@@ -173,9 +173,8 @@
             <artifactId>org.opennms.core.test-api.xml</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrations/opennms-vmware/src/test/java/org/opennms/protocols/vmware/ServiceInstancePoolTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/protocols/vmware/ServiceInstancePoolTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.protocols.vmware;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/opennms-alarms/daemon/pom.xml
+++ b/opennms-alarms/daemon/pom.xml
@@ -130,7 +130,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleListenerManagerIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleListenerManagerIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.alarmd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmPersisterExtensionIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmPersisterExtensionIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.alarmd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.alarmd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmTicketerServiceIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmTicketerServiceIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.alarmd.drools;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;

--- a/opennms-config-dao/common-impl/pom.xml
+++ b/opennms-config-dao/common-impl/pom.xml
@@ -68,7 +68,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>

--- a/opennms-config-dao/common-impl/src/test/java/org/opennms/netmgt/config/dao/common/impl/FileSystemSaveableConfigContainerTest.java
+++ b/opennms-config-dao/common-impl/src/test/java/org/opennms/netmgt/config/dao/common/impl/FileSystemSaveableConfigContainerTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.config.dao.common.impl;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;

--- a/opennms-config-dao/common-impl/src/test/java/org/opennms/netmgt/config/dao/common/impl/PollingJsonStoreReloadableConfigContainerTest.java
+++ b/opennms-config-dao/common-impl/src/test/java/org/opennms/netmgt/config/dao/common/impl/PollingJsonStoreReloadableConfigContainerTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.config.dao.common.impl;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;

--- a/opennms-correlation/drools-correlation-engine/pom.xml
+++ b/opennms-correlation/drools-correlation-engine/pom.xml
@@ -188,7 +188,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsReloadFactsTest.java
+++ b/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsReloadFactsTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.correlation.drools;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;

--- a/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/PersistStateIT.java
+++ b/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/PersistStateIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.correlation.drools;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;

--- a/opennms-dao/pom.xml
+++ b/opennms-dao/pom.xml
@@ -206,7 +206,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImplIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImplIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.dao.hibernate;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.opennms.core.utils.InetAddressUtils.addr;
 
 import java.net.InetAddress;

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/DefaultFilterWatcherTest.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/DefaultFilterWatcherTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.dao.support;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;

--- a/opennms-provision/opennms-provision-persistence/pom.xml
+++ b/opennms-provision/opennms-provision-persistence/pom.xml
@@ -188,7 +188,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
     </dependency>
   </dependencies>

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/FilesystemForeignSourceRepositoryIT.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/FilesystemForeignSourceRepositoryIT.java
@@ -31,7 +31,7 @@ package org.opennms.netmgt.provision.persist;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/opennms-provision/opennms-provisiond/pom.xml
+++ b/opennms-provision/opennms-provisiond/pom.xml
@@ -137,7 +137,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NodeInfoScanIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NodeInfoScanIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.provision.service;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyObject;

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NodeScanIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NodeScanIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.provision.service;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -472,7 +472,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/DuplicatePrimaryAddressIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/DuplicatePrimaryAddressIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.collectd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.net.InetAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -92,8 +93,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
-
-import com.jayway.awaitility.Duration;
 
 /**
  * Test class for <a href="http://issues.opennms.org/browse/NMS-6226">NMS-6226</a>
@@ -317,14 +316,11 @@ public class DuplicatePrimaryAddressIT {
     private void verify() throws Exception {
         int successfulCollections = 5; // At least 5 collections must be performed for the above wait time.
 
-        await().atMost(Duration.ONE_MINUTE).pollInterval(Duration.ONE_HUNDRED_MILLISECONDS).until(new Runnable() {
-            @Override
-            public void run() {
+        await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(100)).untilAsserted(() -> {
                 Assert.assertTrue(successfulCollections <= countMessages("collector.collect: begin:testPackage/1/192.168.1.1/SNMP"));
                 Assert.assertTrue(successfulCollections <= countMessages("collector.collect: end:testPackage/1/192.168.1.1/SNMP"));
                 Assert.assertTrue(successfulCollections <= countMessages("collector.collect: begin:testPackage/3/192.168.1.1/SNMP"));
                 Assert.assertTrue(successfulCollections <= countMessages("collector.collect: end:testPackage/3/192.168.1.1/SNMP"));                
-            }
         });
 
         m_collectd.stop();

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/ThresholdIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/ThresholdIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.collectd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.opennms.core.utils.InetAddressUtils.addr;

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/NotificationThreadsIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/NotificationThreadsIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.notifd;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollOutagesConfigPersistenceIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollOutagesConfigPersistenceIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.poller;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.poller;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;

--- a/pom.xml
+++ b/pom.xml
@@ -4553,12 +4553,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.jayway.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>1.7.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>4.2.0</version>

--- a/smoke-test/src/main/java/org/opennms/smoketest/telemetry/FlowTester.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/telemetry/FlowTester.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.telemetry;
 
-import static com.jayway.awaitility.Awaitility.with;
+import static org.awaitility.Awaitility.with;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/KarafShell.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/KarafShell.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.utils;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/BaseKafkaPersisterIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/BaseKafkaPersisterIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;

--- a/smoke-test/src/test/java/org/opennms/smoketest/EditInRequisitionIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/EditInRequisitionIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.with;
+import static org.awaitility.Awaitility.with;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.concurrent.TimeUnit;

--- a/smoke-test/src/test/java/org/opennms/smoketest/IntegrationAPIIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/IntegrationAPIIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/NodeRestIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/NodeRestIT.java
@@ -29,7 +29,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.hamcrest.Matchers.is;
 import java.util.concurrent.TimeUnit;

--- a/smoke-test/src/test/java/org/opennms/smoketest/NotifdIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/NotifdIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/ReloadDaemonIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ReloadDaemonIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.opennms.netmgt.events.api.EventConstants.RELOAD_DAEMON_CONFIG_SUCCESSFUL_UEI;

--- a/smoke-test/src/test/java/org/opennms/smoketest/ScheduledOutageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ScheduledOutageIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.with;
+import static org.awaitility.Awaitility.with;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.text.SimpleDateFormat;
@@ -109,7 +109,7 @@ public class ScheduledOutageIT extends OpenNMSSeleniumIT {
         findElementByXpath("//form[@action='admin/sched-outages/editoutage.jsp']//button[@name='newOutage']").click();
 
         // Wait till the editor page appears.
-        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("Editing Outage: My-Scheduled-Outage"));
+        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("Editing Outage: My-Scheduled-Outage").apply(driver));
         // Now add all nodes and interfaces...
         findElementByXpath("//form[@id='matchAnyForm']//input[@name='matchAny']").click();
         // ...and confirm the alert box.
@@ -132,7 +132,7 @@ public class ScheduledOutageIT extends OpenNMSSeleniumIT {
         findElementByXpath("//input[@name='addOutage']").click();
 
         // check whether the outage text appears correctly...
-        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText(text));
+        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText(text).apply(driver));
     }
 
     private void testCharactersInName(String name) throws Exception {
@@ -140,7 +140,7 @@ public class ScheduledOutageIT extends OpenNMSSeleniumIT {
             getDriver().get(getBaseUrlInternal() + "opennms/admin/sched-outages/index.jsp");
             enterText(By.xpath("//form[@action='admin/sched-outages/editoutage.jsp']//input[@name='newName']"), name);
             findElementByXpath("//form[@action='admin/sched-outages/editoutage.jsp']//button[@name='newOutage']").click();
-            with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("Editing Outage: "+name));
+            with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("Editing Outage: "+name).apply(driver));
             findElementByXpath("//form[@id='matchAnyForm']//input[@name='matchAny']").click();
             getDriver().switchTo().alert().accept();
 
@@ -159,7 +159,7 @@ public class ScheduledOutageIT extends OpenNMSSeleniumIT {
             findElementByXpath("//input[@name='saveButton']").click();
             getDriver().get(getBaseUrlInternal() + "opennms/element/node.jsp?node=" + REQUISITION_NAME + ":TestMachine");
             findElementByXpath("//a[text()='"+name+"']").click();
-            with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("Editing Outage: "+name));
+            with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("Editing Outage: "+name).apply(driver));
         } finally {
             getDriver().get(getBaseUrlInternal() + "opennms/admin/sched-outages/index.jsp");
 
@@ -200,7 +200,7 @@ public class ScheduledOutageIT extends OpenNMSSeleniumIT {
         findElementByXpath("//form[@action='admin/sched-outages/editoutage.jsp']//button[@name='newOutage']").click();
 
         // Wait till the editor page appears.
-        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("Editing Outage: My-Scheduled-Outage"));
+        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("Editing Outage: My-Scheduled-Outage").apply(driver));
         // Now add all nodes and interfaces...
         findElementByXpath("//form[@id='matchAnyForm']//input[@name='matchAny']").click();
         // ...and confirm the alert box.
@@ -221,7 +221,7 @@ public class ScheduledOutageIT extends OpenNMSSeleniumIT {
         // ...and apply.
         findElementByXpath("//input[@name='setOutageType']").click();
 
-        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("daily"));
+        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("daily").apply(driver));
 
         // This is not working since it's an <input type='image'>
         findElementByXpath("//input[@id='deleteOutageTypeBtn']").click();
@@ -235,6 +235,6 @@ public class ScheduledOutageIT extends OpenNMSSeleniumIT {
         findElementByXpath("//input[@name='setOutageType']").click();
 
         // check whether the outage type text appears correctly...
-        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("weekly"));
+        with().pollInterval(1, SECONDS).await().atMost(10, SECONDS).until(() -> pageContainsText("weekly").apply(driver));
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/SnmpV3IT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/SnmpV3IT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;

--- a/smoke-test/src/test/java/org/opennms/smoketest/StatisticsReportsIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/StatisticsReportsIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.notNullValue;

--- a/smoke-test/src/test/java/org/opennms/smoketest/bsm/BsmEventsIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/bsm/BsmEventsIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.bsm;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.notNullValue;

--- a/smoke-test/src/test/java/org/opennms/smoketest/dcb/DcbEndToEndIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/dcb/DcbEndToEndIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.dcb;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static com.spotify.hamcrest.jackson.JsonMatchers.jsonArray;
 import static com.spotify.hamcrest.jackson.JsonMatchers.jsonBoolean;
 import static com.spotify.hamcrest.jackson.JsonMatchers.jsonInt;

--- a/smoke-test/src/test/java/org/opennms/smoketest/flow/BmpIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/flow/BmpIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.flow;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.preemptive;
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/smoke-test/src/test/java/org/opennms/smoketest/flow/ClockSkewIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/flow/ClockSkewIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.flow;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.notNullValue;

--- a/smoke-test/src/test/java/org/opennms/smoketest/graph/GraphRestServiceIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/graph/GraphRestServiceIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.graph;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.preemptive;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -658,7 +658,7 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
 
     private void createGraphMLAndWaitUntilDone(GraphmlDocument graphmlDocument) {
         graphmlDocument.create(restClient);
-    	await().atMost(30, TimeUnit.SECONDS).pollInterval(5, TimeUnit.SECONDS).until(() -> {
+	await().atMost(30, TimeUnit.SECONDS).pollInterval(5, TimeUnit.SECONDS).untilAsserted(() -> {
             given().accept(ContentType.JSON).get()
                     .then().statusCode(200)
                     .contentType(ContentType.JSON)

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/CollectorListIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/CollectorListIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.hasSize;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsCommandIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsCommandIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.hasSize;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsOnMinionIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsOnMinionIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThan;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/DiscoveryIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/DiscoveryIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThan;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/EventSinkIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/EventSinkIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.notNullValue;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/IpcOverGrpcIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/IpcOverGrpcIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.containsString;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/JMXCollectorIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/JMXCollectorIT.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.containsString;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/JtiTelemetryIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/JtiTelemetryIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThan;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionZSTDRpcIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionZSTDRpcIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.containsString;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartBeatIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartBeatIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MonitorsListCommandIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MonitorsListCommandIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.hasSize;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/NMS14655_IT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/NMS14655_IT.java
@@ -1,6 +1,6 @@
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/NxosTelemetryIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/NxosTelemetryIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.notNullValue;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/RpcOverKafkaIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/RpcOverKafkaIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.containsString;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThan;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearchIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearchIT.java
@@ -27,8 +27,8 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static com.jayway.awaitility.Awaitility.with;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.with;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogOverlappingIpAddressIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogOverlappingIpAddressIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/TrapIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/TrapIT.java
@@ -27,7 +27,7 @@
  *******************************************************************************/
 package org.opennms.smoketest.minion;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;

--- a/smoke-test/src/test/java/org/opennms/smoketest/rest/ReportRestIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/rest/ReportRestIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.rest;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static io.restassured.RestAssured.authentication;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.preemptive;
@@ -146,7 +146,7 @@ public class ReportRestIT extends AbstractRestIT {
              * Delivered Reports
              */
             // Verify list already persisted reports (none yet)
-            await().atMost(1, MINUTES).until(() -> {
+            await().atMost(1, MINUTES).untilAsserted(() -> {
                 LOG.debug("validating no persisted reports exist");
                 given().get("persisted").then().statusCode(204);
             }); 
@@ -163,7 +163,7 @@ public class ReportRestIT extends AbstractRestIT {
             // Verify list already persisted reports work (one)
             LOG.debug("validating report for {} is persisted", user[0]);
             final AtomicReference<Integer> persistedId = new AtomicReference<>(-1);
-            await().atMost(5, MINUTES).pollInterval(5, SECONDS).until(() -> {
+            await().atMost(5, MINUTES).pollInterval(5, SECONDS).untilAsserted(() -> {
                         final String response = given().get("persisted")
                                 .then().log().status()
                                 .assertThat()
@@ -191,7 +191,7 @@ public class ReportRestIT extends AbstractRestIT {
              * Scheduled Reports
              */
             // Verify listing scheduled report works (none yet)
-            await().atMost(1, MINUTES).until(() -> {
+            await().atMost(1, MINUTES).untilAsserted(() -> {
                 LOG.debug("validating no scheduled reports exist");
                 given().get("scheduled").then().statusCode(204);
             });

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/AbstractAdapterIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/AbstractAdapterIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.sentinel;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static io.restassured.RestAssured.preemptive;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/DaoIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/DaoIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.smoketest.sentinel;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 


### PR DESCRIPTION
### Background

We use a mix of both old com.jayway.awaitility (1.7.0) and newer org.awaitility (4.2.0):
```
# old
REMMDGREGOR (⎈|minikube:default) opennms dgregor$ git grep awaitility | grep -i jayway| grep pom.xml | wc
      49      98    4101
# new
REMMDGREGOR (⎈|minikube:default) opennms dgregor$ git grep awaitility | grep -i org.awaitility| grep pom.xml | wc
       7      14     486
```

We’ve run into at least one case where code using the old com.jayway.awaitility (1.7.0) was copied to Horizon Stream and was then difficult to debug, where the newer version would have made the problem clear.

It’s a pretty straightforward upgrade and we only use it in test code.

### Changes

Most common changes:
1. In pom.xml files: `<groupId>com.jayway.awaitility</groupId>` -> `<groupId>org.awaitility</groupId>`
2. `import static com.jayway.awaitility.Awaitility.await;` -> `import static org.awaitility.Awaitility.await;` (and similar for other imports)

Less common changes:
1. Change `com.jayway.awaitility.Duration`s to `java.time.Duration` (slightly more than an import change, but still straightforward). -- https://github.com/OpenNMS/opennms/pull/5773/files#diff-83c224d60a19741a45c5f8ae1c3e77e8fe63943b05cf845c03c804053e0a00fbL111 (and a few more in this file)
2. `until` with a `Runnable` or lambda that doesn't return a `Boolean` -> `untilAsserted` -- https://github.com/OpenNMS/opennms/pull/5773/files#diff-83c224d60a19741a45c5f8ae1c3e77e8fe63943b05cf845c03c804053e0a00fbL111 (and a few more in this file), https://github.com/OpenNMS/opennms/pull/5773/files#diff-10602d515015513dda599ee64a46655b8d2b019142e27d29927682bae7c7794fL112 (plus a few more), https://github.com/OpenNMS/opennms/pull/5773/files#diff-10602d515015513dda599ee64a46655b8d2b019142e27d29927682bae7c7794fL112 (plus a few more)
3. `until ... pageContainsText` -> `until ... pageContainsText(...).apply(driver)`. I don't think the previous form would have ever failed, because I don't think the `pageContainsText` is evaluated until `apply` is called. -- https://github.com/OpenNMS/opennms/pull/5773/files#diff-10602d515015513dda599ee64a46655b8d2b019142e27d29927682bae7c7794fL112 (and a few more in this file)
4. Removed `<dependency>` for `com.jayway.awaitility` from top-level pom.xml. -- https://github.com/OpenNMS/opennms/pull/5773/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L4555
5. Removed an unnecessary `<version>` for `awaitility` (it should use what is in the top-level `pom.xml`'s `dependencyManagement`). -- https://github.com/OpenNMS/opennms/pull/5773/files#diff-ec1020b8d3d40919a90742e0517ae80dba67957249bf6937b28f2c45868e0bedL178

You can see the less common changes by running:
```
git show b9b69fba5731a0edde81063e93457b393b10814d | grep '^[+-]' | grep -v -e '<groupId>' -e '^.import ' | grep -B 1 '^[+-][^+-]' | grep '^+++' | awk '{ print $2 }' | xargs -n 1 git show b9b69fba5731a0edde81063e93457b393b10814d | less
```

That returns these files, all of which are in the list of less common changes above (I'm trying to make this 166 file diff reasonably easy to review <grin>):
```
features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImplTest.java
integrations/opennms-vmware/pom.xml
pom.xml
smoke-test/src/test/java/org/opennms/smoketest/ScheduledOutageIT.java
smoke-test/src/test/java/org/opennms/smoketest/graph/GraphRestServiceIT.java
smoke-test/src/test/java/org/opennms/smoketest/rest/ReportRestIT.java
```

### External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15399

