### PR TITLE
NMS-15086: Synchronize calls to RRD summary endpoint

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/controller/RrdSummaryController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/RrdSummaryController.java
@@ -75,9 +75,11 @@ public class RrdSummaryController {
     /** {@inheritDoc} */
     @RequestMapping(method={ RequestMethod.GET, RequestMethod.POST })
     public ModelAndView processFormSubmission(final HttpServletResponse response, final SummarySpecification command) {
-        final ModelAndView summary = getSummary((SummarySpecification)command);
-        response.setContentType(summary.getView().getContentType());
-        return summary;
+        synchronized (this) {
+            final ModelAndView summary = getSummary((SummarySpecification) command);
+            response.setContentType(summary.getView().getContentType());
+            return summary;
+        }
     }
 
     public void setRrdSummaryService(RrdSummaryService rrdSummaryService) {


### PR DESCRIPTION
This resolves the internal server error, but some of the concurrent curl calls fail to connect to the server. See JIRA issue for more details.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15086

