### PR TITLE
NMS-15394: validate and fix opennms-alarm-history-elastic dependencies

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -169,6 +169,7 @@
                           <feature>minion-api-layer</feature>
                           <feature>sentinel-api-layer</feature>
                           <feature>sentinel-timeseries-api</feature>
+                          <feature>opennms-alarm-history-elastic</feature>
                           <feature>opennms-timseries-api</feature>
                           <feature>opennms-newts</feature>
                       </features>

--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -24,6 +24,10 @@
         <bundle dependency="true">mvn:com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}</bundle>
     </feature>
 
+    <feature name="commons-lang3" version="${commonsLang3Version}" description="Apache :: commons-lang3">
+        <bundle>mvn:org.apache.commons/commons-lang3/${commonsLang3Version}</bundle>
+    </feature>
+
     <feature name="guava" version="${guavaOsgiVersion}" description="Google :: Guava">
         <feature prerequisite="true">wrap</feature>
         <bundle start-level="30" dependency="true">mvn:com.google.guava/guava/${guavaVersion}</bundle>
@@ -91,5 +95,11 @@
         <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/1.70</bundle>
         <bundle start-level="30">mvn:org.bouncycastle/bcpkix-jdk15on/1.70</bundle>
         <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.ssh/${karafVersion}</bundle>
+    </feature>
+
+    <feature name="health-api" version="${project.version}" description="Health API">
+        <feature version="${commonsLang3Version}">commons-lang3</feature>
+        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
+        <bundle dependency="true">mvn:io.vavr/vavr/0.10.0</bundle>
     </feature>
 </features>

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -189,9 +189,7 @@
     </feature>
 
     <feature name="minion-health-check" version="${project.version}" description="Minion :: Health Check">
-        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
-        <bundle dependency="true">mvn:io.vavr/vavr/0.10.0</bundle>
-        <feature>commons-lang3</feature>
+        <feature>health-api</feature>
         <bundle>mvn:org.opennms.features.minion/health-check/${project.version}</bundle>
     </feature>
 

--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -54,6 +54,7 @@
         <feature>camel-core</feature>
         <feature>camel-blueprint</feature>
         <feature>camel-jaxb</feature>
+        <feature>opennms-core-lib</feature>
         <feature>opennms-health</feature>
         <feature>scv-api</feature>
 
@@ -72,10 +73,6 @@
 
         <!-- Useful Commands -->
         <bundle>mvn:org.opennms.core/org.opennms.core.commands/${project.version}</bundle>
-        <bundle>mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
-
-        <!-- SystemProperties -->
-        <bundle>mvn:org.opennms.core/org.opennms.core.sysprops/${project.version}</bundle>
     </feature>
 
     <feature name="sentinel-events-forwarder" description="OpenNMS :: Sentinel :: Events Forwarder" version="${project.version}">

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -363,19 +363,17 @@
         <feature>commons-io</feature>
         <feature>dnsjava</feature>
         <feature>jaxb</feature>
+        <feature>opennms-core-lib</feature>
         <feature>opennms-util</feature>
         <bundle dependency="true">wrap:mvn:javax.inject/javax.inject/1</bundle>
         <bundle dependency="true">mvn:org.codehaus.jackson/jackson-core-asl/${jacksonVersion}</bundle>
         <bundle dependency="true">mvn:org.codehaus.jackson/jackson-mapper-asl/${jacksonVersion}</bundle>
         <bundle dependency="true">mvn:org.codehaus.jackson/jackson-xc/${jacksonVersion}</bundle>
-        <bundle>mvn:org.opennms.core/org.opennms.core.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.commands/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.criteria/${project.version}</bundle>
-        <bundle>mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.logging/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.soa/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.spring/${project.version}</bundle>
-        <bundle>mvn:org.opennms.core/org.opennms.core.sysprops/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.xml/${project.version}</bundle>
     </feature>
     <feature name="opennms-core-camel" version="${project.version}" description="OpenNMS :: Core :: Camel">
@@ -405,6 +403,13 @@
         <feature>postgresql</feature>
         <feature>opennms-core</feature>
         <bundle>mvn:org.opennms.core/org.opennms.core.db/${project.version}</bundle>
+    </feature>
+    <feature name="opennms-core-lib" version="${project.version}" description="OpenNMS :: Core :: Libraries">
+        <feature>owasp-encoder</feature>
+        <feature>owasp-html-sanitizer</feature>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.api/${project.version}</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.sysprops/${project.version}</bundle>
     </feature>
     <feature name="opennms-core-web" version="${project.version}" description="OpenNMS :: Core :: Web">
         <feature>opennms-core</feature>
@@ -543,11 +548,11 @@
         <bundle>mvn:org.opennms.core.ipc.sink.camel/org.opennms.core.ipc.sink.camel.server/${project.version}</bundle>
     </feature>
     <feature name="opennms-core-ipc-sink-kafka-common" version="${project.version}" description="OpenNMS :: Core :: IPC :: Sink :: Kafka :: Common">
+        <feature>health-api</feature>
         <feature>opennms-core-ipc-sink-api</feature>
         <feature>opennms-kafka</feature>
         <feature>opennms-core-camel</feature>
         <feature>opennms-core-ipc-kafka-shell</feature>
-        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/${project.version}</bundle>
     </feature>
     <feature name="opennms-core-ipc-sink-kafka" version="${project.version}" description="OpenNMS :: Core :: IPC :: Sink :: Kafka :: Client">
@@ -587,11 +592,11 @@
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.jms-impl/${project.version}</bundle>
     </feature>
     <feature name="opennms-core-ipc-rpc-kafka" version="${project.version}" description="OpenNMS :: Core :: IPC :: RPC :: Kafka Impl.">
+        <feature>health-api</feature>
         <feature>opennms-kafka</feature>
         <feature>opennms-core-ipc-rpc-api</feature>
         <feature>opennms-core-ipc-kafka-shell</feature>
         <feature>resilience4j</feature>
-        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.kafka/${project.version}</bundle>
     </feature>
@@ -732,10 +737,8 @@
         <bundle>mvn:org.opennms/opennms-detector-registry/${project.version}</bundle>
     </feature>
     <feature name="opennms-provisioning-api" version="${project.version}" description="OpenNMS :: Provisioning :: API">
-        <feature>opennms-model</feature>
         <bundle dependency="true">mvn:org.apache.mina/mina-core/${minaVersion}</bundle>
         <bundle dependency="true">mvn:io.netty/netty/${netty3Version}</bundle>
-        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
         <feature>opentracing-api</feature>
         <feature>commons-lang</feature>
         <feature>opennms-core</feature>
@@ -754,13 +757,12 @@
         <bundle>mvn:org.opennms/opennms-rrd-jrobin/${project.version}</bundle>
     </feature>
     <feature name="opennms-snmp" version="${project.version}" description="OpenNMS :: Core :: SNMP">
+        <feature>opennms-core-lib</feature>
         <feature>org.json</feature>
         <bundle>mvn:org.opennms.core/org.opennms.core.logging/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.implementations.snmp4j/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.joesnmp/${project.version}</bundle>
-        <bundle>mvn:org.opennms.core/org.opennms.core.sysprops/${project.version}</bundle>
-        <bundle>mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
     </feature>
     <feature name="opennms-snmp-commands" version="${project.version}" description="OpenNMS :: Core :: SNMP :: Commands">
         <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.commands/${project.version}</bundle>
@@ -1000,9 +1002,14 @@
     </feature>
 
     <feature name="opennms-alarm-history-elastic" description="OpenNMS :: Features :: Alarms :: History :: Elasticsearch" version="${project.version}">
+        <feature>dropwizard-metrics</feature>
+        <feature>guava</feature>
         <feature>opennms-alarm-history-rest</feature>
         <feature>opennms-jest</feature>
+        <feature>opennms-model</feature>
+        <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarkerVersion}</bundle>
         <bundle dependency="true">mvn:org.mapstruct/mapstruct/${mapstructVersion}</bundle>
+        <bundle dependency="true">mvn:org.opennms/opennms-alarm-api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.alarms.history/org.opennms.features.alarms.history.elastic/${project.version}</bundle>
     </feature>
 
@@ -1045,13 +1052,13 @@
         <feature version="${netty4Version}">netty4</feature>
         <feature>dropwizard-metrics</feature>
         <feature>opennms-collection-api</feature>
+        <feature>opennms-core-lib</feature>
         <feature>opennms-thresholding-api</feature>
         <feature>opennms-osgi-jsr223</feature>
         <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:com.google.code.gson/gson/${gsonVersion}</bundle>
         <bundle>wrap:mvn:io.pkts/pkts-core/${pktsVersion}</bundle>
         <bundle>wrap:mvn:io.pkts/pkts-buffers/${pktsVersion}</bundle>
-        <bundle>mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.config/org.opennms.features.telemetry.config.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/${project.version}</bundle>
@@ -1137,11 +1144,9 @@
     </feature>
     <feature name="opennms-health" version="${project.version}" description="OpenNMS :: Health">
         <feature>commons-io</feature>
-        <feature>commons-lang3</feature>
         <feature>dropwizard-metrics</feature>
+        <feature>health-api</feature>
         <feature>opennms-util</feature>
-        <bundle dependency="true">mvn:io.vavr/vavr/0.10.0</bundle>
-        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.health/org.opennms.core.health.impl/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.health/org.opennms.core.health.shell/${project.version}</bundle>
     </feature>
@@ -1188,7 +1193,7 @@
         <bundle>mvn:org.opennms.features.flows.rest/org.opennms.features.flows.rest.api/${project.version}</bundle>
         <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.flows.rest/org.opennms.features.flows.rest.impl/${project.version}</bundle>
-        <bundle>wrap:mvn:org.freemarker/freemarker/${freemarkerVersion}</bundle>
+        <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarkerVersion}</bundle>
         <bundle>mvn:org.opennms.features.flows.classification.engine/org.opennms.features.flows.classification.engine.impl/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.flows/org.opennms.features.flows.elastic/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.flows/org.opennms.features.flows.processing/${project.version}</bundle>
@@ -1228,10 +1233,12 @@
     <feature name="opennms-osgi-core-rest" version="${project.version}" description="OpenNMS :: Features :: OSGI :: Core :: Rest">
         <details>Core module which provides features to install to listen for rest related services,
             such as @Path annotated interfaces.</details>
+        <feature>felix-http</feature>
         <feature>jax-rs-connector</feature>
         <feature>jax-rs-provider-jackson</feature>
         <bundle>mvn:org.opennms.features/org.opennms.features.rest-provider/${project.version}</bundle>
-        <bundle>mvn:org.opennms.container.bridge/org.opennms.container.bridge.rest/${project.version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.opennms.container.bridge/org.opennms.container.bridge.api/${project.version}</bundle>
+        <bundle dependency="true">mvn:org.opennms.container.bridge/org.opennms.container.bridge.rest/${project.version}</bundle>
     </feature>
     <feature name="opennms-jaas-login-module" version="${project.version}" description="OpenNMS :: OSGi Container :: Karaf JAAS Login Module">
         <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
@@ -1537,9 +1544,9 @@
     </feature>
     <feature name="jira-troubleticketer" version="${project.version}" description="OpenNMS :: Features :: Ticketing :: JIRA">
         <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature>opennms-core-lib</feature>
         <bundle>mvn:org.opennms.features/jira-troubleticketer/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.ticketing/org.opennms.features.ticketing.api/${project.version}</bundle>
-        <bundle>mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
         <bundle>mvn:joda-time/joda-time/${jodaTimeVersion}</bundle>
         <bundle>mvn:org.opennms.features/jira-client/${project.version}</bundle>
     </feature>
@@ -1554,14 +1561,13 @@
         <feature>javax.servlet</feature>
         <feature>quartz</feature>
         <feature>opennms-dao</feature>
+        <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarkerVersion}</bundle>
         <bundle>mvn:org.opennms.features/datachoices/${project.version}</bundle>
-        <bundle>wrap:mvn:org.freemarker/freemarker/${freemarkerVersion}</bundle>
         <bundle>mvn:org.apache.karaf.shell/org.apache.karaf.shell.console/${karafVersion}</bundle>
         <bundle>mvn:org.apache.karaf.shell/org.apache.karaf.shell.core/${karafVersion}</bundle>
         <bundle>mvn:org.codehaus.jackson/jackson-core-asl/${jacksonVersion}</bundle>
         <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/${jacksonVersion}</bundle>
         <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
-        <bundle>mvn:org.freemarker/freemarker/${freemarkerVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.usageanalytics/org.opennms.features.usageanalytics.api/${project.version}</bundle>
@@ -1582,8 +1588,12 @@
         <details>Feature definition for Jest (ElasticSearch Java ReST Client)</details>
         <!-- TODO: what does it actually need? -->
         <feature>guava21</feature>
+        <feature>javax.validation</feature>
+        <feature>health-api</feature>
+        <feature>opennms-core-lib</feature>
         <bundle>mvn:com.google.code.gson/gson/${jestGsonVersion}</bundle>
         <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/${httpcoreVersion}</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.cache/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.jest/org.opennms.features.jest.client/${project.version}</bundle>
         <bundle>mvn:io.searchbox/jest-complete-osgi/${jestVersion}</bundle>
         <bundle>mvn:commons-codec/commons-codec/1.9</bundle>
@@ -1645,10 +1655,10 @@
         <feature>dnsjava</feature>
         <feature version="${netty4Version}">netty4</feature>
         <feature>resilience4j</feature>
+        <feature>health-api</feature>
         <feature>opennms-events-api</feature>
         <feature>opennms-model</feature>
 
-        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
         <bundle dependency="true">mvn:com.github.ben-manes.caffeine/caffeine/${caffeineVersion}</bundle>
         <bundle>mvn:org.opennms.features.dnsresolver/org.opennms.features.dnsresolver.netty/${project.version}</bundle>
     </feature>
@@ -1916,9 +1926,9 @@
 
     <feature name="opennms-deviceconfig-deps" description="OpenNMS :: Features :: Device Config :: Deps" version="${project.version}">
         <feature>commons-net</feature>
-        <feature>opennms-util</feature>
+        <feature>opennms-core-lib</feature>
         <feature>commons-compress</feature>
-        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
+        <feature>opennms-util</feature>
         <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/${project.version}</bundle>
     </feature>
 
@@ -1988,6 +1998,7 @@
     </feature>
 
     <feature name="opennms-timeseries-api" description="OpenNMS :: Timeseries Storage API" version="${project.version}">
+        <feature>fst</feature>
         <feature>opennms-health</feature>
         <feature>opennms-measurements-api</feature>
         <feature>opennms-collection-api</feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -130,9 +130,7 @@
     <feature name="commons-lang" version="${commonsLangVersion}" description="Apache :: commons-lang">
         <bundle>mvn:commons-lang/commons-lang/${commonsLangVersion}</bundle>
     </feature>
-    <feature name="commons-lang3" version="${commonsLang3Version}" description="Apache :: commons-lang3">
-        <bundle>mvn:org.apache.commons/commons-lang3/${commonsLang3Version}</bundle>
-    </feature>
+    <!-- commons-lang3 is in features-core.xml -->
     <feature name="commons-net" version="${commonsNetVersion}" description="Apache :: commons-net">
         <bundle>mvn:commons-net/commons-net/${commonsNetVersion}</bundle>
     </feature>

--- a/container/features/src/main/resources/karaf-extensions.xml
+++ b/container/features/src/main/resources/karaf-extensions.xml
@@ -4,6 +4,7 @@
 
     <feature name="karaf-extender" description="Karaf Extender" version="${project.version}">
         <feature version="${guavaOsgiVersion}" prerequisite="true">guava</feature>
+        <feature version="${project.version}">health-api</feature>
         <bundle>mvn:org.opennms.container/extender/${project.version}</bundle>
     </feature>
 </features>

--- a/features/sentinel/repository/pom.xml
+++ b/features/sentinel/repository/pom.xml
@@ -41,6 +41,7 @@
                                 are included in the repository tar.gz file, add the feature to this list. -->
                             <features>
                                 <!-- OpenNMS features -->
+                                <feature>opennms-alarm-history-elastic</feature>
                                 <feature>opennms-core-ipc-rpc-jms</feature>
                                 <feature>opennms-core-tracing-jaeger</feature>
                                 <feature>opennms-events-sink-dispatcher</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -4268,11 +4268,6 @@
         <artifactId>hibernate-validator</artifactId>
         <version>${hibernateValidatorVersion}</version>
       </dependency>
-      <dependency>
-        <groupId>org.jboss.logging</groupId>
-        <artifactId>jboss-logging</artifactId>
-        <version>${jbossLoggingVersion}</version>
-      </dependency>
       <!-- this should match what's in Karaf's lib/jdk9plus directory -->
       <dependency>
         <groupId>com.sun.istack</groupId>


### PR DESCRIPTION
I don't have the setup to test this well, but it at least loads inside sentinel's `runInPlace.sh` :D

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-15394
