### PR TITLE
Fix MalformedURLException thrown by SeedGenerator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1452,7 +1452,7 @@
       problematic pauses when starting MockSnmpAgent in unit tests.
     -->
     <argLineMemory>-Xmx2g</argLineMemory>
-    <argLine>${argLineMemory} -Djava.security.egd=/dev/./urandom</argLine>
+    <argLine>${argLineMemory} -Djava.security.egd=file:/dev/./urandom</argLine>
     <skipITs>true</skipITs>
     <runPingTests>false</runPingTests>
 

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -37,7 +37,7 @@
     <argLineSAXParser>-Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl</argLineSAXParser>
 
     <!-- set memory and use XML overrides -->
-    <argLine>-Xms1g -Xmx1g -XX:+UseG1GC ${argLineDocumentBuilder} ${argLineSAXParser} -Djava.security.egd=/dev/./urandom</argLine>
+    <argLine>-Xms1g -Xmx1g -XX:+UseG1GC ${argLineDocumentBuilder} ${argLineSAXParser} -Djava.security.egd=file:/dev/./urandom</argLine>
   </properties>
   <build>
     <testResources>


### PR DESCRIPTION
### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### Contribution Checklist

* Please [make an issue in the OpenNMS issue tracker](https://issues.opennms.org) if there isn't one already.<br />Once there is an issue, please:
  1. update the title of this PR to be in the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
  4. once you've created this PR, please link to it in a comment in the JIRA issue
  Don't worry if this sounds like a lot, we can help you get things set up properly.
* **If this code is likely to affect the UI, did you name your branch with `-smoke` in it to trigger smoke tests?**
* If this is a new or updated feature, is there documentation for the new behavior?
* If this is new code, are there unit and/or integration tests?
* If this PR targets a `foundation-*` branch, does it try to avoid changing files in `$OPENNMS_HOME/etc/`?

### What's Next?

A PR should be assigned at least 2 reviewers.  If you know that someone would be a good person to review your code, feel free to add them.

If you need help making additions or changes to the documentation related to your changes, please let us know.

In any case, if anything is unclear or you want help getting your PR ready for merge, please don't hesitate to say something in the comments here,
or in [the #opennms-development chat channel](https://chat.opennms.com/opennms/channels/opennms-development).

Once reviewer(s) accept the PR and the branch passes continuous integration, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the OGP) you are welcome to merge the PR when you're ready.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}

----
The SeedGenerator class uses the value of system property java.security.egd to determine which entropy provider to use when setting up the JVMs random source.

The string "/dev/./urandom" is not a valid URL, so a MalformedURLException is thrown during the SeedGenerator instance creation, and the JVM falls back to using the ThreadedSeedGenerator class, which takes a few seconds to initialize.

This causes the first unit test requiring random bytes to fail when a timeout was used during the test case, as is done with the poller unit/integration tests.