### PR TITLE
NMS-15171: Upgrade HikariCP to 5.x (take 2)

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -307,6 +307,8 @@
     </feature>
     <feature name="quartz" version="${quartzVersion}" description="quartz">
         <feature>c3p0</feature>
+        <!-- Quartz needs HikariCP [2,3) - so we use the latest 2.x here -->
+        <bundle>mvn:com.zaxxer/HikariCP/2.7.9</bundle>
         <bundle>wrap:mvn:org.quartz-scheduler/quartz/${quartzVersion}</bundle>
     </feature>
     <feature name="twitter4j" version="${twitter4jVersion}" description="Twitter4J">

--- a/core/db/src/main/java/org/opennms/core/db/DataSourceFactory.java
+++ b/core/db/src/main/java/org/opennms/core/db/DataSourceFactory.java
@@ -62,6 +62,8 @@ public abstract class DataSourceFactory {
     //private static final Class<?> DEFAULT_FACTORY_CLASS = C3P0ConnectionFactory.class;
     private static final Class<?> DEFAULT_FACTORY_CLASS = HikariCPConnectionFactory.class;
 
+    private static final String DEFAULT_DS_NAME = "opennms";
+
     private static DataSourceConfigurationFactory m_dataSourceConfigFactory;
 
     private static final Map<String, DataSource> m_dataSources = new ConcurrentHashMap<>();
@@ -175,6 +177,13 @@ public abstract class DataSourceFactory {
         }
     }
 
+    /**
+     * @return true if the default datasource is loaded, false otherwise
+     */
+    public static synchronized boolean isDefaultDsLoaded() {
+        return isLoaded(DEFAULT_DS_NAME);
+    }
+
     private static synchronized boolean isLoaded(final String dsName) {
         return m_dataSources.containsKey(dsName);			
     }
@@ -193,7 +202,7 @@ public abstract class DataSourceFactory {
      *             Thrown if the factory has not yet been initialized.
      */
     public static DataSource getInstance() {
-        return getInstance("opennms");
+        return getInstance(DEFAULT_DS_NAME);
     }
 
     /**
@@ -213,7 +222,7 @@ public abstract class DataSourceFactory {
      * @param ds a {@link javax.sql.DataSource} object.
      */
     public static void setInstance(final DataSource ds) {
-        setInstance("opennms", ds);
+        setInstance(DEFAULT_DS_NAME, ds);
     }
 
     /**

--- a/core/db/src/main/java/org/opennms/core/db/HikariCPConnectionFactory.java
+++ b/core/db/src/main/java/org/opennms/core/db/HikariCPConnectionFactory.java
@@ -223,7 +223,7 @@ public class HikariCPConnectionFactory extends BaseConnectionFactory {
      */
     @Override
     public void setMinPool(final int minPool) {
-        LOG.debug("Hikari has no equivalent to setMinPool(). Ignoring.");
+        m_pool.setMinimumIdle(minPool);
     }
 
     /* (non-Javadoc)

--- a/core/test-api/db/src/main/java/org/opennms/core/test/db/TemporaryDatabaseExecutionListener.java
+++ b/core/test-api/db/src/main/java/org/opennms/core/test/db/TemporaryDatabaseExecutionListener.java
@@ -253,7 +253,16 @@ public class TemporaryDatabaseExecutionListener extends AbstractTestExecutionLis
             // NMS-8911: Reduce the max connection lifetime so that HikariCP recycles 
             // connections more aggressively during tests
             pool.setMaxLifetime(500);
+            // Only create connections as needed
+            pool.setMinPool(0);
 
+            // Close the existing datasource, if set
+            if (DataSourceFactory.isDefaultDsLoaded()) {
+                DataSource existingDataSource = DataSourceFactory.getInstance();
+                if (existingDataSource instanceof HikariCPConnectionFactory) {
+                    ((HikariCPConnectionFactory)existingDataSource).close();
+                }
+            }
             DataSourceFactory.setInstance(pool);
         } else {
             DataSourceFactory.setInstance(m_database);

--- a/dependencies/quartz/pom.xml
+++ b/dependencies/quartz/pom.xml
@@ -19,6 +19,12 @@
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
       <version>${quartzVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/features/device-config/monitor/pom.xml
+++ b/features/device-config/monitor/pom.xml
@@ -56,10 +56,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.quartz-scheduler</groupId>
-            <artifactId>quartz</artifactId>
-            <version>${quartzVersion}</version>
-            <scope>compile</scope>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>quartz-dependencies</artifactId>
+           <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/features/device-config/rest/pom.xml
+++ b/features/device-config/rest/pom.xml
@@ -82,9 +82,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.quartz-scheduler</groupId>
-            <artifactId>quartz</artifactId>
-            <version>${quartzVersion}</version>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>quartz-dependencies</artifactId>
+           <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>

--- a/features/perspectivepoller/pom.xml
+++ b/features/perspectivepoller/pom.xml
@@ -50,9 +50,9 @@
       <artifactId>opennms-dao-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.quartz-scheduler</groupId>
-      <artifactId>quartz</artifactId>
-      <version>${quartzVersion}</version>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>quartz-dependencies</artifactId>
+      <type>pom</type>
     </dependency>
     <dependency>
       <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
@@ -167,6 +167,9 @@
     <logger name="org.eclipse.jetty.server.HttpInput" additivity="false" level="INFO">
      <appender-ref ref="RoutingAppender"/>
     </logger>
+   <logger name="com.zaxxer.hikari.pool.ProxyConnection" additivity="false" level="ERROR">
+     <appender-ref ref="RoutingAppender"/>
+    </logger>
 
 
     <!-- Allow any message to pass through the root logger -->

--- a/pom.xml
+++ b/pom.xml
@@ -1698,7 +1698,7 @@
     <pktsVersion>3.0.0</pktsVersion>
     <protobufVersion>3.16.3</protobufVersion>
     <protobuf2Version>2.6.1</protobuf2Version>
-    <postgresqlVersion>42.4.3</postgresqlVersion>
+    <postgresqlVersion>42.5.4</postgresqlVersion>
     <powermockVersion>2.0.9</powermockVersion>
     <okhttpVersion>4.9.3</okhttpVersion>
     <okioVersion>2.8.0</okioVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1626,7 +1626,7 @@
     <gwtPluginVersion>${gwtVersion}</gwtPluginVersion>
     <h2databaseVersion>1.4.197</h2databaseVersion>
     <hibernateValidatorVersion>4.3.2.Final</hibernateValidatorVersion>
-    <hikaricpVersion>2.5.1</hikaricpVersion>
+    <hikaricpVersion>5.0.1</hikaricpVersion>
     <hllVersion>1.6.0</hllVersion>
     <httpcoreVersion>4.4.15</httpcoreVersion>
     <httpclientVersion>4.5.13</httpclientVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4963,6 +4963,11 @@
         <version>${hikaricpVersion}</version>
       </dependency>
       <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP-java7</artifactId>
+        <version>9999.use-HikariCP-not-HikariCP-java7</version>
+      </dependency>
+      <dependency>
         <groupId>net.agkn</groupId>
         <artifactId>hll</artifactId>
         <version>${hllVersion}</version>


### PR DESCRIPTION
JIRA: https://opennms.atlassian.net/browse/NMS-15171

Revised PR for upgrading HikariCP. Updates include:
* All ITs pass cleanly now (limit # of connections in the pool)
* Make sure `HikariCP-java7` doesn't end up in `lib/` (quartz was pulling it in)
* Update log settings to suppress harmless, but possibly scary, stack trace on startup (see https://github.com/pgjdbc/pgjdbc/issues/1102 for details) (our version of Hibernate doesn't support suppress the check in the first place)
