### PR TITLE
NMS-14966: Add smoke test for dual timeseries writes

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -2004,6 +2004,13 @@
         <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.persistence.osgi/${project.version}</bundle>
         <bundle>mvn:org.opennms.features/org.opennms.features.timeseries/${project.version}</bundle>
     </feature>
+    
+    <feature name="inmemory-timeseries-plugin" description="FOR TESTING ONLY" version="${project.version}">
+        <bundle dependency="true">wrap:mvn:com.google.re2j/re2j/${re2jVersion}</bundle>
+        <bundle dependency="true">mvn:org.opennms.features/inmemory-timeseries-plugin/${project.version}</bundle>
+        <feature>opennms-timeseries-api</feature>
+    </feature>
+
 
     <feature name="fst" description="FST" version="${project.version}">
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -2006,9 +2006,9 @@
     </feature>
     
     <feature name="inmemory-timeseries-plugin" description="FOR TESTING ONLY" version="${project.version}">
-        <bundle dependency="true">wrap:mvn:com.google.re2j/re2j/${re2jVersion}</bundle>
-        <bundle dependency="true">mvn:org.opennms.features/inmemory-timeseries-plugin/${project.version}</bundle>
         <feature>opennms-timeseries-api</feature>
+        <bundle dependency="true">wrap:mvn:com.google.re2j/re2j/${re2jVersion}</bundle>
+        <bundle >mvn:org.opennms.features/inmemory-timeseries-plugin/${project.version}</bundle>
     </feature>
 
 

--- a/features/inmemory-timeseries-plugin/pom.xml
+++ b/features/inmemory-timeseries-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>31.0.4-SNAPSHOT</version>
+        <version>31.0.3-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>inmemory-timeseries-plugin</artifactId>

--- a/features/inmemory-timeseries-plugin/pom.xml
+++ b/features/inmemory-timeseries-plugin/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.features</artifactId>
+        <version>31.0.4-SNAPSHOT</version>
+    </parent>
+    <groupId>org.opennms.features</groupId>
+    <artifactId>inmemory-timeseries-plugin</artifactId>
+    <packaging>bundle</packaging>
+    <name>OpenNMS :: Features :: InMemory TimeSeries Plugin</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Karaf-Commands>org.opennms.features.timeseries.plugin.shell</Karaf-Commands>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.opennms.integration.api</groupId>
+            <artifactId>common</artifactId>
+            <version>${opennmsApiVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.re2j</groupId>
+            <artifactId>re2j</artifactId>
+            <version>${re2jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.shell</groupId>
+            <artifactId>org.apache.karaf.shell.core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/features/inmemory-timeseries-plugin/pom.xml
+++ b/features/inmemory-timeseries-plugin/pom.xml
@@ -48,5 +48,10 @@
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.integration.api</groupId>
+            <artifactId>api</artifactId>
+            <version>${opennmsApiVersion}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/InMemoryStorage.java
+++ b/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/InMemoryStorage.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.

--- a/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/InMemoryStorage.java
+++ b/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/InMemoryStorage.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2006-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.timeseries.plugin;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.timeseries.Metric;
+import org.opennms.integration.api.v1.timeseries.Sample;
+import org.opennms.integration.api.v1.timeseries.DataPoint;
+import org.opennms.integration.api.v1.timeseries.Aggregation;
+import org.opennms.integration.api.v1.timeseries.Tag;
+import org.opennms.integration.api.v1.timeseries.TagMatcher;
+import org.opennms.integration.api.v1.timeseries.StorageException;
+import org.opennms.integration.api.v1.timeseries.TimeSeriesStorage;
+import org.opennms.integration.api.v1.timeseries.TimeSeriesData;
+import org.opennms.integration.api.v1.timeseries.TimeSeriesFetchRequest;
+import org.opennms.integration.api.v1.timeseries.immutables.ImmutableDataPoint;
+import org.opennms.integration.api.v1.timeseries.immutables.ImmutableTimeSeriesData;
+
+import com.google.re2j.Pattern;
+
+/**
+ * Simulates a TimeSeriesStorage in memory (ConcurrentHashMap). The implementation is super simple and not very efficient.
+ * For testing and evaluating purposes only, not for production.
+ */
+public class InMemoryStorage implements TimeSeriesStorage {
+
+    private final Map<Metric, Collection<DataPoint>> data;
+
+    public InMemoryStorage () {
+        data = new ConcurrentHashMap<>();
+    }
+
+    public final Map<Metric, Collection<DataPoint>> getAllMetrics() {
+        return data;
+    }
+
+    @Override
+    public void store(final List<Sample> samples) {
+        Objects.requireNonNull(samples);
+        for(Sample sample : samples) {
+            Collection<DataPoint> timeseries = data.computeIfAbsent(sample.getMetric(), k -> new ConcurrentLinkedQueue<>());
+            timeseries.add(new ImmutableDataPoint(sample.getTime(), sample.getValue()));
+        }
+    }
+
+    @Override
+    public List<Metric> findMetrics(Collection<TagMatcher> tagMatchers) {
+        Objects.requireNonNull(tagMatchers);
+        if(tagMatchers.isEmpty()) {
+            throw new IllegalArgumentException("We expect at least one TagMatcher but none was given.");
+        }
+        return data.keySet()
+                .stream()
+                .filter(metric -> this.matches(tagMatchers, metric))
+                .collect(Collectors.toList());
+    }
+
+    /** Each matcher must be matched by at least one tag. */
+    private boolean matches(final Collection<TagMatcher> matchers, final Metric metric) {
+        final Set<Tag> searchableTags = new HashSet<>(metric.getIntrinsicTags());
+        searchableTags.addAll(metric.getMetaTags());
+
+        for(TagMatcher matcher : matchers) {
+            if(searchableTags.stream().noneMatch(t -> this.matches(matcher, t))) {
+                return false; // this TagMatcher didn't find any matching tag => this Metric is not part of search result;
+            }
+        }
+        return true; // all matched
+    }
+
+    private boolean matches(final TagMatcher matcher, final Tag tag) {
+
+        if(!matcher.getKey().equals(tag.getKey())) {
+            return false; // not even the key matches => we are done.
+        }
+
+        // Tags have always a non null value so we don't have to null check for them.
+        if(TagMatcher.Type.EQUALS == matcher.getType()) {
+            return tag.getValue().equals(matcher.getValue());
+        } else if (TagMatcher.Type.NOT_EQUALS == matcher.getType()) {
+            return !tag.getValue().equals(matcher.getValue());
+        } else if (TagMatcher.Type.EQUALS_REGEX == matcher.getType()) {
+            return Pattern.matches(matcher.getValue(), tag.getValue());
+        } else if (TagMatcher.Type.NOT_EQUALS_REGEX == matcher.getType()) {
+            return !Pattern.matches(matcher.getValue(), tag.getValue());
+        } else {
+            throw new IllegalArgumentException("Implement me for " + matcher.getType());
+        }
+    }
+
+    @Override
+    public List<Sample> getTimeseries(TimeSeriesFetchRequest request) throws StorageException {
+        throw new UnsupportedOperationException("use getTimeSeriesData(TimeSeriesFetchRequest request) instead.");
+    }
+
+    @Override
+    public TimeSeriesData getTimeSeriesData(TimeSeriesFetchRequest request) {
+        Objects.requireNonNull(request);
+
+
+        if(request.getAggregation() != Aggregation.NONE) {
+            throw new IllegalArgumentException(String.format("Aggregation %s is not supported.", request.getAggregation()));
+        }
+
+        // get the original metric instead of the one from the request since the one from the request might not have all tags
+        Metric metric = data.keySet().stream()
+                .filter(m -> m.getKey().equals(request.getMetric().getKey()))
+                .findFirst()
+                .orElse(request.getMetric());
+
+        List<DataPoint> dataPoints = Optional.ofNullable(data.get(request.getMetric())).stream()
+                .flatMap(Collection::stream)
+                .filter(sample -> sample.getTime().isAfter(request.getStart()))
+                .filter(sample -> sample.getTime().isBefore(request.getEnd()))
+                .collect(Collectors.toList());
+
+        return ImmutableTimeSeriesData.builder()
+                .metric(metric)
+                .dataPoints(dataPoints)
+                .build();
+    }
+
+    @Override
+    public void delete(Metric metric) {
+        Objects.requireNonNull(metric);
+        this.data.remove(metric);
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getName();
+    }
+
+    /** Exposes the internal data, for validation in tests. */
+    public Map<Metric, Collection<DataPoint>> getData() {
+        return data;
+    }
+}

--- a/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/InMemoryStorage.java
+++ b/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/InMemoryStorage.java
@@ -29,6 +29,7 @@
 package org.opennms.features.timeseries.plugin;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -60,14 +61,10 @@ import com.google.re2j.Pattern;
  */
 public class InMemoryStorage implements TimeSeriesStorage {
 
-    private final Map<Metric, Collection<DataPoint>> data;
-
-    public InMemoryStorage () {
-        data = new ConcurrentHashMap<>();
-    }
+    private final Map<Metric, Collection<DataPoint>> data = new ConcurrentHashMap<>();
 
     public final Map<Metric, Collection<DataPoint>> getAllMetrics() {
-        return data;
+        return Collections.unmodifiableMap(data);
     }
 
     @Override
@@ -92,19 +89,19 @@ public class InMemoryStorage implements TimeSeriesStorage {
     }
 
     /** Each matcher must be matched by at least one tag. */
-    private boolean matches(final Collection<TagMatcher> matchers, final Metric metric) {
+    private static boolean matches(final Collection<TagMatcher> matchers, final Metric metric) {
         final Set<Tag> searchableTags = new HashSet<>(metric.getIntrinsicTags());
         searchableTags.addAll(metric.getMetaTags());
 
         for(TagMatcher matcher : matchers) {
-            if(searchableTags.stream().noneMatch(t -> this.matches(matcher, t))) {
+            if(searchableTags.stream().noneMatch(t -> matches(matcher, t))) {
                 return false; // this TagMatcher didn't find any matching tag => this Metric is not part of search result;
             }
         }
         return true; // all matched
     }
 
-    private boolean matches(final TagMatcher matcher, final Tag tag) {
+    private static boolean matches(final TagMatcher matcher, final Tag tag) {
 
         if(!matcher.getKey().equals(tag.getKey())) {
             return false; // not even the key matches => we are done.
@@ -165,10 +162,5 @@ public class InMemoryStorage implements TimeSeriesStorage {
     @Override
     public String toString() {
         return this.getClass().getName();
-    }
-
-    /** Exposes the internal data, for validation in tests. */
-    public Map<Metric, Collection<DataPoint>> getData() {
-        return data;
     }
 }

--- a/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/shell/GetMetricsCommand.java
+++ b/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/shell/GetMetricsCommand.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.

--- a/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/shell/GetMetricsCommand.java
+++ b/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/shell/GetMetricsCommand.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2006-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.timeseries.plugin.shell;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+
+import org.opennms.integration.api.v1.timeseries.TimeSeriesStorage;
+import org.opennms.features.timeseries.plugin.InMemoryStorage;
+import org.opennms.integration.api.v1.timeseries.DataPoint;
+import org.opennms.integration.api.v1.timeseries.Metric;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Simple diagnostic for looking at timeseries data
+ *
+ */
+@Command(scope = "opennms", name="get-tss-plugin-metrics", description = "This is the description")
+@Service
+public class GetMetricsCommand implements Action {
+
+    @Reference
+    private TimeSeriesStorage storage;
+
+    @Override
+    public Object execute() {
+        for (Map.Entry<Metric, Collection<DataPoint>> entry: ((InMemoryStorage)storage).getAllMetrics().entrySet()) {
+            System.out.println(String.format("Metric <%s> has %d data points",
+                                             entry.getKey().getKey(),
+                                             entry.getValue().size()));
+        }
+        return null;
+    }
+
+}

--- a/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/shell/GetMetricsCommand.java
+++ b/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/shell/GetMetricsCommand.java
@@ -54,7 +54,7 @@ public class GetMetricsCommand implements Action {
                     entry.getKey().getKey(),
                     entry.getValue().size()));
             entry.getValue().stream().forEach(dataPoint ->
-                System.out.println(String.format("\t%d:%f", dataPoint.getTime().toEpochMilli(), dataPoint.getValue())));
+                System.out.printf("\t%d:%f\n", dataPoint.getTime().toEpochMilli(), dataPoint.getValue()));
         });
         return null;
     }

--- a/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/shell/GetMetricsCommand.java
+++ b/features/inmemory-timeseries-plugin/src/main/java/org/opennms/features/timeseries/plugin/shell/GetMetricsCommand.java
@@ -29,25 +29,18 @@
 package org.opennms.features.timeseries.plugin.shell;
 
 import org.apache.karaf.shell.api.action.Action;
-import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
-import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 
 import org.opennms.integration.api.v1.timeseries.TimeSeriesStorage;
 import org.opennms.features.timeseries.plugin.InMemoryStorage;
-import org.opennms.integration.api.v1.timeseries.DataPoint;
-import org.opennms.integration.api.v1.timeseries.Metric;
-
-import java.util.Collection;
-import java.util.Map;
 
 /**
  * Simple diagnostic for looking at timeseries data
  *
  */
-@Command(scope = "opennms", name="get-tss-plugin-metrics", description = "This is the description")
+@Command(scope = "opennms", name="get-tss-plugin-metrics", description = "Print all collected metrics")
 @Service
 public class GetMetricsCommand implements Action {
 
@@ -56,11 +49,13 @@ public class GetMetricsCommand implements Action {
 
     @Override
     public Object execute() {
-        for (Map.Entry<Metric, Collection<DataPoint>> entry: ((InMemoryStorage)storage).getAllMetrics().entrySet()) {
+        ((InMemoryStorage)storage).getAllMetrics().entrySet().forEach(entry -> {
             System.out.println(String.format("Metric <%s> has %d data points",
-                                             entry.getKey().getKey(),
-                                             entry.getValue().size()));
-        }
+                    entry.getKey().getKey(),
+                    entry.getValue().size()));
+            entry.getValue().stream().forEach(dataPoint ->
+                System.out.println(String.format("\t%d:%f", dataPoint.getTime().toEpochMilli(), dataPoint.getValue())));
+        });
         return null;
     }
 

--- a/features/inmemory-timeseries-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/inmemory-timeseries-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,10 @@
+<blueprint
+    xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
+    xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="inMemoryStorage" class="org.opennms.features.timeseries.plugin.InMemoryStorage"/>
+    <service ref="inMemoryStorage" interface="org.opennms.integration.api.v1.timeseries.TimeSeriesStorage"/>
+
+</blueprint>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -186,5 +186,7 @@
 
     <!-- Usage Analytics -->
     <module>usageanalytics</module>
+    
+    <module>inmemory-timeseries-plugin</module>
   </modules>
 </project>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -520,6 +520,8 @@
                 <feature>opennms-deviceconfig-service</feature>
                 <feature>opennms-deviceconfig-monitor</feature>
                 <feature>opennms-timeseries-api</feature>
+                
+                <feature>inmemory-timeseries-plugin</feature>
 
               </features>
               <repository>${project.build.directory}/opennms-repo</repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1787,6 +1787,8 @@
     <!-- configuration manager -->
     <xmlschemaVersion>2.2.5</xmlschemaVersion>
 
+    <re2jVersion>1.7</re2jVersion>
+
     <!-- CI Settings -->
     <ci.rerunFailingTestsCount>0</ci.rerunFailingTestsCount>
     <!-- Limit ITs to 30 minutes by default -->

--- a/smoke-test/src/test/java/org/opennms/smoketest/TimeseriesAPIIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/TimeseriesAPIIT.java
@@ -29,7 +29,7 @@
 package org.opennms.smoketest;
 
 import static org.junit.Assert.assertTrue;
-import static com.jayway.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/smoke-test/src/test/java/org/opennms/smoketest/TimeseriesAPIIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/TimeseriesAPIIT.java
@@ -31,6 +31,7 @@ package org.opennms.smoketest;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -50,6 +51,9 @@ public class TimeseriesAPIIT {
 
     private KarafShell karafShell = new KarafShell(stack.opennms().getSshAddress());
 
+    public static final String CORTEX_PLUGIN_RELEASE = "https://github.com/OpenNMS/opennms-cortex-tss-plugin/releases/download/v2.0.1/opennms-cortex-tss-plugin.kar";
+    public static final Path CORTEX_PLUGIN_KAR = Path.of("target", "opennms-cortex-tss-plugin.kar");
+
     @Before
     public void setUp() throws IOException, InterruptedException {
         // Make sure the Karaf shell is healthy before we start
@@ -61,5 +65,14 @@ public class TimeseriesAPIIT {
         assertTrue(karafShell.runCommandOnce("feature:install opennms-timeseries-api", output -> !output.toLowerCase().contains("error"), false));
 
         KarafShellUtils.testHealthCheckSucceeded(stack.opennms().getSshAddress());
+    }
+
+    @Test
+    public void testDualWrites() throws Exception {
+        assertTrue(karafShell.runCommandOnce("feature:install opennms-timeseries-api", output -> !output.toLowerCase().contains("error"), false));
+        assertTrue(karafShell.runCommandOnce("feature:install inmemory-timeseries-plugin", output -> !output.toLowerCase().contains("error"), false));
+        KarafShellUtils.testHealthCheckSucceeded(stack.opennms().getSshAddress());
+
+
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/TimeseriesAPIIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/TimeseriesAPIIT.java
@@ -31,12 +31,18 @@ package org.opennms.smoketest;
 import static org.junit.Assert.assertTrue;
 import static com.jayway.awaitility.Awaitility.await;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.opennms.smoketest.containers.OpenNMSContainer;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.KarafShell;
 import org.opennms.smoketest.utils.KarafShellUtils;
@@ -48,7 +54,7 @@ public class TimeseriesAPIIT {
     private static final Logger LOG = LoggerFactory.getLogger(TimeseriesAPIIT.class);
 
     @ClassRule
-    public static OpenNMSStack stack = OpenNMSStack.MINIMAL;
+    public static OpenNMSStack stack = OpenNMSStack.MINIMAL_WITH_DEFAULT_LOCALHOST;
 
     private KarafShell karafShell = new KarafShell(stack.opennms().getSshAddress());
 
@@ -70,8 +76,59 @@ public class TimeseriesAPIIT {
         assertTrue(karafShell.runCommandOnce("feature:install opennms-timeseries-api", output -> !output.toLowerCase().contains("error"), false));
         assertTrue(karafShell.runCommandOnce("feature:install inmemory-timeseries-plugin", output -> !output.toLowerCase().contains("error"), false));
         KarafShellUtils.testHealthCheckSucceeded(stack.opennms().getSshAddress());
-        await().atMost(5, TimeUnit.MINUTES)
+        printSummary();
+        long start = System.currentTimeMillis();
+        await().atMost(10, TimeUnit.MINUTES)
                 .pollInterval(5, TimeUnit.SECONDS)
-                .until(() -> karafShell.runCommandOnce("opennms:get-tss-plugin-metrics", output -> !output.isEmpty(), false));
+                .until(() -> karafShell.runCommandOnce("opennms:get-tss-plugin-metrics", output -> output.contains("data points"), false));
+        String summaryUrl = String.format(
+                "http://0.0.0.0:%d/opennms/summary/results.htm?filterRule=ipaddr+iplike+*.*.*.*&startTime=%d&endTime=%d&attributeSieve=.*",
+                stack.opennms().getWebPort(),
+                0,
+                System.currentTimeMillis());
+        Thread.sleep(120000);
+        System.out.println("<KARAF OUT>");
+        karafShell.runCommandOnce("opennms:get-tss-plugin-metrics", output -> {
+            System.out.println(output);
+            return !output.isEmpty();
+        }
+        , false);
+        System.out.println("</KARAF OUT>");
+        System.out.println("SUMMARY URL: " + summaryUrl);
+        URL summary = new URL(summaryUrl);
+        URLConnection connection = summary.openConnection();
+        String userpass = String.format("%s:%s", OpenNMSContainer.ADMIN_USER, OpenNMSContainer.ADMIN_PASSWORD);
+        String basicAuth = new String(Base64.getEncoder().encode(userpass.getBytes()));
+        connection.setRequestProperty("Authorization", "Basic " + basicAuth);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        String input;
+        System.out.println("<SUMMARY CONTENTS>");
+        while ((input = reader.readLine()) != null) {
+            System.out.println(input);
+        }
+        System.out.println("</SUMMARY CONTENTS>");
     }
+
+    private void printSummary() throws Exception {
+
+        String summaryUrl = String.format(
+                "http://0.0.0.0:%d/opennms/summary/results.htm?filterRule=ipaddr+iplike+*.*.*.*&startTime=%d&endTime=%d&attributeSieve=.*",
+                stack.opennms().getWebPort(),
+                0,
+                System.currentTimeMillis());
+        URL summary = new URL(summaryUrl);
+        URLConnection connection = summary.openConnection();
+        String userpass = String.format("%s:%s", OpenNMSContainer.ADMIN_USER, OpenNMSContainer.ADMIN_PASSWORD);
+        String basicAuth = new String(Base64.getEncoder().encode(userpass.getBytes()));
+        connection.setRequestProperty("Authorization", "Basic " + basicAuth);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        String input;
+        System.out.println("<SUMMARY CONTENTS>");
+        while ((input = reader.readLine()) != null) {
+            System.out.println(input);
+        }
+        System.out.println("</SUMMARY CONTENTS>");
+
+    }
+
 }


### PR DESCRIPTION
The `inmemory-timeseries-plugin` feature is a repackaged version of this: https://github.com/OpenNMS/opennms-integration-api/tree/master/test-suites/tss-tests. I pulled it into the project so I could install it as a feature for testing.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14966

