### PR TITLE
Escape JMX resource type labels

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/resource-types.d/jmx-resource.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/resource-types.d/jmx-resource.xml
@@ -80,14 +80,14 @@
       </storageStrategy>
    </resourceType>
 
-   <resourceType name="ALECgraph" label="ALEC Graph Stats" resourceLabel="${name}">
+   <resourceType name="ALECgraph" label="ALEC Graph Stats" resourceLabel="\${name}">
       <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
       <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
          <parameter key="sibling-column-name" value="name" />
       </storageStrategy>
    </resourceType>
 
-   <resourceType name="Eventlogs" label="Eventd Processing Stats" resourceLabel="${name}">
+   <resourceType name="Eventlogs" label="Eventd Processing Stats" resourceLabel="\${name}">
       <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
       <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
          <parameter key="sibling-column-name" value="name" />


### PR DESCRIPTION
The build process is renaming these placeholders to `OpenNMS Base Assembly` instead of leaving them as-is to act as a substitution placeholder at runtime.