### PR TITLE
set parameters for is_pr, use them for jira notify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,10 @@ parameters:
     description: whether to enable running flaky smoke tests
     type: boolean
     default: false
+  is_pr:
+    description: whether this build is a pull request (only valid in non-setup workflows)
+    type: boolean
+    default: false
 
 setup: << pipeline.parameters.trigger-setup >>
 
@@ -597,7 +601,12 @@ workflows:
           context:
             - "CircleCI"
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - create-merge-foundation-branch:
           requires:
             - build
@@ -652,7 +661,12 @@ workflows:
               ignore:
                 - /^from-foundation.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - tarball-assembly:
           context:
             - "CircleCI"
@@ -661,7 +675,12 @@ workflows:
           requires:
             - build
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - minion-image-single-arch:
           matrix:
             parameters:
@@ -686,7 +705,12 @@ workflows:
                 - /^master-.*/
                 - /^release-.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - minion-image-multi-arch:
           context:
             - "CircleCI"
@@ -701,7 +725,12 @@ workflows:
                 - /^master-.*/
                 - /^release-.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - horizon-rpm-build:
           context:
             - "CircleCI"
@@ -715,7 +744,12 @@ workflows:
                 - develop
                 - /.*smoke.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - minion-rpm-build:
           context:
             - "CircleCI"
@@ -729,7 +763,12 @@ workflows:
                 - develop
                 - /.*smoke.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - sentinel-rpm-build:
           context:
             - "CircleCI"
@@ -743,7 +782,12 @@ workflows:
                 - develop
                 - /.*smoke.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - integration-test:
           context:
             - "CircleCI"
@@ -754,7 +798,12 @@ workflows:
               ignore:
                 - /^merge-foundation.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - smoke-test-core:
           context:
             - "CircleCI"
@@ -774,7 +823,12 @@ workflows:
                 - /.*smoke.*/
                 - /^dependabot.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - smoke-test-flaky:
           context:
             - "CircleCI"
@@ -794,7 +848,12 @@ workflows:
                 - /.*smoke.*/
                 - /^dependabot.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - smoke-test-minion:
           context:
             - "CircleCI"
@@ -814,7 +873,12 @@ workflows:
                 - /.*smoke.*/
                 - /^dependabot.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - smoke-test-sentinel:
           context:
             - "CircleCI"
@@ -834,7 +898,12 @@ workflows:
                 - /.*smoke.*/
                 - /^dependabot.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - horizon-publish-oci:
           context:
             - "CircleCI"
@@ -855,7 +924,12 @@ workflows:
                 - /^master-.*/
                 - /^release-.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - sentinel-publish-oci:
           context:
             - "CircleCI"
@@ -876,7 +950,12 @@ workflows:
                 - /^master-.*/
                 - /^release-.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       # These don't actually require `integration-test` but we shouldn't bother
       # spending cycles unless everything else passed
       - horizon-deb-build:
@@ -895,7 +974,12 @@ workflows:
                 - /.*smoke.*/
                 - /.*debian.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - minion-deb-build:
           context:
             - "CircleCI"
@@ -912,7 +996,12 @@ workflows:
                 - /.*smoke.*/
                 - /.*debian.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - sentinel-deb-build:
           context:
             - "CircleCI"
@@ -929,7 +1018,12 @@ workflows:
                 - /.*smoke.*/
                 - /.*debian.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
       - create-merge-foundation-branch:
           context:
             - "CircleCI"
@@ -1007,7 +1101,12 @@ workflows:
                 - /^release-.*/
                 - /^foundation.*/
           post-steps:
-            - jira/notify
+            - when:
+                condition:
+                  not:
+                    equal: [ true, << pipeline.parameters.is_pr >> ]
+                steps:
+                  - jira/notify
 
 jobs:
   trigger-path-filtering:
@@ -1116,12 +1215,18 @@ jobs:
               fp.write(json.dumps(mappings))
 
       - run:
-          name: check for empty trigger config
+          name: post-process the trigger config
           command: |
             if [ "$(grep -c trigger-setup /tmp/pipeline-parameters.json)" -eq 0 ]; then
               # this can happen in the case of merges or other similar "empty" commits
               echo '{ "trigger-setup": false, "trigger-build": true }' > /tmp/pipeline-parameters.json
             fi
+            IS_PR=false
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              IS_PR=true
+            fi
+            cat /tmp/pipeline-parameters.json | jq ".is_pr=${IS_PR}" > /tmp/$$.json
+            mv /tmp/$$.json /tmp/pipeline-parameters.json
       - store_artifacts:
           path: /tmp/pipeline-parameters.json
           destination: pipeline-parameters.json


### PR DESCRIPTION
This PR creates (non-setup) parameters for `is_pr`, so we can decide whether to do jira notifications or not.