### PR TITLE
[NMS-15410] replace a reference to a file by its content.

### DIFF
--- a/docs/modules/deployment/pages/time-series-storage/timeseries/hosted-tss.adoc
+++ b/docs/modules/deployment/pages/time-series-storage/timeseries/hosted-tss.adoc
@@ -34,7 +34,7 @@ If they are blocked, you cannot enable the Cloud Services.
 
 The OpenNMS Cloud Services Connector is an extension that lets your {page-component-title} instance send time series data to the OpenNMS-hosted cloud service.
 The packages for this extension are installed by default in Horizon 31 and later, but they do need to be configured and activated.
-You can use `yum` or `apt` to make sure your `opennms-cloud-plugin` package is up to date.
+You can use `yum` or `apt` to make sure your `opennms-plugin-cloud` package is up to date.
 
 To ensure that the feature is activated on future service restarts, add the feature to a file in `featuresBoot.d`:
 
@@ -43,13 +43,13 @@ echo "opennms-plugin-cloud-core wait-for-kar=opennms-plugin-cloud" | sudo tee ${
 
 === Configure Cloud Services
 
-You must configure your {page-component-title} instance to load the Cloud Services plugin on start, and to direct storage to the cloud service.
-If you are using Horizon 31 or later, copy the example `timeseries.properties` file to your working directory:
+You must configure your {page-component-title} instance to direct storage to the cloud service.
+If you are using Horizon 31 or later add or update the following line in `$\{OPENNMS_HOME}/etc/opennms.properties.d/timeseries.properties`:
 
 [source, console]
-cp ${OPENNMS_HOME}/etc/examples/opennms.properties.d/hosted_tsdb.timeseries.properties ${OPENNMS_HOME}/etc/opennms.properties.d/timeseries.properties
+org.opennms.timeseries.strategy=integration
 
-You can configure custom tags in the following contexts in `$\{OPENNMS_HOME}/etc/opennms.properties.d/timeseries.properties`:
+You can configure custom tags in the following contexts in `timeseries.properties`:
 
 * Asset
 * Interface


### PR DESCRIPTION
### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15410

### Scope: 

1. Rename the package `opennms-cloud-plugin` to `opennms-plugin-cloud`. 

> You can use `yum` or `apt` to make sure your `opennms-cloud-plugin` package is up to date.

Was:
```
opennms@opennms:~$ apt search opennms-cloud-**plugin**

Sorting... Done
Full Text Search... Done
```

Now:
```
opennms@opennms:~$ apt search opennms-**plugin**-cloud
Sorting... Done
Full Text Search... Done
opennms-plugin-cloud/opennms-31 1.0.6-1 all
  OpenNMS :: Plugins :: Cloud Plugin
```

2. Rephrase the line to avoid repetition between lines 39 and 46
> 39: To ensure that the feature is activated on future service restarts, add the feature to a file in `featuresBoot.d`:
> 46: You must configure your {page-component-title} instance to load the Cloud Services plugin on start, and to direct storage to the cloud service.

since the instruction ` to load the Cloud Services plugin on start` already presented at line 39, I removed it from line 46.

3. `opennms.properties.d/hosted_tsdb.timeseries.properties`  doesn't exist if you work with an OpenNMS docker container where cloud-plugin is copied as .kar file. I replaced the reference by the necessary settings in the config file.

> `cp ${OPENNMS_HOME}/etc/examples/opennms.properties.d/hosted_tsdb.timeseries.properties ${OPENNMS_HOME}/etc/opennms.properties.d/timeseries.properties`
to
> org.opennms.timeseries.strategy=integration


NOTES:
3.1 if the user installed the plugin package by yum / apt  commands this file `hosted_tsdb.timeseries.properties` will be presented in the examples. Should I mention that fact there?

3.2 original file `hosted_tsdb.timeseries.properties` contains following rows:
```
org.opennms.timeseries.strategy=integration
org.opennms.timeseries.config.buffer_type=OFFHEAP
org.opennms.timeseries.config.writer_threads=16
org.opennms.timeseries.config.buffer_size=131072
org.opennms.timeseries.config.offheap.batch_size=8192
org.opennms.timeseries.config.offheap.path=/tmp
org.opennms.timeseries.config.offheap.max_file_size=-1
``` 

where only the `org.opennms.timeseries.strategy=integration` line is mandatory, other could be skipped or configured in accordance with user needs. 



