### PR TITLE
NMS-15342: Allow property extenders to index by ifIndex

### DIFF
--- a/features/collection/snmp-collector/src/main/java/org/opennms/netmgt/collectd/SnmpPropertyExtenderProcessor.java
+++ b/features/collection/snmp-collector/src/main/java/org/opennms/netmgt/collectd/SnmpPropertyExtenderProcessor.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.opennms.netmgt.collectd.SnmpCollectionResource;
 import org.opennms.netmgt.collectd.SnmpCollectionSet;
 import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.config.DataCollectionConfigFactory;
 import org.opennms.netmgt.config.api.DataCollectionConfigDao;
 import org.opennms.netmgt.config.datacollection.MibObjProperty;
@@ -94,7 +95,13 @@ public class SnmpPropertyExtenderProcessor {
             // Apply MIB Properties
             collectionSet.getResources().forEach(r -> {
                 mibObjProperties.forEach(p -> {
-                    if (p.getInstance().equals(r.getResourceTypeName())) {
+                    // Property extenders should be able to index by ifIndex similar to how other mibObjs do. See
+                    // NMS-15342.
+                    String resourceName = r.getResourceTypeName();
+                    if (resourceName.equals(CollectionResource.RESOURCE_TYPE_IF)) {
+                        resourceName = "ifIndex";
+                    }
+                    if (p.getInstance().equals(resourceName)) {
                         updateCollectionResource(stringAttributes, (SnmpCollectionResource) r, p);
                     }
                 });

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorWithMibPropertiesIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorWithMibPropertiesIT.java
@@ -289,6 +289,38 @@ public class SnmpCollectorWithMibPropertiesIT implements InitializingBean, TestC
         assertEquals("testDefaultValue", map.get("dot1dStpPortEnableText"));
     }
 
+    /**
+     * Test basic enum-lookup property extender with properties defined against standard ifTable entries
+     *
+     * @throws Exception
+     */
+    @Test
+    @JUnitCollector(
+            datacollectionType = "snmp",
+            datacollectionConfig = "/org/opennms/netmgt/config/datacollection-config-NMS15342.xml",
+            anticipateFiles = {
+                    "1",
+                    "1/Fa0_0",
+                    "1/Fa0_0/strings.properties"
+            },
+            anticipateRrds = {
+                    "1/Fa0_0/ifOperStatus",
+                    "1/Fa0_0/ifAdminStatus"
+            }
+    )
+    @JUnitSnmpAgent(resource = "/org/opennms/netmgt/snmp/snmpTestData1.properties")
+    public void testPropertyExtenderIndexedByIf() throws Exception {
+        System.setProperty("org.opennms.netmgt.collectd.SnmpCollector.limitCollectionToInstances", "true");
+
+        CollectionSet collectionSet = m_collectionSpecification.collect(m_collectionAgent);
+        assertEquals("collection status", CollectionStatus.SUCCEEDED, collectionSet.getStatus());
+        CollectorTestUtils.persistCollectionSet(m_rrdStrategy, m_resourceStorageDao, m_collectionSpecification, collectionSet);
+
+        Map<String, String> map = m_resourceStorageDao.getStringAttributes(ResourcePath.get("snmp", "1", "Fa0_0"));
+        assertEquals("UP", map.get("ifAdminStatusTXT"));
+        assertEquals("UP", map.get("ifOperStatusTXT"));
+    }
+
     /* (non-Javadoc)
      * @see org.opennms.core.test.TestContextAware#setTestContext(org.springframework.test.context.TestContext)
      */

--- a/opennms-services/src/test/resources/org/opennms/netmgt/config/datacollection-config-NMS15342.xml
+++ b/opennms-services/src/test/resources/org/opennms/netmgt/config/datacollection-config-NMS15342.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<datacollection-config rrdRepository="%rrdRepository%">
+	<snmp-collection name="default" snmpStorageFlag="select">
+		<rrd step="300">
+			<rra>RRA:AVERAGE:0.5:1:2016</rra>
+			<rra>RRA:AVERAGE:0.5:12:1488</rra>
+			<rra>RRA:AVERAGE:0.5:288:366</rra>
+			<rra>RRA:MAX:0.5:288:366</rra>
+			<rra>RRA:MIN:0.5:288:366</rra>
+		</rrd>
+
+		<groups>
+            <group name="custom-group" ifType="ignore">
+            <mibObj oid=".1.3.6.1.2.1.2.2.1.7" instance="ifIndex" alias="ifAdminStatus" type="integer"/>
+            <mibObj oid=".1.3.6.1.2.1.2.2.1.8" instance="ifIndex" alias="ifOperStatus" type="integer"/>
+            <property instance="ifIndex" alias="ifAdminStatusTXT" class-name="org.opennms.netmgt.collectd.EnumLookupPropertyExtender">
+               <parameter key="enum-attribute" value="ifAdminStatus"/>
+               <parameter key="default-value" value="DEFAULT"/>
+               <parameter key="1" value="UP"/>
+               <parameter key="2" value="DOWN"/>
+               <parameter key="3" value="TESTING"/>
+            </property>
+            <property instance="ifIndex" alias="ifOperStatusTXT" class-name="org.opennms.netmgt.collectd.EnumLookupPropertyExtender">
+               <parameter key="enum-attribute" value="ifOperStatus"/>
+               <parameter key="default-value" value="DEFAULT"/>
+               <parameter key="1" value="UP"/>
+               <parameter key="2" value="DOWN"/>
+               <parameter key="3" value="TESTING"/>
+               <parameter key="4" value="UNKNOWN"/>
+               <parameter key="5" value="DORMANT"/>
+               <parameter key="6" value="NOT_PRESENT"/>
+               <parameter key="7" value="LOWER_LAYER_DOWN"/>
+            </property>
+          </group>
+        </groups>
+        <systems>
+            <systemDef name="system">
+                <sysoidMask>.1.3.6.1.4.1.9.1.</sysoidMask>
+                <collect>
+                    <includeGroup>custom-group</includeGroup>
+                </collect>
+            </systemDef>
+        </systems>
+	</snmp-collection>
+</datacollection-config>


### PR DESCRIPTION
Interface-level resources are given the resourceType `if,` which is used as a reference in thresholding config files and possibly elsewhere. Rather than changing that, this just adjusts SnmpPropertyExtender matching to allow `ifIndex` to match with `if` resources.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15342
