### PR TITLE
NMS-14589: remove POI which is no longer needed

### DIFF
--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -721,20 +721,6 @@
     <!-- these should all be <scope>compile</scope> -->
 
     <dependency>
-      <groupId>org.apache.poi</groupId>
-      <artifactId>poi</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.rometools</groupId>
       <artifactId>rome</artifactId>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -4633,11 +4633,6 @@
         <scope>runtime</scope>
       </dependency>
       <dependency>
-        <groupId>org.apache.poi</groupId>
-        <artifactId>poi</artifactId>
-        <version>3.17</version>
-      </dependency>
-      <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>${postgresqlVersion}</version>


### PR DESCRIPTION
Removing POI dependency altogether. It is not anywhere in our dependencies anymore.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-14589

