### PR TITLE
NMS-15072: fix transient old c3p0 dependency

### DIFF
--- a/dependencies/quartz/pom.xml
+++ b/dependencies/quartz/pom.xml
@@ -19,6 +19,16 @@
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
       <version>${quartzVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>c3p0</groupId>
+          <artifactId>c3p0</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.mchange</groupId>
+      <artifactId>c3p0</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1104,6 +1104,7 @@
                <bannedDependencies>
                  <excludes>
                    <exclude>asm:*</exclude>                          <!-- use: org.ow2.asm.* -->
+                   <exclude>c3p0:c3p0</exclude>                      <!-- use: com.mchange:c3p0 -->
                    <exclude>commons-logging:*</exclude>              <!-- use: jcl-over-slf4j -->
                    <exclude>com.github.detro:*</exclude>             <!-- use: com.codeborne.phantomjsdriver -->
                    <exclude>com.github.detro.ghostdriver:*</exclude> <!-- use: com.codeborne.phantomjsdriver -->
@@ -1633,7 +1634,7 @@
     <commonsNetVersion>3.8.0</commonsNetVersion>
     <commonsValidatorVersion>1.6</commonsValidatorVersion>
     <concurrentTreesVersion>2.5.0</concurrentTreesVersion>
-    <c3p0Version>0.9.5.4</c3p0Version>
+    <c3p0Version>0.9.5.5</c3p0Version>
     <cxfVersion>3.5.5</cxfVersion>
     <cxfXjcVersion>3.3.2</cxfXjcVersion>
     <dhcp4javaVersion>1.1.0</dhcp4javaVersion>


### PR DESCRIPTION
This PR makes sure Quartz doesn't pull in an old c3p0 jar through a dependency on `c3p0:c3p0` (before it got moved to `com.mchange:c3p0`)

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15072

