### PR TITLE
NMS-13216: always handle reload event in Scriptd

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/Executor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/Executor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2003-2020 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2003-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -184,30 +184,9 @@ public class Executor {
         @Override
         public void run() {
 
-            // check for reload event
             if (isReloadConfigEvent(m_event)) {
-                try {
-                    ScriptdConfigFactory.reload();
-                    m_config = ScriptdConfigFactory.getInstance();
-                    registerEventProcessor();
-                    loadConfig();
-
-                    for (final ReloadScript script : m_config.getReloadScripts()) {
-                        if (script.getContent().isPresent()) {
-                            try {
-                                m_scriptManager.exec(script.getLanguage(), "", 0, 0, script.getContent().get());
-                            } catch (BSFException e) {
-                                LOG.error("Reload script[{}] failed.", script, e);
-                            }
-                        } else {
-                            LOG.warn("Reload Script does not have script contents: " + script);
-                        }
-                    }
-
-                    LOG.debug("Scriptd configuration reloaded");
-                } catch (Throwable e) {
-                    LOG.error("Unable to reload Scriptd configuration: ", e);
-                }
+                // reloads are handled by Scriptd#handleReloadConfigEvent
+                return;
             }
 
             if (m_config.getTransactional()) {
@@ -220,6 +199,32 @@ public class Executor {
             }
 
         } // end run
+    }
+
+    protected void doReload() {
+        try {
+            ScriptdConfigFactory.reload();
+            m_config = ScriptdConfigFactory.getInstance();
+            registerEventProcessor();
+            loadConfig();
+
+            for (final ReloadScript script : m_config.getReloadScripts()) {
+                final var scriptContent = script.getContent();
+                if (scriptContent.isPresent()) {
+                    try {
+                        m_scriptManager.exec(script.getLanguage(), "", 0, 0, scriptContent.get());
+                    } catch (BSFException e) {
+                        LOG.error("Reload script[{}] failed.", script, e);
+                    }
+                } else {
+                    LOG.warn("Reload Script does not have script contents: {}", script);
+                }
+            }
+
+            LOG.debug("Scriptd configuration reloaded");
+        } catch (final Exception e) {
+            LOG.error("Unable to reload Scriptd configuration", e);
+        }
     }
 
     private void executeEventScripts(IEvent m_event) {
@@ -306,14 +311,14 @@ public class Executor {
     }
 
 
-    private static boolean isReloadConfigEvent(IEvent event) {
+    protected static boolean isReloadConfigEvent(IEvent event) {
         boolean isTarget = false;
         
         if (EventConstants.RELOAD_DAEMON_CONFIG_UEI.equals(event.getUei())) {
             List<IParm> parmCollection = event.getParmCollection();
             
             for (IParm parm : parmCollection) {
-                if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Scriptd".equalsIgnoreCase(parm.getValue().getContent())) {
+                if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && Scriptd.NAME.equalsIgnoreCase(parm.getValue().getContent())) {
                     isTarget = true;
                     break;
                 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/Scriptd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/Scriptd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,6 +36,10 @@ import org.opennms.netmgt.config.ScriptdConfigFactory;
 import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.annotations.EventHandler;
+import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.access.BeanFactoryReference;
@@ -50,6 +54,7 @@ import org.springframework.beans.factory.access.BeanFactoryReference;
  * @author <a href="mailto:jim.doble@tavve.com">Jim Doble</a>
  * @author <a href="http://www.opennms.org/">OpenNMS.org</a>
  */
+@EventListener(name = Scriptd.NAME)
 public final class Scriptd extends AbstractServiceDaemon {
     
     private static final Logger LOG = LoggerFactory.getLogger(Scriptd.class);
@@ -139,5 +144,12 @@ public final class Scriptd extends AbstractServiceDaemon {
      */
     public static Scriptd getInstance() {
         return m_singleton;
+    }
+
+    @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
+    public void handleReloadConfigEvent(final IEvent event) {
+        if (Executor.isReloadConfigEvent(event)) {
+            m_executor.doReload();
+        }
     }
 }


### PR DESCRIPTION
@jeffgdotorg noticed that my previous "fix" would never handle the reload event, because the processor would never get registered if there were no Scriptd scripts. :D

This fixes it to process reload events separately.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-13216

