### PR TITLE
NMS-15291: Add health check for core container

### DIFF
--- a/opennms-container/core/Dockerfile
+++ b/opennms-container/core/Dockerfile
@@ -137,6 +137,7 @@ RUN rm -rf /usr/share/opennms/share/rrd \
 # Add templates replaced at runtime and entrypoint
 COPY --chown=10001:0 ./container-fs/confd /etc/confd
 COPY --chown=10001:0 ./container-fs/entrypoint.sh /
+COPY --chown=10001:0 ./container-fs/health.sh /
 
 # Allow users in the root group to access them with the same authorization as the directory and file owner
 RUN chmod -R g=u /usr/share/opennms/etc

--- a/opennms-container/core/container-fs/health.sh
+++ b/opennms-container/core/container-fs/health.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if ssh -o StrictHostKeyChecking=no -p 8101 localhost health-check | grep --quiet "Everything is awesome"; then 
+if curl http://localhost:8980/opennms/rest/health/probe | grep --quiet "Everything is awesome"; then 
   exit 0;
 else
   exit 1;

--- a/opennms-container/core/container-fs/health.sh
+++ b/opennms-container/core/container-fs/health.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if ssh -o StrictHostKeyChecking=no -p 8101 localhost health-check | grep --quiet "Everything is awesome"; then 
+  exit 0;
+else
+  exit 1;
+fi


### PR DESCRIPTION
Basic health check script based off of similar scripts used by sentinel/minion. The documentation still has 
```
test: [ 'CMD', 'curl', '-f', '-I', 'http://localhost:8980/opennms/login.jsp' ]
```
listed for the health check in the recommended docker-compose file. 

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15291
