### PR TITLE
NMS-15572: reenable license maven plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -894,13 +894,14 @@ jobs:
                 ;;
             esac
             ulimit -n 65536 || :
-            ./compile.pl -DskipTests=true -Dbuild.skip.tarball=false \
+            ./assemble.pl -DskipTests=true -Dbuild.skip.tarball=false \
               -DupdatePolicy=never \
               -Daether.connector.resumeDownloads=false \
               -Daether.connector.basic.threads=1 \
               -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
               -DvaadinJavaMaxMemory=<< parameters.vaadin-javamaxmem >> \
               -DmaxCpus=<< parameters.number-vcpu >> \
+              -Denable.license=true \
               -Pbuild-bamboo \
               -Prun-expensive-tasks \
               -Dopennms.home=/opt/opennms \
@@ -918,7 +919,7 @@ jobs:
             cp ./opennms-assemblies/xsds/target/*-xsds.tar.gz "./target/artifacts/opennms-${OPENNMS_VERSION}-xsds.tar.gz"
             cp opennms-doc/guide-all/target/*.tar.gz "./target/artifacts/opennms-${OPENNMS_VERSION}-docs.tar.gz"
             cp target/*-source.tar.gz ./target/artifacts/
-            cp opennms-full-assembly/target/generated-sources/license/THIRD-PARTY.txt ./target/artifacts/ || :
+            cp opennms-full-assembly/target/generated-sources/license/THIRD-PARTY.txt ./target/artifacts/
       - run:
           name: Build Minion OCI
           command: |

--- a/container/features/src/license/THIRD-PARTY.properties
+++ b/container/features/src/license/THIRD-PARTY.properties
@@ -3,6 +3,7 @@ colt--colt--1.2.0=mit
 com.eclipsesource.jaxrs--features--1.0.2.ONMS=epl_v1
 findbugs--annotations--1.0.0=lgpl_v2_1
 javax.transaction--jta--1.1=cddl_v1_1
+org.codehaus.jettison--jettison--1.1=apache_v2
 org.jinterop--j-interop--2.0.8=lgpl_v3
 org.jinterop--j-interopdeps--2.0.8=lgpl_v3
 org.opennms--jicmp-api--2.0.1=gpl_v2_cpe

--- a/opennms-assemblies/http-remoting/src/license/THIRD-PARTY.properties
+++ b/opennms-assemblies/http-remoting/src/license/THIRD-PARTY.properties
@@ -1,9 +1,5 @@
 bsh--bsh--1.3.0=spl_v1_0
 findbugs--annotations--1.0.0=lgpl_v2_1
 javax.transaction--jta--1.1=cddl_v1_1
-org.jinterop--j-interop--2.0.8=lgpl_v3
-org.jinterop--j-interopdeps--2.0.8=lgpl_v3
-org.opennms--jicmp-api--2.0.1=gpl_v2_cpe
-org.opennms--jicmp6-api--2.0.1=gpl_v2_cpe
 org.samba.jcifs--jcifs--1.3.19=lgpl_v2_1
 org.simpleframework--org.simpleframework--3.1.3=lgpl_v2_1

--- a/opennms-webapp/src/license/THIRD-PARTY.properties
+++ b/opennms-webapp/src/license/THIRD-PARTY.properties
@@ -8,4 +8,3 @@ opensymphony--ognl--2.6.11=bsd_3
 org.opennms--jrrd2-api--2.0.3=gpl_v2_cpe
 org.samba.jcifs--jcifs--1.3.19=lgpl_v2_1
 org.simpleframework--org.simpleframework--3.1.3=lgpl_v2_1
-poi--poi--2.5.1-final-20040804=apache_v2

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,6 @@
           <verbose>true</verbose>
           <acceptPomPackaging>true</acceptPomPackaging>
           <errorRemedy>xmlOutput</errorRemedy>
-          <excludedArtifacts>^.*opennms.*$</excludedArtifacts>
           <excludedScopes>system,test</excludedScopes>
           <deployMissingFile>true</deployMissingFile>
           <failOnBlacklist>true</failOnBlacklist>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
           <useDefaultContentSanitizers>true</useDefaultContentSanitizers>
           <useDefaultUrlReplacements>true</useDefaultUrlReplacements>
           <useMissingFile>true</useMissingFile>
+          <useRepositoryMissingFiles>false</useRepositoryMissingFiles>
           <!-- normalize license names for sanity -->
           <licenseMerges>
             <licenseMerge>
@@ -1827,16 +1828,6 @@
         <runPingTests>true</runPingTests>
         <skipPdfGeneration>false</skipPdfGeneration>
       </properties>
-      <!--
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-      -->
     </profile>
     <profile>
       <id>enable.license</id>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.0.ONMS.1</version>
         <inherited>true</inherited>
         <executions>
           <execution>


### PR DESCRIPTION
The plugin walks dependencies _anyway_, so the only time we actually need to generate these things is in the assembly stage

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15572

