### PR TITLE
NMS-15476: Rest API for Statistics Sharing status and metadata

### DIFF
--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsMetadataDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsMetadataDTO.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsageStatisticsMetadataDTO {
+    public static class UsageStatisticsMetadataItem {
+        public String key;
+        public String name;
+        public String description;
+        public String datatype; // "string", "number", "object"
+
+        public UsageStatisticsMetadataItem() {
+        }
+
+        public UsageStatisticsMetadataItem(String key, String name, String description, String datatype) {
+            this.key = key;
+            this.name = name;
+            this.description = description;
+            this.datatype = datatype;
+        }
+    }
+
+    private List<UsageStatisticsMetadataItem> metadata = new ArrayList<>();
+
+    public UsageStatisticsMetadataDTO() {
+    }
+
+    public List<UsageStatisticsMetadataItem> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(List<UsageStatisticsMetadataItem> list) {
+        this.metadata = list;
+    }
+}

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTO.java
@@ -2,7 +2,7 @@
  * This file is part of OpenNMS(R).
  *
  * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsStatusDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsStatusDTO.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.internal;
+
+public class UsageStatisticsStatusDTO {
+    private boolean isEnabled;
+
+    public boolean getEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        isEnabled = enabled;
+    }
+}

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
@@ -29,7 +29,6 @@
 package org.opennms.features.datachoices.web;
 
 import java.io.IOException;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
@@ -39,8 +38,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-
+import org.opennms.features.datachoices.internal.UsageStatisticsMetadataDTO;
 import org.opennms.features.datachoices.internal.UsageStatisticsReportDTO;
+import org.opennms.features.datachoices.internal.UsageStatisticsStatusDTO;
 
 @Path("/datachoices")
 public interface DataChoiceRestService {
@@ -51,4 +51,14 @@ public interface DataChoiceRestService {
     @GET
     @Produces(value={MediaType.APPLICATION_JSON})
     UsageStatisticsReportDTO getUsageStatistics() throws ServletException, IOException;
+
+    @GET
+    @Path("status")
+    @Produces(value={MediaType.APPLICATION_JSON})
+    UsageStatisticsStatusDTO getStatus() throws ServletException, IOException;
+
+    @GET
+    @Path("meta")
+    @Produces(value={MediaType.APPLICATION_JSON})
+    UsageStatisticsMetadataDTO getMetadata() throws ServletException, IOException;
 }

--- a/features/datachoices/src/main/resources/web/datachoicesMetadata.json
+++ b/features/datachoices/src/main/resources/web/datachoicesMetadata.json
@@ -1,0 +1,46 @@
+{
+  "metadata": [
+    {
+      "key": "systemId",
+      "name": "System tracking UUID",
+      "description": "Acts as a \"primary key\" for a system's data over time",
+      "datatype": "string"
+    },
+    {
+      "key": "packageName",
+      "name": "Product name",
+      "description": "Which core product (Horizon vs. Meridian) is in use?",
+      "datatype": "string"
+    },
+    {
+      "key": "version",
+      "name": "Product version",
+      "description": "Which version of the core product is in use?",
+      "datatype": "string"
+    },
+    {
+      "key": "osName",
+      "name": "OS name",
+      "description": "Which operating system is in use on the core system?",
+      "datatype": "string"
+    },
+    {
+      "key": "nodesBySysOid",
+      "name": "Top-twenty sysObjectIDs",
+      "description": "Which device types dominate the set of SNMP-enabled nodes?",
+      "datatype": "object"
+    },
+    {
+      "key": "services",
+      "name": "Services",
+      "description": "Which services are being used on the core system?",
+      "datatype": "object"
+    },
+    {
+      "key": "installedFeatures",
+      "name": "Installed Features",
+      "description": "Which features are installed on the core system?",
+      "datatype": "object"
+    }
+  ]
+}


### PR DESCRIPTION
Add Rest endpoints in Datachoices Rest service to return current "enabled" status along with metadata.

The metadata maps keys in the datachoices data response to names, descriptions, and any other data the UI may need to display the new Usage Statistics Sharing UI.

Metadata data is in a json resource file. It will be updated in a subsequent PR, there are just some initial values there.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15476

