### PR TITLE
NMS-15606: Remove unneeded config option to avoid side effects

### DIFF
--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogUtils.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogUtils.java
@@ -62,7 +62,6 @@ public abstract class SyslogUtils {
         instanceConfiguration.setSendLocalName(destination.isSendLocalName());
         instanceConfiguration.setSendLocalTimestamp(destination.isSendLocalTime());
         instanceConfiguration.setTruncateMessage(destination.isTruncateMessage());
-        instanceConfiguration.setUseStructuredData(SyslogConstants.USE_STRUCTURED_DATA_DEFAULT);
 
         try {
             Syslog.createInstance(destination.getName(), instanceConfiguration);


### PR DESCRIPTION
This line is not needed and is causing maxMessageSize to get overwritten, see https://github.com/graylog-labs/syslog4j-graylog2/blob/master/src/main/java/org/graylog2/syslog4j/impl/AbstractSyslogConfig.java#L64

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15606

