### PR TITLE
Asynchronous polling engine & benchmarking tool

### DIFF
--- a/docs/modules/operation/pages/deep-dive/service-assurance/configuration.adoc
+++ b/docs/modules/operation/pages/deep-dive/service-assurance/configuration.adoc
@@ -64,7 +64,7 @@ During evaluation of an expression, the following scopes are available:
 
 By default, the number of polls active at any given time is limited by the number of threads that are allocated to pollerd.
 Each thread is responsible for one poll, and will block until the poll is completed; this is true even when the polling is done by a Minion at a remote location.
-In this case, the thread is blocked for the duration of the RPC.
+In this case, the thread is blocked for the duration of the remote procedure call.
 
 If you have hundreds of locations and hundreds of nodes at each location, you may want to reduce the number of threads required on your {page-component-title} instance.
 Each thread allocates a fixed amount of system memory.

--- a/docs/modules/operation/pages/deep-dive/service-assurance/configuration.adoc
+++ b/docs/modules/operation/pages/deep-dive/service-assurance/configuration.adoc
@@ -58,3 +58,31 @@ During evaluation of an expression, the following scopes are available:
 * Node metadata
 * Interface metadata
 * Service metadata
+
+[[ga-pollerd-configuration-async]]
+== Asynchronous engine
+
+By default, the number of polls active at any given time is limited by the number of threads that are allocated to the daemon.
+Each thread is responsible for one poll, and will block until the poll is completed.
+This is true, even when the polling is done by a Minion at a remote location.
+In this case, the thread will block for the duration of the RPC.
+
+In scenarios where there are hundreds of different locations, and hundreds of nodes at each of these, it can be desirable to reduce the number of threads required on the core.
+Each thread allocates a fixed amount of system memory, and too many threads active at a given time can extraneous load on the system due to context switching.
+
+For these reasons, we have developed a new asynchronous mode for the poller.
+When enabled, threads are released while the polls are active, allowing Minions to process more polls than there are threads.
+
+To enable the feature, set the following attributes in the top level element of `etc/poller-configuration.xml`:
+[source, xml]
+----
+<poller-configuration threads="30"
+                      asyncPollingEngineEnabled="true" <1>
+                      maxConcurrentAsyncPolls="200" <2>
+----
+
+<1> Enable the asynchronous engine.
+<2> Used to limit the number of polls active, since each of these still consume some memory resources.
+
+In this mode, threads are only used to trigger the execution of the poll, so the number can be typically reduced.
+The actual number of polls active, or in-flight, can be observed via the `NumPollsInFlight` metrics associated with the daemon's MBeans.

--- a/docs/modules/operation/pages/deep-dive/service-assurance/configuration.adoc
+++ b/docs/modules/operation/pages/deep-dive/service-assurance/configuration.adoc
@@ -62,27 +62,27 @@ During evaluation of an expression, the following scopes are available:
 [[ga-pollerd-configuration-async]]
 == Asynchronous engine
 
-By default, the number of polls active at any given time is limited by the number of threads that are allocated to the daemon.
-Each thread is responsible for one poll, and will block until the poll is completed.
-This is true, even when the polling is done by a Minion at a remote location.
-In this case, the thread will block for the duration of the RPC.
+By default, the number of polls active at any given time is limited by the number of threads that are allocated to pollerd.
+Each thread is responsible for one poll, and will block until the poll is completed; this is true even when the polling is done by a Minion at a remote location.
+In this case, the thread is blocked for the duration of the RPC.
 
-In scenarios where there are hundreds of different locations, and hundreds of nodes at each of these, it can be desirable to reduce the number of threads required on the core.
-Each thread allocates a fixed amount of system memory, and too many threads active at a given time can extraneous load on the system due to context switching.
+If you have hundreds of locations and hundreds of nodes at each location, you may want to reduce the number of threads required on your {page-component-title} instance.
+Each thread allocates a fixed amount of system memory.
+Having too many threads active at a given time can cause extensive load on the system.
 
-For these reasons, we have developed a new asynchronous mode for the poller.
-When enabled, threads are released while the polls are active, allowing Minions to process more polls than there are threads.
+When enabled, the asynchronous polling mode mitigates this load.
+It allows threads to be released while polls are active, enabling Minions to process more polls than the number of threads available.
 
-To enable the feature, set the following attributes in the top level element of `etc/poller-configuration.xml`:
+To enable the feature, set the following attributes in the top-level element of `etc/poller-configuration.xml`:
+
 [source, xml]
 ----
 <poller-configuration threads="30"
                       asyncPollingEngineEnabled="true" <1>
                       maxConcurrentAsyncPolls="200" <2>
 ----
-
-<1> Enable the asynchronous engine.
+<1> Enables the asynchronous polling engine.
 <2> Used to limit the number of polls active, since each of these still consume some memory resources.
 
-In this mode, threads are only used to trigger the execution of the poll, so the number can be typically reduced.
-The actual number of polls active, or in-flight, can be observed via the `NumPollsInFlight` metrics associated with the daemon's MBeans.
+In this mode, threads are used only to trigger a poll to run; this means that the number of threads can typically be reduced.
+You can see the actual number of active (in-flight) polls by reviewing the `NumPollsInFlight` metrics associated with pollerd's MBeans.

--- a/docs/modules/operation/pages/deep-dive/service-assurance/configuration.adoc
+++ b/docs/modules/operation/pages/deep-dive/service-assurance/configuration.adoc
@@ -82,7 +82,7 @@ To enable the feature, set the following attributes in the top-level element of 
                       maxConcurrentAsyncPolls="200" <2>
 ----
 <1> Enables the asynchronous polling engine.
-<2> Used to limit the number of polls active, since each of these still consume some memory resources.
+<2> Used to limit the number of polls active, since each of these still consumes some memory resources.
 
 In this mode, threads are used only to trigger a poll to run; this means that the number of threads can typically be reduced.
 You can see the actual number of active (in-flight) polls by reviewing the `NumPollsInFlight` metrics associated with pollerd's MBeans.

--- a/features/poller/shell/src/main/java/org/opennms/netmgt/poller/shell/Benchmark.java
+++ b/features/poller/shell/src/main/java/org/opennms/netmgt/poller/shell/Benchmark.java
@@ -70,7 +70,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Command(scope = "opennms", name = "poller-benchmark", description = "Benchmark pollerd by creating N nodes/services and waiting for them all to be polled.")
+@Command(scope = "opennms", name = "poller-benchmark", description = "Benchmark pollerd by creating N nodes/services and waiting for them to be polled.")
 @Service
 public class Benchmark implements Action {
 
@@ -93,10 +93,10 @@ public class Benchmark implements Action {
 
     private final int batchSize = 100;
 
-    @Option(name = "-n", aliases = "--nodes", description = "Number of nodes & services to create. A single service per interface per node is created.")
+    @Option(name = "-n", aliases = "--nodes", description = "Number of nodes and services to create. A single service per interface per node is created.")
     int numNodes = 100;
 
-    @Option(name = "-r", aliases = "--recycle", description = "Recycle nodes created by a previous run instead of deleting/recreating these.")
+    @Option(name = "-r", aliases = "--recycle", description = "Recycle nodes created by a previous run instead of deleting/recreating them.")
     boolean recycleNetwork = false;
 
     private final Set<Integer> allMonitoredServiceIds = new HashSet<>();

--- a/features/poller/shell/src/main/java/org/opennms/netmgt/poller/shell/Benchmark.java
+++ b/features/poller/shell/src/main/java/org/opennms/netmgt/poller/shell/Benchmark.java
@@ -1,0 +1,288 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.poller.shell;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.opennms.core.criteria.Alias;
+import org.opennms.core.criteria.Criteria;
+import org.opennms.core.criteria.restrictions.AnyRestriction;
+import org.opennms.core.criteria.restrictions.EqRestriction;
+import org.opennms.core.criteria.restrictions.GeRestriction;
+import org.opennms.core.criteria.restrictions.InRestriction;
+import org.opennms.core.daemon.DaemonReloadEnum;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.ServiceTypeDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.xml.event.Event;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Command(scope = "opennms", name = "poller-benchmark", description = "Benchmark pollerd by creating N nodes/services and waiting for them all to be polled.")
+@Service
+public class Benchmark implements Action {
+
+    @Reference
+    private SessionUtils sessionUtils;
+    @Reference
+    private MonitoringLocationDao monitoringLocationDao;
+    @Reference
+    private NodeDao nodeDao;
+    @Reference
+    private IpInterfaceDao ipInterfaceDao;
+    @Reference
+    private IpInterfaceDao ipIfaceDao;
+    @Reference
+    private MonitoredServiceDao monitoredServiceDao;
+    @Reference
+    private ServiceTypeDao serviceTypeDao;
+    @Reference
+    private EventForwarder eventForwarder;
+
+    private final int batchSize = 100;
+
+    @Option(name = "-n", aliases = "--nodes", description = "Number of nodes & services to create. A single service per interface per node is created.")
+    int numNodes = 100;
+
+    @Option(name = "-r", aliases = "--recycle", description = "Recycle nodes created by a previous run instead of deleting/recreating these.")
+    boolean recycleNetwork = false;
+
+    private final Set<Integer> allMonitoredServiceIds = new HashSet<>();
+
+    @Override
+    public Object execute() {
+        System.out.println(new Date() + ": Benchmarking started...");
+
+        long startOfPoll;
+        if (!recycleNetwork) {
+            System.out.println(new Date() + ": Destroying old network...");
+            List<Event> eventsToSend = destroyOldNetwork();
+            System.out.println(new Date() + ": Notifying pollerd of deleted services...");
+            for (Event e : eventsToSend) {
+                eventForwarder.sendNow(e);
+            }
+            System.out.println(new Date() + ": Building new network...");
+            eventsToSend = buildNewNetwork();
+            System.out.println(new Date() + ": Notifying pollerd of new services...");
+            // Start the timeout after the entities have been pushed to the DB and *before* we send the events
+            startOfPoll = System.currentTimeMillis();
+            for (Event e : eventsToSend) {
+                eventForwarder.sendNow(e);
+            }
+        } else {
+            System.out.println(new Date() + ": Recycling network from previous run...");
+            recycleNetwork();
+            numNodes = allMonitoredServiceIds.size();
+            System.out.printf("%s: Tracking %d services\n", new Date(), numNodes);
+            startOfPoll = System.currentTimeMillis();
+        }
+
+        System.out.println(new Date() + ": Waiting for services to be polled...");
+        waitForServices(startOfPoll);
+        long endOfPoll = System.currentTimeMillis();
+        System.out.println(new Date() + ": Benchmarking done.");
+        System.out.println(new Date() + ": Services polled in: " + getDurationBreakdown(endOfPoll - startOfPoll));
+
+        return null;
+    }
+
+    private void waitForServices(long startOfPoll) {
+        Date lastPollLimit = new Date(startOfPoll);
+        long totalNumServices = allMonitoredServiceIds.size();
+        while(true) {
+            long numServicesMatching = sessionUtils.withTransaction(() -> {
+                final Criteria criteria = criteriaForBenchmarkServices();
+                criteria.addRestriction(new AnyRestriction(
+                        new GeRestriction("lastGood", lastPollLimit),
+                        new GeRestriction("lastFail", lastPollLimit)));
+                return monitoredServiceDao.countMatching(criteria);
+            });
+
+            if (numServicesMatching >= totalNumServices) {
+                System.out.printf("All %d services have been polled.\n", totalNumServices);
+                break;
+            } else {
+                System.out.printf("Still waiting for %d (out of %d) services...\n", (totalNumServices - numServicesMatching), totalNumServices);
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    System.out.println("Interrupted. Aborting.");
+                    Thread.interrupted();
+                    break;
+                }
+            }
+        }
+    }
+
+    private Criteria criteriaForBenchmarkServices() {
+        final Criteria criteria = new Criteria(OnmsMonitoredService.class);
+        criteria.addRestriction(new InRestriction("status", Arrays.asList("A", "N")));
+        criteria.setAliases(Arrays.asList(new Alias("ipInterface", "ipInterface", Alias.JoinType.LEFT_JOIN),
+                new Alias("ipInterface.node", "node", Alias.JoinType.LEFT_JOIN)));
+        criteria.addRestriction(new EqRestriction("node.operatingSystem", Benchmark.class.getCanonicalName()));
+        return criteria;
+    }
+
+    private void recycleNetwork() {
+        sessionUtils.withTransaction(() -> {
+            final Criteria criteria = criteriaForBenchmarkServices();
+            for (OnmsMonitoredService svc : monitoredServiceDao.findMatching(criteria)) {
+                allMonitoredServiceIds.add(svc.getId());
+            }
+        });
+    }
+
+    private List<Event> destroyOldNetwork() {
+        List<Event> eventsToSend = new LinkedList<>();
+
+        AtomicBoolean nodesRemaining = new AtomicBoolean(true);
+        while (nodesRemaining.get()) {
+            sessionUtils.withTransaction(() -> {
+                final Criteria criteria = new Criteria(OnmsNode.class);
+                criteria.addRestriction(new EqRestriction("operatingSystem", Benchmark.class.getCanonicalName()));
+                criteria.setLimit(batchSize);
+                List<OnmsNode> nodes = nodeDao.findMatching(criteria);
+                nodes.forEach(node -> {
+                    nodeDao.delete(node);
+
+                    EventBuilder eventBuilder = new EventBuilder(EventConstants.NODE_DELETED_EVENT_UEI, Benchmark.class.getCanonicalName())
+                            .setNode(node);
+                    eventBuilder.addParam(EventConstants.PARM_NODE_LABEL, node.getLabel());
+                    eventsToSend.add(eventBuilder.getEvent());
+                });
+                nodesRemaining.set(!nodes.isEmpty());
+            });
+        }
+
+        return eventsToSend;
+    }
+
+    private List<Event> buildNewNetwork() {
+        List<Event> eventsToSend = new LinkedList<>();
+        InetAddress loopbackAddress = InetAddressUtils.addr("127.0.0.1");
+        final var icmpServiceType = serviceTypeDao.findByName("ICMP");
+
+        for (int i = 0; i < numNodes; i++) {
+            final int k = i;
+            sessionUtils.withTransaction(() -> {
+                final var node = new OnmsNode();
+                node.setLabel("bench-n" + k);
+                node.setLocation(this.monitoringLocationDao.getDefaultLocation());
+                node.setOperatingSystem(Benchmark.class.getCanonicalName());
+                nodeDao.saveOrUpdate(node);
+
+                final var iface = new OnmsIpInterface();
+                iface.setNode(node);
+                iface.setIpAddress(loopbackAddress);
+                node.addIpInterface(iface);
+                ipIfaceDao.saveOrUpdate(iface);
+
+                final var svcICMP = new OnmsMonitoredService();
+                svcICMP.setIpInterface(iface);
+                svcICMP.setServiceType(icmpServiceType);
+                svcICMP.setStatus("A");
+                iface.addMonitoredService(svcICMP);
+                monitoredServiceDao.saveOrUpdate(svcICMP);
+                allMonitoredServiceIds.add(svcICMP.getId());
+
+                EventBuilder eventBuilder = new EventBuilder(EventConstants.NODE_GAINED_SERVICE_EVENT_UEI, "benchmark")
+                        .setNode(node)
+                        .setInterface(iface.getIpAddress())
+                        .setService(svcICMP.getServiceName());
+                eventBuilder.addParam(EventConstants.PARM_NODE_LABEL, node.getLabel());
+                eventsToSend.add(eventBuilder.getEvent());
+            });
+
+            if ((i+1) % batchSize == 0) {
+                System.out.printf("Created %d/%d nodes\n", (i+1), numNodes);
+            }
+        }
+        return eventsToSend;
+    }
+
+    /**
+     * Pulled form https://stackoverflow.com/a/7663966
+     * Convert a millisecond duration to a string format
+     * @param millis A duration to convert to a string form
+     * @return A string of the form "X Days Y Hours Z Minutes A Seconds".
+     */
+    public static String getDurationBreakdown(long millis) {
+        if(millis < 0) {
+            throw new IllegalArgumentException("Duration must be greater than zero!");
+        }
+
+        long days = TimeUnit.MILLISECONDS.toDays(millis);
+        millis -= TimeUnit.DAYS.toMillis(days);
+        long hours = TimeUnit.MILLISECONDS.toHours(millis);
+        millis -= TimeUnit.HOURS.toMillis(hours);
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(millis);
+        millis -= TimeUnit.MINUTES.toMillis(minutes);
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(millis);
+
+        StringBuilder sb = new StringBuilder(64);
+        sb.append(days);
+        sb.append(" Days ");
+        sb.append(hours);
+        sb.append(" Hours ");
+        sb.append(minutes);
+        sb.append(" Minutes ");
+        sb.append(seconds);
+        sb.append(" Seconds");
+
+        return(sb.toString());
+    }
+
+
+}

--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -32,6 +32,7 @@
             <attrib name="TasksCompleted" alias="ONMSPollerTasksCpt" type="counter"/>
             <attrib name="TaskQueuePendingCount" alias="ONMSPollerTskQPCnt" type="gauge"/>
             <attrib name="TaskQueueRemainingCapacity" alias="ONMSPollerTskQRCap" type="gauge"/>
+            <attrib name="NumPollsInFlight" alias="ONMSPollsInFlight" type="gauge"/>
          </mbean>
 
          <mbean name="org.opennms.core.ipc.sink.kafka.heartbeat" resource-type="kafkaLag" objectname="org.opennms.core.ipc.sink.kafka:name=*.Lag,type=gauges">

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
@@ -161,7 +161,7 @@ report.onms.pollerd.inflight.columns=ONMSPollsInFlight
 report.onms.pollerd.inflight.type=interfaceSnmp
 report.onms.pollerd.inflight.command=--title="OpenNMS Pollerd Polls In Flight" \
  --vertical-label="In Flight" \
- DEF:inflight={rrd1}:ONMSPollsInFlight:MAX \
+ DEF:inflight={rrd1}:ONMSPollsInFlight:AVERAGE \
  LINE1:inflight#0000ff:"In Flight" \
  GPRINT:inflight:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:inflight:MIN:"Min  \\: %8.2lf %s" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
@@ -1,6 +1,7 @@
 reports=onms.manager.uptime, onms.queued.updates, onms.queued.pending, \
 onms.pollerd.threadpool, onms.pollerd.completedRatio, onms.pollerd.polls, \
 onms.pollerd.taskqueue, \
+onms.pollerd.inflight, \
 onms.collectd.threadpool, \
 onms.collectd.completedRatio, onms.collectd.collectableServiceCount, \
 onms.collectd.taskqueue, \
@@ -154,6 +155,17 @@ report.onms.pollerd.taskqueue.command=--title="OpenNMS Pollerd Task Queue" \
  GPRINT:active:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:active:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:active:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.onms.pollerd.inflight.name=OpenNMS Poller Polls In Flight
+report.onms.pollerd.inflight.columns=ONMSPollsInFlight
+report.onms.pollerd.inflight.type=interfaceSnmp
+report.onms.pollerd.inflight.command=--title="OpenNMS Pollerd Polls In Flight" \
+ --vertical-label="In Flight" \
+ DEF:inflight={rrd1}:ONMSPollsInFlight:MAX \
+ LINE1:inflight#0000ff:"In Flight" \
+ GPRINT:inflight:AVERAGE:" Avg  \\: %8.2lf %s" \
+ GPRINT:inflight:MIN:"Min  \\: %8.2lf %s" \
+ GPRINT:inflight:MAX:"Max  \\: %8.2lf %s\\n"
 
 ###
 ## OpenNMS Collectd

--- a/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/poller/PollerConfiguration.java
+++ b/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/poller/PollerConfiguration.java
@@ -95,6 +95,15 @@ public class PollerConfiguration implements Serializable {
     private Integer m_defaultCriticalPathRetries;
 
     /**
+     * Flag which indicates if the async polling engine is enabled
+     */
+    @XmlAttribute(name="asyncPollingEngineEnabled")
+    private Boolean m_asyncPollingEngineEnabled;
+
+    @XmlAttribute(name="maxConcurrentAsyncPolls")
+    private Integer m_maxConcurrentAsyncPolls;
+
+    /**
      * Configuration of node-outage functionality
      */
     @XmlElement(name="node-outage")
@@ -277,11 +286,27 @@ public class PollerConfiguration implements Serializable {
         m_defaultCriticalPathRetries = retries;
     }
 
+    public Boolean getAsyncPollingEngineEnabled() {
+        return Objects.requireNonNullElse(m_asyncPollingEngineEnabled, false);
+    }
+
+    public void setAsyncPollingEngineEnabled(Boolean asyncPollingEngineEnabled) {
+        m_asyncPollingEngineEnabled = asyncPollingEngineEnabled;
+    }
+
+    public Integer getMaxConcurrentAsyncPolls() {
+        return Objects.requireNonNullElse(m_maxConcurrentAsyncPolls, 100);
+    }
+
+    public void setMaxConcurrentAsyncPolls(Integer maxConcurrentAsyncPolls) {
+        m_maxConcurrentAsyncPolls = maxConcurrentAsyncPolls;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(getThreads(), getNextOutageId(), getServiceUnresponsiveEnabled(), getPathOutageEnabled(),
                 getDefaultCriticalPathIp(), getDefaultCriticalPathTimeout(), getDefaultCriticalPathRetries(),
-                getNodeOutage(), getPackages(), getMonitors());
+                getNodeOutage(), getPackages(), getMonitors(), getAsyncPollingEngineEnabled(), getMaxConcurrentAsyncPolls());
     }
 
     @Override
@@ -298,7 +323,9 @@ public class PollerConfiguration implements Serializable {
                 && Objects.equals(getDefaultCriticalPathRetries(), that.getDefaultCriticalPathRetries())
                 && Objects.equals(getNodeOutage(), that.getNodeOutage())
                 && Objects.equals(getPackages(), that.getPackages())
-                && Objects.equals(getMonitors(), that.getMonitors());
+                && Objects.equals(getMonitors(), that.getMonitors())
+                && Objects.equals(getAsyncPollingEngineEnabled(), that.getAsyncPollingEngineEnabled())
+                && Objects.equals(getMaxConcurrentAsyncPolls(), that.getMaxConcurrentAsyncPolls());
     }
     @Override
     public String toString() {
@@ -313,6 +340,8 @@ public class PollerConfiguration implements Serializable {
                 ",nodeOutage=" + getNodeOutage() +
                 ",packages=" + getPackages() +
                 ",monitors=" + getMonitors() +
+                ",asyncPollingEngineEnabled=" + getAsyncPollingEngineEnabled() +
+                ",maxConcurrentAsyncPolls=" + getMaxConcurrentAsyncPolls() +
                 "]";
     }
 

--- a/opennms-config-jaxb/src/main/resources/xsds/poller-configuration.xsd
+++ b/opennms-config-jaxb/src/main/resources/xsds/poller-configuration.xsd
@@ -96,6 +96,26 @@
           </restriction>
         </simpleType>
       </attribute>
+
+      <attribute default="false" name="asyncPollingEngineEnabled" use="optional">
+        <annotation>
+          <documentation>Flag which indicates if the async engine is enabled</documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="string">
+            <pattern value="(true|false)"/>
+          </restriction>
+        </simpleType>
+      </attribute>
+
+      <attribute default="100" name="maxConcurrentAsyncPolls" use="optional">
+        <simpleType>
+          <restriction base="int">
+            <minInclusive value="1" />
+          </restriction>
+        </simpleType>
+      </attribute>
     </complexType>
   </element>
 

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfig.java
@@ -97,6 +97,20 @@ public interface PollerConfig extends PathOutageConfig {
      */
     boolean isServiceUnresponsiveEnabled();
 
+
+    /**
+     * Returns true if we want to do things async
+     *
+     * @return a boolean.
+     */
+    boolean isAsyncEngineEnabled();
+
+    /**
+     *
+     * @return
+     */
+    int getMaxConcurrentAsyncPolls();
+
     /**
      * This method is used to rebuild the package against ip list mapping when
      * needed. When a node gained service event occurs, poller has to determine
@@ -417,4 +431,5 @@ public interface PollerConfig extends PathOutageConfig {
      * @return a Lock
      */
     Lock getWriteLock();
+
 }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
@@ -1213,4 +1213,26 @@ abstract public class PollerConfigManager implements PollerConfig  {
             getReadLock().unlock();
         }
     }
+
+
+    @Override
+    public boolean isAsyncEngineEnabled() {
+        try {
+            getReadLock().lock();
+            return m_config.getAsyncPollingEngineEnabled();
+        } finally {
+            getReadLock().unlock();
+        }
+    }
+
+    @Override
+    public int getMaxConcurrentAsyncPolls() {
+        try {
+            getReadLock().lock();
+            return m_config.getMaxConcurrentAsyncPolls();
+        } finally {
+            getReadLock().unlock();
+        }
+    }
+
 }

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -499,5 +499,14 @@
           <groupId>org.opennms</groupId>
           <artifactId>opennms-provisiond</artifactId>
       </dependency>
+      <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>io.github.resilience4j</groupId>
+          <artifactId>resilience4j-bulkhead</artifactId>
+          <version>${resilience4jVersion}</version>
+      </dependency>
   </dependencies>
 </project>

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/AsyncPollingEngine.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/AsyncPollingEngine.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.poller;
+
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import org.opennms.netmgt.poller.pollables.PollableService;
+import org.opennms.netmgt.poller.pollables.PollableServiceConfig;
+import org.opennms.netmgt.scheduler.PostponeNecessary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+public class AsyncPollingEngine {
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncPollingEngine.class);
+
+    private static final Executor executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+            .setNameFormat("Poller-AsyncPollingEngine-%d")
+            .build());
+
+    private final int maxConcurrentCalls;
+    private final Bulkhead bulkhead;
+
+    public AsyncPollingEngine(int maxConcurrentCalls) {
+        this.maxConcurrentCalls = maxConcurrentCalls;
+        final BulkheadConfig bulkheadConfig = BulkheadConfig.custom()
+                .maxConcurrentCalls(maxConcurrentCalls)
+                .maxWaitDuration(Duration.ofMillis(500))
+                .build();
+        bulkhead = Bulkhead.of("asyncPollingEngine", bulkheadConfig);
+    }
+
+    /**
+     * The scheduler has triggered a poll on the given service
+     * this could be done at the normal interval, or a modified interval based on the
+     * downtime model
+     *
+     * @param svc service
+     */
+    public void triggerScheduledPollOnService(PollableService svc) {
+        // Rate-limit the # of polls
+        try {
+            bulkhead.acquirePermission();
+        } catch (BulkheadFullException e) {
+            LOG.info("Postponing poll for {}. Too many concurrent polls already in progress (max=%d).", maxConcurrentCalls);
+            throw new PostponeNecessary("BulkheadFullException postpone poll");
+        }
+
+        // Trigger the poll, without affecting any of the existing state
+        final CompletionStage<PollStatus> future;
+        try {
+            future = svc.getPollConfig().asyncPoll();
+        } catch (Throwable t) {
+            bulkhead.releasePermission();
+            throw new RuntimeException(String.format("Failed to trigger poll asynchronously for svc=%s", svc), t);
+        }
+
+        // When we're done, we want to process the result
+        future.whenCompleteAsync((res,ex) -> {
+            try {
+                if (ex == null) {
+                    processPollResult(svc, res);
+                } else {
+                    processPollResult(svc, PollableServiceConfig.errorToPollStatus(svc, ex));
+                }
+            } finally {
+                bulkhead.releasePermission();
+            }
+        }, executor);
+    }
+
+    private void processPollResult(PollableService svc, PollStatus status) {
+        // Trigger the run, and feed the result back instantly
+        svc.doRunWithPreemptivePollStatus(status);
+    }
+
+    public long getNumPollsInFlight() {
+        return bulkhead.getMetrics().getMaxAllowedConcurrentCalls() - bulkhead.getMetrics().getAvailableConcurrentCalls();
+    }
+}

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/AsyncPollingEngine.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/AsyncPollingEngine.java
@@ -75,7 +75,7 @@ public class AsyncPollingEngine {
         try {
             bulkhead.acquirePermission();
         } catch (BulkheadFullException e) {
-            LOG.info("Postponing poll for {}. Too many concurrent polls already in progress (max=%d).", maxConcurrentCalls);
+            LOG.info("Postponing poll for {}. Too many concurrent polls in progress (max=%d).", maxConcurrentCalls);
             throw new PostponeNecessary("BulkheadFullException postpone poll");
         }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/Pollerd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/Pollerd.java
@@ -158,11 +158,16 @@ public class Pollerd extends AbstractSpringContextJmxServiceDaemon<org.opennms.n
             return 0L;
         }
     }
-    
+
+    @Override
+    public long getNumPollsInFlight() {
+        return getDaemon().getNetwork().getContext().getAsyncPollingEngine().getNumPollsInFlight();
+    }
+
     private ThreadPoolExecutor getExecutor() {
         return (ThreadPoolExecutor) ((LegacyScheduler) getDaemon().getScheduler()).getRunner();
     }
-    
+
     private boolean getThreadPoolStatsStatus() {
         return (getDaemon().getScheduler() instanceof LegacyScheduler);
     }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/PollerdMBean.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/PollerdMBean.java
@@ -93,4 +93,6 @@ public interface PollerdMBean extends BaseOnmsMBean {
      * @return The number of open slots on our ExecutorService queue.
      */
     public long getTaskQueueRemainingCapacity();
+
+    public long getNumPollsInFlight();
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollConfig.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollConfig.java
@@ -31,6 +31,9 @@ package org.opennms.netmgt.poller.pollables;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.scheduler.Timer;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 
 /**
  * Represents a PollConfig
@@ -39,7 +42,9 @@ import org.opennms.netmgt.scheduler.Timer;
  * @version $Id: $
  */
 public interface PollConfig extends Timer {
-    
+
+    CompletionStage<PollStatus> asyncPoll();
+
     /**
      * <p>poll</p>
      *

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollContext.java
@@ -30,9 +30,9 @@ package org.opennms.netmgt.poller.pollables;
 
 import java.net.InetAddress;
 import java.util.Date;
-import java.util.Map;
 
 import org.opennms.netmgt.poller.PollStatus;
+import org.opennms.netmgt.poller.AsyncPollingEngine;
 import org.opennms.netmgt.xml.event.Event;
 
 /**
@@ -108,5 +108,9 @@ public interface PollContext {
     public boolean isServiceUnresponsiveEnabled();
 
     void trackPoll(PollableService service, PollStatus result);
+
+    boolean isAsyncEngineEnabled();
+
+    AsyncPollingEngine getAsyncPollingEngine();
 
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableServiceConfig.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableServiceConfig.java
@@ -164,7 +164,7 @@ public class PollableServiceConfig implements PollConfig, ScheduleInterval {
 
             @Override
             public PollStatus onTimedOut(Throwable cause) {
-                LOG.warn("No response was received when remotely invoking the poll for {}."
+                LOG.warn("No response received when remotely invoking the poll for {}."
                         + " Marking the service as UNKNOWN.", service);
                 return PollStatus.unknown(String.format("No response received for %s. %s", service, cause));
             }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableServiceConfig.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableServiceConfig.java
@@ -159,7 +159,7 @@ public class PollableServiceConfig implements PollConfig, ScheduleInterval {
             public PollStatus onInterrupted(Throwable cause) {
                 LOG.warn("Interrupted while invoking the poll for {}."
                         + " Marking the service as UNKNOWN.", service);
-                return PollStatus.unknown("Interrupted while invoking the poll for"+service+". "+t);
+                return PollStatus.unknown("Interrupted while invoking the poll for "+service+". "+t);
             }
 
             @Override

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/MockPollerConfig.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/MockPollerConfig.java
@@ -434,6 +434,16 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
         return m_serviceUnresponsiveEnabled;
     }
 
+    @Override
+    public boolean isAsyncEngineEnabled() {
+        return false;
+    }
+
+    @Override
+    public int getMaxConcurrentAsyncPolls() {
+        return 0;
+    }
+
     public void setNextOutageIdSql(final String nextOutageIdSql) {
         m_nextOutageIdSql = nextOutageIdSql;
     }

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
@@ -46,6 +46,7 @@ import org.opennms.netmgt.mock.MockNetwork;
 import org.opennms.netmgt.mock.MockService;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
+import org.opennms.netmgt.poller.AsyncPollingEngine;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.pollables.PendingPollEvent;
 import org.opennms.netmgt.poller.pollables.PollContext;
@@ -176,6 +177,16 @@ public class MockPollContext implements PollContext, EventListener {
     @Override
     public void trackPoll(PollableService service, PollStatus result) {
         // pass, nothing to track
+    }
+
+    @Override
+    public boolean isAsyncEngineEnabled() {
+        return false;
+    }
+
+    @Override
+    public AsyncPollingEngine getAsyncPollingEngine() {
+        return null;
     }
 
 


### PR DESCRIPTION
JIRA: https://opennms.atlassian.net/browse/NMS-15623

Here's a patch that adds support for asynchronous polling to pollerd. The behaviour is optional is done in a very unobtrusive way, allowing us to vet the solution is practice without affecting existing solutions.

When enabled, polls are triggered by the thread pools, using a configurable rate-limiter for back-pressure, and then the thread is released. When the poll is complete, execution is passed to cached thread poll (implicitly bounded by the rate limit) and the node lock  is acquired before processing the results.
