### PR TITLE
NMS-15633: bump to latest groovy 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1681,7 +1681,7 @@
     <freemarkerVersion>2.3.23</freemarkerVersion>
     <fstVersion>2.47</fstVersion>
     <geronimoVersion>1.1.1</geronimoVersion>
-    <groovyVersion>2.5.16</groovyVersion>
+    <groovyVersion>2.5.22</groovyVersion>
     <grpcVersion>1.24.0</grpcVersion>
     <gsonVersion>2.8.5</gsonVersion>
     <guavaVersion>18.0</guavaVersion>


### PR DESCRIPTION
Develop (future Horizon 32) is already on Groovy 3, but older releases should get updated to the latest 2.x for security reasons.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15633

