### PR TITLE
NMS-15481: Usage Stats Sharing UI: Initial UI page and API wireup

### DIFF
--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
@@ -31,6 +31,7 @@ package org.opennms.features.datachoices.web;
 import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -38,6 +39,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.opennms.features.datachoices.internal.UsageStatisticsMetadataDTO;
 import org.opennms.features.datachoices.internal.UsageStatisticsReportDTO;
 import org.opennms.features.datachoices.internal.UsageStatisticsStatusDTO;
@@ -56,6 +58,11 @@ public interface DataChoiceRestService {
     @Path("status")
     @Produces(value={MediaType.APPLICATION_JSON})
     UsageStatisticsStatusDTO getStatus() throws ServletException, IOException;
+
+    @POST
+    @Path("status")
+    @Consumes({MediaType.APPLICATION_JSON})
+    Response setStatus(@Context HttpServletRequest request, UsageStatisticsStatusDTO dto) throws ServletException, IOException;
 
     @GET
     @Path("meta")

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/DataChoiceRestServiceImpl.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/DataChoiceRestServiceImpl.java
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.util.Objects;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
 import org.opennms.features.datachoices.internal.StateManager;
 import org.opennms.features.datachoices.internal.UsageStatisticsMetadataDTO;
 import org.opennms.features.datachoices.internal.UsageStatisticsReportDTO;
@@ -98,6 +99,17 @@ public class DataChoiceRestServiceImpl implements DataChoiceRestService {
         }
 
         return dto;
+    }
+
+    @Override
+    public Response setStatus(HttpServletRequest request, UsageStatisticsStatusDTO dto) throws ServletException, IOException {
+        try {
+            m_stateManager.setEnabled(dto.getEnabled(), request.getRemoteUser());
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+
+        return Response.accepted().build();
     }
 
     @Override

--- a/features/datachoices/src/main/resources/web/datachoicesMetadata.json
+++ b/features/datachoices/src/main/resources/web/datachoicesMetadata.json
@@ -1,46 +1,436 @@
 {
-  "metadata": [
-    {
-      "key": "systemId",
-      "name": "System tracking UUID",
-      "description": "Acts as a \"primary key\" for a system's data over time",
-      "datatype": "string"
-    },
-    {
-      "key": "packageName",
-      "name": "Product name",
-      "description": "Which core product (Horizon vs. Meridian) is in use?",
-      "datatype": "string"
-    },
-    {
-      "key": "version",
-      "name": "Product version",
-      "description": "Which version of the core product is in use?",
-      "datatype": "string"
-    },
-    {
-      "key": "osName",
-      "name": "OS name",
-      "description": "Which operating system is in use on the core system?",
-      "datatype": "string"
-    },
-    {
-      "key": "nodesBySysOid",
-      "name": "Top-twenty sysObjectIDs",
-      "description": "Which device types dominate the set of SNMP-enabled nodes?",
-      "datatype": "object"
-    },
-    {
-      "key": "services",
-      "name": "Services",
-      "description": "Which services are being used on the core system?",
-      "datatype": "object"
-    },
-    {
-      "key": "installedFeatures",
-      "name": "Installed Features",
-      "description": "Which features are installed on the core system?",
-      "datatype": "object"
-    }
-  ]
+    "metadata": [
+        {
+            "key": "alarms",
+            "name": "Current alarm count",
+            "description": "How many alarms currently exist in the system?",
+            "datatype": "number"
+        },
+        {
+            "key": "applianceCounts",
+            "name": "applianceCounts",
+            "description": "",
+            "datatype": "object"
+        },
+        {
+            "key": "applications",
+            "name": "Current count of Applications",
+            "description": "Current number of Applications defined in the system",
+            "datatype": "number"
+        },
+        {
+            "key": "availableProcessors",
+            "name": "System CPU count",
+            "description": "How many CPU cores does the core OS kernel see?",
+            "datatype": "number"
+        },
+        {
+            "key": "businessEdgeCount",
+            "name": "Current business service count",
+            "description": "Number of business services defined in the system",
+            "datatype": "number"
+        },
+        {
+            "key": "cloudInstanceType",
+            "name": "Cloud instance type (Cloud VM only)",
+            "description": "Name of the instance type (e.g. t2.large, Standard_F2s, e2-standard-4, ...)",
+            "datatype": "string"
+        },
+        {
+            "key": "cloudName",
+            "name": "Cloud name (Cloud VM only)",
+            "description": "Name of the cloud environment (e.g. EC2, AzurePublicCloud, AWS GovCloud...)",
+            "datatype": "string"
+        },
+        {
+            "key": "cloudRegion",
+            "name": "Cloud region (Cloud VM only)",
+            "description": "Name of the least-granular region / location / availability zone designation of this instance's placement in the cloud (e.g. us-east-1a, eastus, ...)",
+            "datatype": "string"
+        },
+        {
+            "key": "cloudVendor",
+            "name": "Cloud vendor(Cloud VM only)",
+            "description": "Name of the cloud vendor (e.g. AWS, Azure, GCP, AlibabaCloud, OpenStack...)",
+            "datatype": "string"
+        },
+        {
+            "key": "coreFlowsPersisted",
+            "name": "Flows persisted",
+            "description": "Number of flow records persisted since the core last started up",
+            "datatype": "number"
+        },
+        {
+            "key": "coreNewtsSamplesInserted",
+            "name": "coreNewtsSamplesInserted",
+            "description": "",
+            "datatype": "number"
+        },
+        {
+            "key": "coreQueuedUpdatesCompleted",
+            "name": "Metrics persisted",
+            "description": "Number of metric data items persisted to time-series storage since the core last started up",
+            "datatype": "number"
+        },
+        {
+            "key": "databaseProductName",
+            "name": "RDBMS type",
+            "description": "Whether PostgreSQL or some other RDBMS is in use",
+            "datatype": "string"
+        },
+        {
+            "key": "databaseProductVersion",
+            "name": "RDBMS version",
+            "description": "Version of RDBMS in use",
+            "datatype": "string"
+        },
+        {
+            "key": "dcbCumulativeTimeInWebUi",
+            "name": "DCB: cumulative time in web UI",
+            "description": "Total time, in seconds, that any user has spent using the DCB UI, from entry to exit; must survive a restart",
+            "datatype": "number"
+        },
+        {
+            "key": "dcbFailed",
+            "name": "DCB: cumulative backup failure count",
+            "description": "Total number of config backup attempts ever failed in this system, including deleted entries; must survive a restart",
+            "datatype": "number"
+        },
+        {
+            "key": "dcbSucceed",
+            "name": "DCB: cumulative config count",
+            "description": "Total number of device configs ever successfully stored in this system, including deleted entries; must survive a restart",
+            "datatype": "number"
+        },
+        {
+            "key": "dcbWebUiEntries",
+            "name": "DCB: cumulative web UI entries",
+            "description": "Total number of times any user has entered the DCB UI, excluding manual refreshes; must survive a restart",
+            "datatype": "number"
+        },
+        {
+            "key": "destinationPathCount",
+            "name": "Current destination path count",
+            "description": "Site's level of granularity when using notifications",
+            "datatype": "number"
+        },
+        {
+            "key": "enlinkdLinksByProtocol",
+            "name": "Enlinkd: Links by protocol",
+            "description": "Number of links found by Enlinkd, broken down by link protocol",
+            "datatype": "number"
+        },
+        {
+            "key": "enlinkdNodesWithLinks",
+            "name": "Enlinkd: Nodes with links",
+            "description": "Number of nodes having at least one link",
+            "datatype": "number"
+        },
+        {
+            "key": "eventLogsProcessed",
+            "name": "Event-logs processed",
+            "description": "Number of event-logs processed by Eventd since the core last started up",
+            "datatype": "number"
+        },
+        {
+            "key": "events",
+            "name": "Current event count",
+            "description": "How many events have been created since the system was installed?",
+            "datatype": "number"
+        },
+        {
+            "key": "freePhysicalMemorySize",
+            "name": "Physical memory size",
+            "description": "How much physical memory does the core OS kernel see?",
+            "datatype": "string"
+        },
+        {
+            "key": "groups",
+            "name": "Current group count",
+            "description": "How many groups the system's users are organized into for notification purposes",
+            "datatype": "number"
+        },
+        {
+            "key": "inContainer",
+            "name": "inContainer",
+            "description": "",
+            "datatype": "object"
+        },
+        {
+            "key": "installedFeatures",
+            "name": "List of Karaf features installed",
+            "description": "Which features are installed on the core system?",
+            "datatype": "object"
+        },
+        {
+            "key": "installedOIAPlugins",
+            "name": "List of OIA plugins loaded",
+            "description": "Which OpenNMS-provided or third-party plugins are installed at the site",
+            "datatype": "string"
+        },
+        {
+            "key": "ipInterfaces",
+            "name": "Current IP interfaces count",
+            "description": "How many IP addresses does the system know about across all devices?",
+            "datatype": "number"
+        },
+        {
+            "key": "ipInterfacesPerNodeMode",
+            "name": "ipInterfacesPerNodeMode",
+            "description": "Arithmetic mode of the number of IP interfaces per node, calculated both canonically and with zero-interface nodes excluded from consideration. The string key divides the two sets; the lists are empty if no mode exists for its considered population.",
+            "datatype": "string"
+        },
+        {
+            "key": "ipInterfacesPerNodeStats",
+            "name": "ipInterfacesPerNodeStats",
+            "description": "Statistical breakdown of the distribution of IP interfaces across nodes. For the population of nodes, characterize the number of IP interfaces per node as minimum, maximum, arithmetic mean (rounded value), and median (rounded value). Each set is calculated both canonically and with zero-interface nodes excluded from the population; the topmost string key divides the two sets.",
+            "datatype": "object"
+        },
+        {
+            "key": "isRunningInContainer",
+            "name": "Is running in container",
+            "description": "Whether or not the core is detected to be running inside a containerized environment",
+            "datatype": "string"
+        },
+        {
+            "key": "metaRestEndpointForReadingKpis",
+            "name": "Meta: REST endpoint for reading all KPIs",
+            "description": "Create a REST API endpoint which exposes all the KPIs",
+            "datatype": "string"
+        },
+        {
+            "key": "minions",
+            "name": "Minion count",
+            "description": "How many Minions are registered?",
+            "datatype": "number"
+        },
+        {
+            "key": "monitoredServices",
+            "name": "Monitored services count",
+            "description": "How many monitored services exist in the system's inventory?",
+            "datatype": "number"
+        },
+        {
+            "key": "monitoringLocations",
+            "name": "Monitoring locations count",
+            "description": "How many monitoring locations are defined?",
+            "datatype": "number"
+        },
+        {
+            "key": "nodes",
+            "name": "nodes",
+            "description": "",
+            "datatype": "number"
+        },
+        {
+            "key": "nodesBySysOid",
+            "name": "Top-ten sysObjectIDs",
+            "description": "Which device types dominate the set of SNMP-enabled nodes?",
+            "datatype": "object"
+        },
+        {
+            "key": "nodesWithDeviceConfigBySysOid",
+            "name": "DCB: device count by sysObjectID",
+            "description": "Number of nodes with at least one config backed up, broken down by sysObjectID, including nodes that lack a sysObjectID",
+            "datatype": "object"
+        },
+        {
+            "key": "notificationEnablementStatus",
+            "name": "Notifications globally enabled?",
+            "description": "Are notifications in use on this installation?",
+            "datatype": "string"
+        },
+        {
+            "key": "notifications",
+            "name": "Current number of open Notifications",
+            "description": "Current number of unresolved Notifications in the system",
+            "datatype": "number"
+        },
+        {
+            "key": "onCallRoleCount",
+            "name": "Current on-call role count",
+            "description": "Whether, and to what degree, on-call roles are in use at the site",
+            "datatype": "number"
+        },
+        {
+            "key": "onmsStartupTimeSeconds",
+            "name": "OpenNMS startup time",
+            "description": "Duration of most recent app startup, from JVM start to state indicated by \"Startup complete\" in manager.log, in whole seconds",
+            "datatype": "number"
+        },
+        {
+            "key": "osArch",
+            "name": "OS architecture",
+            "description": "Which CPU architecture is the core system?",
+            "datatype": "string"
+        },
+        {
+            "key": "osName",
+            "name": "OS name",
+            "description": "Which operating system is in use on the core system?",
+            "datatype": "string"
+        },
+        {
+            "key": "osVersion",
+            "name": "OS version",
+            "description": "Which OS kernel version is in use on the core system?",
+            "datatype": "string"
+        },
+        {
+            "key": "outages",
+            "name": "Current number of open Outages",
+            "description": "Current number of unresolved Outages in the system",
+            "datatype": "number"
+        },
+        {
+            "key": "packageName",
+            "name": "Product name",
+            "description": "Which core product (Horizon vs. Meridian) is in use?",
+            "datatype": "string"
+        },
+        {
+            "key": "pollsCompleted",
+            "name": "Polls completed",
+            "description": "Number of polls completed since the core last started up",
+            "datatype": "number"
+        },
+        {
+            "key": "provisiondImportThreadPoolSize",
+            "name": "provisiondImportThreadPoolSize",
+            "description": "",
+            "datatype": "number"
+        },
+        {
+            "key": "provisiondRequisitionSchemeCount",
+            "name": "Provisiond thread pool sizes, requisition-def counts",
+            "description": "Whether Provisiond's thread pools have been tuned; whether and which types of external requisitions are in use.",
+            "datatype": "object"
+        },
+        {
+            "key": "provisiondRescanThreadPoolSize",
+            "name": "provisiondRescanThreadPoolSize",
+            "description": "",
+            "datatype": "number"
+        },
+        {
+            "key": "provisiondScanThreadPoolSize",
+            "name": "provisiondScanThreadPoolSize",
+            "description": "",
+            "datatype": "number"
+        },
+        {
+            "key": "provisiondWriteThreadPoolSize",
+            "name": "provisiondWriteThreadPoolSize",
+            "description": "",
+            "datatype": "number"
+        },
+        {
+            "key": "requisitionCount",
+            "name": "Current requisition count",
+            "description": "Number of requisitions present in the system",
+            "datatype": "number"
+        },
+        {
+            "key": "requisitionWithChangedFSCount",
+            "name": "Current foreign-source definition count",
+            "description": "Degree of detector / policy customization in use from one requisition to the next",
+            "datatype": "number"
+        },
+        {
+            "key": "rpcStrategy",
+            "name": "RPC strategy",
+            "description": "Whether Minions get their polling / collecting instructions via Kafka or ActiveMQ",
+            "datatype": "string"
+        },
+        {
+            "key": "services",
+            "name": "List of enabled service daemons",
+            "description": "Which optional daemon-having features are enabled at the site, and which on-by-default ones have been disabled",
+            "datatype": "object"
+        },
+        {
+            "key": "servicesPerInterfaceMode",
+            "name": "servicesPerInterfaceMode",
+            "description": "Arithmetic mode of the number of services per IP interface, calculated both canonically and with zero-service interfaces excluded from consideration. The string key divides the two sets; the lists are empty if no mode exists for its considered population.",
+            "datatype": "string"
+        },
+        {
+            "key": "servicesPerInterfaceStats",
+            "name": "servicesPerInterfaceStats",
+            "description": "Statistical breakdown of the distribution of IP services across IP interfaces. For the population of IP interfaces, characterize the number of services per interface as minimum, maximum, arithmetic mean (rounded value), and median (rounded value). Each set is calculated both canonically and with zero-service interfaces excluded from the population; the topmost string key divides the two sets.",
+            "datatype": "object"
+        },
+        {
+            "key": "sinkStrategy",
+            "name": "Sink strategy",
+            "description": "Whether Minions ship traps, syslogs, flows, and streaming telemetry via Kafka or ActiveMQ",
+            "datatype": "string"
+        },
+        {
+            "key": "situations",
+            "name": "Current situation count",
+            "description": "Whether ALEC is likely in use and how much work it's doing",
+            "datatype": "number"
+        },
+        {
+            "key": "snmpInterfaces",
+            "name": "Current SNMP interfaces count",
+            "description": "How many SNMP interfaces does the system know about across all devices?",
+            "datatype": "number"
+        },
+        {
+            "key": "snmpInterfacesPerNodeMode",
+            "name": "snmpInterfacesPerNodeMode",
+            "description": "Arithmetic mode of the number of SNMP interfaces per node, calculated both canonically and with zero-interface nodes excluded from consideration. The string key divides the two sets; the lists are empty if no mode exists for its considered population.",
+            "datatype": "string"
+        },
+        {
+            "key": "snmpInterfacesPerNodeStats",
+            "name": "snmpInterfacesPerNodeStats",
+            "description": "Statistical breakdown of the distribution of SNMP interfaces across nodes. For the population of nodes, characterize the number of SNMP interfaces per node as minimum, maximum, arithmetic mean (rounded value), and median (rounded value). Each set is calculated both canonically and with zero-interface nodes excluded from the population; the topmost string key divides the two sets.",
+            "datatype": "object"
+        },
+        {
+            "key": "snmpInterfacesWithFlows",
+            "name": "SNMP interfaces with flows",
+            "description": "Whether flows are being ingested, and a notion of how widely flows are exported to us",
+            "datatype": "object"
+        },
+        {
+            "key": "systemId",
+            "name": "System tracking UUID",
+            "description": "Acts as a \"primary key\" for a system's data over time",
+            "datatype": "string"
+        },
+        {
+            "key": "totalPhysicalMemorySize",
+            "name": "totalPhysicalMemorySize",
+            "description": "",
+            "datatype": "number"
+        },
+        {
+            "key": "tssPlugins",
+            "name": "TSS plugin loaded, if any",
+            "description": "In case time-series strategy is TSS, which TSS plugin is registered",
+            "datatype": "object"
+        },
+        {
+            "key": "tssStrategies",
+            "name": "Time-series strategy",
+            "description": "Whether the site uses RRDTool / JRobin, Newts, or a TSS plugin for time-series persisting",
+            "datatype": "string"
+        },
+        {
+            "key": "users",
+            "name": "Current user count",
+            "description": "Number of login accounts defined locally to the installation; may exclude SSO users",
+            "datatype": "number"
+        },
+        {
+            "key": "version",
+            "name": "Product version",
+            "description": "Which version of the core product in use?",
+            "datatype": "string"
+        }
+   ]
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build --base=/opennms/ui/",
+    "watch": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --watch",
     "serve": "vite preview",
     "test": "vitest run",
     "lint": "eslint --ignore-path ../.gitignore --ext .ts,.vue .",

--- a/ui/src/components/UsageStatistics/UsageStatisticsHeader.vue
+++ b/ui/src/components/UsageStatistics/UsageStatisticsHeader.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="usage-stats-header">
+    <div>
+      <p>
+        Anonymous OpenNMS usage statistics is sent to <a href="#">OpenNMS Statistics</a>.
+        This helps improve your OpenNMS software, subject to our <a href="#">privacy policy</a>.
+      </p>
+    </div>
+    <div class="spacer-medium"></div>
+    <div class="flex title-padding">
+      <div id="status-chip-wrapper">
+        <FeatherChipList mode="single" label="Usage statistics status">
+          <FeatherChip
+            :id="status.enabled ? 'chip-status-enabled' : 'chip-status-disabled'"
+          >
+            <template #icon>
+              <FeatherIcon :icon="status.enabled ? CheckCircle : Remove" />
+            </template>
+              {{ status.enabled ? 'Enabled' : 'Disabled' }}
+          </FeatherChip>
+        </FeatherChipList>
+      </div>
+      <div
+        class="flex button-wrapper"
+      >
+        <FeatherButton
+          class="button"
+          secondary
+          @click="updateStatus"
+          >{{ status.enabled ? 'Disable' : 'Enable' }}</FeatherButton
+        >
+      </div>
+    </div>
+    <div class="spacer-large"></div>
+    <div>
+      <h2>List of data points</h2>
+    </div>
+    <div class="flex title-padding">
+      <p>
+        Copy the full JSON payload to your clipboard
+      </p>
+      <div
+        class="flex button-wrapper"
+      >
+        <FeatherButton
+          class="button"
+          secondary
+          @click="copyJson"
+          >Copy Json</FeatherButton
+        >
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useStore } from 'vuex'
+import { FeatherButton } from '@featherds/button'
+import { FeatherChip, FeatherChipList } from '@featherds/chips'
+import { FeatherIcon } from '@featherds/icon'
+import CheckCircle from '@featherds/icon/action/CheckCircle'
+import Remove from '@featherds/icon/action/Remove'
+import { ConfigurationHelper } from '../Configuration/ConfigurationHelper'
+import useSnackbar from '@/composables/useSnackbar'
+import { UsageStatisticsData, UsageStatisticsStatus } from '@/types/usageStatistics'
+
+const { showSnackBar } = useSnackbar()
+const store = useStore()
+const status = computed<UsageStatisticsStatus>(() => store.state.usageStatisticsModule.status )
+const statistics = computed<UsageStatisticsData>(() => store.state.usageStatisticsModule.statistics )
+
+const copyJson = async () => {
+  const json = JSON.stringify(statistics.value, null, 2)
+
+  try {
+    await ConfigurationHelper.copyToClipboard(json)
+
+    showSnackBar({
+      msg: 'Copied Usage Statistics Json to clipboard'
+    })
+  } catch (err) {
+    showSnackBar({
+      msg: `Could not copy to clipboard. Your environment may be insecure. (${err})`,
+      error: true
+    })
+  }
+}
+
+const updateStatus = () => {
+  if (status.value.enabled) {
+    store.dispatch('usageStatisticsModule/disableSharing')
+  } else {
+    store.dispatch('usageStatisticsModule/enableSharing')
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@featherds/styles/mixins/elevation";
+@import "@featherds/styles/mixins/typography";
+@import "@featherds/styles/themes/variables";
+
+.usage-stats-header {
+  display: flex;
+  flex-direction: column;
+  margin-left: 20px;
+  max-width: 760px;
+}
+
+.flex {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.spacer-medium {
+  margin-bottom: 0.25rem;
+}
+.spacer-large {
+  margin-bottom: 2rem;
+}
+
+#chip-status-enabled {
+  background-color: rgb(201, 220, 205);
+
+  .label {
+    color: rgb(51, 112, 33);
+    font-size: 3rem;
+  }
+  .feather-icon {
+    color: rgb(51, 112, 33);
+  }
+}
+
+#chip-status-disabled {
+  background-color: rgb(219, 221, 224);
+  font-size: 1rem;
+  .label {
+    color: rgb(117, 117, 117);
+  }
+  .feather-icon {
+    color: rgb(117, 117, 117);
+  }
+}
+
+#status-chip-wrapper div.chip-list.single div.chip {
+  margin-left: 0px;
+}
+</style>

--- a/ui/src/components/UsageStatistics/UsageStatisticsModal.vue
+++ b/ui/src/components/UsageStatistics/UsageStatisticsModal.vue
@@ -1,0 +1,42 @@
+<template>
+  <!-- eslint-disable-next-line vue/no-mutating-props -->
+  <FeatherDialog v-model="props.visible" relative :labels="labels" @update:modelValue="$emit('close')">
+    <div class="content">
+      <slot name="content" />
+    </div>
+  </FeatherDialog>
+</template>
+
+<script setup lang="ts">
+import { FeatherDialog } from '@featherds/dialog'
+
+const props = defineProps({
+  subtitle: {
+    required: false,
+    type: String
+  },
+  visible: {
+    required: true,
+    type: Boolean
+  }
+})
+
+const labels = reactive({
+  title: 'Usage Statistics',
+  close: 'Close'
+})
+
+watchEffect(() => {
+  labels.title = props.subtitle ? `Usage Statistics: ${props.subtitle}` : 'Usage Statistics'
+})
+</script>
+
+<style scoped lang="scss">
+.content {
+  min-height: 300px;
+  max-height: 500px;
+  min-width: 550px;
+  overflow: auto;
+  position: relative;
+}
+</style>

--- a/ui/src/components/UsageStatistics/UsageStatisticsTable.vue
+++ b/ui/src/components/UsageStatistics/UsageStatisticsTable.vue
@@ -1,0 +1,284 @@
+<template>
+  <div>
+    <div
+      ref="tableWrap"
+      id="wrap"
+      class="usage-stats-table"
+    >
+      <table summary="Usage Statistics Sharing">
+        <thead>
+          <tr>
+            <FeatherSortHeader
+              scope="col"
+              property="name"
+              :sort="sortStates.name"
+              v-on:sort-changed="sortByColumnHandler"
+              >Name</FeatherSortHeader
+            >
+
+            <FeatherSortHeader
+              scope="col"
+              property="key"
+              :sort="sortStates.key"
+              v-on:sort-changed="sortByColumnHandler"
+              >Key name</FeatherSortHeader
+            >
+
+            <FeatherSortHeader
+              scope="col"
+              property="description"
+              :sort="sortStates.description"
+              v-on:sort-changed="sortByColumnHandler"
+              >Description</FeatherSortHeader
+            >
+
+            <FeatherSortHeader
+              scope="col"
+              property="latestValue"
+              :sort="sortStates.latestValue"
+              v-on:sort-changed="sortByColumnHandler"
+              >Latest value</FeatherSortHeader
+            >
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="row in filteredData"
+            :key="row.key"
+          >
+            <td>{{ row.name }}</td>
+            <td>{{ row.key }}</td>
+            <td>{{ row.description }}</td>
+            <td v-if="row.isLink">
+              <a href="#" @click.prevent="() => showFullValue(row)">See full value</a>
+            </td>
+            <td v-else-if="shouldClipValue(row)">
+              {{ getClippedValue(row) }}
+              <a href="#" @click.prevent="() => showFullValue(row)">See full value</a>
+            </td>
+            <td v-else>{{ row.latestValue }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <UsageStatisticsModal
+    @close="showValueModalVisible = false"
+    :subtitle="showValueModalSubtitle"
+    :visible="showValueModalVisible"
+  >
+    <template v-slot:content>
+      <div v-if="showValueModalVisible">
+        <div class="full-value-wrapper">
+          <div class="full-value-contents">
+            {{ showValueModalContent }}
+          </div>
+        </div>
+      </div>
+    </template>
+  </UsageStatisticsModal>
+</template>
+
+<script setup lang="ts">
+import { useStore } from 'vuex'
+import { FeatherSortHeader, SORT } from '@featherds/table'
+import { isNumber, isString } from '@/lib/utils'
+import { FeatherSortObject } from '@/types'
+import UsageStatisticsModal from './UsageStatisticsModal.vue'
+import {
+  UsageStatisticsData,
+  UsageStatisticsMetadata,
+  UsageStatisticsMetadataItem
+} from '@/types/usageStatistics'
+
+interface StatisticsItem {
+  // this is just for sorting
+  [b: string]: string | boolean
+  key: string
+  name: string
+  description: string
+  isLink: boolean
+  latestValue: string
+}
+
+const STRING_CLIP_LENGTH = 100
+
+const store = useStore()
+
+const sortStates: Record<string, SORT> = reactive({
+  name: SORT.NONE,
+  key: SORT.ASCENDING,
+  description: SORT.NONE,
+  latestValue: SORT.NONE
+})
+
+const showValueModalContent = ref('')
+const showValueModalSubtitle = ref('')
+const showValueModalVisible = ref(false)
+
+const currentSort = ref({ property: 'key', value: SORT.ASCENDING } as FeatherSortObject)
+const statistics = computed<UsageStatisticsData>(() => store.state.usageStatisticsModule.statistics )
+const metadata = computed<UsageStatisticsMetadata>(() => store.state.usageStatisticsModule.metadata )
+
+const metadataMap = computed<Map<string,UsageStatisticsMetadataItem>>(() => {
+  const map = new Map<string,UsageStatisticsMetadataItem>()
+
+  for (const obj of metadata.value.metadata) {
+    const item = {
+      key: obj.key,
+      name: obj.name || '',
+      description: obj.description || '',
+      datatype: obj.datatype
+    } as UsageStatisticsMetadataItem
+
+    map.set(obj.key, item)
+  }
+
+  return map
+})
+
+const filteredData = computed<StatisticsItem[]>(() => {
+  const items = [] as StatisticsItem[]
+
+  if (statistics.value && metadata.value) {
+    for (const key of Object.keys(statistics.value)) {
+      const statsObj = statistics.value[key]
+      const metaItem = metadataMap.value.get(key)
+
+      let latestValue = ''
+      let isLink = false
+
+      if (isString(statsObj) || isNumber(statsObj)) {
+        latestValue = (statsObj as string)?.toString() || ''
+      } else {
+        isLink = true
+      }
+
+      const statsItem = {
+        key,
+        name: metaItem?.name || '',
+        description: metaItem?.description || '',
+        isLink,
+        latestValue
+      } as StatisticsItem
+
+      items.push(statsItem)
+    }
+  }
+
+  // Determine Sort Order
+  let sortOrderValues = [0, 0]
+  if (currentSort.value.value === SORT.ASCENDING) {
+    sortOrderValues = [-1, 1]
+  } else if (currentSort.value.value === SORT.DESCENDING) {
+    sortOrderValues = [1, -1]
+  }
+
+  // Sort the Items
+  const currentSortKey = currentSort.value.property
+
+  const sortedItems = items.sort((a, b) => {
+    if (a[currentSortKey] > b[currentSortKey]) {
+      return sortOrderValues[0]
+    } else if (a[currentSortKey] < b[currentSortKey]) {
+      return sortOrderValues[1]
+    } else {
+      return 0
+    }
+  })
+
+  return sortedItems
+})
+
+const shouldClipValue = (row: StatisticsItem) => {
+  return !row.isLink && row.latestValue && row.latestValue.length > STRING_CLIP_LENGTH
+}
+
+const getClippedValue = (row: StatisticsItem) => {
+  return `${row.latestValue.substring(0, STRING_CLIP_LENGTH)}...`
+}
+
+const sortByColumnHandler = (sortObj: FeatherSortObject) => {
+  for (const key in sortStates) {
+    sortStates[key] = SORT.NONE
+  }
+
+  sortStates[`${sortObj.property}`] = sortObj.value
+  currentSort.value = sortObj
+}
+
+const showFullValue = (item: StatisticsItem) => {
+  const obj = statistics.value[item.key] || {}
+
+  const value = {
+    [item.key]: obj
+  }
+
+  const json = JSON.stringify(value, null, 2)
+
+  // show and populate modal
+  showValueModalSubtitle.value = item.name || item.key || ''
+  showValueModalContent.value = json
+  showValueModalVisible.value = true
+}
+
+onMounted(() => {
+  const wrap = document.getElementById('wrap')
+  const thead = document.querySelector('div.usage-stats-table table thead') as HTMLElement
+
+  if (wrap && thead) {
+    wrap.addEventListener('scroll', function () {
+      const translate = `translate(0, ${this.scrollTop}px)`
+      thead.style.transform = translate
+    })
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+@import "@featherds/styles/mixins/elevation";
+@import "@featherds/styles/mixins/typography";
+@import "@featherds/styles/themes/variables";
+@import "@featherds/table/scss/table";
+
+#wrap {
+  height: calc(100vh - 310px);
+  overflow: auto;
+  white-space: nowrap;
+
+  table {
+    margin-top: 0px !important;
+    font-size: 12px !important;
+    @include table;
+    @include table-condensed;
+    @include row-striped;
+
+    .option {
+      margin-left: 8px;
+      height: 43px;
+      line-height: 3.5;
+      padding-left: 15px;
+      text-transform: capitalize;
+    }
+  }
+
+  thead {
+    z-index: 2;
+    position: relative;
+    background: var($surface);
+  }
+}
+
+.full-value-wrapper {
+  min-height: 300px;
+  min-width: 550px;
+  max-width: 660px;
+}
+
+.full-value-contents {
+  display: block;
+  font-family: monospace;
+  white-space: pre;
+  margin: 0;
+}
+</style>

--- a/ui/src/containers/UsageStatistics.vue
+++ b/ui/src/containers/UsageStatistics.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="card">
+    <div class="feather-row">
+      <div class="feather-col-12">
+        <BreadCrumbs :items="breadcrumbs" />
+      </div>
+    </div>
+    <div class="feather-row">
+      <div class="feather-col-12">
+        <div class="usage-stats-container">
+          <div class="table-container">
+            <div class="title-container">
+              <span class="title">Usage Statistics Sharing</span>
+            </div>
+            <UsageStatisticsHeader />
+            <div class="spacer-medium"></div>
+            <UsageStatisticsTable />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useStore } from 'vuex'
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import UsageStatisticsHeader from '@/components/UsageStatistics/UsageStatisticsHeader.vue'
+import UsageStatisticsTable from '@/components/UsageStatistics/UsageStatisticsTable.vue'
+import { BreadCrumb } from '@/types'
+
+const store = useStore()
+const homeUrl = computed<string>(() => store.state.menuModule.mainMenu?.homeUrl)
+
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Usage Statistics Collection', to: '#', position: 'last' }
+  ]
+})
+
+// TODO: Spinner until we get data
+onMounted(async () => {
+  store.dispatch('usageStatisticsModule/getStatus')
+  store.dispatch('usageStatisticsModule/getMetadata')
+  store.dispatch('usageStatisticsModule/getStatistics')
+})
+</script>
+
+<style lang="scss" scoped>
+@import "@featherds/styles/mixins/elevation";
+@import "@featherds/styles/mixins/typography";
+@import "@featherds/styles/themes/variables";
+
+.card {
+  background: var($surface);
+  padding: 0px 20px 20px 20px;
+
+  .usage-stats-container {
+    display: flex;
+
+    .table-container {
+      width: 35rem;
+      flex: auto;
+
+      .title-container {
+        display: flex;
+        justify-content: space-between;
+
+        .title {
+          @include headline1;
+          margin: 24px 0px 24px 19px;
+          display: block;
+        }
+      }
+    }
+  }
+}
+.spacer-medium {
+  margin-bottom: 0.25rem;
+}
+</style>

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,0 +1,10 @@
+export const isNumber = (value: any) => {
+  return typeof(value) === 'number'
+}
+
+/**
+ * Returns true if value is non-null and is a primitive string or a String object
+ */
+export const isString = (value: any) => {
+  return value !== null && (typeof(value) === 'string' || value instanceof String)
+}

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -174,6 +174,22 @@ const router = createRouter({
       }
     },
     {
+      path: '/usage-statistics',
+      name: 'Usage Statistics',
+      component: () => import('@/containers/UsageStatistics.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'Must be admin to access Usage Statistics.' })
+            router.push(from.path)
+          }
+        }
+
+        if (rolesAreLoaded.value) checkRoles()
+        else whenever(rolesAreLoaded, () => checkRoles())
+      }
+    },
+    {
       path: '/:pathMatch(.*)*', // catch other paths and redirect
       redirect: '/'
     }

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -39,6 +39,12 @@ import { getInfo } from './infoService'
 import { getOpenApi } from './helpService'
 import { getResources, getResourceForNode } from './resourceService'
 import { getPlugins } from './pluginService'
+import {
+  getUsageStatistics,
+  getUsageStatisticsMetadata,
+  getUsageStatisticsStatus,
+  setUsageStatisticsStatus
+} from './usageStatisticsService'
 
 export default {
   search,
@@ -86,5 +92,9 @@ export default {
   getAliases,
   getCredentialsByAlias,
   addCredentials,
-  updateCredentials
+  updateCredentials,
+  getUsageStatistics,
+  getUsageStatisticsMetadata, 
+  getUsageStatisticsStatus,
+  setUsageStatisticsStatus
 }

--- a/ui/src/services/usageStatisticsService.ts
+++ b/ui/src/services/usageStatisticsService.ts
@@ -1,0 +1,54 @@
+import { rest } from './axiosInstances'
+import { UsageStatisticsData, UsageStatisticsMetadata, UsageStatisticsStatus } from '@/types/usageStatistics'
+
+const endpoint = '/datachoices'
+
+const getUsageStatistics = async (): Promise<UsageStatisticsData | false> => {
+  try {
+    const url = `${endpoint}`
+    const resp = await rest.get(url)
+    return resp.data
+  } catch (err) {
+    return false
+  }
+}
+
+const getUsageStatisticsMetadata = async (): Promise<UsageStatisticsMetadata | false> => {
+  try {
+    const url = `${endpoint}/meta`
+    const resp = await rest.get(url)
+    return resp.data
+  } catch (err) {
+    return false
+  }
+}
+
+const getUsageStatisticsStatus = async (): Promise<UsageStatisticsStatus | false> => {
+  try {
+    const url = `${endpoint}/status`
+    const resp = await rest.get(url)
+    return resp.data
+  } catch (err) {
+    return false
+  }
+}
+
+const setUsageStatisticsStatus = async (enabled: boolean) : Promise<any | false> => {
+  try {
+    const status = {
+      enabled
+    }
+    const url = `${endpoint}/status`
+    const resp = await rest.post(url, status)
+    return resp
+  } catch (err) {
+    return false
+  }
+}
+
+export {
+  getUsageStatistics,
+  getUsageStatisticsMetadata,
+  getUsageStatisticsStatus,
+  setUsageStatisticsStatus
+}

--- a/ui/src/store/index.ts
+++ b/ui/src/store/index.ts
@@ -20,6 +20,7 @@ import pluginModule from './plugin'
 import deviceModule from './device'
 import scvModule from './scv'
 import menuModule from './menu'
+import usageStatisticsModule from './usageStatistics'
 
 export default createStore({
   modules: {
@@ -41,6 +42,7 @@ export default createStore({
     pluginModule,
     deviceModule,
     scvModule,
-    menuModule
+    menuModule,
+    usageStatisticsModule
   }
 })

--- a/ui/src/store/usageStatistics/actions.ts
+++ b/ui/src/store/usageStatistics/actions.ts
@@ -1,0 +1,72 @@
+import { VuexContext } from '@/types'
+import API from '@/services'
+import useSnackbar from '@/composables/useSnackbar'
+
+const { showSnackBar } = useSnackbar()
+
+const getStatistics = async (context: VuexContext) => {
+  const data = await API.getUsageStatistics()
+
+  if (data) {
+    context.commit('SAVE_STATISTICS', data)
+  }
+}
+
+const getMetadata = async (context: VuexContext) => {
+  const metadata = await API.getUsageStatisticsMetadata()
+
+  if (metadata) {
+    context.commit('SAVE_METADATA', metadata)
+  }
+}
+
+const getStatus = async (context: VuexContext) => {
+  const status = await API.getUsageStatisticsStatus()
+  
+  if (status) {
+    context.commit('SAVE_STATUS', status)
+  }
+}
+
+const enableSharing = async (context: VuexContext) => {
+  const success = await updateSharing(true)
+
+  if (success) {
+    getStatus(context)
+  }
+}
+
+const disableSharing = async (context: VuexContext) => {
+  const success = await updateSharing(false)
+
+  if (success) {
+    getStatus(context)
+  }
+}
+
+const updateSharing = async (enable: boolean) => {
+  const resp = await API.setUsageStatisticsStatus(enable)
+
+  const success = !!(resp && (resp.status === 200 || resp.status === 202))
+
+  if (success) {
+    showSnackBar({
+      msg: `Statistics sharing ${enable ? 'enabled' : 'disabled'}.`
+    })
+  } else {
+    showSnackBar({
+      msg: `Error attempting to ${enable ? 'enable' : 'disable'} statistics sharing.`,
+      error: true
+    })
+  }
+
+  return success
+}
+
+export default {
+  getStatistics,
+  getMetadata,
+  getStatus,
+  enableSharing,
+  disableSharing
+}

--- a/ui/src/store/usageStatistics/index.ts
+++ b/ui/src/store/usageStatistics/index.ts
@@ -1,0 +1,10 @@
+import state from './state'
+import mutations from './mutations'
+import actions from './actions'
+
+export default {
+  state,
+  actions,
+  mutations,
+  namespaced: true
+}

--- a/ui/src/store/usageStatistics/mutations.ts
+++ b/ui/src/store/usageStatistics/mutations.ts
@@ -1,0 +1,20 @@
+import { State } from './state'
+import { UsageStatisticsData, UsageStatisticsMetadata, UsageStatisticsStatus } from '@/types/usageStatistics'
+
+const SAVE_STATISTICS = (state: State, statistics: UsageStatisticsData) => {
+  state.statistics = statistics
+}
+
+const SAVE_METADATA = (state: State, metadata: UsageStatisticsMetadata) => {
+  state.metadata = metadata
+}
+
+const SAVE_STATUS = (state: State, status: UsageStatisticsStatus) => {
+  state.status = status
+}
+
+export default {
+  SAVE_STATISTICS,
+  SAVE_METADATA,
+  SAVE_STATUS
+}

--- a/ui/src/store/usageStatistics/state.ts
+++ b/ui/src/store/usageStatistics/state.ts
@@ -1,0 +1,22 @@
+import {
+  UsageStatisticsData,
+  UsageStatisticsMetadata,
+  UsageStatisticsMetadataItem,
+  UsageStatisticsStatus
+} from '@/types/usageStatistics'
+
+export interface State {
+  status: UsageStatisticsStatus
+  metadata: UsageStatisticsMetadata
+  statistics: object
+}
+
+const state: State = {
+  status: { enabled: false } as UsageStatisticsStatus,
+  metadata: {
+    metadata: [] as UsageStatisticsMetadataItem[]
+  } as UsageStatisticsMetadata,
+  statistics: {} as UsageStatisticsData
+}
+
+export default state

--- a/ui/src/types/usageStatistics.d.ts
+++ b/ui/src/types/usageStatistics.d.ts
@@ -1,0 +1,19 @@
+import { UsageStatisticsMetadata } from '@/types/usageStatistics';
+export interface UsageStatisticsStatus {
+  enabled: boolean
+}
+
+export interface UsageStatisticsData {
+  [key: string]: any
+}
+
+export interface UsageStatisticsMetadataItem {
+  key: string
+  name: string
+  description: string
+  datatype: string
+}
+
+export interface UsageStatisticsMetadata {
+  metadata: UsageStatisticsMetadataItem[]
+}


### PR DESCRIPTION
New "Usage Statistics Sharing" Vue UI screen to display current usage statistics and allow using to enable/disable statistics collection.

Basing this on `develop` since it won't be directly accessible right now and does not impact any other functionality. Future work (i.e. changes to how opt-in/opt-out works, etc.) will be done in a feature branch until it's ready to be merged to `develop` as a whole.

Adds a new "Usage Statistics Sharing" Vue page. Displays statistics in a sortable, scrollable table; items that are objects or large strings have a clickable link to display the full value in a modal popup. User can also copy entire Json to clipboard. Also displays status of whether statistics sharing is enabled, plus a button to enable/disable sharing.

Also:

- updates "Datachoices" Rest service with `status POST` endpoint to enable/disable sharing. The existing `POST` endpoint seemed to have issues, including `POSTing` with a query string and less control over access (causing 403 errors, for example)
- updated `datachoicesMetadata.json` file with many more entries (returned by `rest/datachoices/meta`)
- added a `watch` to `package.json`, so `yarn watch` will run build in watch mode

A few things will need additional work, will do in subsequent PRs:

- links to sharing documentation and privacy policy don't work
- styling, for example the "Enabled/Disabled" chip

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15481
