### PR TITLE
NMS-15479: Usage Stats Sharing notice dialog

### DIFF
--- a/docs/modules/development/pages/rest/osgi.adoc
+++ b/docs/modules/development/pages/rest/osgi.adoc
@@ -18,7 +18,9 @@ First, create a public interface that must contain jax-rs annotations.
 public interface DataChoiceRestService {
 
     @POST <2>
-    void updateCollectUsageStatisticFlag(@Context HttpServletRequest request, @QueryParam("action") String action);
+    @Path("status")
+    @Consumes({MediaType.APPLICATION_JSON})
+    Response setStatus(@Context HttpServletRequest request, UsageStatisticsStatusDTO dto);
 
     @GET
     @Produces(value={MediaType.APPLICATION_JSON})
@@ -42,8 +44,9 @@ NOTE: The class may or may not repeat the jax-rs annotations from the interface.
 public class DataChoiceRestServiceImpl implements DataChoiceRestService {
 
     @Override
-    public void updateCollectUsageStatisticFlag(HttpServletRequest request, String action) {
-       // do something
+    public Response setStatus(HttpServletRequest request, UsageStatisticsStatusDTO dto) throws ServletException, IOException {
+        // do something
+        return Response.accepted().build();
     }
 
     @Override

--- a/features/config/upgrade/src/main/resources/changelog-cm/32.0.0/changelog-cm.xml
+++ b/features/config/upgrade/src/main/resources/changelog-cm/32.0.0/changelog-cm.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -7,6 +6,11 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
-    <include file="changelog-cm/30.0.0/changelog-cm.xml"/>
-    <include file="changelog-cm/32.0.0/changelog-cm.xml"/>
+    <changeSet author="stheleman" id="32.0.0-update-schema-datachoices">
+        <cm:changeSchema schemaId="org.opennms.features.datachoices">
+            <cm:put name="initialNoticeAcknowledged" type="boolean"/>
+            <cm:put name="initialNoticeAcknowledgedAt" type="string"/>
+            <cm:put name="initialNoticeAcknowledgedBy" type="string"/>
+        </cm:changeSchema>
+    </changeSet>
 </databaseChangeLog>

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/StateManager.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/StateManager.java
@@ -63,6 +63,9 @@ public class StateManager {
     private static final String SYSTEM_ID_KEY = "systemid";
     private static final String ACKNOWLEDGED_BY_KEY = "acknowledged-by";
     private static final String ACKNOWLEDGED_AT_KEY = "acknowledged-at";
+    private static final String INITIAL_NOTICE_ACKNOWLEDGED_KEY = "initialNoticeAcknowledged";
+    private static final String INITIAL_NOTICE_ACKNOWLEDGED_AT_KEY = "initialNoticeAcknowledgedAt";
+    private static final String INITIAL_NOTICE_ACKNOWLEDGED_BY_KEY = "initialNoticeAcknowledgedBy";
 
     private final List<StateChangeHandler> m_listeners = Lists.newArrayList();
     private final CmProperties propertiesCache;
@@ -84,9 +87,20 @@ public class StateManager {
         propertiesCache.setProperty(ENABLED_KEY, enabled);
         propertiesCache.setProperty(ACKNOWLEDGED_BY_KEY, user == null ? "" : user);
         propertiesCache.setProperty(ACKNOWLEDGED_AT_KEY, new Date().toString());
+
         for (StateChangeHandler listener : m_listeners) {
             listener.onIsEnabledChanged(enabled);
         }
+    }
+
+    public Boolean isInitialNoticeAcknowledged() throws IOException {
+        return (Boolean) propertiesCache.getProperty(INITIAL_NOTICE_ACKNOWLEDGED_KEY);
+    }
+
+    public void setInitialNoticeAcknowledged(boolean status, String user) throws Exception {
+        propertiesCache.setProperty(INITIAL_NOTICE_ACKNOWLEDGED_KEY, status);
+        propertiesCache.setProperty(INITIAL_NOTICE_ACKNOWLEDGED_BY_KEY, user == null ? "" : user);
+        propertiesCache.setProperty(INITIAL_NOTICE_ACKNOWLEDGED_AT_KEY, new Date().toString());
     }
 
     public String getOrGenerateSystemId() throws IOException {

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsStatusDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsStatusDTO.java
@@ -29,13 +29,24 @@
 package org.opennms.features.datachoices.internal;
 
 public class UsageStatisticsStatusDTO {
-    private boolean isEnabled;
+    // note, these can be null (user never chose a status)
+    private Boolean isEnabled;
 
-    public boolean getEnabled() {
+    private Boolean initialNoticeAcknowledged;
+
+    public Boolean getEnabled() {
         return isEnabled;
     }
 
-    public void setEnabled(boolean enabled) {
+    public void setEnabled(Boolean enabled) {
         isEnabled = enabled;
+    }
+
+    public Boolean getInitialNoticeAcknowledged() {
+        return initialNoticeAcknowledged;
+    }
+
+    public void setInitialNoticeAcknowledged(Boolean status) {
+        this.initialNoticeAcknowledged = status;
     }
 }

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
@@ -36,7 +36,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -46,10 +45,6 @@ import org.opennms.features.datachoices.internal.UsageStatisticsStatusDTO;
 
 @Path("/datachoices")
 public interface DataChoiceRestService {
-
-    @POST
-    void updateCollectUsageStatisticFlag(@Context HttpServletRequest request, @QueryParam("action") String action);
-
     @GET
     @Produces(value={MediaType.APPLICATION_JSON})
     UsageStatisticsReportDTO getUsageStatistics() throws ServletException, IOException;

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/AdminPageNavEntry.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/AdminPageNavEntry.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,11 +34,11 @@ public class AdminPageNavEntry implements PageNavEntry {
 
     @Override
     public String getName() {
-        return "Data Choices";
+        return "Usage Statistics Sharing";
     }
 
     @Override
     public String getUrl() {
-        return "javascript:void(0)\" onclick=\"showDataChoicesModal();\"";
+        return "ui/index.html#/usage-statistics";
     }
 }

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/DataChoiceRestServiceImpl.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/DataChoiceRestServiceImpl.java
@@ -62,28 +62,6 @@ public class DataChoiceRestServiceImpl implements DataChoiceRestService {
     private static final String METADATA_RESOURCE_PATH = "web/datachoicesMetadata.json";
 
     @Override
-    public void updateCollectUsageStatisticFlag(HttpServletRequest request, String action) {
-        if (action == null) {
-            return;
-        }
-
-        try {
-            switch (action) {
-            case "enable":
-                m_stateManager.setEnabled(true, request.getRemoteUser());
-                break;
-            case "disable":
-                m_stateManager.setEnabled(false, request.getRemoteUser());
-                break;
-            default:
-                // pass
-            }
-        } catch (Exception e) {
-            throw Throwables.propagate(e);
-        }
-    }
-
-    @Override
     public UsageStatisticsReportDTO getUsageStatistics() throws ServletException, IOException {
         return m_usageStatisticsReporter.generateReport();
     }
@@ -94,6 +72,7 @@ public class DataChoiceRestServiceImpl implements DataChoiceRestService {
 
         try {
             dto.setEnabled(m_stateManager.isEnabled());
+            dto.setInitialNoticeAcknowledged(m_stateManager.isInitialNoticeAcknowledged());
         } catch (Exception e) {
             throw Throwables.propagate(e);
         }
@@ -104,7 +83,15 @@ public class DataChoiceRestServiceImpl implements DataChoiceRestService {
     @Override
     public Response setStatus(HttpServletRequest request, UsageStatisticsStatusDTO dto) throws ServletException, IOException {
         try {
-            m_stateManager.setEnabled(dto.getEnabled(), request.getRemoteUser());
+            final String remoteUser = request.getRemoteUser();
+
+            if (dto.getEnabled() != null) {
+                m_stateManager.setEnabled(dto.getEnabled().booleanValue(), remoteUser);
+            }
+
+            if (dto.getInitialNoticeAcknowledged() != null) {
+                m_stateManager.setInitialNoticeAcknowledged(dto.getInitialNoticeAcknowledged().booleanValue(), remoteUser);
+            }
         } catch (Exception e) {
             throw Throwables.propagate(e);
         }

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/ModalInjector.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/ModalInjector.java
@@ -28,33 +28,32 @@
 
 package org.opennms.features.datachoices.web.internal;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.opennms.features.datachoices.internal.StateManager;
-import org.opennms.web.api.HtmlInjector;
-
 import com.google.common.collect.Maps;
-
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.opennms.features.datachoices.internal.StateManager;
+import org.opennms.web.api.HtmlInjector;
 
 public class ModalInjector implements HtmlInjector {
     private StateManager m_stateManager;
 
     @Override
-    public String inject(HttpServletRequest request) throws TemplateException, IOException {  
-        if (isPage("/opennms/admin/index.jsp", request)) {
-            return generateModalHtml(false);
-        } else if (m_stateManager.isEnabled() == null && isPage("/opennms/index.jsp", request) && isUserInAdminRole(request)) {
+    public String inject(HttpServletRequest request) throws TemplateException, IOException {
+        // only display this notice if user never chose to opt-in or opt-out
+        if ((m_stateManager.isInitialNoticeAcknowledged() == null ||
+            !m_stateManager.isInitialNoticeAcknowledged().booleanValue()) &&
+            isPage("/opennms/index.jsp", request) &&
+            isUserInAdminRole(request)) {
             return generateModalHtml(true);
         }
+
         return null;
     }
 

--- a/features/datachoices/src/main/resources/web/modal.ftl.html
+++ b/features/datachoices/src/main/resources/web/modal.ftl.html
@@ -1,71 +1,72 @@
-<div class="modal" id="datachoices-modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title">Help Improve OpenNMS</h4>
-            </div>
-            <div class="modal-body">
-                <p>Please opt-in to send anonymous OpenNMS usage statistics to <a target="_blank" href="https://stats.opennms.org">OpenNMS Statistics</a>. This will help us improve your OpenNMS software, subject to our <a target="_blank" href="https://www.opennms.com/privacy/">privacy policy</a>. You can change this setting at any time from the Admin menu.</p>
-				<div id="previewCard" class="card">
-				    <div class="card-header" role="tab" id="headingThree">
-				      <h6 class="mb-0 card-title">
-				        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#previewCard" href="#datachoices-preview">
-				          Show me what is being sent.
-				        </a>
-				      </h6>
-				    </div>
-				    <div id="datachoices-preview" class="card-collapse collapse" role="tabpanel">
-				      <div class="card-body">
-				        <div id="datachoices-preview-spinner" class="text-center"><i class="fa fa-spinner fa-spin fa-3x"></i></div>
-				        <div id="datachoices-preview-content"></div>
-				      </div>
-				    </div>
-				  </div>
-            </div>
-            <div class="modal-footer">
-                <button id="datachoices-enable" type="button" class="btn btn-success" data-dismiss="modal">Opt-in</button>
-           		<button id="datachoices-disable" type="button" class="btn btn-secondary" data-dismiss="modal">Opt-out</button>
-            </div>
-        </div>
-    </div>
+<style>
+    #usage-statistics-sharing-modal .modal-dialog {
+       position: fixed;
+       top: auto;
+       right: auto;
+       left: calc(50% - 400px);
+       bottom: 0;
+       min-width: 800px;
+    }
+</style>
+
+<div class="modal" id="usage-statistics-sharing-modal" tabindex="-1" role="dialog">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h4 class="modal-title">Usage Statistics Sharing Notice</h4>
+			</div>
+			<div class="modal-body">
+				<p>Anonymous OpenNMS usage statistics is sent to
+					<a target="_blank" href="https://stats.opennms.org">OpenNMS Statistics</a>.
+					This will help us improve your OpenNMS software, subject to our
+					<a target="_blank" href="https://www.opennms.com/privacy/">privacy policy</a>.</p>
+			</div>
+			<div class="modal-footer">
+				<button id="usage-statistics-sharing-notice-learn-more" type="button" class="btn btn-success">Learn More</button>
+				<button id="usage-statistics-sharing-notice-dismiss" type="button" class="btn btn-secondary" data-dismiss="modal">Dismiss</button>
+			</div>
+		</div>
+	</div>
 </div>
 
 <script type="text/javascript">
-(function(){
+(function() {
+    function ackInitialNotice(redirectUrl) {
+        var data = { initialNoticeAcknowledged: true };
+        $.ajax({
+            url: 'rest/datachoices/status',
+            method: 'POST',
+            dataType: 'json',
+            contentType: 'application/json',
+            processData: false,
+            data: JSON.stringify(data),
+            statusCode: {
+                 202: function() {
+                    if (redirectUrl) {
+                        window.location = redirectUrl;
+                    }
+                }
+            }
+        });
+    }
+
     $(document).ready(function() {
-    	$('#datachoices-preview').on('show.bs.collapse', function () {
-    		$.get('rest/datachoices')
-    		  .done(function(data) {
-    			  $('#datachoices-preview-content').html("<pre>" + JSON.stringify(data, null, 2) + "</pre>");
-    		  })
-    		  .fail(function() {
-    			  $('#datachoices-preview-content').html("<p>There was an error retrieving the content. See server logs for details.</p>");
-    		  })
-    		  .always(function() {
-    			  $('#datachoices-preview-spinner').hide();
-    		  });
-   		});
-   		$('#datachoices-modal').on('shown.bs.modal', function () {
-   		    $(this).find('.modal-dialog').css({height:'auto', 'max-height':'100%'});
-   			$('#datachoices-enable').focus();
- 		});
-    	$('#datachoices-enable').click(function() {
-    		$.post('rest/datachoices?action=enable');
-    	});
-    	$('#datachoices-disable').click(function() {
-    		$.post('rest/datachoices?action=disable');
-    	});
-    	<#if showOnLoad>
-    	$('#datachoices-modal').modal({
-    		  keyboard: false,
-    		  backdrop: 'static'
-    	});
-    	</#if>
+        $('#usage-statistics-sharing-modal').on('shown.bs.modal', function () {
+            $(this).find('.modal-dialog').css({height:'auto', 'max-height':'100%'});
+            $('#usage-statistics-sharing-notice-learn-more').focus();
+        });
+        $('#usage-statistics-sharing-notice-dismiss').click(function() {
+            ackInitialNotice();
+        });
+        $('#usage-statistics-sharing-notice-learn-more').click(function() {
+            ackInitialNotice('ui/index.html#/usage-statistics');
+        });
+        <#if showOnLoad>
+            $('#usage-statistics-sharing-modal').modal({
+                keyboard: false,
+                backdrop: 'static'
+            });
+        </#if>
     });
 })();
-<#if !showOnLoad>
-function showDataChoicesModal() {
-	$('#datachoices-modal').modal('show');
-}
-</#if>
 </script>

--- a/ui/src/components/UsageStatistics/UsageStatisticsHeader.vue
+++ b/ui/src/components/UsageStatistics/UsageStatisticsHeader.vue
@@ -2,8 +2,8 @@
   <div class="usage-stats-header">
     <div>
       <p>
-        Anonymous OpenNMS usage statistics is sent to <a href="https://stats.opennms.org">OpenNMS Statistics</a>.
-        This helps improve your OpenNMS software, subject to our <a href="https://www.opennms.com/privacy/">privacy policy</a>.
+        Anonymous OpenNMS usage statistics is sent to <a href="https://stats.opennms.org" target="_blank">OpenNMS Statistics</a>.
+        This helps improve your OpenNMS software, subject to our <a href="https://www.opennms.com/privacy/" target="_blank">privacy policy</a>.
       </p>
     </div>
     <div class="spacer-medium"></div>

--- a/ui/src/store/usageStatistics/actions.ts
+++ b/ui/src/store/usageStatistics/actions.ts
@@ -50,12 +50,14 @@ const updateSharing = async (enable: boolean) => {
   const success = !!(resp && (resp.status === 200 || resp.status === 202))
 
   if (success) {
-    showSnackBar({
-      msg: `Statistics sharing ${enable ? 'enabled' : 'disabled'}.`
-    })
+    if (enable) {
+      showSnackBar({ msg: 'Usage Statistics Sharing is now enabled. Thank you for helping us improve OpenNMS.' })
+    } else {
+      showSnackBar({ msg: 'Usage Statistics Sharing is now disabled.' })
+    }
   } else {
     showSnackBar({
-      msg: `Error attempting to ${enable ? 'enable' : 'disable'} statistics sharing.`,
+      msg: `Error attempting to ${enable ? 'enable' : 'disable'} Usage Statistics Sharing.`,
       error: true
     })
   }

--- a/ui/src/types/usageStatistics.d.ts
+++ b/ui/src/types/usageStatistics.d.ts
@@ -1,6 +1,7 @@
 import { UsageStatisticsMetadata } from '@/types/usageStatistics';
 export interface UsageStatisticsStatus {
-  enabled: boolean
+  enabled: boolean | null,
+  initialNoticeAcknowledged?: boolean | null
 }
 
 export interface UsageStatisticsData {


### PR DESCRIPTION
NMS-15479: Usage Statistics Sharing notice dialog and support for displaying notice initially.

- Displays a new "notice" dialog / toast at bottom of screen when an Admin user logs in and has not yet acknowledged the notice
- Notice has buttons for just dismissing it or else going to Usage Stats Sharing UI page
- Clicking on either button results in boolean value being set in CM configuration to ack the notice; dialog won't be displayed any more
- If user had previously enabled/disabled stats sharing and it's in the database, that selection will be respected
- Removed old Data Choices popup and link on admin page; new link is "Usage Statistics Sharing"
- Removed old DataChoiceRestService endpoint for enable/disable sharing status, it's superceded by `rest/datachoices/status` endpoint.
- Updated documentation section which used the removed endpoint as a sample and replace with new endpoint

**NOTE:** this PR does not set `enabled` to `true` by default, will handle that in subsequent PR.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15479

