### PR TITLE
NMS-14779: Update Backshift to 1.3.2

### DIFF
--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -2660,8 +2660,8 @@
             "dev": true
         },
         "backshift": {
-            "version": "git+https://github.com/OpenNMS/backshift.git#fdc1e6e9695935a954d49eafd12fde8dd92b134c",
-            "from": "git+https://github.com/OpenNMS/backshift.git#v1.3.1",
+            "version": "git+https://github.com/OpenNMS/backshift.git#5cf10c577ac6a0518d22611794e0388f7a358a4a",
+            "from": "git+https://github.com/OpenNMS/backshift.git#v1.3.2",
             "requires": {
                 "c3": "~0.4.11",
                 "d3": "~3.5.16",

--- a/core/web-assets/package.json
+++ b/core/web-assets/package.json
@@ -88,7 +88,7 @@
         "angular-sanitize": "~1.5.11",
         "angular-ui-router": "^1.0.22",
         "angular-ui-sortable": "^0.19.0",
-        "backshift": "git+https://github.com/OpenNMS/backshift.git#v1.3.1",
+        "backshift": "git+https://github.com/OpenNMS/backshift.git#v1.3.2",
         "bootbox": "^4.4.0",
         "bootstrap": "~4.3.1",
         "c3": "~0.4.18",


### PR DESCRIPTION
This PR bumps backshift to the version containing POW fixes as part of NMS-14779