### PR TITLE
NMS-15485: Enable Usage Stats Sharing by default

### DIFF
--- a/features/config/upgrade/src/main/resources/changelog-cm/32.0.0/changelog-cm.xml
+++ b/features/config/upgrade/src/main/resources/changelog-cm/32.0.0/changelog-cm.xml
@@ -13,4 +13,22 @@
             <cm:put name="initialNoticeAcknowledgedBy" type="string"/>
         </cm:changeSchema>
     </changeSet>
+
+    <changeSet author="stheleman" id="32.0.0-cm-enable-usage-statistics-sharing-by-default-if-not-disabled" runAlways="true">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*)
+                FROM kvstore_jsonb
+                WHERE context = 'CM_CONFIG'
+                AND key = 'org.opennms.features.datachoices'
+                AND (value -> 'configs' -> 'default' ->> 'enabled') IS NULL;
+            </sqlCheck>
+        </preConditions>
+        <sql>
+            UPDATE kvstore_jsonb
+            SET value = jsonb_set(value, '{configs, default, enabled}', 'true')
+            WHERE context = 'CM_CONFIG'
+            AND key = 'org.opennms.features.datachoices'
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Enable Usage Statistics Sharing by default, but respecting any previously-made choice.

Updates CM `org.opennms.features.datachoices` `enabled` value to `true`, if it was `null` (never previously opted in or out), doesn't change it if it was `false`.

Note, CM (Configuration Management) liquibase updates run on OpenNMS application startup; this will run just once.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15485

