### PR TITLE
NMS-15421: Fixing typo for event uei.opennms.org/internal/schedOutagesChanged

### DIFF
--- a/core/test-api/services/src/main/resources/minimal-eventconf.xml
+++ b/core/test-api/services/src/main/resources/minimal-eventconf.xml
@@ -1302,7 +1302,7 @@
     <uei>uei.opennms.org/internal/schedOutagesChanged</uei>
     <event-label>OpenNMS-defined internal event: scehduled outage configuration changed</event-label>
     <descr>
-      This event is sent by the WebUI or the user when scheduled outage configuration has changed and shoule be reloaded
+      This event is sent by the WebUI or the user when scheduled outage configuration has changed and should be reloaded
     </descr>
     <logmsg dest='logndisplay'>
       The scheduled outage configuration has been changed and should be reloaded

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.internal.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.internal.events.xml
@@ -112,7 +112,7 @@
    <event>
       <uei>uei.opennms.org/internal/schedOutagesChanged</uei>
       <event-label>OpenNMS-defined internal event: scehduled outage configuration changed</event-label>
-      <descr>This event is sent by the WebUI or the user when scheduled outage configuration has changed and shoule be
+      <descr>This event is sent by the WebUI or the user when scheduled outage configuration has changed and should be
             reloaded</descr>
       <logmsg dest="logndisplay">
             The scheduled outage configuration has been changed and should be reloaded

--- a/opennms-base-assembly/src/main/resources/contrib/qosdaemon/qos_example_configuration/opennms_fault_config/eventconf.xml
+++ b/opennms-base-assembly/src/main/resources/contrib/qosdaemon/qos_example_configuration/opennms_fault_config/eventconf.xml
@@ -1441,7 +1441,7 @@
     <uei>uei.opennms.org/internal/schedOutagesChanged</uei>
     <event-label>OpenNMS-defined internal event: scehduled outage configuration changed</event-label>
     <descr>
-      This event is sent by the WebUI or the user when scheduled outage configuration has changed and shoule be reloaded
+      This event is sent by the WebUI or the user when scheduled outage configuration has changed and should be reloaded
     </descr>
     <logmsg dest='logndisplay'>
       The scheduled outage configuration has been changed and should be reloaded

--- a/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/eventconf-speedtest/eventconf.xml
+++ b/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/eventconf-speedtest/eventconf.xml
@@ -1300,7 +1300,7 @@
     <uei>uei.opennms.org/internal/schedOutagesChanged</uei>
     <event-label>OpenNMS-defined internal event: scehduled outage configuration changed</event-label>
     <descr>
-      This event is sent by the WebUI or the user when scheduled outage configuration has changed and shoule be reloaded
+      This event is sent by the WebUI or the user when scheduled outage configuration has changed and should be reloaded
     </descr>
     <logmsg dest='logndisplay'>
       The scheduled outage configuration has been changed and should be reloaded

--- a/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/eventconf-wildcard/eventconf.xml
+++ b/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/eventconf-wildcard/eventconf.xml
@@ -1318,7 +1318,7 @@
     <uei>uei.opennms.org/internal/schedOutagesChanged</uei>
     <event-label>OpenNMS-defined internal event: scehduled outage configuration changed</event-label>
     <descr>
-      This event is sent by the WebUI or the user when scheduled outage configuration has changed and shoule be reloaded
+      This event is sent by the WebUI or the user when scheduled outage configuration has changed and should be reloaded
     </descr>
     <logmsg dest='logndisplay'>
       The scheduled outage configuration has been changed and should be reloaded

--- a/opennms-dao-mock/src/main/resources/minimal-eventconf.xml
+++ b/opennms-dao-mock/src/main/resources/minimal-eventconf.xml
@@ -1302,7 +1302,7 @@
     <uei>uei.opennms.org/internal/schedOutagesChanged</uei>
     <event-label>OpenNMS-defined internal event: scehduled outage configuration changed</event-label>
     <descr>
-      This event is sent by the WebUI or the user when scheduled outage configuration has changed and shoule be reloaded
+      This event is sent by the WebUI or the user when scheduled outage configuration has changed and should be reloaded
     </descr>
     <logmsg dest='logndisplay'>
       The scheduled outage configuration has been changed and should be reloaded

--- a/opennms-services/src/test/resources/org/opennms/netmgt/mock/eventconf.xml
+++ b/opennms-services/src/test/resources/org/opennms/netmgt/mock/eventconf.xml
@@ -1434,7 +1434,7 @@
     <uei>uei.opennms.org/internal/schedOutagesChanged</uei>
     <event-label>OpenNMS-defined internal event: scehduled outage configuration changed</event-label>
     <descr>
-      This event is sent by the WebUI or the user when scheduled outage configuration has changed and shoule be reloaded
+      This event is sent by the WebUI or the user when scheduled outage configuration has changed and should be reloaded
     </descr>
     <logmsg dest='logndisplay'>
       The scheduled outage configuration has been changed and should be reloaded


### PR DESCRIPTION
fix: typo 


* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15421

