### PR TITLE
NMS-15596: Update opennms.service

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.service
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.service
@@ -5,6 +5,7 @@ Requires=network.target network-online.target
 After=${install.postgresql.service}.service postgresql-10.service postgresql-11.service postgresql-12.service network.target network-online.target
 
 [Service]
+AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE
 User=root
 Environment="OPENNMS_HOME=${install.dir}"
 


### PR DESCRIPTION
(backport to 2020)

Update the opennms.service to include:
AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15596
