### PR TITLE
NMS-15636: enable third-party txt generation for packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,7 @@ export OPTS_PROFILES=-Prun-expensive-tasks
 
 export BUILDDEFINES=\
 	-Dopennms.home=/usr/share/opennms \
+	-Denable.license=true \
 	-Ddist.dir=$(CURDIR)/debian -Ddist.name=temp \
 	-Dinstall.dir=/usr/share/opennms \
 	-Dinstall.bin.dir=/usr/share/opennms/bin \

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -545,6 +545,7 @@ echo "=== BUILDING ASSEMBLIES ==="
 	-Dinstall.version="%{version}-%{release}" \
 	-Ddist.name="%{name}-%{version}-%{release}.%{_arch}" \
 	-Dopennms.home="%{instprefix}" \
+	-Denable.license=true \
 	-Dinstall.bin.dir="%{bindir}" \
 	-Dinstall.pid.file=/var/run/opennms/opennms.pid \
 	-Dbuild=all \


### PR DESCRIPTION
Turns out we _were_ generating the third-party license txt file, but it only made it into the tarball version (used in ocis) and not the RPM and Debian packages.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15636

