### PR TITLE
NMS-15493: Usage stats, don't display notice if opted-out

### DIFF
--- a/features/config/upgrade/src/main/resources/changelog-cm/32.0.0/changelog-cm.xml
+++ b/features/config/upgrade/src/main/resources/changelog-cm/32.0.0/changelog-cm.xml
@@ -8,7 +8,7 @@
 
     <changeSet author="stheleman" id="32.0.0-update-schema-datachoices">
         <cm:changeSchema schemaId="org.opennms.features.datachoices">
-            <cm:put name="initialNoticeAcknowledged" type="boolean"/>
+            <cm:put name="initialNoticeAcknowledged" type="boolean" default="false"/>
             <cm:put name="initialNoticeAcknowledgedAt" type="string"/>
             <cm:put name="initialNoticeAcknowledgedBy" type="string"/>
         </cm:changeSchema>

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/StateManager.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/StateManager.java
@@ -28,19 +28,17 @@
 
 package org.opennms.features.datachoices.internal;
 
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-
 import org.opennms.features.config.service.api.ConfigUpdateInfo;
 import org.opennms.features.config.service.api.ConfigurationManagerService;
 import org.opennms.features.config.service.util.CmProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
 
 /**
  * Maintains state in cfg file:

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/ModalInjector.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/ModalInjector.java
@@ -46,9 +46,13 @@ public class ModalInjector implements HtmlInjector {
 
     @Override
     public String inject(HttpServletRequest request) throws TemplateException, IOException {
-        // only display this notice if user never chose to opt-in or opt-out
-        if ((m_stateManager.isInitialNoticeAcknowledged() == null ||
-            !m_stateManager.isInitialNoticeAcknowledged().booleanValue()) &&
+        // don't display Usage Statistics Sharing notice if already acked or user previously opted-out
+        boolean noticeAcked = m_stateManager.isInitialNoticeAcknowledged() != null &&
+            m_stateManager.isInitialNoticeAcknowledged().booleanValue();
+        boolean optedOut = m_stateManager.isEnabled() != null && !m_stateManager.isEnabled().booleanValue();
+        boolean hideNotice = noticeAcked || optedOut;
+
+        if (!hideNotice &&
             isPage("/opennms/index.jsp", request) &&
             isUserInAdminRole(request)) {
             return generateModalHtml(true);


### PR DESCRIPTION
If user already opted-out of Usage Statistics Sharing, do not display the notice.

Also fixes a bug where `initialNoticeAcknowledged` should be set to an actual `boolean` value and not `null`.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15493

