### PR TITLE
NMS-15639: OpenAPI docs for Requisition REST service

### DIFF
--- a/features/measurements/api/pom.xml
+++ b/features/measurements/api/pom.xml
@@ -66,5 +66,9 @@
       <artifactId>org.opennms.core.test-api.xml</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
@@ -28,10 +28,8 @@
 
 package org.opennms.netmgt.measurements.model;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.Maps;
+import org.codehaus.jackson.annotate.JsonProperty;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -39,10 +37,10 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlValue;
-
-import org.codehaus.jackson.annotate.JsonProperty;
-
-import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Query response.
@@ -121,6 +119,7 @@ public class QueryResponse {
     }
 
     @XmlElement(name = "timestamps")
+    @JsonProperty("timestamps")
     public long[] getTimestamps() {
         return timestamps;
     }
@@ -136,6 +135,7 @@ public class QueryResponse {
         }
     }
 
+    @com.fasterxml.jackson.annotation.JsonSetter
     public void setTimestamps(final long[] timestamps) {
         this.timestamps = timestamps;
     }
@@ -167,6 +167,7 @@ public class QueryResponse {
         }
     }
 
+    @com.fasterxml.jackson.annotation.JsonSetter
     public void setColumns(final Map<String, double[]> columns) {
         final int N = columns.keySet().size();
         this.labels = new String[N];
@@ -187,6 +188,7 @@ public class QueryResponse {
         this.constants = constants;
     }
 
+    @com.fasterxml.jackson.annotation.JsonSetter
     public void setConstants(final Map<String,Object> constants) {
         final List<QueryConstant> c = new ArrayList<>();
         for (final Map.Entry<String,Object> entry : constants.entrySet()) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -63,6 +64,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("alarmRestService")
 @Path("alarms")
+@Tag(name = "Alarms", description = "Alarms API V1")
 public class AlarmRestService extends AlarmRestServiceBase {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmStatsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmStatsRestService.java
@@ -45,6 +45,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.opennms.core.criteria.Alias.JoinType;
@@ -67,6 +68,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("alarmStatsRestService")
 @Path("stats/alarms")
+@Tag(name = "Alarms Stats", description = "Alarms Stats API")
 @Transactional
 public class AlarmStatsRestService extends AlarmRestServiceBase {
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.AssetRecordDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.events.api.EventConstants;
@@ -66,6 +67,7 @@ import com.google.common.base.Strings;
 
 @Component("assetRecordResource")
 @Path("assetRecord")
+@Tag(name = "Asset Records", description = "Asset Records API")
 @Transactional
 public class AssetRecordResource extends OnmsRestService {
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetSuggestionsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetSuggestionsRestService.java
@@ -45,6 +45,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.netmgt.dao.api.AssetRecordDao;
 import org.opennms.netmgt.model.OnmsAssetRecord;
@@ -64,6 +65,7 @@ import org.springframework.util.Assert;
  */
 @Component("assetSuggestionsRestService")
 @Path("assets")
+@Tag(name = "Asset", description = "Asset API")
 public class AssetSuggestionsRestService extends OnmsRestService implements InitializingBean {
 
     /** The Constant BLACK_LIST. */

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
@@ -51,6 +51,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 import org.opennms.core.config.api.JaxbListWrapper;
@@ -79,6 +80,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("availabilityRestService")
 @Path("availability")
+@Tag(name = "Availability", description = "Availability API")
 @Transactional
 @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
 public class AvailabilityRestService extends OnmsRestService {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
@@ -45,6 +45,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.CategoryDao;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsCategoryCollection;
@@ -66,6 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("categoryRestService")
 @Path("categories")
+@Tag(name = "Categories", description = "Categories API")
 @Transactional
 public class CategoryRestService extends OnmsRestService {
 	

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ConfigRestService.java
@@ -32,6 +32,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.ConfigurationResourceException;
 import org.opennms.web.rest.v1.config.AgentConfigurationResource;
 import org.opennms.web.rest.v1.config.DataCollectionConfigResource;
@@ -50,6 +51,7 @@ import org.springframework.stereotype.Component;
 
 @Component("configRestService")
 @Path("config")
+@Tag(name = "Config", description = "Config API")
 public class ConfigRestService extends OnmsRestService {
 
     @Path("datacollection")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
@@ -52,6 +52,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.opennms.core.criteria.Alias.JoinType;
@@ -69,6 +70,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("eventRestService")
 @Path("events")
+@Tag(name = "Events", description = "Events API")
 public class EventRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(EventRestService.class);
     private static final DateTimeFormatter ISO8601_FORMATTER_MILLIS = ISODateTimeFormat.dateTime();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
@@ -61,6 +61,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
@@ -77,6 +78,7 @@ import com.google.common.collect.ImmutableSet;
 
 @Component
 @Path("filesystem")
+@Tag(name = "FileSystem", description = "File System API")
 public class FilesystemRestService {
     private static final Logger LOG = LoggerFactory.getLogger(FilesystemRestService.class);
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceConfigRestService.java
@@ -50,6 +50,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.netmgt.config.PollerConfig;
 import org.opennms.netmgt.config.api.CollectdConfigFactory;
@@ -77,6 +78,7 @@ import com.google.common.collect.Lists;
  */
 @Component("foreignSourceConfigRestService")
 @Path("foreignSourcesConfig")
+@Tag(name = "ForeignSourcesConfig", description = "Foreign Sources Config API")
 public class ForeignSourceConfigRestService extends OnmsRestService implements InitializingBean {
     private static final Logger LOG = LoggerFactory.getLogger(ForeignSourceConfigRestService.class);
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceRestService.java
@@ -46,6 +46,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.joda.time.Duration;
 import org.opennms.netmgt.provision.persist.ForeignSourceRepository;
 import org.opennms.netmgt.provision.persist.StringIntervalPropertyEditor;
@@ -125,6 +126,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("foreignSourceRestService")
 @Path("foreignSources")
+@Tag(name = "ForeignSources", description = "Foreign Sources API")
 public class ForeignSourceRestService extends OnmsRestService {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(ForeignSourceRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GraphRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GraphRestService.java
@@ -45,6 +45,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.GraphDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.ResourceDao;
@@ -69,6 +70,7 @@ import com.google.common.collect.Maps;
  */
 @Component("graphRestService")
 @Path("graphs")
+@Tag(name = "Graphs", description = "Graphs API")
 public class GraphRestService extends OnmsRestService {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GroupRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GroupRestService.java
@@ -47,6 +47,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsCategoryCollection;
 import org.opennms.netmgt.model.OnmsGroup;
@@ -71,6 +72,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("groupRestService")
 @Path("groups")
+@Tag(name = "Groups", description = "Groups API")
 @Transactional
 public class GroupRestService extends OnmsRestService {
 	

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HardwareInventoryResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HardwareInventoryResource.java
@@ -44,6 +44,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.HwEntityAttributeTypeDao;
 import org.opennms.netmgt.dao.api.HwEntityDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -85,6 +86,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("hardwareInventoryResource")
 @Path("hardwareInventory")
+@Tag(name = "HardwareInventory", description = "Hardware Inventory API")
 @Transactional
 public class HardwareInventoryResource extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(HardwareInventoryResource.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HeatMapRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HeatMapRestService.java
@@ -40,6 +40,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.model.HeatMapDTOCollection;
@@ -55,6 +56,7 @@ import com.google.common.collect.Lists;
 
 @Component("heatMapRestService")
 @Path("heatmap")
+@Tag(name = "Heatmap", description = "Heatmap API")
 public class HeatMapRestService extends OnmsRestService {
     /**
      * Property and default value for category filtering

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/IfServicesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/IfServicesRestService.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -90,6 +91,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("ifServicesRestService")
 @Path("ifservices")
+@Tag(name = "Ifservices", description = "Ifservices API")
 @Transactional
 public class IfServicesRestService extends OnmsRestService {
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
@@ -44,6 +44,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.resource.Vault;
 import org.opennms.core.time.CentralizedDateTimeFormat;
 import org.opennms.core.utils.SystemInfoUtils;
@@ -60,6 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("infoRestService")
 @Path("info")
+@Tag(name = "Info", description = "Info API")
 @Transactional
 public class InfoRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(InfoRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/KscRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/KscRestService.java
@@ -53,6 +53,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.netmgt.config.KSC_PerformanceReportFactory;
 import org.opennms.netmgt.config.kscReports.Graph;
@@ -66,6 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("kscRestService")
 @Path("ksc")
+@Tag(name = "Ksc", description = "Ksc API")
 public class KscRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(KscRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/LogRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/LogRestService.java
@@ -53,12 +53,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.io.input.ReversedLinesFileReader;
 import org.opennms.web.api.Authentication;
 import org.springframework.stereotype.Component;
 
 @Component
 @Path("logs")
+@Tag(name = "Logs", description = "Logs API")
 public class LogRestService {
 
     public static final int DEFAULT_NUM_LINES = 5000;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MinionRestService.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.MinionDao;
 import org.opennms.netmgt.model.OnmsMinionCollection;
@@ -50,6 +51,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("minionRestService")
 @Path("minions")
+@Tag(name = "Minions", description = "Minions API")
 public class MinionRestService extends OnmsRestService {
     @Autowired
     private MinionDao m_minionDao;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MonitoringLocationsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MonitoringLocationsRestService.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.joda.time.Duration;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.events.api.EventProxy;
@@ -66,6 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("monitoringLocationsRestService")
 @Path("monitoringLocations")
+@Tag(name = "MonitoringLocations", description = "Monitoring Locations API")
 public class MonitoringLocationsRestService extends OnmsRestService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MonitoringLocationsRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -50,6 +50,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -90,6 +91,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("nodeRestService")
 @Path("nodes")
+@Tag(name = "Nodes", description = "Nodes API")
 @Transactional
 public class NodeRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
@@ -46,6 +46,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.restrictions.Restrictions;
@@ -66,6 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("notificationRestService")
 @Path("notifications")
+@Tag(name = "Notifications", description = "Notifications API")
 public class NotificationRestService extends OnmsRestService {
     @Autowired
     private NotificationDao m_notifDao;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
@@ -44,6 +44,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.restrictions.Restrictions;
@@ -77,6 +78,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("outageRestService")
 @Path("outages")
+@Tag(name = "Outages", description = "Outages API")
 public class OutageRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(OutageRestService.class);
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionNamesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionNamesRestService.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.MediaType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.web.svclayer.api.RequisitionAccessService;
 
@@ -52,6 +53,7 @@ import org.springframework.stereotype.Component;
  */
 @Component("requisitionNamesRestService")
 @Path("requisitionNames")
+@Tag(name = "RequisitionNames", description = "Requisition Names API")
 public class RequisitionNamesRestService extends OnmsRestService {
 
     /** The m_access service. */

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
@@ -47,6 +47,13 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 import javax.xml.bind.ValidationException;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.provision.persist.ForeignSourceRepositoryFactory;
 import org.opennms.netmgt.provision.persist.requisition.DeployedRequisitionStats;
@@ -147,6 +154,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("deployed/count")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Get the number of deployed requisitions",
+            description = "Get the number of deployed requisitions (returns plaintext rather than XML or JSON).",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Get the number of deployed requisitions (returns plaintext rather than XML or JSON).")
+            }
+    )
     public String getDeployedCount() {
         return Integer.toString(m_accessService.getDeployedCount());
     }
@@ -196,6 +212,13 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("deployed")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get a list of all deployed (active) requisitions.",
+            description = "Get a list of all deployed (active) requisitions.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionCollection.class)), responseCode = "200"),
+            }
+    )
     public RequisitionCollection getDeployedRequisitions() throws ParseException {
         return m_accessService.getDeployedRequisitions();
     }
@@ -208,6 +231,13 @@ public class RequisitionRestService extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get all active requisitions.",
+            description = "Get all active requisitions.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionCollection.class)), responseCode = "200"),
+            }
+    )
     public RequisitionCollection getRequisitions() throws ParseException {
         return m_accessService.getRequisitions();
     }
@@ -220,6 +250,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("count")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Get the number of undeployed requisitions",
+            description = "Get the number of undeployed requisitions (returns plaintext rather than XML or JSON).",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Get the number of undeployed requisitions (returns plaintext rather than XML or JSON).")
+            }
+    )
     public String getPendingCount() {
         return Integer.toString(m_accessService.getPendingCount());
     }
@@ -233,6 +272,14 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the active requisition for the given foreign source name.",
+            description = "Get the active requisition for the given foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = Requisition.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+            }
+    )
     public Requisition getRequisition(@PathParam("foreignSource") final String foreignSource) {
         final Requisition requisition = m_accessService.getRequisition(foreignSource);
         if (requisition == null) {
@@ -251,6 +298,14 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the list of nodes being requisitioned for the given foreign source name.",
+            description = "Get the list of nodes being requisitioned for the given foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionNodeCollection.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+            }
+    )
     public RequisitionNodeCollection getNodes(@PathParam("foreignSource") final String foreignSource) throws ParseException {
         final RequisitionNodeCollection results = m_accessService.getNodes(foreignSource);
         if (results == null) {
@@ -270,6 +325,14 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the node with the given foreign ID for the given foreign source name.",
+            description = "Get the node with the given foreign ID for the given foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionNode.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+            }
+    )
     public RequisitionNode getNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionNode node = m_accessService.getNode(foreignSource, foreignId);
         if (node == null) {
@@ -289,6 +352,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the interfaces for the node with the given foreign ID and foreign source name.",
+            description = "Get the interfaces for the node with the given foreign ID and foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionInterfaceCollection.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+
+            }
+    )
     public RequisitionInterfaceCollection getInterfacesForNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionInterfaceCollection ifaces = m_accessService.getInterfacesForNode(foreignSource, foreignId);
         if (ifaces == null) {
@@ -309,6 +381,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the interface with the given IP for the node with the specified foreign ID and foreign source name.",
+            description = "Get the interface with the given IP for the node with the specified foreign ID and foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionInterface.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+
+            }
+    )
     public RequisitionInterface getInterfaceForNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress) throws ParseException {
         final RequisitionInterface iface = m_accessService.getInterfaceForNode(foreignSource, foreignId, ipAddress);
         if (iface == null) {
@@ -329,6 +410,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the services for the interface with the specified IP address, foreign ID, and foreign source name.",
+            description = "Get the services for the interface with the specified IP address, foreign ID, and foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionMonitoredServiceCollection.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+
+            }
+    )
     public RequisitionMonitoredServiceCollection getServicesForInterface(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress) throws ParseException {
         final RequisitionMonitoredServiceCollection services = m_accessService.getServicesForInterface(foreignSource, foreignId, ipAddress);
         if (services == null) {
@@ -350,6 +440,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services/{service}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the given service with the specified IP address, foreign ID, and foreign source name.",
+            description = "Get the given service with the specified IP address, foreign ID, and foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionMonitoredService.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+
+            }
+    )
     public RequisitionMonitoredService getServiceForInterface(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress, @PathParam("service") String service) throws ParseException {
         final RequisitionMonitoredService monitoredService = m_accessService.getServiceForInterface(foreignSource, foreignId, ipAddress, service);
         if (monitoredService == null) {
@@ -369,6 +468,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/categories")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the categories for the node with the given foreign ID and foreign source name.",
+            description = "Get the categories for the node with the given foreign ID and foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionCategoryCollection.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+
+            }
+    )
     public RequisitionCategoryCollection getCategories(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionCategoryCollection categories = m_accessService.getCategories(foreignSource, foreignId);
         if (categories == null) {
@@ -389,6 +497,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/categories/{category}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the category with the given name for the node with the specified foreign ID and foreign source name.",
+            description = "Get the category with the given name for the node with the specified foreign ID and foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionCategory.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+
+            }
+    )
     public RequisitionCategory getCategory(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("category") final String category) throws ParseException {
         final RequisitionCategory reqCategory = m_accessService.getCategory(foreignSource, foreignId, category);
         if (reqCategory == null) {
@@ -408,6 +525,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/assets")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the assets for the node with the given foreign ID and foreign source name.",
+            description = "Get the assets for the node with the given foreign ID and foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionAssetCollection.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+
+            }
+    )
     public RequisitionAssetCollection getAssetParameters(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionAssetCollection assets = m_accessService.getAssetParameters(foreignSource, foreignId);
         if (assets == null) {
@@ -428,6 +554,15 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/assets/{parameter}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the value of the asset for the given assetName for the node with the given foreign ID and foreign source name.",
+            description = "Get the value of the asset for the given assetName for the node with the given foreign ID and foreign source name.",
+            responses = {
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionAsset.class)), responseCode = "200"),
+                    @ApiResponse(responseCode = "404")
+
+            }
+    )
     public RequisitionAsset getAssetParameter(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("parameter") final String parameter) throws ParseException {
         final RequisitionAsset asset = m_accessService.getAssetParameter(foreignSource, foreignId, parameter);
         if (asset == null) {
@@ -445,7 +580,20 @@ public class RequisitionRestService extends OnmsRestService {
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    public Response addOrReplaceRequisition(@Context final UriInfo uriInfo, final Requisition requisition) {
+    @Operation(summary = "Adds or replaces a requisition.",
+            description = "Adds or replaces a requisition.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = Requisition.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response addOrReplaceRequisition(@Context final UriInfo uriInfo,
+                                            @RequestBody(description = "Requisition")  final Requisition requisition) {
         try {
             requisition.validate();
         } catch (final ValidationException e) {
@@ -468,7 +616,21 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    public Response addOrReplaceNode(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, RequisitionNode node) {
+    @Operation(summary = "Adds or replaces a node in the specified requisition.",
+            description = "Adds or replaces a node in the specified requisition. This operation can be very helpful when working with large requisitions.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = RequisitionNode.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response addOrReplaceNode(@Context final UriInfo uriInfo,
+                                     @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
+                                     @RequestBody(description = "Node" ) RequisitionNode node) {
         try {
             node.validate();
         } catch (final ValidationException e) {
@@ -492,7 +654,22 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/interfaces")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    public Response addOrReplaceInterface(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, RequisitionInterface iface) {
+    @Operation(summary = "Adds or replaces an interface for the given node in the specified requisition.",
+            description = "Adds or replaces an interface for the given node in the specified requisition.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = RequisitionInterface.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response addOrReplaceInterface(@Context final UriInfo uriInfo,
+                                          @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
+                                          @Parameter(required = true) @PathParam("foreignId") String foreignId,
+                                          @RequestBody(description = "Interface") RequisitionInterface iface) {
         try {
             final RequisitionNode node = m_accessService.getNode(foreignSource, foreignId);
             iface.validate(node);
@@ -518,7 +695,23 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    public Response addOrReplaceService(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, @PathParam("ipAddress") String ipAddress, RequisitionMonitoredService service) {
+    @Operation(summary = "Adds or replaces a service on the given interface in the specified requisition.",
+            description = "Adds or replaces a service on the given interface in the specified requisition.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = RequisitionMonitoredService.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response addOrReplaceService(@Context final UriInfo uriInfo,
+                                        @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
+                                        @Parameter(required = true) @PathParam("foreignId") String foreignId,
+                                        @Parameter(required = true) @PathParam("ipAddress") String ipAddress,
+                                        @RequestBody(description = "Monitored Service") RequisitionMonitoredService service) {
         try {
             service.validate();
         } catch (final ValidationException e) {
@@ -542,7 +735,22 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/categories")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    public Response addOrReplaceNodeCategory(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, RequisitionCategory category) {
+    @Operation(summary = "Adds or replaces a category for the given node in the specified requisition.",
+            description = "Adds or replaces a category for the given node in the specified requisition.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = RequisitionCategory.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response addOrReplaceNodeCategory(@Context final UriInfo uriInfo,
+                                             @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
+                                             @Parameter(required = true) @PathParam("foreignId") String foreignId,
+                                             @RequestBody(description = "Category") RequisitionCategory category) {
         try {
             category.validate();
         } catch (final ValidationException e) {
@@ -566,7 +774,22 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/assets")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    public Response addOrReplaceNodeAssetParameter(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, RequisitionAsset asset) {
+    @Operation(summary = "Adds or replaces an asset for the given node in the specified requisition.",
+            description = "Adds or replaces an asset for the given node in the specified requisition.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = RequisitionAsset.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response addOrReplaceNodeAssetParameter(@Context final UriInfo uriInfo,
+                                                   @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
+                                                   @Parameter(required = true) @PathParam("foreignId") String foreignId,
+                                                   @RequestBody(description = "Asset") RequisitionAsset asset) {
         try {
             asset.validate();
         } catch (final ValidationException e) {
@@ -587,7 +810,19 @@ public class RequisitionRestService extends OnmsRestService {
     @PUT
     @Path("{foreignSource}/import")
     @Transactional
-    public Response importRequisition(@Context final UriInfo uriInfo, @PathParam("foreignSource") final String foreignSource, @QueryParam("rescanExisting") final String rescanExisting) {
+    @Operation(
+            summary = "Performs an import or synchronize on the specified requisition.",
+            description = "Performs an import or synchronize on the specified requisition. This turns the \"active\" requisition into a \"deployed\" requisition.",
+            responses = {
+                    @ApiResponse(
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response importRequisition(@Context final UriInfo uriInfo,
+                                      @Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
+                                      @Parameter(description = "If it is newly added or removed. Existing nodes are not scanned until the next rescan interval. This request type is useful when applying changes to a subset of nodes in a requisition.") @QueryParam("rescanExisting") final String rescanExisting) {
         LOG.debug("importRequisition: Importing requisition for foreign source {}", foreignSource);
         m_accessService.importRequisition(foreignSource, rescanExisting);
         return Response.accepted().header("Location", uriInfo.getBaseUriBuilder().path(this.getClass()).path(this.getClass(), "getRequisition").build(foreignSource)).build();
@@ -604,7 +839,22 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    public Response updateRequisition(@Context final UriInfo uriInfo, @PathParam("foreignSource") final String foreignSource, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update the specified requisition.",
+            description = "Update the specified requisition.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = MultivaluedMapImpl.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response updateRequisition(@Context final UriInfo uriInfo,
+                                      @Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
+                                      @RequestBody(description = "Requisition key/value pairs") final MultivaluedMapImpl params) {
         m_accessService.updateRequisition(foreignSource, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
     }
@@ -621,7 +871,23 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    public Response updateNode(@Context final UriInfo uriInfo, @PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update the specified node for the given requisition.",
+            description = "Update the specified node for the given requisition.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = MultivaluedMapImpl.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response updateNode(@Context final UriInfo uriInfo,
+                               @Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
+                               @Parameter(required = true) @PathParam("foreignId") final String foreignId,
+                               @RequestBody(description = "Node key/value pairs")  final MultivaluedMapImpl params) {
         m_accessService.updateNode(foreignSource, foreignId, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
     }
@@ -639,7 +905,24 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    public Response updateInterface(@Context final UriInfo uriInfo, @PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update the specified IP address for the given node and requisition.",
+            description = "Update the specified IP address for the given node and requisition.",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(
+                                    schema = @Schema(implementation = MultivaluedMapImpl.class)
+                            ),
+                            headers = @Header(name = "Location"),
+                            responseCode = "202"
+                    )
+            }
+    )
+    public Response updateInterface(@Context final UriInfo uriInfo,
+                                    @Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
+                                    @Parameter(required = true) @PathParam("foreignId") final String foreignId,
+                                    @Parameter(required = true) @PathParam("ipAddress") final String ipAddress,
+                                        @RequestBody(description = "Interface key/value pairs") final MultivaluedMapImpl params) {
         m_accessService.updateInterface(foreignSource, foreignId, ipAddress, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
     }
@@ -653,7 +936,12 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}")
     @Transactional
-    public Response deletePendingRequisition(@PathParam("foreignSource") final String foreignSource) {
+    @Operation(
+            summary = "Delete the pending requisition for the named foreign source.",
+            description = "Delete the pending requisition for the named foreign source.",
+            responses = @ApiResponse(responseCode = "202")
+    )
+    public Response deletePendingRequisition(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource) {
         m_accessService.deletePendingRequisition(foreignSource);
         return Response.accepted().build();
     }
@@ -667,7 +955,12 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("deployed/{foreignSource}")
     @Transactional
-    public Response deleteDeployedRequisition(@PathParam("foreignSource") final String foreignSource) {
+    @Operation(
+            summary = "Delete the active requisition for the named foreign source.",
+            description = "Delete the active requisition for the named foreign source.",
+            responses = @ApiResponse(responseCode = "202")
+    )
+    public Response deleteDeployedRequisition(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource) {
         m_accessService.deleteDeployedRequisition(foreignSource);
         return Response.accepted().build();
     }
@@ -682,7 +975,13 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}")
     @Transactional
-    public Response deleteNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) {
+    @Operation(
+            summary = "Delete the node with the given foreign ID from the given requisition.",
+            description = "Delete the node with the given foreign ID from the given requisition.",
+            responses = @ApiResponse(responseCode = "202")
+    )
+    public Response deleteNode(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
+                               @Parameter(required = true) @PathParam("foreignId") final String foreignId) {
         m_accessService.deleteNode(foreignSource, foreignId);
         return Response.accepted().build();
     }
@@ -698,7 +997,14 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Transactional
-    public Response deleteInterface(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") String ipAddress) {
+    @Operation(
+            summary = "Delete the IP address from the requisitioned node with the given foreign ID.",
+            description = "Delete the IP address from the requisitioned node with the given foreign ID.",
+            responses = @ApiResponse(responseCode = "202")
+    )
+    public Response deleteInterface(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
+                                    @Parameter(required = true) @PathParam("foreignId") final String foreignId,
+                                    @Parameter(required = true) @PathParam("ipAddress") String ipAddress) {
         m_accessService.deleteInterface(foreignSource, foreignId, ipAddress);
         return Response.accepted().build();
     }
@@ -715,7 +1021,15 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services/{service}")
     @Transactional
-    public Response deleteInterfaceService(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress, @PathParam("service") final String service) {
+    @Operation(
+            summary = "Delete the service from the requisitioned interface with the given IP address and foreign ID.",
+            description = "Delete the service from the requisitioned interface with the given IP address and foreign ID.",
+            responses = @ApiResponse(responseCode = "202")
+    )
+    public Response deleteInterfaceService(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
+                                           @Parameter(required = true) @PathParam("foreignId") final String foreignId,
+                                           @Parameter(required = true) @PathParam("ipAddress") final String ipAddress,
+                                           @Parameter(required = true) @PathParam("service") final String service) {
         m_accessService.deleteInterfaceService(foreignSource, foreignId, ipAddress, service);
         return Response.accepted().build();
     }
@@ -731,7 +1045,14 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/categories/{category}")
     @Transactional
-    public Response deleteCategory(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("category") final String category) {
+    @Operation(
+            summary = "Delete the category from the node with the given foreign ID.",
+            description = "Delete the category from the node with the given foreign ID.",
+            responses = @ApiResponse(responseCode = "202")
+    )
+    public Response deleteCategory(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
+                                   @Parameter(required = true) @PathParam("foreignId") final String foreignId,
+                                   @Parameter(required = true) @PathParam("category") final String category) {
         m_accessService.deleteCategory(foreignSource, foreignId, category);
         return Response.accepted().build();
     }
@@ -747,7 +1068,14 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/assets/{parameter}")
     @Transactional
-    public Response deleteAssetParameter(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("parameter") final String parameter) {
+    @Operation(
+            summary = "Delete the field from the node’s assets with the given foreign ID and asset name.",
+            description = "Delete the field from the node’s assets with the given foreign ID and asset name.",
+            responses = @ApiResponse(responseCode = "202")
+    )
+    public Response deleteAssetParameter(@Parameter(required = true)  @PathParam("foreignSource") final String foreignSource,
+                                         @Parameter(required = true) @PathParam("foreignId") final String foreignId,
+                                         @Parameter(required = true) @PathParam("parameter") final String parameter) {
         m_accessService.deleteAssetParameter(foreignSource, foreignId, parameter);
         return Response.accepted().build();
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
@@ -54,6 +54,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.provision.persist.ForeignSourceRepositoryFactory;
 import org.opennms.netmgt.provision.persist.requisition.DeployedRequisitionStats;
@@ -129,6 +130,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("requisitionRestService")
 @Path("requisitions")
+@Tag(name = "Requisitions", description = "Requisitions API")
 public class RequisitionRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(RequisitionRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
@@ -50,8 +50,6 @@ import javax.xml.bind.ValidationException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -80,24 +78,24 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- *<p>RESTful service to the OpenNMS Provisioning Groups.  In this API, these "groups" of nodes
- *are aptly named and treated as requisitions.</p>
- *<p>This current implementation supports CRUD operations for managing provisioning requisitions.  Requisitions
- *are first POSTed and no provisioning (import) operations are taken.  This is done so that a) the XML can be
- *verified and b) so that the operations can happen at a later time.  They are moved to the deployed state
- *(put in the active requisition repository) when an import is run.
- *<ul>
- *<li>GET/PUT/POST pending requisitions</li>
- *<li>GET pending and deployed count</li>
- *</ul>
- *</p>
- *<p>Example 1: Create a new requisition <i>Note: The foreign-source attribute typically has a 1 to 1
- *relationship to a provisioning group and to the name used in this requisition.  The relationship is
- *implied by name and it is best practice to use the same for all three.  If a foreign source definition
- *exists with the same name, it will be used during the provisioning (import) operations in lieu of the
- *default foreign source</i></p>
- *<pre>
- *curl -X POST \
+ * <p>RESTful service to the OpenNMS Provisioning Groups.  In this API, these "groups" of nodes
+ * are aptly named and treated as requisitions.</p>
+ * <p>This current implementation supports CRUD operations for managing provisioning requisitions.  Requisitions
+ * are first POSTed and no provisioning (import) operations are taken.  This is done so that a) the XML can be
+ * verified and b) so that the operations can happen at a later time.  They are moved to the deployed state
+ * (put in the active requisition repository) when an import is run.
+ * <ul>
+ * <li>GET/PUT/POST pending requisitions</li>
+ * <li>GET pending and deployed count</li>
+ * </ul>
+ * </p>
+ * <p>Example 1: Create a new requisition <i>Note: The foreign-source attribute typically has a 1 to 1
+ * relationship to a provisioning group and to the name used in this requisition.  The relationship is
+ * implied by name and it is best practice to use the same for all three.  If a foreign source definition
+ * exists with the same name, it will be used during the provisioning (import) operations in lieu of the
+ * default foreign source</i></p>
+ * <pre>
+ * curl -X POST \
  *     -H "Content-Type: application/xml" \
  *     -d "&lt;?xml version="1.0" encoding="UTF-8"?&gt;
  *         &lt;model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"
@@ -114,10 +112,10 @@ import org.springframework.transaction.annotation.Transactional;
  *         &lt;/model-import&gt;" \
  *     -u admin:admin \
  *     http://localhost:8980/opennms/rest/requisitions
- *</pre>
- *<p>Example 2: Query all deployed requisitions</p>
- *<pre>
- *curl -X GET \
+ * </pre>
+ * <p>Example 2: Query all deployed requisitions</p>
+ * <pre>
+ * curl -X GET \
  *     -H "Content-Type: application/xml" \
  *     -u admin:admin \
  *        http://localhost:8980/opennms/rest/requisitions/deployed \
@@ -156,15 +154,7 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("deployed/count")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(
-            summary = "Get the number of deployed requisitions",
-            description = "Get the number of deployed requisitions (returns plaintext rather than XML or JSON).",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "Get the number of deployed requisitions (returns plaintext rather than XML or JSON).")
-            }
-    )
+    @Operation(summary = "Get the number of deployed requisitions", description = "Get the number of deployed requisitions (returns plaintext rather than XML or JSON).", responses = {@ApiResponse(responseCode = "200", description = "Get the number of deployed requisitions (returns plaintext rather than XML or JSON).")})
     public String getDeployedCount() {
         return Integer.toString(m_accessService.getDeployedCount());
     }
@@ -195,7 +185,7 @@ public class RequisitionRestService extends OnmsRestService {
 
     /**
      * get a plain text with the current selected foreign source repository strategy
-     * 
+     *
      * @return the current strategy.
      */
     @GET
@@ -214,13 +204,7 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("deployed")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get a list of all deployed (active) requisitions.",
-            description = "Get a list of all deployed (active) requisitions.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionCollection.class)), responseCode = "200"),
-            }
-    )
+    @Operation(summary = "Get a list of all deployed (active) requisitions.", responses = {@ApiResponse(responseCode = "200", description = "Get a list of all deployed (active) requisitions.")})
     public RequisitionCollection getDeployedRequisitions() throws ParseException {
         return m_accessService.getDeployedRequisitions();
     }
@@ -233,13 +217,9 @@ public class RequisitionRestService extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get all active requisitions.",
-            description = "Get all active requisitions.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionCollection.class)), responseCode = "200"),
-            }
-    )
+    @Operation(summary = "Get all active requisitions.", responses = {@ApiResponse(responseCode = "200", description = "Get all active requisitions.")
+
+    })
     public RequisitionCollection getRequisitions() throws ParseException {
         return m_accessService.getRequisitions();
     }
@@ -252,15 +232,7 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("count")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(
-            summary = "Get the number of undeployed requisitions",
-            description = "Get the number of undeployed requisitions (returns plaintext rather than XML or JSON).",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "Get the number of undeployed requisitions (returns plaintext rather than XML or JSON).")
-            }
-    )
+    @Operation(summary = "Get the number of undeployed requisitions", responses = {@ApiResponse(responseCode = "200", description = "Get the number of undeployed requisitions (returns plaintext rather than XML or JSON).")})
     public String getPendingCount() {
         return Integer.toString(m_accessService.getPendingCount());
     }
@@ -274,14 +246,8 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the active requisition for the given foreign source name.",
-            description = "Get the active requisition for the given foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = Requisition.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
-            }
-    )
+    @Operation(summary = "Get the active requisition for the given foreign source name.", responses = {@ApiResponse(responseCode = "200",
+            description = "Get the active requisition for the given foreign source name."), @ApiResponse(responseCode = "404")})
     public Requisition getRequisition(@PathParam("foreignSource") final String foreignSource) {
         final Requisition requisition = m_accessService.getRequisition(foreignSource);
         if (requisition == null) {
@@ -300,14 +266,9 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the list of nodes being requisitioned for the given foreign source name.",
-            description = "Get the list of nodes being requisitioned for the given foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionNodeCollection.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
-            }
-    )
+    @Operation(summary = "Get the list of nodes being requisitioned for the given foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the list of nodes being requisitioned for the given foreign source name."
+
+    ), @ApiResponse(responseCode = "404")})
     public RequisitionNodeCollection getNodes(@PathParam("foreignSource") final String foreignSource) throws ParseException {
         final RequisitionNodeCollection results = m_accessService.getNodes(foreignSource);
         if (results == null) {
@@ -320,21 +281,14 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns the node with the foreign ID specified for the given foreign source
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionNode} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the node with the given foreign ID for the given foreign source name.",
-            description = "Get the node with the given foreign ID for the given foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionNode.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
-            }
-    )
+    @Operation(summary = "Get the node with the given foreign ID for the given foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the node with the given foreign ID for the given foreign source name."), @ApiResponse(responseCode = "404")})
     public RequisitionNode getNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionNode node = m_accessService.getNode(foreignSource, foreignId);
         if (node == null) {
@@ -347,22 +301,16 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns a collection of interfaces for a given node in the specified foreign source
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionInterfaceCollection} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the interfaces for the node with the given foreign ID and foreign source name.",
-            description = "Get the interfaces for the node with the given foreign ID and foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionInterfaceCollection.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
+    @Operation(summary = "Get the interfaces for the node with the given foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the interfaces for the node with the given foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
 
-            }
-    )
+    })
     public RequisitionInterfaceCollection getInterfacesForNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionInterfaceCollection ifaces = m_accessService.getInterfacesForNode(foreignSource, foreignId);
         if (ifaces == null) {
@@ -375,23 +323,15 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns the interface with the given foreign source/foreignid/ipaddress combination.
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param ipAddress a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param ipAddress     a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionInterface} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the interface with the given IP for the node with the specified foreign ID and foreign source name.",
-            description = "Get the interface with the given IP for the node with the specified foreign ID and foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionInterface.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
-
-            }
-    )
+    @Operation(summary = "Get the interface with the given IP for the node with the specified foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the interface with the given IP for the node with the specified foreign ID and foreign source name."), @ApiResponse(responseCode = "404")})
     public RequisitionInterface getInterfaceForNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress) throws ParseException {
         final RequisitionInterface iface = m_accessService.getInterfaceForNode(foreignSource, foreignId, ipAddress);
         if (iface == null) {
@@ -404,23 +344,17 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns a collection of services for a given foreignSource/foreignId/interface combination.
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param ipAddress a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param ipAddress     a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionMonitoredServiceCollection} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the services for the interface with the specified IP address, foreign ID, and foreign source name.",
-            description = "Get the services for the interface with the specified IP address, foreign ID, and foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionMonitoredServiceCollection.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
+    @Operation(summary = "Get the services for the interface with the specified IP address, foreign ID, and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the services for the interface with the specified IP address, foreign ID, and foreign source name."), @ApiResponse(responseCode = "404")
 
-            }
-    )
+    })
     public RequisitionMonitoredServiceCollection getServicesForInterface(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress) throws ParseException {
         final RequisitionMonitoredServiceCollection services = m_accessService.getServicesForInterface(foreignSource, foreignId, ipAddress);
         if (services == null) {
@@ -433,24 +367,18 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns a service for a given foreignSource/foreignId/interface/service-name combination.
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param ipAddress a {@link java.lang.String} object.
-     * @param service a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param ipAddress     a {@link java.lang.String} object.
+     * @param service       a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionMonitoredService} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services/{service}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the given service with the specified IP address, foreign ID, and foreign source name.",
-            description = "Get the given service with the specified IP address, foreign ID, and foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionMonitoredService.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
+    @Operation(summary = "Get the given service with the specified IP address, foreign ID, and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the given service with the specified IP address, foreign ID, and foreign source name."), @ApiResponse(responseCode = "404")
 
-            }
-    )
+    })
     public RequisitionMonitoredService getServiceForInterface(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress, @PathParam("service") String service) throws ParseException {
         final RequisitionMonitoredService monitoredService = m_accessService.getServiceForInterface(foreignSource, foreignId, ipAddress, service);
         if (monitoredService == null) {
@@ -463,22 +391,16 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns a collection of categories for a given node in the specified foreign source
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionCategoryCollection} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/categories")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the categories for the node with the given foreign ID and foreign source name.",
-            description = "Get the categories for the node with the given foreign ID and foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionCategoryCollection.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
+    @Operation(summary = "Get the categories for the node with the given foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the categories for the node with the given foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
 
-            }
-    )
+    })
     public RequisitionCategoryCollection getCategories(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionCategoryCollection categories = m_accessService.getCategories(foreignSource, foreignId);
         if (categories == null) {
@@ -491,23 +413,17 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns the requested category for a given node in the specified foreign source
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param category a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param category      a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionCategory} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/categories/{category}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the category with the given name for the node with the specified foreign ID and foreign source name.",
-            description = "Get the category with the given name for the node with the specified foreign ID and foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionCategory.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
+    @Operation(summary = "Get the category with the given name for the node with the specified foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the category with the given name for the node with the specified foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
 
-            }
-    )
+    })
     public RequisitionCategory getCategory(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("category") final String category) throws ParseException {
         final RequisitionCategory reqCategory = m_accessService.getCategory(foreignSource, foreignId, category);
         if (reqCategory == null) {
@@ -520,22 +436,16 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns a collection of assets for a given node in the specified foreign source
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionAssetCollection} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/assets")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the assets for the node with the given foreign ID and foreign source name.",
-            description = "Get the assets for the node with the given foreign ID and foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionAssetCollection.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
+    @Operation(summary = "Get the assets for the node with the given foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the assets for the node with the given foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
 
-            }
-    )
+    })
     public RequisitionAssetCollection getAssetParameters(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionAssetCollection assets = m_accessService.getAssetParameters(foreignSource, foreignId);
         if (assets == null) {
@@ -548,23 +458,17 @@ public class RequisitionRestService extends OnmsRestService {
      * Returns the requested category for a given node in the specified foreign source
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param parameter a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param parameter     a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionAsset} object.
      * @throws java.text.ParseException if any.
      */
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/assets/{parameter}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(
-            summary = "Get the value of the asset for the given assetName for the node with the given foreign ID and foreign source name.",
-            description = "Get the value of the asset for the given assetName for the node with the given foreign ID and foreign source name.",
-            responses = {
-                    @ApiResponse(content = @Content(schema = @Schema(implementation = RequisitionAsset.class)), responseCode = "200"),
-                    @ApiResponse(responseCode = "404")
+    @Operation(summary = "Get the value of the asset for the given assetName for the node with the given foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the value of the asset for the given assetName for the node with the given foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
 
-            }
-    )
+    })
     public RequisitionAsset getAssetParameter(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("parameter") final String parameter) throws ParseException {
         final RequisitionAsset asset = m_accessService.getAssetParameter(foreignSource, foreignId, parameter);
         if (asset == null) {
@@ -582,20 +486,8 @@ public class RequisitionRestService extends OnmsRestService {
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces a requisition.",
-            description = "Adds or replaces a requisition.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = Requisition.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response addOrReplaceRequisition(@Context final UriInfo uriInfo,
-                                            @RequestBody(description = "Requisition")  final Requisition requisition) {
+    @Operation(summary = "Adds or replaces a requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces a requisition.")})
+    public Response addOrReplaceRequisition(@Context final UriInfo uriInfo, @RequestBody(description = "Requisition") final Requisition requisition) {
         try {
             requisition.validate();
         } catch (final ValidationException e) {
@@ -611,28 +503,15 @@ public class RequisitionRestService extends OnmsRestService {
      * Updates or adds a node to a requisition
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param node a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionNode} object.
+     * @param node          a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionNode} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @POST
     @Path("{foreignSource}/nodes")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces a node in the specified requisition.",
-            description = "Adds or replaces a node in the specified requisition. This operation can be very helpful when working with large requisitions.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = RequisitionNode.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response addOrReplaceNode(@Context final UriInfo uriInfo,
-                                     @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
-                                     @RequestBody(description = "Node" ) RequisitionNode node) {
+    @Operation(summary = "Adds or replaces a node in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces a node in the specified requisition. This operation can be very helpful when working with large requisitions.")})
+    public Response addOrReplaceNode(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @RequestBody(description = "Node") RequisitionNode node) {
         try {
             node.validate();
         } catch (final ValidationException e) {
@@ -648,30 +527,16 @@ public class RequisitionRestService extends OnmsRestService {
      * Updates or adds an interface to a node
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param iface a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionInterface} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param iface         a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionInterface} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @POST
     @Path("{foreignSource}/nodes/{foreignId}/interfaces")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces an interface for the given node in the specified requisition.",
-            description = "Adds or replaces an interface for the given node in the specified requisition.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = RequisitionInterface.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response addOrReplaceInterface(@Context final UriInfo uriInfo,
-                                          @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
-                                          @Parameter(required = true) @PathParam("foreignId") String foreignId,
-                                          @RequestBody(description = "Interface") RequisitionInterface iface) {
+    @Operation(summary = "Adds or replaces an interface for the given node in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces an interface for the given node in the specified requisition.")})
+    public Response addOrReplaceInterface(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @Parameter(required = true) @PathParam("foreignId") String foreignId, @RequestBody(description = "Interface") RequisitionInterface iface) {
         try {
             final RequisitionNode node = m_accessService.getNode(foreignSource, foreignId);
             iface.validate(node);
@@ -688,32 +553,17 @@ public class RequisitionRestService extends OnmsRestService {
      * Updates or adds a service to an interface
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param ipAddress a {@link java.lang.String} object.
-     * @param service a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionMonitoredService} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param ipAddress     a {@link java.lang.String} object.
+     * @param service       a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionMonitoredService} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @POST
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces a service on the given interface in the specified requisition.",
-            description = "Adds or replaces a service on the given interface in the specified requisition.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = RequisitionMonitoredService.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response addOrReplaceService(@Context final UriInfo uriInfo,
-                                        @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
-                                        @Parameter(required = true) @PathParam("foreignId") String foreignId,
-                                        @Parameter(required = true) @PathParam("ipAddress") String ipAddress,
-                                        @RequestBody(description = "Monitored Service") RequisitionMonitoredService service) {
+    @Operation(summary = "Adds or replaces a service on the given interface in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces a service on the given interface in the specified requisition.")})
+    public Response addOrReplaceService(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @Parameter(required = true) @PathParam("foreignId") String foreignId, @Parameter(required = true) @PathParam("ipAddress") String ipAddress, @RequestBody(description = "Monitored Service") RequisitionMonitoredService service) {
         try {
             service.validate();
         } catch (final ValidationException e) {
@@ -729,30 +579,16 @@ public class RequisitionRestService extends OnmsRestService {
      * Updates or adds a category to a node
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param category a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionCategory} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param category      a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionCategory} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @POST
     @Path("{foreignSource}/nodes/{foreignId}/categories")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces a category for the given node in the specified requisition.",
-            description = "Adds or replaces a category for the given node in the specified requisition.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = RequisitionCategory.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response addOrReplaceNodeCategory(@Context final UriInfo uriInfo,
-                                             @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
-                                             @Parameter(required = true) @PathParam("foreignId") String foreignId,
-                                             @RequestBody(description = "Category") RequisitionCategory category) {
+    @Operation(summary = "Adds or replaces a category for the given node in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces a category for the given node in the specified requisition.")})
+    public Response addOrReplaceNodeCategory(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @Parameter(required = true) @PathParam("foreignId") String foreignId, @RequestBody(description = "Category") RequisitionCategory category) {
         try {
             category.validate();
         } catch (final ValidationException e) {
@@ -768,30 +604,16 @@ public class RequisitionRestService extends OnmsRestService {
      * Updates or adds an asset parameter to a node
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param asset a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionAsset} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param asset         a {@link org.opennms.netmgt.provision.persist.requisition.RequisitionAsset} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @POST
     @Path("{foreignSource}/nodes/{foreignId}/assets")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces an asset for the given node in the specified requisition.",
-            description = "Adds or replaces an asset for the given node in the specified requisition.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = RequisitionAsset.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response addOrReplaceNodeAssetParameter(@Context final UriInfo uriInfo,
-                                                   @Parameter(required = true) @PathParam("foreignSource") String foreignSource,
-                                                   @Parameter(required = true) @PathParam("foreignId") String foreignId,
-                                                   @RequestBody(description = "Asset") RequisitionAsset asset) {
+    @Operation(summary = "Adds or replaces an asset for the given node in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces an asset for the given node in the specified requisition.")})
+    public Response addOrReplaceNodeAssetParameter(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @Parameter(required = true) @PathParam("foreignId") String foreignId, @RequestBody(description = "Asset") RequisitionAsset asset) {
         try {
             asset.validate();
         } catch (final ValidationException e) {
@@ -812,19 +634,8 @@ public class RequisitionRestService extends OnmsRestService {
     @PUT
     @Path("{foreignSource}/import")
     @Transactional
-    @Operation(
-            summary = "Performs an import or synchronize on the specified requisition.",
-            description = "Performs an import or synchronize on the specified requisition. This turns the \"active\" requisition into a \"deployed\" requisition.",
-            responses = {
-                    @ApiResponse(
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response importRequisition(@Context final UriInfo uriInfo,
-                                      @Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
-                                      @Parameter(description = "If it is newly added or removed. Existing nodes are not scanned until the next rescan interval. This request type is useful when applying changes to a subset of nodes in a requisition.") @QueryParam("rescanExisting") final String rescanExisting) {
+    @Operation(summary = "Performs an import or synchronize on the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Performs an import or synchronize on the specified requisition. This turns the \"active\" requisition into a \"deployed\" requisition.")})
+    public Response importRequisition(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(description = "If it is newly added or removed. Existing nodes are not scanned until the next rescan interval. This request type is useful when applying changes to a subset of nodes in a requisition.") @QueryParam("rescanExisting") final String rescanExisting) {
         LOG.debug("importRequisition: Importing requisition for foreign source {}", foreignSource);
         m_accessService.importRequisition(foreignSource, rescanExisting);
         return Response.accepted().header("Location", uriInfo.getBaseUriBuilder().path(this.getClass()).path(this.getClass(), "getRequisition").build(foreignSource)).build();
@@ -834,29 +645,15 @@ public class RequisitionRestService extends OnmsRestService {
      * Updates the requisition with foreign source "foreignSource"
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param params a {@link org.opennms.web.rest.support.MultivaluedMapImpl} object.
+     * @param params        a {@link org.opennms.web.rest.support.MultivaluedMapImpl} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @PUT
     @Path("{foreignSource}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    @Operation(
-            summary = "Update the specified requisition.",
-            description = "Update the specified requisition.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = MultivaluedMapImpl.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response updateRequisition(@Context final UriInfo uriInfo,
-                                      @Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
-                                      @RequestBody(description = "Requisition key/value pairs") final MultivaluedMapImpl params) {
+    @Operation(summary = "Update the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Update the specified requisition.")})
+    public Response updateRequisition(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @RequestBody(description = "Requisition key/value pairs") final MultivaluedMapImpl params) {
         m_accessService.updateRequisition(foreignSource, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
     }
@@ -865,31 +662,16 @@ public class RequisitionRestService extends OnmsRestService {
      * Updates the node with foreign id "foreignId" in foreign source "foreignSource"
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param params a {@link org.opennms.web.rest.support.MultivaluedMapImpl} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param params        a {@link org.opennms.web.rest.support.MultivaluedMapImpl} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @PUT
     @Path("{foreignSource}/nodes/{foreignId}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    @Operation(
-            summary = "Update the specified node for the given requisition.",
-            description = "Update the specified node for the given requisition.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = MultivaluedMapImpl.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response updateNode(@Context final UriInfo uriInfo,
-                               @Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
-                               @Parameter(required = true) @PathParam("foreignId") final String foreignId,
-                               @RequestBody(description = "Node key/value pairs")  final MultivaluedMapImpl params) {
+    @Operation(summary = "Update the specified node for the given requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Update the specified node for the given requisition.")})
+    public Response updateNode(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @RequestBody(description = "Node key/value pairs") final MultivaluedMapImpl params) {
         m_accessService.updateNode(foreignSource, foreignId, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
     }
@@ -898,33 +680,17 @@ public class RequisitionRestService extends OnmsRestService {
      * Updates a specific interface
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param ipAddress a {@link java.lang.String} object.
-     * @param params a {@link org.opennms.web.rest.support.MultivaluedMapImpl} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param ipAddress     a {@link java.lang.String} object.
+     * @param params        a {@link org.opennms.web.rest.support.MultivaluedMapImpl} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @PUT
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    @Operation(
-            summary = "Update the specified IP address for the given node and requisition.",
-            description = "Update the specified IP address for the given node and requisition.",
-            responses = {
-                    @ApiResponse(
-                            content = @Content(
-                                    schema = @Schema(implementation = MultivaluedMapImpl.class)
-                            ),
-                            headers = @Header(name = "Location"),
-                            responseCode = "202"
-                    )
-            }
-    )
-    public Response updateInterface(@Context final UriInfo uriInfo,
-                                    @Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
-                                    @Parameter(required = true) @PathParam("foreignId") final String foreignId,
-                                    @Parameter(required = true) @PathParam("ipAddress") final String ipAddress,
-                                        @RequestBody(description = "Interface key/value pairs") final MultivaluedMapImpl params) {
+    @Operation(summary = "Update the specified IP address for the given node and requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Update the specified IP address for the given node and requisition.")})
+    public Response updateInterface(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("ipAddress") final String ipAddress, @RequestBody(description = "Interface key/value pairs") final MultivaluedMapImpl params) {
         m_accessService.updateInterface(foreignSource, foreignId, ipAddress, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
     }
@@ -938,11 +704,7 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}")
     @Transactional
-    @Operation(
-            summary = "Delete the pending requisition for the named foreign source.",
-            description = "Delete the pending requisition for the named foreign source.",
-            responses = @ApiResponse(responseCode = "202")
-    )
+    @Operation(summary = "Delete the pending requisition for the named foreign source.", responses = @ApiResponse(responseCode = "202", description = "Delete the pending requisition for the named foreign source."))
     public Response deletePendingRequisition(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource) {
         m_accessService.deletePendingRequisition(foreignSource);
         return Response.accepted().build();
@@ -957,11 +719,7 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("deployed/{foreignSource}")
     @Transactional
-    @Operation(
-            summary = "Delete the active requisition for the named foreign source.",
-            description = "Delete the active requisition for the named foreign source.",
-            responses = @ApiResponse(responseCode = "202")
-    )
+    @Operation(summary = "Delete the active requisition for the named foreign source.", responses = @ApiResponse(responseCode = "202", description = "Delete the active requisition for the named foreign source."))
     public Response deleteDeployedRequisition(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource) {
         m_accessService.deleteDeployedRequisition(foreignSource);
         return Response.accepted().build();
@@ -971,19 +729,14 @@ public class RequisitionRestService extends OnmsRestService {
      * Delete the node with the given foreign ID for the specified foreign source
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}")
     @Transactional
-    @Operation(
-            summary = "Delete the node with the given foreign ID from the given requisition.",
-            description = "Delete the node with the given foreign ID from the given requisition.",
-            responses = @ApiResponse(responseCode = "202")
-    )
-    public Response deleteNode(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
-                               @Parameter(required = true) @PathParam("foreignId") final String foreignId) {
+    @Operation(summary = "Delete the node with the given foreign ID from the given requisition.", responses = @ApiResponse(responseCode = "202", description = "Delete the node with the given foreign ID from the given requisition."))
+    public Response deleteNode(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId) {
         m_accessService.deleteNode(foreignSource, foreignId);
         return Response.accepted().build();
     }
@@ -992,21 +745,15 @@ public class RequisitionRestService extends OnmsRestService {
      * <p>deleteInterface</p>
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param ipAddress a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param ipAddress     a {@link java.lang.String} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Transactional
-    @Operation(
-            summary = "Delete the IP address from the requisitioned node with the given foreign ID.",
-            description = "Delete the IP address from the requisitioned node with the given foreign ID.",
-            responses = @ApiResponse(responseCode = "202")
-    )
-    public Response deleteInterface(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
-                                    @Parameter(required = true) @PathParam("foreignId") final String foreignId,
-                                    @Parameter(required = true) @PathParam("ipAddress") String ipAddress) {
+    @Operation(summary = "Delete the IP address from the requisitioned node with the given foreign ID.", description = "Delete the IP address from the requisitioned node with the given foreign ID.", responses = @ApiResponse(responseCode = "202"))
+    public Response deleteInterface(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("ipAddress") String ipAddress) {
         m_accessService.deleteInterface(foreignSource, foreignId, ipAddress);
         return Response.accepted().build();
     }
@@ -1015,23 +762,16 @@ public class RequisitionRestService extends OnmsRestService {
      * <p>deleteInterfaceService</p>
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param ipAddress a {@link java.lang.String} object.
-     * @param service a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param ipAddress     a {@link java.lang.String} object.
+     * @param service       a {@link java.lang.String} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services/{service}")
     @Transactional
-    @Operation(
-            summary = "Delete the service from the requisitioned interface with the given IP address and foreign ID.",
-            description = "Delete the service from the requisitioned interface with the given IP address and foreign ID.",
-            responses = @ApiResponse(responseCode = "202")
-    )
-    public Response deleteInterfaceService(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
-                                           @Parameter(required = true) @PathParam("foreignId") final String foreignId,
-                                           @Parameter(required = true) @PathParam("ipAddress") final String ipAddress,
-                                           @Parameter(required = true) @PathParam("service") final String service) {
+    @Operation(summary = "Delete the service from the requisitioned interface with the given IP address and foreign ID.", responses = @ApiResponse(responseCode = "202", description = "Delete the service from the requisitioned interface with the given IP address and foreign ID."))
+    public Response deleteInterfaceService(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("ipAddress") final String ipAddress, @Parameter(required = true) @PathParam("service") final String service) {
         m_accessService.deleteInterfaceService(foreignSource, foreignId, ipAddress, service);
         return Response.accepted().build();
     }
@@ -1040,21 +780,15 @@ public class RequisitionRestService extends OnmsRestService {
      * <p>deleteCategory</p>
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param category a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param category      a {@link java.lang.String} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/categories/{category}")
     @Transactional
-    @Operation(
-            summary = "Delete the category from the node with the given foreign ID.",
-            description = "Delete the category from the node with the given foreign ID.",
-            responses = @ApiResponse(responseCode = "202")
-    )
-    public Response deleteCategory(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource,
-                                   @Parameter(required = true) @PathParam("foreignId") final String foreignId,
-                                   @Parameter(required = true) @PathParam("category") final String category) {
+    @Operation(summary = "Delete the category from the node with the given foreign ID.", responses = @ApiResponse(responseCode = "202", description = "Delete the category from the node with the given foreign ID."))
+    public Response deleteCategory(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("category") final String category) {
         m_accessService.deleteCategory(foreignSource, foreignId, category);
         return Response.accepted().build();
     }
@@ -1063,21 +797,15 @@ public class RequisitionRestService extends OnmsRestService {
      * <p>deleteAssetParameter</p>
      *
      * @param foreignSource a {@link java.lang.String} object.
-     * @param foreignId a {@link java.lang.String} object.
-     * @param parameter a {@link java.lang.String} object.
+     * @param foreignId     a {@link java.lang.String} object.
+     * @param parameter     a {@link java.lang.String} object.
      * @return a {@link javax.ws.rs.core.Response} object.
      */
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/assets/{parameter}")
     @Transactional
-    @Operation(
-            summary = "Delete the field from the node’s assets with the given foreign ID and asset name.",
-            description = "Delete the field from the node’s assets with the given foreign ID and asset name.",
-            responses = @ApiResponse(responseCode = "202")
-    )
-    public Response deleteAssetParameter(@Parameter(required = true)  @PathParam("foreignSource") final String foreignSource,
-                                         @Parameter(required = true) @PathParam("foreignId") final String foreignId,
-                                         @Parameter(required = true) @PathParam("parameter") final String parameter) {
+    @Operation(summary = "Delete the field from the node’s assets with the given foreign ID and asset name.", responses = @ApiResponse(responseCode = "202", description = "Delete the field from the node’s assets with the given foreign ID and asset name."))
+    public Response deleteAssetParameter(@Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("parameter") final String parameter) {
         m_accessService.deleteAssetParameter(foreignSource, foreignId, parameter);
         return Response.accepted().build();
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ResourceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ResourceRestService.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang3.StringUtils;
 import org.opennms.features.distributed.kvstore.api.JsonStore;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -74,6 +75,7 @@ import com.google.gson.Gson;
  */
 @Component("resourceRestService")
 @Path("resources")
+@Tag(name = "Resources", description = "Resources API")
 public class ResourceRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResourceRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.CollectdConfigFactory;
 import org.opennms.netmgt.config.NotifdConfigFactory;
@@ -90,6 +91,7 @@ import org.springframework.stereotype.Component;
  */
 @Component("scheduledOutagesRestService")
 @Path("sched-outages")
+@Tag(name = "Sched-outages", description = "Scheduled Outages API")
 public class ScheduledOutagesRestService extends OnmsRestService {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(ScheduledOutagesRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/SnmpConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/SnmpConfigRestService.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.SnmpConfigAccessService;
 import org.opennms.netmgt.config.SnmpEventInfo;
@@ -100,6 +101,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("snmpConfigRestService")
 @Path("snmpConfig")
+@Tag(name = "SnmpConfig", description = "SNMP Config API")
 @Transactional
 public class SnmpConfigRestService extends OnmsRestService {
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/TimelineRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/TimelineRestService.java
@@ -50,6 +50,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.core.utils.InetAddressUtils;
@@ -64,6 +65,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("timelineRestService")
 @Path("timeline")
+@Tag(name = "Timeline", description = "Timeline API")
 public class TimelineRestService extends OnmsRestService {
 
     private static class TimescaleDescriptor {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.config.UserManager;
 import org.opennms.netmgt.model.OnmsUser;
 import org.opennms.netmgt.model.OnmsUserList;
@@ -69,6 +70,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("userRestService")
 @Path("users")
+@Tag(name = "Users", description = "Users API")
 @Transactional
 public class UserRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(UserRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WebAssetsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WebAssetsRestService.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.io.IOUtils;
 import org.opennms.web.assets.api.AssetLocator;
 import org.opennms.web.assets.api.AssetResource;
@@ -59,6 +60,7 @@ import org.springframework.util.FileCopyUtils;
 
 @Component("webAssetsRestService")
 @Path("web-assets")
+@Tag(name = "Web-Assets", description = "Web Assets API")
 public class WebAssetsRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(WebAssetsRestService.class);
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WhoamiRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WhoamiRestService.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opennms.netmgt.config.UserManager;
@@ -50,6 +51,7 @@ import com.google.common.base.Strings;
 
 @Component("whoamiRestService")
 @Path("whoami")
+@Tag(name = "Whoami", description = "Whoami API")
 public class WhoamiRestService {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
@@ -89,6 +90,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("alarms")
 @Transactional
+@Tag(name = "Alarms", description = "Alarms API")
 public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,AlarmDTO,SearchBean,Integer,Integer> {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationRestService.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.ApplicationDao;
@@ -66,6 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("applications")
 @Transactional
+@Tag(name = "Applications", description = "Applications API")
 public class ApplicationRestService extends AbstractDaoRestService<OnmsApplication,OnmsApplication,Integer,Integer> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApplicationRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationStatusRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationStatusRestService.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.ApplicationDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.OutageDao;
@@ -53,6 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("perspectivepoller")
 @Transactional
+@Tag(name = "PerspectivePoller", description = "Perspective Poller API")
 public class ApplicationStatusRestService {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DiscoveryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DiscoveryRestService.java
@@ -40,6 +40,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.soa.ServiceRegistry;
 import org.opennms.netmgt.config.discovery.DiscoveryConfiguration;
 import org.opennms.netmgt.config.discovery.ExcludeRange;
@@ -62,6 +63,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("discovery")
 @Transactional
+@Tag(name = "Discovery", description = "Discovery API")
 public class DiscoveryRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(org.opennms.web.rest.v2.DiscoveryRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -39,6 +39,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
@@ -64,6 +65,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("ipinterfaces")
 @Transactional
+@Tag(name = "IpInterfaces", description = "Ip Interfaces API")
 public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterface,SearchBean,Integer,String> {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MenuRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MenuRestService.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.time.CentralizedDateTimeFormat;
 import org.opennms.web.rest.support.menu.HttpMenuRequestContext;
 import org.opennms.web.rest.support.menu.MainMenu;
@@ -52,6 +53,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Path("menu")
+@Tag(name = "Menu", description = "Menu API")
 public class MenuRestService {
     private static final Logger LOG = LoggerFactory.getLogger(MenuRestService.class);
     private static final String WEB_INF_PREFIX = "/WEB-INF";

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.MinionDao;
@@ -66,6 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("minions")
 @Transactional
+@Tag(name = "Minion", description = "Minion API")
 public class MinionRestService extends AbstractDaoRestService<OnmsMinion,OnmsMinion,String,String> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MinionRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
@@ -61,6 +62,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("monitoringLocations")
 @Transactional
+@Tag(name = "MonitoringLocations", description = "Monitoring Locations API")
 public class MonitoringLocationRestService extends AbstractDaoRestService<OnmsMonitoringLocation,OnmsMonitoringLocation,String,String> {
     private static final Logger LOG = LoggerFactory.getLogger(MonitoringLocationRestService.class);
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -49,6 +49,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
@@ -87,6 +88,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("nodes")
 @Transactional
+@Tag(name = "Nodes", description = "Node API")
 public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,Integer,String> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
@@ -62,6 +63,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("notifications")
 @Transactional
+@Tag(name = "Notifications", description = "Notifications API")
 public class NotificationRestService extends AbstractDaoRestService<OnmsNotification,SearchBean,Integer,Integer> {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
@@ -60,6 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("outages")
 @Transactional
+@Tag(name = "Outages", description = "Outages API")
 public class OutageRestService extends AbstractDaoRestService<OnmsOutage,SearchBean,Integer,Integer> {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ProvisiondStatusRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ProvisiondStatusRestService.java
@@ -33,6 +33,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.netmgt.provision.service.MonitorHolder;
 import org.opennms.netmgt.provision.service.TimeTrackingMonitor;
@@ -51,6 +52,7 @@ import java.util.Map;
 @Component
 @Path("provisiond")
 @Transactional
+@Tag(name = "Provisiond", description = "Provisiond API")
 public class ProvisiondStatusRestService {
     private MonitorHolder getMonitorHolder() {
         return BeanUtils.getBean("provisiondContext", "monitorHolder", MonitorHolder.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
@@ -62,6 +63,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("snmpinterfaces")
 @Transactional
+@Tag(name = "SnmpInterfaces", description = "SNMP Interfaces API")
 public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInterface,SearchBean,Integer,String> {
 
     @Autowired

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpMetadataRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpMetadataRestService.java
@@ -29,6 +29,7 @@
 package org.opennms.web.rest.v2;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.snmpmetadata.SnmpMetadataBase;
@@ -47,6 +48,7 @@ import javax.ws.rs.core.Response;
 @Component
 @Path("snmpmetadata")
 @Transactional
+@Tag(name = "SnmpMetadata", description = "SNMP metadata API")
 public class SnmpMetadataRestService {
 
     /** The node DAO. */

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UserDefinedLinkRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UserDefinedLinkRestService.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.UriInfo;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 import org.opennms.core.config.api.JaxbListWrapper;
@@ -58,6 +59,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("userdefinedlinks")
 @Transactional
+@Tag(name = "UserDefinedLinks", description = "User Defined Links API")
 public class UserDefinedLinkRestService extends AbstractDaoRestService<UserDefinedLink,UserDefinedLink,Integer,Integer> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeCategoriesRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventRestApi.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.cxf.jaxrs.ext.search.SearchContext;
 import org.opennms.netmgt.xml.event.Event;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,6 +51,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @Path("events")
+@Tag(name = "Events", description = "Events API V2")
 public interface EventRestApi {
 
     @GET

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v1.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v1.xml
@@ -29,6 +29,37 @@
     -->
     <bean id="springResourceContextProvider" class="org.opennms.web.rest.support.SpringResourceContextProvider"/>
 
+    <!-- CXF OpenApiFeature -->
+    <bean id="securityScheme" class="io.swagger.v3.oas.models.security.SecurityScheme">
+        <property name="type">
+            <value type="io.swagger.v3.oas.models.security.SecurityScheme.Type">HTTP</value>
+        </property>
+        <property name="scheme" value="basic" />
+    </bean>
+    <util:map id="securityDefinitionsMap" map-class="java.util.HashMap">
+        <entry key="basicAuth" value-ref = "securityScheme" />
+    </util:map>
+
+    <bean id="openApiCustomizer" class="org.apache.cxf.jaxrs.openapi.OpenApiCustomizer">
+        <property name="dynamicBasePath" value="true" />
+    </bean>
+    <!-- Register the OpenAPI feature -->
+    <!-- See https://cxf.apache.org/docs/openapifeature.html -->
+    <bean id="openApiFeatureV1" class="org.apache.cxf.jaxrs.openapi.OpenApiFeature">
+        <property name="title" value="OpenNMS V1 RESTful API" />
+        <property name="version" value="1.0.0" />
+        <property name="description" value="OpenNMS V1 RESTful API" />
+        <property name="license" value="OpenNMS(R) Licensing (GNU Affero General Public License)" />
+        <property name="licenseUrl" value="http://www.gnu.org/licenses/agpl.html" />
+        <property name="contactName" value="OpenNMS" />
+        <property name="contactUrl" value="http://www.opennms.com/" />
+        <property name="securityDefinitions" ref="securityDefinitionsMap" />
+        <property name="customizer" ref="openApiCustomizer" />
+        <property name="useContextBasedConfig" value="true" />
+        <property name="scan" value="false" />
+        <property name="scannerClass" value="io.swagger.v3.jaxrs2.integration.JaxrsApplicationScanner"/>
+    </bean>
+
     <jaxrs:server id="cxf-rest-v1" address="/" basePackages="org.opennms.web.rest.v1">
       <jaxrs:properties>
         <!-- Use the ResourceContextProvider defined above -->
@@ -57,6 +88,9 @@
       <jaxrs:outInterceptors>
         <ref bean="gzipOutInterceptor" />
       </jaxrs:outInterceptors>
+        <jaxrs:features>
+            <ref bean="openApiFeatureV1" />
+        </jaxrs:features>
     </jaxrs:server>
 
 </beans>

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
@@ -29,6 +29,14 @@
     -->
     <bean id="springResourceContextProvider" class="org.opennms.web.rest.support.SpringResourceContextProvider"/>
 
+    <!-- Used by MenuRestService -->
+    <bean id="dispatcherServletPath" class="java.lang.String">
+        <constructor-arg value="${opennms.home}/jetty-webapps/opennms/WEB-INF/dispatcher-servlet.xml" />
+    </bean>
+    <bean id="menuProvider" class="org.opennms.web.rest.support.menu.MenuProvider">
+        <constructor-arg ref="dispatcherServletPath"/>
+    </bean>
+
     <!-- CXF OpenApiFeature -->
     <bean id="securityScheme" class="io.swagger.v3.oas.models.security.SecurityScheme">
         <property name="type">
@@ -39,12 +47,15 @@
     <util:map id="securityDefinitionsMap" map-class="java.util.HashMap">
         <entry key="basicAuth" value-ref = "securityScheme" />
     </util:map>
+
     <bean id="openApiCustomizer" class="org.apache.cxf.jaxrs.openapi.OpenApiCustomizer">
         <property name="dynamicBasePath" value="true" />
     </bean>
-    <bean id="openApiFeature" class="org.apache.cxf.jaxrs.openapi.OpenApiFeature">
+    <!-- Register the OpenAPI feature -->
+    <!-- See https://cxf.apache.org/docs/openapifeature.html -->
+    <bean id="openApiFeatureV2" class="org.apache.cxf.jaxrs.openapi.OpenApiFeature">
         <property name="title" value="OpenNMS V2 RESTful API" />
-        <property name="version" value="0.1.0" />
+        <property name="version" value="1.0.0" />
         <property name="description" value="OpenNMS V2 RESTful API" />
         <property name="license" value="OpenNMS(R) Licensing (GNU Affero General Public License)" />
         <property name="licenseUrl" value="http://www.gnu.org/licenses/agpl.html" />
@@ -52,13 +63,9 @@
         <property name="contactUrl" value="http://www.opennms.com/" />
         <property name="securityDefinitions" ref="securityDefinitionsMap" />
         <property name="customizer" ref="openApiCustomizer" />
-    </bean>
-    <!-- Used by MenuRestService -->
-    <bean id="dispatcherServletPath" class="java.lang.String">
-        <constructor-arg value="${opennms.home}/jetty-webapps/opennms/WEB-INF/dispatcher-servlet.xml" />
-    </bean>
-    <bean id="menuProvider" class="org.opennms.web.rest.support.menu.MenuProvider">
-        <constructor-arg ref="dispatcherServletPath"/>
+        <property name="useContextBasedConfig" value="true" />
+        <property name="scan" value="false" />
+        <property name="scannerClass" value="io.swagger.v3.jaxrs2.integration.JaxrsApplicationScanner"/>
     </bean>
 
     <jaxrs:server id="cxf-rest-v2" address="/" basePackages="org.opennms.web.rest.v2,org.opennms.web.rest.v2.bsm,,org.opennms.web.rest.v2.status">
@@ -97,7 +104,7 @@
         <ref bean="gzipOutInterceptor" />
       </jaxrs:outInterceptors>
         <jaxrs:features>
-            <ref bean="openApiFeature" />
+            <ref bean="openApiFeatureV2" />
         </jaxrs:features>
     </jaxrs:server>
 

--- a/ui/src/containers/OpenAPI.vue
+++ b/ui/src/containers/OpenAPI.vue
@@ -18,6 +18,20 @@
       />
     </div>
   </div>
+   <div class="feather-row doc-row">
+      <div class="feather-col-12">
+        <rapi-doc
+          id="thedocV1"
+          ref="docV1"
+          class="doc"
+          render-style="read"
+          fetch-credentials="include"
+          update-route="false"
+          allow-authentication="false"
+          show-header="false"
+        />
+      </div>
+    </div>
 </template>
   
 <script setup lang="ts">
@@ -28,6 +42,7 @@ import { BreadCrumb } from '@/types'
 
 const store = useStore()
 const doc = ref()
+const docV1 = ref()
 
 const homeUrl = computed<string>(() => store.state.menuModule.mainMenu?.homeUrl)
 
@@ -44,45 +59,66 @@ const getTheme = computed(() => {
   return 'light'
 })
 
+const openApiSpec = computed<string>(() => store.state.helpModule?.openApi )
+const openApiSpecV1 = computed<string>(() => store.state.helpModule?.openApiV1 )
+
 const setup = async () => {
-  const theme = getTheme.value
+  
   const docEl = document.getElementById('thedoc')
+  const docElV1 = document.getElementById('thedocV1')
   const http = 'http', https = 'https'
   let openApiSpec = await store.dispatch('helpModule/getOpenApi')
+  let openApiSpecV1 = await store.dispatch('helpModule/getOpenApiV1')
   const protocol = window.location.protocol.slice(0, -1)
+
+  let modifiedOpenApiSpec = openApiSpec
+  let modifiedOpenApiV1Spec = openApiSpecV1
 
   if (protocol === https) {
     const openApiSpecString = JSON.stringify(openApiSpec)
     const modifiedOpenApiSpecString = openApiSpecString.replaceAll(http, https)
-    openApiSpec = JSON.parse(modifiedOpenApiSpecString)
+    modifiedOpenApiSpec = JSON.parse(modifiedOpenApiSpecString)
+
+    const openApiSpecStringV1 = JSON.stringify(openApiSpecV1)
+    const modifiedOpenApiSpecStringV1 = openApiSpecStringV1.replaceAll(http, https)
+    modifiedOpenApiV1Spec = JSON.parse(modifiedOpenApiSpecStringV1)
   }
 
-  doc.value.loadSpec(openApiSpec)
+  doc.value.loadSpec(modifiedOpenApiSpec)
+  docV1.value.loadSpec(modifiedOpenApiV1Spec)
 
-  if (docEl) {
+  setTheme(docEl)
+  setTheme(docElV1)
+  
+}
+
+const setTheme = (element: HTMLElement | null) => {
+  const theme = getTheme.value
+  if (element) {
     if (theme === 'light') {
-      docEl.setAttribute('theme', 'light')
-      docEl.setAttribute('bg-color', '#fff')
-      docEl.setAttribute('nav-bg-color', '#f4f7fc')
-      docEl.setAttribute('nav-text-color', '#131736')
-      docEl.setAttribute('nav-hover-bg-color', '#fff')
-      docEl.setAttribute('nav-hover-text-color', '#00BFCB')
-      docEl.setAttribute('nav-accent-color', '#00BFCB')
-      docEl.setAttribute('primary-color', '#00BFCB')
+      element.setAttribute('theme', 'light')
+      element.setAttribute('bg-color', '#fff')
+      element.setAttribute('nav-bg-color', '#f4f7fc')
+      element.setAttribute('nav-text-color', '#131736')
+      element.setAttribute('nav-hover-bg-color', '#fff')
+      element.setAttribute('nav-hover-text-color', '#00BFCB')
+      element.setAttribute('nav-accent-color', '#00BFCB')
+      element.setAttribute('primary-color', '#00BFCB')
     } else {
-      docEl.setAttribute('theme', 'dark')
-      docEl.setAttribute('bg-color', '#15182B')
-      docEl.setAttribute('nav-bg-color', '#0a0c1b')
-      docEl.setAttribute('nav-text-color', '#fff')
-      docEl.setAttribute('nav-hover-bg-color', '#3a3d4d')
-      docEl.setAttribute('nav-hover-text-color', '#fff')
-      docEl.setAttribute('nav-accent-color', '#b5eff3')
-      docEl.setAttribute('primary-color', '#00BFCB')
+      element.setAttribute('theme', 'dark')
+      element.setAttribute('bg-color', '#15182B')
+      element.setAttribute('nav-bg-color', '#0a0c1b')
+      element.setAttribute('nav-text-color', '#fff')
+      element.setAttribute('nav-hover-bg-color', '#3a3d4d')
+      element.setAttribute('nav-hover-text-color', '#fff')
+      element.setAttribute('nav-accent-color', '#b5eff3')
+      element.setAttribute('primary-color', '#00BFCB')
     }
   }
 }
 
 watch(getTheme, () => setup())
+
 onMounted(() => {
   setup()
 })

--- a/ui/src/services/helpService.ts
+++ b/ui/src/services/helpService.ts
@@ -1,4 +1,4 @@
-import { v2 } from './axiosInstances'
+import { v2, rest } from './axiosInstances'
 
 const endpoint = '/openapi.json'
 
@@ -11,4 +11,13 @@ const getOpenApi = async (): Promise<Record<string, unknown>> => {
   }
 }
 
-export { getOpenApi }
+const getOpenApiV1 = async (): Promise<Record<string, unknown>> => {
+  try {
+    const resp = await rest.get(endpoint)
+    return resp.data
+  } catch (err) {
+    return {}
+  }
+}
+
+export { getOpenApiV1, getOpenApi }

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -36,7 +36,7 @@ import { search } from './searchService'
 import { getLogs, getLog } from './logsService'
 import { getWhoAmI } from './whoAmIService'
 import { getInfo } from './infoService'
-import { getOpenApi } from './helpService'
+import { getOpenApiV1, getOpenApi } from './helpService'
 import { getResources, getResourceForNode } from './resourceService'
 import { getPlugins } from './pluginService'
 
@@ -66,6 +66,7 @@ export default {
   getNotificationSummary,
   getFileNames,
   getFileExtensions,
+  getOpenApiV1,
   getOpenApi,
   getProvisionDService,
   populateProvisionD,

--- a/ui/src/store/help/actions.ts
+++ b/ui/src/store/help/actions.ts
@@ -1,12 +1,19 @@
 import { VuexContext } from '@/types'
 import API from '@/services'
 
-const getOpenApi = async (context: VuexContext) => {
+const getOpenApi = async (context: VuexContext ) => {
   const openApi = await API.getOpenApi()
   context.commit('SET_OPEN_API', openApi)
   return openApi
 }
 
+const getOpenApiV1 = async (context: VuexContext ) => {
+  const openApi = await API.getOpenApiV1()
+  context.commit('SET_OPEN_API_V1', openApi)
+  return openApi
+}
+
 export default {
-  getOpenApi
+  getOpenApi,
+  getOpenApiV1
 }

--- a/ui/src/store/help/mutations.ts
+++ b/ui/src/store/help/mutations.ts
@@ -4,6 +4,11 @@ const SET_OPEN_API = (state: State, openApi: Record<string, unknown>) => {
   state.openApi = openApi
 }
 
+const SET_OPEN_API_V1 = (state: State, openApi: Record<string, unknown>) => {
+  state.openApiV1 = openApi
+}
+
 export default {
-  SET_OPEN_API
+  SET_OPEN_API,
+  SET_OPEN_API_V1
 }

--- a/ui/src/store/help/state.ts
+++ b/ui/src/store/help/state.ts
@@ -1,9 +1,11 @@
 export interface State {
   openApi: Record<string, unknown>
+  openApiV1: Record<string, unknown>
 }
 
 const state: State = {
-  openApi: {}
+  openApi: {},
+  openApiV1: {}
 }
 
 export default state


### PR DESCRIPTION
feat: configured openapi to include V1 REST on a separate json so V1 and V2 are available. Other fixes to allow doc be generated.
- Added OpenApi feature for rest V1 endpoints
- Generation of openapi.json
- Generate swagger UI
- Added Requisitions requested changes to match [documentation](https://docs.opennms.com/horizon/latest/development/rest/requisitions.html)
- Both api/v2 and rest generated documentation can be found under help menu > API Documentation

Swagger generated UI can be seen at:
1. V1 : http://localhost:8980/opennms/rest/api-docs?url=openapi.json
2. V2 : http://localhost:8980/opennms/api/v2/api-docs?url=openapi.json

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15639

