### PR TITLE
NMS-15262: Footer on Vue UI pages

### DIFF
--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -240,6 +240,10 @@
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
+      <artifactId>opennms-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
       <artifactId>opennms-web-api</artifactId>
       <scope>${onmsLibScope}</scope>
     </dependency>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MainMenu.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MainMenu.java
@@ -38,6 +38,8 @@ public class MainMenu {
     public String noticeStatus;
     public String username;
     public String baseNodeUrl;
+    public String copyrightDates;
+    public String version;
 
     final public List<TopMenuEntry> menus = new ArrayList<>();
     public TopMenuEntry helpMenu;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuProvider.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuProvider.java
@@ -34,6 +34,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -43,9 +44,9 @@ import java.util.function.Consumer;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
+import org.opennms.core.resource.Vault;
 import org.opennms.web.api.Authentication;
 import org.opennms.web.rest.support.menu.xml.MenuXml;
-
 /**
  * Creates a MainMenu object that is used by the MenuRestService, which provides this data to the
  * new Vue UI Menubar.
@@ -106,6 +107,9 @@ public class MenuProvider {
             mainMenu.noticeStatus = context.getNoticeStatus();
             // TODO: Remove
             mainMenu.notices = buildNotices(context);
+
+            mainMenu.copyrightDates = String.format("2002-%d", LocalDate.now().getYear());
+            mainMenu.version = Vault.getProperty("version.display");
 
             // Parse out menu data from "dispatcher-servlet.xml"
             MenuXml.BeansElement xBeans = null;

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build --base=/opennms/ui/",
+    "build:dev": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --minify false",
     "watch": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --watch",
     "serve": "vite preview",
     "test": "vitest run",

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -13,6 +13,9 @@
         </keep-alive>
       </router-view>
     </div>
+    <template v-slot:footer>
+      <Footer />
+    </template>
   </FeatherAppLayout>
 </template>
 
@@ -22,6 +25,7 @@
 >
 import { useStore } from 'vuex'
 import { FeatherAppLayout } from '@featherds/app-layout'
+import Footer from './components/Layout/Footer.vue'
 import Menubar from './components/Layout/Menubar.vue'
 import Spinner from './components/Common/Spinner.vue'
 import Snackbar from '@/components/Common/Snackbar.vue'

--- a/ui/src/components/Layout/Footer.vue
+++ b/ui/src/components/Layout/Footer.vue
@@ -1,0 +1,33 @@
+<template>
+  <div style="height: 1rem"></div>
+  <div class="footer">
+    <p>
+      OpenNMS <a href="../about/index.jsp">Copyright</a> © {{ mainMenu.copyrightDates || '--' }}
+      <a href="http://www.opennms.com/">The OpenNMS Group, Inc.</a>
+      OpenNMS&reg; is a registered trademark of
+      <a href="http://www.opennms.com">The OpenNMS Group, Inc.</a>
+      - Version: {{ mainMenu.version || '--' }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useStore } from 'vuex'
+import { MainMenu } from '@/types/mainMenu'
+
+const store = useStore()
+const mainMenu = computed<MainMenu>(() => store.state.menuModule.mainMenu)
+
+</script>
+
+<style lang="scss" scoped>
+.footer {
+  display: block;
+  text-align: center;
+  margin-left: -15px;
+  margin-right: -15px;
+  padding: 0.25rem 0.42rem;
+  background-color: #e9ecef;
+  border-top: 1px solid rgba(0, 0, 0, .125);
+}
+</style>

--- a/ui/src/types/mainMenu.d.ts
+++ b/ui/src/types/mainMenu.d.ts
@@ -30,6 +30,8 @@ export interface MainMenu {
   noticeStatus: string
   username: string
   baseNodeUrl: string
+  copyrightDates: string
+  version: string
   
   menus: TopMenuItem[]
   helpMenu: TopMenuItem | null


### PR DESCRIPTION
Add a footer similar to the "legacy" footer to the newer Vue UI pages.

This uses styling taken from legacy page, but alignment will be slightly different since it uses same font as Vue UI rather than old UI.

Menu Rest service updated to include the `copyrightDates` and `version` which are retrieved dynamically, Vue footer uses these.

Also added a `build:dev` `npm/yarn` script entry to build UI in non-minified mode without having to edit the `vite.config.ts` file.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15262

