### PR TITLE
add an SSH server for junit tests

### DIFF
--- a/core/test-api/lib/src/main/java/org/opennms/core/test/OpenNMSJUnit4ClassRunner.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/OpenNMSJUnit4ClassRunner.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -54,9 +54,10 @@ public class OpenNMSJUnit4ClassRunner extends SpringJUnit4ClassRunner {
         "org.opennms.core.test.BeanUtilsTestContextInjectionExecutionListener",
         "org.opennms.test.OpenNMSConfigurationExecutionListener",
         "org.opennms.core.test.db.TemporaryDatabaseExecutionListener",
-        "org.opennms.core.test.snmp.JUnitSnmpAgentExecutionListener",
-        "org.opennms.core.test.http.JUnitHttpServerExecutionListener",
         "org.opennms.core.test.dns.JUnitDNSServerExecutionListener",
+        "org.opennms.core.test.http.JUnitHttpServerExecutionListener",
+        "org.opennms.core.test.snmp.JUnitSnmpAgentExecutionListener",
+        "org.opennms.core.test.ssh.JUnitSshServerExecutionListener",
         "org.opennms.core.collection.test.JUnitCollectorExecutionListener",
         "org.springframework.test.context.support.DependencyInjectionTestExecutionListener",
         "org.springframework.test.context.support.DirtiesContextTestExecutionListener",
@@ -77,7 +78,7 @@ public class OpenNMSJUnit4ClassRunner extends SpringJUnit4ClassRunner {
 
         // Make a deep copy of the existing listeners
         List<TestExecutionListener> oldListeners = getTestContextManager().getTestExecutionListeners();
-        List<TestExecutionListener> listeners = new ArrayList<TestExecutionListener>(oldListeners.size());
+        List<TestExecutionListener> listeners = new ArrayList<>(oldListeners.size());
         for (TestExecutionListener old : oldListeners) {
             listeners.add(old);
         }
@@ -86,7 +87,8 @@ public class OpenNMSJUnit4ClassRunner extends SpringJUnit4ClassRunner {
         // Register the standard set of execution listeners
         for (final String className : STANDARD_LISTENER_CLASS_NAMES) {
             try {
-                final TestExecutionListener listener = (TestExecutionListener)Class.forName(className).newInstance();
+                final var standardListenerClazz = Class.forName(className);
+				final TestExecutionListener listener = (TestExecutionListener)standardListenerClazz.getDeclaredConstructor().newInstance();
                 getTestContextManager().registerTestExecutionListeners(listener);
             } catch (final Exception e) {
             	LOG.info("Failed while attempting to load default unit test listener class {}: {}", className, e.getLocalizedMessage());
@@ -95,7 +97,7 @@ public class OpenNMSJUnit4ClassRunner extends SpringJUnit4ClassRunner {
 
         // Add any additional listeners that may have been specified manually in the test
         final Comparator<TestExecutionListener> comparator = new ClassNameComparator();
-        final TreeSet<TestExecutionListener> standardListeners = new TreeSet<TestExecutionListener>(comparator);
+        final TreeSet<TestExecutionListener> standardListeners = new TreeSet<>(comparator);
         standardListeners.addAll(getTestContextManager().getTestExecutionListeners());
         for (final TestExecutionListener listener : listeners) {
             if (!standardListeners.contains(listener)) {

--- a/core/test-api/pom.xml
+++ b/core/test-api/pom.xml
@@ -26,6 +26,7 @@
     <module>services</module>
     <module>schema</module>
     <module>snmp</module>
+    <module>ssh</module>
     <module>xml</module>
   </modules>
   <dependencyManagement>

--- a/core/test-api/ssh/pom.xml
+++ b/core/test-api/ssh/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.test-api</artifactId>
+    <version>31.0.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.opennms.core.test-api</groupId>
+  <artifactId>org.opennms.core.test-api.ssh</artifactId>
+  <name>OpenNMS :: Core :: Test API :: SSH</name>
+  <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>
+              org.opennms.core.test.ssh.annotations.*;version="${project.version}",
+              org.opennms.core.test.ssh.*;version="${project.version}"
+            </Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+	<dependency>
+	  <groupId>org.apache.sshd</groupId>
+	  <artifactId>sshd-core</artifactId>
+	</dependency>
+	<dependency>
+	  <groupId>org.opennms.core</groupId>
+	  <artifactId>org.opennms.core.lib</artifactId>
+	</dependency>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>spring-test-dependencies</artifactId>
+      <scope>compile</scope>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/JUnitSshServerExecutionListener.java
+++ b/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/JUnitSshServerExecutionListener.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.test.ssh;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.apache.sshd.core.CoreModuleProperties;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.opennms.core.test.ssh.annotations.JUnitSshServer;
+import org.opennms.core.utils.InetAddressUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+import org.springframework.util.SocketUtils;
+
+public class JUnitSshServerExecutionListener extends AbstractTestExecutionListener {
+    private static final Logger LOG = LoggerFactory.getLogger(JUnitSshServerExecutionListener.class);
+
+    private SshServer server;
+
+    @Override
+    public void beforeTestMethod(final TestContext testContext) throws Exception {
+        super.beforeTestMethod(testContext);
+
+        if (server == null) {
+            startServer(testContext);
+        }
+    }
+
+    private void startServer(final TestContext testContext) throws IOException {
+        final var testMethod = testContext.getTestMethod();
+        final var config = testMethod.getAnnotation(JUnitSshServer.class);
+
+        InetAddress host = null;
+        if (config != null && config.listenHostname() != null && !config.listenHostname().isBlank()) {
+            try {
+                host = InetAddress.getByName(config.listenHostname());
+            } catch (final UnknownHostException e) {
+                LOG.error("unable to determine InetAddress from hostname {}" , config.listenHostname(), e);
+                throw e;
+            }
+        }
+        if (host == null) {
+            host = InetAddressUtils.getLocalHostAddress();
+        }
+
+        final var port = (config != null && config.port() > 0)? config.port() : SocketUtils.findAvailableTcpPort();
+
+        server = SshServer.setUpDefaultServer();
+        server.setHost(host.getCanonicalHostName());
+        server.setPort(port);
+        server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        server.setPublickeyAuthenticator((s, publicKey, session) -> true);
+        server.setPasswordAuthenticator((username, password, session) -> {
+            for (final var login : config.logins()) {
+                if (username.equals(login.username()) && password.equals(login.password())) {
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        CoreModuleProperties.WELCOME_BANNER.set(server, "JUnitSshServer SSH 0.0");
+
+        server.start();
+
+        if (testContext.getTestInstance() instanceof SshServerDataProviderAware) {
+            final var provider = new JUnitSshServerDataProvider(server, host, port);
+            LOG.debug("injecting data provider into SshServerDataProviderAware test: {}", testContext.getTestInstance());
+            ((SshServerDataProviderAware)testContext.getTestInstance()).setSshServerDataProvider(provider);
+        }
+    }
+
+    @Override
+    public void afterTestMethod(final TestContext testContext) throws Exception {
+        super.afterTestMethod(testContext);
+
+        this.server.stop();
+        server = null;
+    }
+
+    public static class JUnitSshServerDataProvider implements SshServerDataProvider {
+        private SshServer server;
+        private InetAddress host;
+        private int port;
+
+        public JUnitSshServerDataProvider(final SshServer server, final InetAddress host, final int port) {
+            this.server = server;
+            this.host = host;
+            this.port = port;
+        }
+
+        @Override
+        public InetAddress getHost() {
+            return host;
+        }
+
+        @Override
+        public int getPort() {
+            return port;
+        }
+
+        @Override
+        public void setIdentification(final String banner) {
+            CoreModuleProperties.SERVER_IDENTIFICATION.set(server, banner);
+        }
+    }
+}

--- a/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/SshServerDataProvider.java
+++ b/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/SshServerDataProvider.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.test.ssh;
+
+import java.net.InetAddress;
+
+public interface SshServerDataProvider {
+    /* the hostname that the SSH server is listening on */
+    InetAddress getHost();
+
+    /* the port the SSH server is listening on */
+    int getPort();
+
+    /* override the identification string, note that "SSH-2.0-" is always prepended to this by Mina SSHd */
+    void setIdentification(String bannerText);
+}

--- a/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/SshServerDataProviderAware.java
+++ b/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/SshServerDataProviderAware.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.test.ssh;
+
+public interface SshServerDataProviderAware {
+    public void setSshServerDataProvider(SshServerDataProvider provider);
+}

--- a/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/annotations/JUnitSshServer.java
+++ b/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/annotations/JUnitSshServer.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.test.ssh.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD,ElementType.TYPE})
+public @interface JUnitSshServer {
+    SshLogin[] logins() default {};
+    String listenHostname() default "";
+    int port() default 0;
+}

--- a/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/annotations/SshLogin.java
+++ b/core/test-api/ssh/src/main/java/org/opennms/core/test/ssh/annotations/SshLogin.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.test.ssh.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD,ElementType.TYPE})
+public @interface SshLogin {
+    String username() default "admin";
+    String password() default "admin";
+}

--- a/features/poller/monitors/core/pom.xml
+++ b/features/poller/monitors/core/pom.xml
@@ -151,6 +151,11 @@
       <artifactId>org.opennms.core.ipc.rpc.utils</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -207,6 +212,10 @@
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.activemq</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.ssh</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -150,6 +150,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.ssh</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.dependencies</groupId>
       <artifactId>jasypt-dependencies</artifactId>
       <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -2485,6 +2485,12 @@
       </dependency>
       <dependency>
         <groupId>org.opennms.core.test-api</groupId>
+        <artifactId>org.opennms.core.test-api.ssh</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.opennms.core.test-api</groupId>
         <artifactId>org.opennms.core.test-api.xml</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>


### PR DESCRIPTION
My work laptop doesn't have `sshd` running, so a few ssh-related tests fail. This PR fixes that by not relying on an external sshd, instead creating one using Apache Mina.