### PR TITLE
NMS-15696: Remove @Transactional annotation from JdbcFilterDao

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
@@ -62,8 +62,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.codahale.metrics.JmxReporter;
@@ -76,7 +74,6 @@ import com.codahale.metrics.Timer;
  * @author <a href="mailto:dj@opennms.org">DJ Gregor</a>
  * @version $Id: $
  */
-@Transactional
 public class JdbcFilterDao implements FilterDao, InitializingBean {
     private static final Logger LOG = LoggerFactory.getLogger(JdbcFilterDao.class);
     private static final Pattern SQL_KEYWORD_PATTERN = Pattern.compile("\\s+(?:AND|OR|(?:NOT )?(?:LIKE|IN)|IS (?:NOT )?DISTINCT FROM)\\s+|(?:\\s+IS (?:NOT )?NULL|::(?:TIMESTAMP|INET))(?!\\w)|(?<!\\w)(?:NOT\\s+|IPLIKE(?=\\())", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
@@ -146,7 +143,6 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
     }
 
     @PreDestroy
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void destroy() throws Exception {
         if (jmxReporter != null) {
             jmxReporter.stop();


### PR DESCRIPTION
JIRA: https://opennms.atlassian.net/browse/NMS-15696

This class doesn't use Spring/Hibernate, so injecting transaction support via AOP adds unnecessary overhead and leaves us with possible deadlock scenarios. More details in the associated JIRA.