### PR TITLE
NMS-15714: normalize Karaf sshd

### DIFF
--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -168,14 +168,15 @@
     </feature>
 
     <!-- override the default Karaf ssh with a version from a newer release -->
-    <feature name="ssh" description="Provide a SSHd server on Karaf" version="4.3.9">
+    <feature name="ssh" description="Provide an SSHd server on Karaf" version="${karafSshdVersion}">
         <feature>shell</feature>
         <feature>jaas</feature>
-        <bundle start-level="30">mvn:org.apache.sshd/sshd-osgi/2.9.2</bundle>
-        <bundle start-level="30">mvn:org.apache.sshd/sshd-scp/2.9.2</bundle>
-        <bundle start-level="30">mvn:org.apache.sshd/sshd-sftp/2.9.2</bundle>
-        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/1.70</bundle>
-        <bundle start-level="30">mvn:org.bouncycastle/bcpkix-jdk15on/1.70</bundle>
+        <bundle start-level="30">mvn:org.apache.sshd/sshd-osgi/${minaSshdVersion}</bundle>
+        <bundle start-level="30">mvn:org.apache.sshd/sshd-scp/${minaSshdVersion}</bundle>
+        <bundle start-level="30">mvn:org.apache.sshd/sshd-sftp/${minaSshdVersion}</bundle>
+        <bundle start-level="30">mvn:org.bouncycastle/bcutil-jdk18on/1.72</bundle>
+        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk18on/1.72</bundle>
+        <bundle start-level="30">mvn:org.bouncycastle/bcpkix-jdk18on/1.72</bundle>
         <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.ssh/${karafVersion}</bundle>
     </feature>
 </features>

--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -63,7 +63,7 @@
                         <feature>shell-compat</feature>
                         <feature>feature</feature>
                         <feature>jaas</feature>
-                        <feature>ssh</feature>
+                        <feature>ssh/${karafSshdVersion}</feature>
                         <feature>management</feature>
                         <feature>bundle</feature>
                         <feature>config</feature>

--- a/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -33,7 +33,7 @@ featuresBoot = ( \
     instance/${karafVersion}, \
     package/${karafVersion}, \
     log/${karafVersion}, \
-    ssh/${karafVersion}, \
+    ssh/${karafSshdVersion}, \
     aries-blueprint/${karafVersion}, \
     framework/${karafVersion}, \
     system/${karafVersion}, \

--- a/container/karaf/src/main/filtered-resources/etc/overrides.properties
+++ b/container/karaf/src/main/filtered-resources/etc/overrides.properties
@@ -9,5 +9,11 @@ mvn:org.apache.qpid/proton-j/0.34.0
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1
+mvn:org.apache.sshd/sshd/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-common/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-core/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-osgi/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-scp/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-sftp/${minaSshdVersion}
 mvn:org.codehaus.jettison/jettison/${jettisonVersion}
 mvn:org.scala-lang/scala-library/${scala11LibraryVersion}

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -81,9 +81,10 @@
                         <feature>scv-jceks-impl</feature>
                         <feature>scv-shell</feature>
 
-                        <!-- OPENNMS: Additional tools -->
+                        <!-- OPENNMS: Additional or overrided tools -->
                         <feature>hawtio</feature>
                         <feature>jolokia</feature>
+                        <feature>ssh/${karafSshdVersion}</feature>
                     </bootFeatures>
                     <blacklistedFeatures>
                         <!-- make sure the custom opennms features don't make it in -->
@@ -91,6 +92,7 @@
                         <feature>opennms-http-whiteboard</feature>
                         <feature>jetty/9.4.40.v20210413</feature>
                         <feature>pax-jetty/9.4.40.v20210413</feature>
+                        <feature>ssh/${karafVersion}</feature>
                     </blacklistedFeatures>
                     <installedBundles>
                         <!-- override for security (see etc/overrides.properties) -->

--- a/container/shared/src/main/filtered-resources/etc/blacklisted.properties
+++ b/container/shared/src/main/filtered-resources/etc/blacklisted.properties
@@ -4,3 +4,6 @@ spring-security
 # no karaf Spring repos
 mvn:org.apache.karaf.features/spring
 mvn:org.apache.karaf.features/spring-legacy
+
+# we use the 4.3.9 version instead
+ssh/${karafVersion}

--- a/container/shared/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/container/shared/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -36,7 +36,7 @@ featuresBoot = \
     instance/${karafVersion}, \
     package/${karafVersion}, \
     log/${karafVersion}, \
-    ssh/${karafVersion}, \
+    ssh/${karafSshdVersion}, \
     framework/${karafVersion}, \
     system/${karafVersion}, \
     eventadmin/${karafVersion}, \

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -9,6 +9,12 @@ mvn:org.apache.qpid/proton-j/0.34.0
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/${jasyptVersion}_1
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt-spring31/${jasyptVersion}_1
 mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstreamVersion}_1
+mvn:org.apache.sshd/sshd/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-common/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-core/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-osgi/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-scp/${minaSshdVersion}
+mvn:org.apache.sshd/sshd-sftp/${minaSshdVersion}
 mvn:org.codehaus.jettison/jettison/${jettisonVersion}
 mvn:org.scala-lang/scala-library/${scala11LibraryVersion}
 

--- a/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -36,7 +36,7 @@ featuresBoot = \
     instance/${karafVersion}, \
     package/${karafVersion}, \
     log/${karafVersion}, \
-    ssh/${karafVersion}, \
+    ssh/${karafSshdVersion}, \
     framework/${karafVersion}, \
     system/${karafVersion}, \
     eventadmin/${karafVersion}, \

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -261,7 +261,7 @@
                 <feature>service-wrapper</feature>
                 <feature>shell-compat</feature>
                 <feature>shell</feature>
-                <feature>ssh</feature>
+                <feature>ssh/${karafSshdVersion}</feature>
                 <feature>standard</feature>
                 <feature>system</feature>
                 <feature>war</feature>
@@ -326,7 +326,6 @@
                 <feature>service-wrapper</feature>
                 <feature>shell-compat</feature>
                 <feature>shell</feature>
-                <feature>ssh</feature>
                 <feature>standard</feature>
                 <feature>system</feature>
                 <feature>war</feature>

--- a/opennms-full-assembly/src/assembly/components/osgi.xml
+++ b/opennms-full-assembly/src/assembly/components/osgi.xml
@@ -13,10 +13,13 @@
         <exclude>**/*jasypt*/1.9.2_1/*</exclude>
         <exclude>**/jettison/1.3.*</exclude>
         <exclude>**/jettison/1.3.*/*</exclude>
+        <exclude>**/proton-j/0.14.0/*</exclude>
         <exclude>**/proton-j/0.14.0</exclude>
         <exclude>**/proton-j/0.14.0/*</exclude>
         <exclude>**/scala-library/2.11.0</exclude>
         <exclude>**/scala-library/2.11.0/*</exclude>
+        <exclude>**/sshd-*/2.8.0</exclude>
+        <exclude>**/sshd-*/2.8.0/*</exclude>
         <exclude>**/*xstream*/1.4.8_1</exclude>
         <exclude>**/*xstream*/1.4.8_1/*</exclude>
       </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -1792,6 +1792,8 @@
     <zookeeperVersion>3.4.14</zookeeperVersion>
     <zookeeper2Version>3.5.9</zookeeper2Version>
     <zstdJniVersion>1.4.9-1</zstdJniVersion>
+    <minaSshdVersion>2.10.0</minaSshdVersion>
+    <karafSshdVersion>${karafVersion}.ONMS_1</karafSshdVersion>
 
     <springVersion>4.2.9.RELEASE_1</springVersion>
     <patchedSpringVersion>4.2.9.RELEASE_1.ONMS.1</patchedSpringVersion>
@@ -5164,6 +5166,26 @@
         <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-generator-annprocess</artifactId>
         <version>${jmhVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-core</artifactId>
+        <version>${minaSshdVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-osgi</artifactId>
+        <version>${minaSshdVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-scp</artifactId>
+        <version>${minaSshdVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-sftp</artifactId>
+        <version>${minaSshdVersion}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR cleans up our Karaf sshd upgrade/dependencies, and bumps the version to 2.10.0, which should solve some disconnect issues we've seen in the real world.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15714

