### PR TITLE
NMS-15471: legacy formatter fixes

### DIFF
--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/DateTimeAdapter.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/DateTimeAdapter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,17 +33,18 @@ import java.util.Date;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 public class DateTimeAdapter extends XmlAdapter<String, Date> {
+    private static final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
 
     /** {@inheritDoc} */
     @Override
     public String marshal(final Date date) throws Exception {
-        return date == null ? null : EventConstants.formatToString(date);
+        return date == null ? null : formatter.format(date);
     }
 
     /** {@inheritDoc} */
     @Override
     public Date unmarshal(final String string) throws Exception {
-        return (string == null || string.isEmpty()) ? null : EventConstants.parseToDate(string);
+        return (string == null || string.isEmpty()) ? null : formatter.parse(string);
     }
 
 }

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/DateTimeAdapter.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/DateTimeAdapter.java
@@ -33,18 +33,18 @@ import java.util.Date;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 public class DateTimeAdapter extends XmlAdapter<String, Date> {
-    private static final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+    private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
     /** {@inheritDoc} */
     @Override
     public String marshal(final Date date) throws Exception {
-        return date == null ? null : formatter.format(date);
+        return date == null ? null : FORMATTER.format(date);
     }
 
     /** {@inheritDoc} */
     @Override
     public Date unmarshal(final String string) throws Exception {
-        return (string == null || string.isEmpty()) ? null : formatter.parse(string);
+        return (string == null || string.isEmpty()) ? null : FORMATTER.parse(string);
     }
 
 }

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
@@ -1037,36 +1037,42 @@ public abstract class EventConstants {
     /** Constant <code>OID_SNMP_IFINDEX</code> */
     public static final SnmpObjId OID_SNMP_IFINDEX = SnmpObjId.get(".1.3.6.1.2.1.2.2.1.1");
 
-    protected static EventDatetimeFormatter m_eventDatetimeFormatter;
-
-    static {
-        if (Boolean.parseBoolean("org.opennms.events.legacyFormatter")) {
-            m_eventDatetimeFormatter = new LegacyDatetimeFormatter();
-        } else {
-            m_eventDatetimeFormatter = new ISODatetimeFormatter();
-        }
-    }
-
     /**
      * A utility method to parse a string into a 'Date' instance.
      *
+     * @deprecated use {@link #getEventDatetimeFormatter()} instead
      * @param timeString a {@link java.lang.String} object
      * @return a {@link java.util.Date} object
      * @throws java.text.ParseException if any
      */
     public static final Date parseToDate(final String timeString) throws ParseException {
-        return m_eventDatetimeFormatter.parse(timeString);
+        return getEventDatetimeFormatter().parse(timeString);
     }
 
     /**
      * A utility method to format a 'Date' into a string.
      *
+     * @deprecated use {@link #getEventDatetimeFormatter()} instead
      * @param date a {@link java.util.Date} object
      * @return a {@link java.lang.String} object
      */
     public static final String formatToString(final Date date) {
-        return m_eventDatetimeFormatter.format(date);
+        return getEventDatetimeFormatter().format(date);
     }
+
+    /**
+     * Get the appropriate instance of an event date/time formatter based on whether
+     * the system property org.opennms.events.legacyFormatter is true or false.
+     *
+     * @return a formatter instance
+     */
+    public static EventDatetimeFormatter getEventDatetimeFormatter() {
+        if (Boolean.getBoolean("org.opennms.events.legacyFormatter")) {
+            return new LegacyDatetimeFormatter();
+        } else {
+            return new ISODatetimeFormatter();
+        }
+	}
 
 	/**
 	 * Converts the value of a parm ('Value') of the instance to a string

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatter.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatter.java
@@ -60,22 +60,6 @@ public class LegacyDatetimeFormatter implements EventDatetimeFormatter {
         return formatter;
     });
 
-    public static final ThreadLocal<DateFormat> FORMATTER_FULL_GMT = ThreadLocal.withInitial(() -> {
-        int timeFormat = DateFormat.FULL;
-        // The DateFormat.FULL format for France/Germany do not include the seconds digit
-        // which is necessary to have sub-minute resolution in event times. For these
-        // locales, we'll fall back to using DateFormat.LONG.
-        final String language = Locale.getDefault().getLanguage();
-        if (language.equals(Locale.FRANCE.getLanguage()) || language.equals(Locale.GERMANY.getLanguage())) {
-            timeFormat = DateFormat.LONG;
-        }
-
-        final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.FULL, timeFormat);
-        formatter.setLenient(true);
-        formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
-        return formatter;
-    });
-
     public static final ThreadLocal<DateFormat> FORMATTER_LONG_GMT = ThreadLocal.withInitial(() -> {
         final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.LONG);
         formatter.setLenient(true);

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatter.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatter.java
@@ -31,12 +31,21 @@ package org.opennms.netmgt.events.api;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
+/**
+ * A datetime formatter that attempts to mimic, as closely as possible, formatting in pre-2019 OpenNMS releases.
+ * This will not work <em>exactly</em> the same unless you change the <code>-Djava.locale.provider=<code>
+ * property during startup to be <code>COMPAT</code> by default.
+ */
 public class LegacyDatetimeFormatter implements EventDatetimeFormatter {
     public static final ThreadLocal<DateFormat> FORMATTER_FULL = ThreadLocal.withInitial(() -> {
         int timeFormat = DateFormat.FULL;
@@ -84,35 +93,46 @@ public class LegacyDatetimeFormatter implements EventDatetimeFormatter {
         return formatter;
     });
 
+    private static final List<ThreadLocal<DateFormat>> preferredOrder = Arrays.asList(FORMATTER_LONG, FORMATTER_CUSTOM, FORMATTER_FULL, FORMATTER_DEFAULT);
+
     @Override
     public Date parse(final String dateString) throws ParseException {
         if (dateString == null) {
             throw new ParseException("time was null!", -1);
         }
-        try {
-            return FORMATTER_LONG.get().parse(dateString);
-        } catch (final ParseException parseException) {
-            try {
-                return FORMATTER_CUSTOM.get().parse(dateString);
-            } catch (final ParseException pe) {
+        final String noUtc = dateString.replaceAll("UTC$", "GMT");
+        Exception e = null;
+        for (final String attempt : Arrays.asList(dateString, noUtc)) {
+            for (final ThreadLocal<DateFormat> formatter : preferredOrder) {
+                final DateFormat dateFormatter = formatter.get();
+                // System.err.println("attempt=" + attempt + ", formatter=" + dateFormatter);
                 try {
-                    return FORMATTER_FULL.get().parse(dateString);
-                } catch (final Exception fpe) {
-                    try {
-                        return Date.from(ZonedDateTime.parse(dateString).toInstant());
-                    } catch (final DateTimeParseException dtpe) {
-                        throw new ParseException("failed to parse " + dateString + " as an ISO date; giving up", dtpe.getErrorIndex());
-                    } catch (final Exception isoe) {
-                        throw new ParseException("failed to parse " + dateString + " as an ISO date; giving up", 0);
+                    return dateFormatter.parse(attempt);
+                } catch (final ParseException pe) {
+                    if (e == null) {
+                        e = pe;
                     }
                 }
             }
         }
+
+        // we tried all the "legacy" formatters, either ISO will work, or we give up
+
+        ParseException thrown = null;
+        try {
+            return Date.from(ZonedDateTime.parse(dateString).toInstant());
+        } catch (final DateTimeParseException dtpe) {
+            thrown = new ParseException("failed to parse " + dateString + " as any legacy format; giving up", dtpe.getErrorIndex());
+        } catch (final Exception isoe) {
+            thrown = new ParseException("failed to parse " + dateString + " as any legacy format; giving up", 0);
+        }
+        thrown.initCause(e);
+        throw thrown;
     }
 
     @Override
     public String format(final Date date) {
-        return FORMATTER_LONG_GMT.get().format(date);
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(date.toInstant().atZone(ZoneId.systemDefault()));
     }
 
 }

--- a/features/events/api/src/test/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatterTest.java
+++ b/features/events/api/src/test/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatterTest.java
@@ -56,7 +56,7 @@ public class LegacyDatetimeFormatterTest {
     public void testFormat() throws Exception {
         final LegacyDatetimeFormatter formatter = new LegacyDatetimeFormatter();
         final String date = formatter.format(new Date(0));
-        assertEquals("Thursday, January 1, 1970 12:00:00 AM GMT", date);
+        assertEquals("1970-01-01T00:00:00Z", date);
     }
 
     @Test

--- a/features/events/api/src/test/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatterTest.java
+++ b/features/events/api/src/test/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatterTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.events.api;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LegacyDatetimeFormatterTest {
+    private TimeZone oldZone;
+
+    @Before
+    public void setUp() {
+        oldZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("Etc/UTC")));
+    }
+
+    @After
+    public void tearDown() {
+        TimeZone.setDefault(oldZone);
+    }
+
+    @Test
+    public void testFormat() throws Exception {
+        final LegacyDatetimeFormatter formatter = new LegacyDatetimeFormatter();
+        final String date = formatter.format(new Date(0));
+        assertEquals("Thursday, January 1, 1970 12:00:00 AM GMT", date);
+    }
+
+    @Test
+    public void testParse() throws Exception {
+        final LegacyDatetimeFormatter formatter = new LegacyDatetimeFormatter();
+
+        // "default" format (DateFormat.FULL + DateFormat.LONG)
+        Date date = formatter.parse("Thursday, January 1, 1970 12:00:03 AM GMT");
+        assertEquals(new Date(3000), date);
+
+        // "custom" format (old XML format)
+        date = formatter.parse("Thursday, 1 January 1970 00:00:03 o'clock GMT");
+        assertEquals(new Date(3000), date);
+
+        // "full" format
+        date = formatter.parse("Thursday, January 1, 1970 12:00:03 AM GMT");
+        assertEquals(new Date(3000), date);
+
+        date = formatter.parse("1970-01-01T00:00:03+00:00");
+        assertEquals(new Date(3000), date);
+    }
+}

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DestinationPathManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DestinationPathManager.java
@@ -53,14 +53,13 @@ import org.opennms.netmgt.events.api.EventDatetimeFormatter;
  * @author David Hustace <david@opennms.org>
  */
 public abstract class DestinationPathManager {
+    private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
     private DestinationPaths allPaths;
 
     private Map<String, Path> m_destinationPaths;
 
     private Header oldHeader;
-
-    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
 
     /**
      * <p>parseXML</p>
@@ -273,7 +272,7 @@ public abstract class DestinationPathManager {
     private Header rebuildHeader() {
         Header header = oldHeader;
     
-        header.setCreated(formatter.format(new Date()));
+        header.setCreated(FORMATTER.format(new Date()));
     
         return header;
     }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DestinationPathManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DestinationPathManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -45,29 +45,22 @@ import org.opennms.netmgt.config.destinationPaths.Header;
 import org.opennms.netmgt.config.destinationPaths.Path;
 import org.opennms.netmgt.config.destinationPaths.Target;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventDatetimeFormatter;
 
 /**
  * <p>Abstract DestinationPathManager class.</p>
  *
  * @author David Hustace <david@opennms.org>
- * @version $Id: $
  */
 public abstract class DestinationPathManager {
 
-    /**
-     * 
-     */
     private DestinationPaths allPaths;
 
-    /**
-     * 
-     */
     private Map<String, Path> m_destinationPaths;
 
-    /**
-     * 
-     */
     private Header oldHeader;
+
+    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
 
     /**
      * <p>parseXML</p>
@@ -280,7 +273,7 @@ public abstract class DestinationPathManager {
     private Header rebuildHeader() {
         Header header = oldHeader;
     
-        header.setCreated(EventConstants.formatToString(new Date()));
+        header.setCreated(formatter.format(new Date()));
     
         return header;
     }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/GroupManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/GroupManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -113,7 +113,7 @@ public abstract class GroupManager implements GroupConfig {
         }
     }
 
-    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+    private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupManager.class);
 
@@ -259,7 +259,7 @@ public abstract class GroupManager implements GroupConfig {
     public synchronized void saveGroups() throws Exception {
         Header header = m_oldHeader;
 
-        if (header != null) header.setCreated(formatter.format(new Date()));
+        if (header != null) header.setCreated(FORMATTER.format(new Date()));
     
         final List<Group> groups = new ArrayList<>();
         for (final Group grp : m_groups.values()) {

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/GroupManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/GroupManager.java
@@ -58,6 +58,7 @@ import org.opennms.netmgt.config.groups.Role;
 import org.opennms.netmgt.config.groups.Schedule;
 import org.opennms.netmgt.config.users.DutySchedule;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventDatetimeFormatter;
 import org.opennms.netmgt.model.OnmsGroup;
 import org.opennms.netmgt.model.OnmsGroupList;
 import org.slf4j.Logger;
@@ -111,6 +112,8 @@ public abstract class GroupManager implements GroupConfig {
             return list;
         }
     }
+
+    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupManager.class);
 
@@ -256,7 +259,7 @@ public abstract class GroupManager implements GroupConfig {
     public synchronized void saveGroups() throws Exception {
         Header header = m_oldHeader;
 
-        if (header != null) header.setCreated(EventConstants.formatToString(new Date()));
+        if (header != null) header.setCreated(formatter.format(new Date()));
     
         final List<Group> groups = new ArrayList<>();
         for (final Group grp : m_groups.values()) {

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationManager.java
@@ -84,7 +84,7 @@ import org.springframework.util.Assert;
 public abstract class NotificationManager {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationManager.class);
 
-    private EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+    private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
     /**
      * Object containing all Notification objects parsed from the xml file
@@ -1147,7 +1147,7 @@ public abstract class NotificationManager {
     private Header rebuildHeader() {
         Header header = oldHeader;
 
-        header.setCreated(formatter.format(new Date()));
+        header.setCreated(FORMATTER.format(new Date()));
 
         return header;
     }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -63,6 +63,7 @@ import org.opennms.netmgt.config.notifications.Notification;
 import org.opennms.netmgt.config.notifications.Notifications;
 import org.opennms.netmgt.config.notifications.Parameter;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventDatetimeFormatter;
 import org.opennms.netmgt.filter.FilterDaoFactory;
 import org.opennms.netmgt.filter.api.FilterParseException;
 import org.opennms.netmgt.xml.event.Event;
@@ -82,6 +83,8 @@ import org.springframework.util.Assert;
  */
 public abstract class NotificationManager {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationManager.class);
+
+    private EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
 
     /**
      * Object containing all Notification objects parsed from the xml file
@@ -1144,7 +1147,7 @@ public abstract class NotificationManager {
     private Header rebuildHeader() {
         Header header = oldHeader;
 
-        header.setCreated(EventConstants.formatToString(new Date()));
+        header.setCreated(formatter.format(new Date()));
 
         return header;
     }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/UserManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/UserManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -63,6 +63,7 @@ import org.opennms.netmgt.config.users.Password;
 import org.opennms.netmgt.config.users.User;
 import org.opennms.netmgt.config.users.Userinfo;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventDatetimeFormatter;
 import org.opennms.netmgt.model.OnmsUser;
 import org.opennms.netmgt.model.OnmsUserList;
 
@@ -85,6 +86,8 @@ public abstract class UserManager implements UserConfig {
     private final ReadWriteLock m_readWriteLock = new ReentrantReadWriteLock();
     private final Lock m_readLock = m_readWriteLock.readLock();
     private final Lock m_writeLock = m_readWriteLock.writeLock();
+
+    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
 
     protected GroupManager m_groupManager;
     /**
@@ -952,7 +955,7 @@ public abstract class UserManager implements UserConfig {
 
         final Header header = oldHeader;
         if (header != null) {
-            header.setCreated(EventConstants.formatToString(new Date()));
+            header.setCreated(formatter.format(new Date()));
             userinfo.setHeader(header);
         }
         oldHeader = header;

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/UserManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/UserManager.java
@@ -87,7 +87,7 @@ public abstract class UserManager implements UserConfig {
     private final Lock m_readLock = m_readWriteLock.readLock();
     private final Lock m_writeLock = m_readWriteLock.writeLock();
 
-    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+    private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
     protected GroupManager m_groupManager;
     /**
@@ -955,7 +955,7 @@ public abstract class UserManager implements UserConfig {
 
         final Header header = oldHeader;
         if (header != null) {
-            header.setCreated(formatter.format(new Date()));
+            header.setCreated(FORMATTER.format(new Date()));
             userinfo.setHeader(header);
         }
         oldHeader = header;

--- a/opennms-model/src/test/java/org/opennms/netmgt/model/events/EventConstantsTest.java
+++ b/opennms-model/src/test/java/org/opennms/netmgt/model/events/EventConstantsTest.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.model.events;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -42,16 +43,29 @@ import java.util.concurrent.Callable;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.LegacyDatetimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * NOTE: if you run this test in Eclipse, it doesn't properly inherit the
+ * <code>java.locale.providers=CLDR,COMPAT</code> property from the
+ * top-level <code>pom.xml</code> file. You will need to set it manually
+ * by specifying <code>java.locale.providers=CLDR,COMPAT</code> in your JUnit
+ * run configuration.
+ */
 @RunWith(Parameterized.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class EventConstantsTest {
+    private static final Logger LOG = LoggerFactory.getLogger(EventConstantsTest.class);
 
     // Test Parameters
     private final Locale m_testLocale;
@@ -72,15 +86,67 @@ public class EventConstantsTest {
             return Arrays.asList(new Object[][] {
                             {
                                 new Locale("en", "US"),
+                                TimeZone.getTimeZone("UTC"),
+                                "2011-03-10T22:40:37Z",
+                                "2011-03-10T22:40:37Z",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 10:40:37 PM UTC",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 22:40:37 o'clock UTC",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 10:40:37 PM UTC",
+                                Long.valueOf(1299796837 * 1000L)
+                            },
+                            {
+                                new Locale("en", "US"),
                                 TimeZone.getTimeZone("CET"),
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
                                 "Thursday, March 10, 2011 10:40:37 PM GMT",
-                                "Thursday, March 10, 2011 11:40:37 PM CET",
+                                "Thursday, March 10, 2011 05:40:37 PM EST",
                                 "Thursday, 10 March 2011 22:40:37 o'clock GMT",
-                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "Thursday, 10 March 2011 17:40:37 o'clock EST",
                                 "Thursday, March 10, 2011 10:40:37 PM GMT",
-                                "Thursday, March 10, 2011 11:40:37 PM CET",
+                                "Thursday, March 10, 2011 05:40:37 PM EST",
+                                Long.valueOf(1299796837 * 1000L)
+                            },
+                            {
+                                new Locale("en", "US"),
+                                TimeZone.getTimeZone("CST"),
+                                "2011-03-10T16:40:37-06:00",
+                                "2011-03-10T16:40:37-06:00",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 04:40:37 PM CST",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 16:40:37 o'clock CST",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 04:40:37 PM CST",
+                                Long.valueOf(1299796837 * 1000L)
+                            },
+                            {
+                                new Locale("en", "US"),
+                                TimeZone.getTimeZone("MST"),
+                                "2011-03-10T15:40:37-07:00",
+                                "2011-03-10T15:40:37-07:00",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 03:40:37 PM MST",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 15:40:37 o'clock MST",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 03:40:37 PM MST",
+                                Long.valueOf(1299796837 * 1000L)
+                            },
+                            {
+                                new Locale("en", "US"),
+                                TimeZone.getTimeZone("PST"),
+                                "2011-03-10T14:40:37-08:00",
+                                "2011-03-10T14:40:37-08:00",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 02:40:37 PM PST",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 14:40:37 o'clock PST",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 02:40:37 PM PST",
                                 Long.valueOf(1299796837 * 1000L)
                             },
                             {
@@ -88,12 +154,12 @@ public class EventConstantsTest {
                                 TimeZone.getTimeZone("CET"),
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
-                                "giovedì 10 marzo 2011 22.40.37 GMT",
-                                "giovedì 10 marzo 2011 23.40.37 CET",
+                                "giovedì 10 marzo 2011 22:40:37 GMT",
+                                "giovedì 10 marzo 2011 17:40:37 EST",
                                 "Thursday, 10 March 2011 22:40:37 o'clock GMT",
-                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
-                                "giovedì 10 marzo 2011 22.40.37 GMT",
-                                "giovedì 10 marzo 2011 23.40.37 CET",
+                                "Thursday, 10 March 2011 17:40:37 o'clock EST",
+                                "giovedì 10 marzo 2011 22:40:37 GMT",
+                                "giovedì 10 marzo 2011 17:40:37 EST",
                                 Long.valueOf(1299796837 * 1000L)
                             },
                             {
@@ -102,11 +168,11 @@ public class EventConstantsTest {
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
                                 "jeudi 10 mars 2011 22:40:37 GMT",
-                                "jeudi 10 mars 2011 23:40:37 CET",
+                                "jeudi 10 mars 2011 17:40:37 EST",
                                 "Thursday, 10 March 2011 22:40:37 o'clock GMT",
-                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "Thursday, 10 March 2011 17:40:37 o'clock EST",
                                 "jeudi 10 mars 2011 22:40:37 GMT",
-                                "jeudi 10 mars 2011 23:40:37 CET",
+                                "jeudi 10 mars 2011 17:40:37 EST",
                                 Long.valueOf(1299796837 * 1000L)
                             },
                             {
@@ -115,11 +181,11 @@ public class EventConstantsTest {
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
                                 "jeudi 10 mars 2011 22:40:37 GMT",
-                                "jeudi 10 mars 2011 23:40:37 CET",
+                                "jeudi 10 mars 2011 17:40:37 EST",
                                 "Thursday, 10 March 2011 22:40:37 o'clock GMT",
-                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "Thursday, 10 March 2011 17:40:37 o'clock EST",
                                 "jeudi 10 mars 2011 22:40:37 GMT",
-                                "jeudi 10 mars 2011 23:40:37 CET",
+                                "jeudi 10 mars 2011 17:40:37 EST",
                                 Long.valueOf(1299796837 * 1000L)
                             },
                             {
@@ -128,11 +194,11 @@ public class EventConstantsTest {
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
                                 "Donnerstag, 10. März 2011 22:40:37 GMT",
-                                "Donnerstag, 10. März 2011 23:40:37 MEZ",
+                                "Donnerstag, 10. März 2011 17:40:37 EST",
                                 "Thursday, 10 March 2011 22:40:37 o'clock GMT",
-                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "Thursday, 10 March 2011 17:40:37 o'clock EST",
                                 "Donnerstag, 10. März 2011 22:40:37 GMT",
-                                "Donnerstag, 10. März 2011 23:40:37 MEZ",
+                                "Donnerstag, 10. März 2011 17:40:37 EST",
                                 Long.valueOf(1299796837 * 1000L)
                             }
             });
@@ -202,75 +268,138 @@ public class EventConstantsTest {
     }
 
     @Test
-    public void testEventDateParse() throws Exception {
-        // default (implicit legacyFormatter=false)
-        Date date = EventConstants.getEventDatetimeFormatter().parse(m_gmtText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    public void testEventGmtDateParse() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
+        parseText(m_gmtText);
+    }
 
-        date = EventConstants.getEventDatetimeFormatter().parse(m_zoneText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    @Test
+    public void testEventZoneDateParse() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
+        parseText(m_zoneText);
+    }
 
-        // disable legacy formatter
+    @Test
+    public void testEventLegacyGmtDateParse() throws Exception {
         System.setProperty("org.opennms.events.legacyFormatter", "false");
         assertThrows(() -> {
             return EventConstants.getEventDatetimeFormatter().parse(m_legacyGmtText);
         });
+    }
+
+    @Test
+    public void testEventLegacyZoneDateParse() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
         assertThrows(() -> {
             return EventConstants.getEventDatetimeFormatter().parse(m_legacyZoneText);
         });
+    }
+
+    @Test
+    public void testEventLegacyOldXmlGmtDateParse() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
         assertThrows(() -> {
             return EventConstants.getEventDatetimeFormatter().parse(m_legacyOldXmlGmtText);
         });
+    }
+
+    @Test
+    public void testEventLegacyOldXmlZoneDateParse() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
         assertThrows(() -> {
             return EventConstants.getEventDatetimeFormatter().parse(m_legacyOldXmlZoneText);
         });
+    }
+
+    @Test
+    public void testEventLegacyFullGmtDateParse() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
         assertThrows(() -> {
             return EventConstants.getEventDatetimeFormatter().parse(m_legacyFullGmtText);
         });
+    }
+
+    @Test
+    public void testEventLegacyFullZoneDateParse() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
         assertThrows(() -> {
             return EventConstants.getEventDatetimeFormatter().parse(m_legacyFullZoneText);
         });
+    }
 
-        // enable legacy formatter
+    @Test
+    public void testEventGmtDateParseLegacyFormatter() throws Exception {
         System.setProperty("org.opennms.events.legacyFormatter", "true");
+        parseText(m_gmtText);
+    }
 
-        date = EventConstants.getEventDatetimeFormatter().parse(m_gmtText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    @Test
+    public void testEventZoneDateParseLegacyFormatter() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+        parseText(m_zoneText);
+    }
 
-        date = EventConstants.getEventDatetimeFormatter().parse(m_zoneText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    @Test
+    public void testEventLegacyGmtDateParseLegacyFormatter() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+        parseText(m_legacyGmtText);
+    }
 
-        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyGmtText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    @Test
+    public void testEventLegacyZoneDateParseLegacyFormatter() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+        parseText(m_legacyZoneText);
+    }
 
-        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyZoneText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    @Test
+    public void testEventLegacyOldXmlGmtDateParseLegacyFormatter() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+        parseText(m_legacyOldXmlGmtText);
+    }
 
-        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyOldXmlGmtText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    @Test
+    public void testEventLegacyOldXmlZoneDateParseLegacyFormatter() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+        parseText(m_legacyOldXmlZoneText);
+    }
 
-        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyOldXmlZoneText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    @Test
+    public void testEventLegacyFullGmtDateParseLegacyFormatter() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+        parseText(m_legacyFullGmtText);
+    }
 
-        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyFullGmtText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
-
-        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyFullZoneText);
-        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+    @Test
+    public void testEventLegacyFullZoneDateParseLegacyFormatter() throws Exception {
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+        parseText(m_legacyFullZoneText);
     }
 
     @Test
     public void testFormatToString() throws Exception {
-        String formatted = EventConstants.getEventDatetimeFormatter().format(new Date(m_timestamp));
-        assertEquals(m_testLocale + ": formatted string should equal " + m_gmtText, m_gmtText, formatted);
-
         System.setProperty("org.opennms.events.legacyFormatter", "false");
-        formatted = EventConstants.getEventDatetimeFormatter().format(new Date(m_timestamp));
+        String formatted = EventConstants.getEventDatetimeFormatter().format(new Date(m_timestamp));
+        LOG.debug("formatted date as " + m_testLocale.getDisplayLanguage() + ", " + m_testTimeZone.getID() + ": " + formatted);
         assertEquals(m_testLocale + ": formatted string should equal " + m_gmtText, m_gmtText, formatted);
+    }
 
+    @Test
+    public void testFormatToStringLegacyFormatter() throws Exception {
         System.setProperty("org.opennms.events.legacyFormatter", "true");
-        formatted = EventConstants.getEventDatetimeFormatter().format(new Date(m_timestamp));
-        assertEquals(m_testLocale + ": formatted string should equal " + m_legacyGmtText, m_legacyGmtText, formatted);
+        String formatted = EventConstants.getEventDatetimeFormatter().format(new Date(m_timestamp));
+        LOG.debug("formatted date as " + m_testLocale.getDisplayLanguage() + ", " + m_testTimeZone.getID() + ": " + formatted + " (legacy)");
+        assertEquals(m_testLocale + ": formatted string should equal " + m_gmtText, m_gmtText, formatted);
+    }
+
+    private void parseText(final String text) throws ParseException {
+        LOG.debug("parsing text as " + m_testLocale.getDisplayLanguage() + ", " + m_testTimeZone.getID() + ": " + text);
+        try {
+            Date date = EventConstants.getEventDatetimeFormatter().parse(text);
+            assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+        } catch (final ParseException e) {
+            e.printStackTrace();
+            throw e;
+        }
     }
 
     private void assertThrows(Callable<?> c) {

--- a/opennms-model/src/test/java/org/opennms/netmgt/model/events/EventConstantsTest.java
+++ b/opennms-model/src/test/java/org/opennms/netmgt/model/events/EventConstantsTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.model.events;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Calendar;
@@ -37,6 +38,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.concurrent.Callable;
 
 import org.junit.After;
 import org.junit.Before;
@@ -46,6 +48,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.LegacyDatetimeFormatter;
 
 @RunWith(Parameterized.class)
 public class EventConstantsTest {
@@ -55,6 +58,12 @@ public class EventConstantsTest {
     private final TimeZone m_testTimeZone;
     private final String m_gmtText;
     private final String m_zoneText;
+    private final String m_legacyGmtText;
+    private final String m_legacyZoneText;
+    private final String m_legacyOldXmlGmtText;
+    private final String m_legacyOldXmlZoneText;
+    private final String m_legacyFullGmtText;
+    private final String m_legacyFullZoneText;
     private final Long m_timestamp;
     private final Calendar m_timestampCalendar;
 
@@ -66,6 +75,12 @@ public class EventConstantsTest {
                                 TimeZone.getTimeZone("CET"),
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 11:40:37 PM CET",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "Thursday, March 10, 2011 10:40:37 PM GMT",
+                                "Thursday, March 10, 2011 11:40:37 PM CET",
                                 Long.valueOf(1299796837 * 1000L)
                             },
                             {
@@ -73,6 +88,12 @@ public class EventConstantsTest {
                                 TimeZone.getTimeZone("CET"),
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
+                                "giovedì 10 marzo 2011 22.40.37 GMT",
+                                "giovedì 10 marzo 2011 23.40.37 CET",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "giovedì 10 marzo 2011 22.40.37 GMT",
+                                "giovedì 10 marzo 2011 23.40.37 CET",
                                 Long.valueOf(1299796837 * 1000L)
                             },
                             {
@@ -80,6 +101,12 @@ public class EventConstantsTest {
                                 TimeZone.getTimeZone("CET"),
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
+                                "jeudi 10 mars 2011 22:40:37 GMT",
+                                "jeudi 10 mars 2011 23:40:37 CET",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "jeudi 10 mars 2011 22:40:37 GMT",
+                                "jeudi 10 mars 2011 23:40:37 CET",
                                 Long.valueOf(1299796837 * 1000L)
                             },
                             {
@@ -87,6 +114,12 @@ public class EventConstantsTest {
                                 TimeZone.getTimeZone("CET"),
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
+                                "jeudi 10 mars 2011 22:40:37 GMT",
+                                "jeudi 10 mars 2011 23:40:37 CET",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "jeudi 10 mars 2011 22:40:37 GMT",
+                                "jeudi 10 mars 2011 23:40:37 CET",
                                 Long.valueOf(1299796837 * 1000L)
                             },
                             {
@@ -94,16 +127,40 @@ public class EventConstantsTest {
                                 TimeZone.getTimeZone("CET"),
                                 "2011-03-10T23:40:37+01:00",
                                 "2011-03-10T23:40:37+01:00",
+                                "Donnerstag, 10. März 2011 22:40:37 GMT",
+                                "Donnerstag, 10. März 2011 23:40:37 MEZ",
+                                "Thursday, 10 March 2011 22:40:37 o'clock GMT",
+                                "Thursday, 10 March 2011 23:40:37 o'clock CET",
+                                "Donnerstag, 10. März 2011 22:40:37 GMT",
+                                "Donnerstag, 10. März 2011 23:40:37 MEZ",
                                 Long.valueOf(1299796837 * 1000L)
                             }
             });
     }
 
-    public EventConstantsTest(final Locale locale, final TimeZone timeZone, final String gmtText, final String zoneText, final Long timestamp) {
+    public EventConstantsTest(
+        final Locale locale,
+        final TimeZone timeZone,
+        final String gmtText,
+        final String zoneText,
+        final String legacyGmtText,
+        final String legacyZoneText,
+        final String legacyOldXmlGmtText,
+        final String legacyOldXmlZoneText,
+        final String legacyFullGmtText,
+        final String legacyFullZoneText,
+        final Long timestamp
+    ) {
         m_testLocale = locale;
         m_testTimeZone = timeZone;
         m_gmtText = gmtText;
         m_zoneText = zoneText;
+        m_legacyGmtText = legacyGmtText;
+        m_legacyZoneText = legacyZoneText;
+        m_legacyOldXmlGmtText = legacyOldXmlGmtText;
+        m_legacyOldXmlZoneText = legacyOldXmlZoneText;
+        m_legacyFullGmtText = legacyFullGmtText;
+        m_legacyFullZoneText = legacyFullZoneText;
         m_timestamp = timestamp;
         m_timestampCalendar = new GregorianCalendar();
         m_timestampCalendar.setTime(new Date(m_timestamp));
@@ -119,31 +176,110 @@ public class EventConstantsTest {
 
         m_defaultLocale = Locale.getDefault();
         m_defaultTimeZone = TimeZone.getDefault();
+
         Locale.setDefault(m_testLocale);
         TimeZone.setDefault(m_testTimeZone);
+        System.clearProperty("org.opennms.events.legacyFormatter");
+
+        LegacyDatetimeFormatter.FORMATTER_FULL.remove();
+        LegacyDatetimeFormatter.FORMATTER_LONG.remove();
+        LegacyDatetimeFormatter.FORMATTER_LONG_GMT.remove();
+        LegacyDatetimeFormatter.FORMATTER_CUSTOM.remove();
+        LegacyDatetimeFormatter.FORMATTER_DEFAULT.remove();
     }
 
     @After
     public void tearDown() {
         Locale.setDefault(m_defaultLocale);
         TimeZone.setDefault(m_defaultTimeZone);
+        System.clearProperty("org.opennms.events.legacyFormatter");
     }
 
     @Test
     public void testNms12261() throws Exception {
-        final Date date = EventConstants.parseToDate("2019-08-27T07:13:53+00:00");
+        final Date date = EventConstants.getEventDatetimeFormatter().parse("2019-08-27T07:13:53+00:00");
         assertEquals(1566890033000l, date.getTime());
     }
 
     @Test
     public void testEventDateParse() throws Exception {
-        final Date date = EventConstants.parseToDate(m_zoneText);
+        // default (implicit legacyFormatter=false)
+        Date date = EventConstants.getEventDatetimeFormatter().parse(m_gmtText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_zoneText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        // disable legacy formatter
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
+        assertThrows(() -> {
+            return EventConstants.getEventDatetimeFormatter().parse(m_legacyGmtText);
+        });
+        assertThrows(() -> {
+            return EventConstants.getEventDatetimeFormatter().parse(m_legacyZoneText);
+        });
+        assertThrows(() -> {
+            return EventConstants.getEventDatetimeFormatter().parse(m_legacyOldXmlGmtText);
+        });
+        assertThrows(() -> {
+            return EventConstants.getEventDatetimeFormatter().parse(m_legacyOldXmlZoneText);
+        });
+        assertThrows(() -> {
+            return EventConstants.getEventDatetimeFormatter().parse(m_legacyFullGmtText);
+        });
+        assertThrows(() -> {
+            return EventConstants.getEventDatetimeFormatter().parse(m_legacyFullZoneText);
+        });
+
+        // enable legacy formatter
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_gmtText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_zoneText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyGmtText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyZoneText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyOldXmlGmtText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyOldXmlZoneText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyFullGmtText);
+        assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
+
+        date = EventConstants.getEventDatetimeFormatter().parse(m_legacyFullZoneText);
         assertEquals(m_testLocale + ": time should equal " + m_timestamp, m_timestamp.longValue(), date.getTime());
     }
 
     @Test
     public void testFormatToString() throws Exception {
-        final String formatted = EventConstants.formatToString(new Date(m_timestamp));
+        String formatted = EventConstants.getEventDatetimeFormatter().format(new Date(m_timestamp));
         assertEquals(m_testLocale + ": formatted string should equal " + m_gmtText, m_gmtText, formatted);
+
+        System.setProperty("org.opennms.events.legacyFormatter", "false");
+        formatted = EventConstants.getEventDatetimeFormatter().format(new Date(m_timestamp));
+        assertEquals(m_testLocale + ": formatted string should equal " + m_gmtText, m_gmtText, formatted);
+
+        System.setProperty("org.opennms.events.legacyFormatter", "true");
+        formatted = EventConstants.getEventDatetimeFormatter().format(new Date(m_timestamp));
+        assertEquals(m_testLocale + ": formatted string should equal " + m_legacyGmtText, m_legacyGmtText, formatted);
+    }
+
+    private void assertThrows(Callable<?> c) {
+        Exception caught = null;
+        try {
+            c.call();
+        } catch (final Exception e) {
+            caught = e;
+        }
+        assertNotNull(caught);
     }
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/rtc/AvailabilityServiceHibernateImpl.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/rtc/AvailabilityServiceHibernateImpl.java
@@ -79,7 +79,7 @@ public class AvailabilityServiceHibernateImpl implements AvailabilityService {
 	@Autowired
 	private OutageDao m_outageDao;
 
-    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+    private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
     /**
      * Builds a map of configured categories, keyed by label.
@@ -121,7 +121,7 @@ public class AvailabilityServiceHibernateImpl implements AvailabilityService {
         final EuiLevel level = new EuiLevel();
 
         // set created in m_header and add to level
-        header.setCreated(formatter.format(curDate));
+        header.setCreated(FORMATTER.format(curDate));
         level.setHeader(header);
 
         final Category levelCat = new Category();

--- a/opennms-services/src/main/java/org/opennms/netmgt/rtc/AvailabilityServiceHibernateImpl.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/rtc/AvailabilityServiceHibernateImpl.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -41,6 +41,7 @@ import org.opennms.core.criteria.restrictions.NullRestriction;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventDatetimeFormatter;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsOutage;
@@ -77,6 +78,8 @@ public class AvailabilityServiceHibernateImpl implements AvailabilityService {
 
 	@Autowired
 	private OutageDao m_outageDao;
+
+    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
 
     /**
      * Builds a map of configured categories, keyed by label.
@@ -118,7 +121,7 @@ public class AvailabilityServiceHibernateImpl implements AvailabilityService {
         final EuiLevel level = new EuiLevel();
 
         // set created in m_header and add to level
-        header.setCreated(EventConstants.formatToString(curDate));
+        header.setCreated(formatter.format(curDate));
         level.setHeader(header);
 
         final Category levelCat = new Category();

--- a/opennms-services/src/main/java/org/opennms/netmgt/rtc/utils/LegacyEuiLevelMapper.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/rtc/utils/LegacyEuiLevelMapper.java
@@ -59,7 +59,7 @@ public class LegacyEuiLevelMapper {
     private final Header m_header;
     private final DataManager m_dataMgr;
 
-    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+    private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
     /**
      * Constructor
@@ -92,7 +92,7 @@ public class LegacyEuiLevelMapper {
         EuiLevel level = new EuiLevel();
 
         // set created in m_header and add to level
-        m_header.setCreated(formatter.format(curDate));
+        m_header.setCreated(FORMATTER.format(curDate));
         level.setHeader(m_header);
 
         org.opennms.netmgt.xml.rtc.Category levelCat = new org.opennms.netmgt.xml.rtc.Category();

--- a/opennms-services/src/main/java/org/opennms/netmgt/rtc/utils/LegacyEuiLevelMapper.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/rtc/utils/LegacyEuiLevelMapper.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,6 +31,7 @@ package org.opennms.netmgt.rtc.utils;
 import java.util.Date;
 
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventDatetimeFormatter;
 import org.opennms.netmgt.rtc.DataManager;
 import org.opennms.netmgt.rtc.datablock.RTCCategory;
 import org.opennms.netmgt.xml.rtc.EuiLevel;
@@ -57,6 +58,8 @@ public class LegacyEuiLevelMapper {
      */
     private final Header m_header;
     private final DataManager m_dataMgr;
+
+    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
 
     /**
      * Constructor
@@ -89,7 +92,7 @@ public class LegacyEuiLevelMapper {
         EuiLevel level = new EuiLevel();
 
         // set created in m_header and add to level
-        m_header.setCreated(EventConstants.formatToString(curDate));
+        m_header.setCreated(formatter.format(curDate));
         level.setHeader(m_header);
 
         org.opennms.netmgt.xml.rtc.Category levelCat = new org.opennms.netmgt.xml.rtc.Category();

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/SnmpTrapForwarderHelper.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/SnmpTrapForwarderHelper.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,6 +32,7 @@ import java.net.UnknownHostException;
 
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventDatetimeFormatter;
 import org.opennms.netmgt.snmp.SnmpTrapBuilder;
 import org.opennms.netmgt.snmp.SnmpV2TrapBuilder;
 import org.opennms.netmgt.snmp.SnmpV3TrapBuilder;
@@ -40,9 +41,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class SnmpTrapForwarderHelper extends AbstractEventForwarder implements EventForwarder {
-    private static final Logger LOG = LoggerFactory.getLogger(SnmpTrapForwarderHelper.class);
+	private static final Logger LOG = LoggerFactory.getLogger(SnmpTrapForwarderHelper.class);
 
-        String source_ip;
+	private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+
+	String source_ip;
 	
 	String ip;
 	String community;
@@ -390,7 +393,7 @@ public abstract class SnmpTrapForwarderHelper extends AbstractEventForwarder imp
              else
                      snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.2.0", "OctetString", "text", "null");
              if (event.getCreationTime() != null)
-                     snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.3.0", "OctetString", "text", EventConstants.formatToString(event.getCreationTime()));
+                     snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.3.0", "OctetString", "text", formatter.format(event.getCreationTime()));
              else
                      snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.3.0", "OctetString", "text", "null");
              if (event.getMasterStation() != null)
@@ -412,7 +415,7 @@ public abstract class SnmpTrapForwarderHelper extends AbstractEventForwarder imp
              } else
                      snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.8.0", "OctetString", "text", "null");
              if (event.getTime() != null)
-                     snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.9.0", "OctetString", "text", EventConstants.formatToString(event.getTime()));
+                     snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.9.0", "OctetString", "text", formatter.format(event.getTime()));
              else
                      snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.9.0", "OctetString", "text", "null");
              if (event.getHost() != null)

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/SnmpTrapForwarderHelper.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/SnmpTrapForwarderHelper.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public abstract class SnmpTrapForwarderHelper extends AbstractEventForwarder implements EventForwarder {
 	private static final Logger LOG = LoggerFactory.getLogger(SnmpTrapForwarderHelper.class);
 
-	private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+	private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
 	String source_ip;
 	
@@ -393,7 +393,7 @@ public abstract class SnmpTrapForwarderHelper extends AbstractEventForwarder imp
              else
                      snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.2.0", "OctetString", "text", "null");
              if (event.getCreationTime() != null)
-                     snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.3.0", "OctetString", "text", formatter.format(event.getCreationTime()));
+                     snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.3.0", "OctetString", "text", FORMATTER.format(event.getCreationTime()));
              else
                      snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.3.0", "OctetString", "text", "null");
              if (event.getMasterStation() != null)
@@ -415,7 +415,7 @@ public abstract class SnmpTrapForwarderHelper extends AbstractEventForwarder imp
              } else
                      snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.8.0", "OctetString", "text", "null");
              if (event.getTime() != null)
-                     snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.9.0", "OctetString", "text", formatter.format(event.getTime()));
+                     snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.9.0", "OctetString", "text", FORMATTER.format(event.getTime()));
              else
                      snmpTrapHelper.addVarBinding(trap, ".1.3.6.1.4.1.5813.20.1.9.0", "OctetString", "text", "null");
              if (event.getHost() != null)

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/SnmpTrapHelper.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/SnmpTrapHelper.java
@@ -104,7 +104,7 @@ public class SnmpTrapHelper {
      */
     private Map<String, Object> m_factoryMap;
 
-    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+    private static final EventDatetimeFormatter FORMATTER = EventConstants.getEventDatetimeFormatter();
 
 	/**
      * Constructs a new SNMPTrapHelper.
@@ -1130,7 +1130,7 @@ public class SnmpTrapHelper {
         addVarBinding(trapBuilder, ".1.3.6.1.4.1.5813.20.1.8.0", // OPENNMS-MIB::openNMS-event-nodeid 
                       EventConstants.TYPE_SNMP_OCTET_STRING, Long.toString(event.getNodeid()));
         addVarBinding(trapBuilder, ".1.3.6.1.4.1.5813.20.1.9.0", // OPENNMS-MIB::openNMS-event-time
-                      EventConstants.TYPE_SNMP_OCTET_STRING, formatter.format(event.getTime()));
+                      EventConstants.TYPE_SNMP_OCTET_STRING, FORMATTER.format(event.getTime()));
         addVarBinding(trapBuilder, ".1.3.6.1.4.1.5813.20.1.10.0", // OPENNMS-MIB::openNMS-event-host
                       EventConstants.TYPE_SNMP_OCTET_STRING, event.getHost());
         addVarBinding(trapBuilder, ".1.3.6.1.4.1.5813.20.1.11.0", // OPENNMS-MIB::openNMS-event-interface

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/SnmpTrapHelper.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/SnmpTrapHelper.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2003-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2003-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,6 +37,7 @@ import java.util.Map;
 import org.opennms.core.utils.Base64;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventDatetimeFormatter;
 import org.opennms.netmgt.eventd.AbstractEventUtil;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpTrapBuilder;
@@ -103,7 +104,9 @@ public class SnmpTrapHelper {
      */
     private Map<String, Object> m_factoryMap;
 
-    /**
+    private final EventDatetimeFormatter formatter = EventConstants.getEventDatetimeFormatter();
+
+	/**
      * Constructs a new SNMPTrapHelper.
      */
     public SnmpTrapHelper() {
@@ -1127,7 +1130,7 @@ public class SnmpTrapHelper {
         addVarBinding(trapBuilder, ".1.3.6.1.4.1.5813.20.1.8.0", // OPENNMS-MIB::openNMS-event-nodeid 
                       EventConstants.TYPE_SNMP_OCTET_STRING, Long.toString(event.getNodeid()));
         addVarBinding(trapBuilder, ".1.3.6.1.4.1.5813.20.1.9.0", // OPENNMS-MIB::openNMS-event-time
-                      EventConstants.TYPE_SNMP_OCTET_STRING, EventConstants.formatToString(event.getTime()));
+                      EventConstants.TYPE_SNMP_OCTET_STRING, formatter.format(event.getTime()));
         addVarBinding(trapBuilder, ".1.3.6.1.4.1.5813.20.1.10.0", // OPENNMS-MIB::openNMS-event-host
                       EventConstants.TYPE_SNMP_OCTET_STRING, event.getHost());
         addVarBinding(trapBuilder, ".1.3.6.1.4.1.5813.20.1.11.0", // OPENNMS-MIB::openNMS-event-interface


### PR DESCRIPTION
Guess who should have written more unit tests the first time? \<grin>
Turns out `Boolean.parseBoolean()` != `Boolean.getBoolean()` 😅

Anyway, in the process of adding test coverage, I discovered my error in the original NMS-15471 patch.
I considered just fixing the bug, but the code is cleaner and more testable this way.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15471