### PR TITLE
NMS-15686: use the activemq feature that doesn't pull in the war

### DIFF
--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -293,7 +293,7 @@
                 <feature>spring-websocket/${springVersion}</feature>
 
                 <!-- All of the OpenNMS features -->
-                <feature>activemq-broker</feature>
+                <feature>activemq-broker-noweb</feature>
                 <feature>aries-blueprint</feature>
                 <feature>aries-proxy</feature>
                 <feature>blueprint-web</feature>


### PR DESCRIPTION
This PR switches the activemq broker feature we use to the version that doesn't pull in the war, since we don't use/need it.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15686

