### PR TITLE
NMS-14884: Handle JMX `PASSWORD-CLEAR` as `PASSWORD_CLEAR`

### DIFF
--- a/core/jmx/api/src/main/java/org/opennms/netmgt/jmx/connection/JmxConnectionConfig.java
+++ b/core/jmx/api/src/main/java/org/opennms/netmgt/jmx/connection/JmxConnectionConfig.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/core/jmx/api/src/main/java/org/opennms/netmgt/jmx/connection/JmxConnectionConfig.java
+++ b/core/jmx/api/src/main/java/org/opennms/netmgt/jmx/connection/JmxConnectionConfig.java
@@ -106,6 +106,9 @@ public class JmxConnectionConfig {
         if ("PASSWORD_CLEAR".equals(getFactory())) {
             return PasswordStrategy.PASSWORD_CLEAR;
         }
+        if ("PASSWORD-CLEAR".equals(getFactory())) {
+            return PasswordStrategy.PASSWORD_CLEAR;
+        }
         if ("SASL".equals(getFactory())) {
             return PasswordStrategy.SASL;
         }


### PR DESCRIPTION
Documentation and default configs reference `PASSWORD-CLEAR` for JMX credentials though the code is looking for `PASSWORD_CLEAR`.  This PR updates the JmxConnectionConfig to accept either version of the setting, so users with existing configs don't need to update, so this shouldn't be a breaking change for existing Meridians.

Will follow up with a separate PR to change the docs and defaults to be consistent.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-14884

