### PR TITLE
NMS-15708: various corrections/clarifications in Sentinel docs

### DIFF
--- a/docs/modules/deployment/pages/sentinel/introduction.adoc
+++ b/docs/modules/deployment/pages/sentinel/introduction.adoc
@@ -1,17 +1,11 @@
 = Sentinel
 
-Sentinel provides scalability for data processing, including flows and streaming telemetry.
+Sentinel provides scalability for data processing of flows and streaming telemetry received by one or more Minions.
 It also supports thresholding for streaming telemetry if you are using OpenNMS xref:deployment:time-series-storage/newts/introduction.adoc#ga-opennms-operation-newts[Newts].
-If you are using Minions or looking for scalable flow processing, you need Sentinel.
+If you need to scale processing capacity for flow and/or streaming telemetry, you need Sentinel.
 
-Sentinel is a Karaf container that handles data processing for OpenNMS and Minion, spawning new containers as necessary to deal with increased data volume.
+As your flow and streaming telemetry volumes increase, additional Sentinel instances can be deployed to meet your processing needs.
 
-This section describes how to install the Sentinel to scale individual components.
+In most cases, you can disable adapters and listeners in {page-component-title} that are also run by a Sentinel instance.
 
-Keep the following in mind when using Sentinel:
-
-* Use only for distribution of Telemetryd functionality (such as processing flows, or use the existing telemetry adapters to store measurements data to OpenNMS Newts).
-* Requires a Minion to work as a (message) producer.
-* In most cases, you should disable adapters and listeners in {page-component-title} that are also run by a Sentinel instance.
-
-NOTE: At the moment Sentinel can distribute only flows.
+This section describes how to install Sentinel components.

--- a/docs/modules/deployment/pages/sentinel/runtime/install.adoc
+++ b/docs/modules/deployment/pages/sentinel/runtime/install.adoc
@@ -13,14 +13,14 @@
 
 * Linux physical server or a virtual machine running a supported Linux operating system
 * Internet access to download the installation packages
-* Ensure DNS is configured so that `localhost` and your servers host name are resolved properly
+* Ensure DNS is configured so that `localhost` and your server's host name are resolved properly
 * {page-component-title} Core instance runs on latest stable release
 * Java {compatible-javajdk} is installed
 * System user with administrative permissions (`sudo`) to perform the installation tasks
 ifeval::["{page-component-title}" == "Horizon"]
 +
 NOTE: If you run Debian, you may have to install and configure `sudo` yourself.
-A guide can be found in the link:https://wiki.debian.org/sudo/[Debian Wiki].
+See https://wiki.debian.org/sudo/[Debian Wiki] for guidance.
 endif::[]
 
 include::../../time-sync.adoc[]
@@ -84,7 +84,7 @@ endif::[]
 ====
 
 TIP: Password or encryption algorithm changes happen immediately.
-It is not required to restart the Sentinel
+It is not required to restart the Sentinel.
 
 TIP: By default the Karaf Shell is restricted to 127.0.0.1.
 If you want enable remote access, set `sshHost=0.0.0.0` in `org.apache.karaf.shell.cfg`.

--- a/docs/modules/deployment/pages/sentinel/runtime/install.adoc
+++ b/docs/modules/deployment/pages/sentinel/runtime/install.adoc
@@ -13,13 +13,14 @@
 
 * Linux physical server or a virtual machine running a supported Linux operating system
 * Internet access to download the installation packages
-* Ensure DNS is configured, localhost and your servers host name is resolved properly
+* Ensure DNS is configured so that `localhost` and your servers host name are resolved properly
 * {page-component-title} Core instance runs on latest stable release
-* Java installed {compatible-javajdk}
-* System user with administrative permissions (sudo) to perform the installation tasks
+* Java {compatible-javajdk} is installed
+* System user with administrative permissions (`sudo`) to perform the installation tasks
 ifeval::["{page-component-title}" == "Horizon"]
-NOTE: If you run Debian, you have to install and configure `sudo` yourself.
-         A guide can be found in the link:https://wiki.debian.org/sudo/[Debian Wiki].
++
+NOTE: If you run Debian, you may have to install and configure `sudo` yourself.
+A guide can be found in the link:https://wiki.debian.org/sudo/[Debian Wiki].
 endif::[]
 
 include::../../time-sync.adoc[]
@@ -67,7 +68,7 @@ IMPORTANT: Change the default user/password _admin/admin_ for the Karaf shell an
 
 [{tabs}]
 ====
-CentOS/RHEL 7/8::
+CentOS/RHEL 7/8/9::
 +
 --
 include::centos-rhel/secure-karaf.adoc[]
@@ -83,13 +84,13 @@ endif::[]
 ====
 
 TIP: Password or encryption algorithm changes happen immediately.
-     It is not required to restart the Sentinel
+It is not required to restart the Sentinel
 
 TIP: By default the Karaf Shell is restricted to 127.0.0.1.
-     If you want enable remote access, set `sshHost=0.0.0.0` in `org.apache.karaf.shell.cfg`.
-     The change is applied immediately and a Sentinel restart is not required.
-     If you have a firewall running on your host, allow `8301/tcp` to grant access to the Karaf Shell.
+If you want enable remote access, set `sshHost=0.0.0.0` in `org.apache.karaf.shell.cfg`.
+The change is applied immediately and a Sentinel restart is not required.
+If you have a firewall running on your host, allow `8301/tcp` to grant access to the Karaf Shell.
 
 == Set up flow processing
 
-To set up flow processing with Sentinel, see xref:operation:deep-dive/flows/sentinel/sentinel.adoc#flows-scaling[scale flows data].
+Once you have Sentinel installed, see xref:operation:deep-dive/flows/sentinel/sentinel.adoc#flows-scaling[scale flows data] to setup flow processing.

--- a/docs/modules/operation/pages/deep-dive/flows/aggregation.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/aggregation.adoc
@@ -5,7 +5,7 @@ The flow query engine supports rendering the top _N_ metrics from pre-aggregated
 You can use these statistics to help alleviate computation load on the Elasticsearch cluster, particularly in environments with large volumes of flows (more than 10,000 per second).
 To use this functionality, you must <<deep-dive/flows/basic.adoc#kafka-forwarder-config, enable the Kafka forwarder>> and set up the streaming analytics tool to process flows and persist aggregates in Elasticsearch.
 
-Set the following properties in `$OPENNMS_HOME/etc/org.opennms.features.flows.persistence.elastic.cfg` to control the query engine to use aggregated flows:
+Set the following properties in `$\{OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.elastic.cfg` to control the query engine to use aggregated flows:
 
 [options="autowidth"]
 |===

--- a/docs/modules/operation/pages/deep-dive/flows/basic.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/basic.adoc
@@ -57,14 +57,23 @@ elasticIndexStrategy=daily
 
 ** See <<deep-dive/elasticsearch/introduction.adoc#ga-elasticsearch-integration-configuration, General Elasticsearch configuration>> for a complete set of configuration options.
 
-== Enable protocols
+== Multi-protocol listener
 
-Follow these steps to enable one or more of the protocols that you want to handle.
+With most tools, if you are monitoring multiple flow protocols, you must set up a listener on its own UDP port for each protocol.
+However, {page-component-title} allows a multi-port listener option; this listener, named `Multi-UDP-9999`, is enabled by default and monitors multiple protocols on a single UDP port (`9999`). 
+The default configuration includes support for Netflow v5, Netflow v9, sFlow, and IPFIX.
+You can edit `$\{OPENNMS_HOME}/etc/telemetryd-configuration.xml` to change the port number and add or remove protocols.
+
+IMPORTANT: Make sure your firewall allow list includes the ports that you have configured to receive flow data.
+
+== Enable individual protocols
+
+Follow these steps to enable one or more protocols that you want to handle individually or that are not included in the default multi-protocol listener.
 
 NOTE: This example uses the NetFlow v5 protocol.
 You can follow the same steps for any of the other flow-related protocols.
 
-. Edit or create `$\{OPENNMS_HOME}/etc/telemetryd-configuration.xml` to enable protocols:
+. Edit `$\{OPENNMS_HOME}/etc/telemetryd-configuration.xml` to enable protocols:
 +
 [source, xml]
 ----
@@ -79,21 +88,16 @@ You can follow the same steps for any of the other flow-related protocols.
     </adapter>
 </queue>
 ----
++
+NOTE:  The default configuration file provides example configurations for many protocols.
+To enable one of these protocols, find the correct example `listener` and `adapter` elements and change their `enabled` attributes to `true`.
 
-. Reload the daemons to apply your changes:
+. Reload the daemon to apply your changes:
 +
 [source, console]
 ${OPENNMS_HOME}/bin/send-event.pl -p 'daemonName Telemetryd' uei.opennms.org/internal/reloadDaemonConfig
 
-This configuration opens a UDP socket bound to `0.0.0.0:8877`; NetFlow v5 messages are forwarded to this socket (see <<deep-dive/admin/configuration/daemon-config-files.adoc#daemon-reload, Reload daemons by CLI>> for more information).
-
-=== Multi-port listener
-
-Normally, if you are monitoring multiple flow protocols, you must set up a listener on its own UDP port for each protocol.
-By default, {page-component-title} allows a multi-port listener option; this monitors multiple protocols on a single UDP port (`9999`).
-You can edit `$\{OPENNMS_HOME}/etc/telemetryd-configuration.xml` to change the port number and add or remove protocols.
-
-IMPORTANT: Make sure your firewall allow list includes the ports that you have configured to receive flow data.
+This configuration opens a UDP socket bound to `0.0.0.0:8877` to listen and process NetFlow v5 messages that are are forwarded to this port.
 
 == Enable flows on your devices
 
@@ -163,10 +167,9 @@ admin@opennms()> config:update
 After you set up basic flows monitoring, you may want to do some of the following tasks:
 
 * Classify data flows.
-+
 {page-component-title} resolves flows to application names.
 You can create rules to override the default classifications (see xref:deep-dive/flows/classification-engine.adoc[]).
 
-* xref:deep-dive/flows/distributed.adoc[Enable remote flows data collection].
-* xref:deep-dive/flows/sentinel/sentinel.adoc[Scale to manage large volumes of flows data].
+* xref:deep-dive/flows/distributed.adoc[Enable remote flows data collection] with Minions.
+* xref:deep-dive/flows/sentinel/sentinel.adoc[Scale to manage large volumes of flows data] with Sentinels.
 * Add https://github.com/OpenNMS/nephron[OpenNMS Nephron] for aggregation and streaming analytics.

--- a/docs/modules/operation/pages/deep-dive/flows/basic.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/basic.adoc
@@ -89,7 +89,7 @@ You can follow the same steps for any of the other flow-related protocols.
 </queue>
 ----
 +
-NOTE:  The default configuration file provides example configurations for many protocols.
+NOTE: The default configuration file provides example configurations for many protocols.
 To enable one of these protocols, find the correct example `listener` and `adapter` elements and change their `enabled` attributes to `true`.
 
 . Reload the daemon to apply your changes:

--- a/docs/modules/operation/pages/deep-dive/flows/classification-engine.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/classification-engine.adoc
@@ -2,8 +2,8 @@
 [[ga-flow-support-classification-engine]]
 = Flows Classification
 
-For improved flows management, OpenNMS uses a classification engine that applies user- and/or pre-defined rules to filter and classify flows.
-(Pre-defined rules are inspired by the https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml[IANA Service Name and Transport Protocol Port Number Registry].)
+For improved flows management, {page-component-title} uses a classification engine that applies pre-defined and user-defined rules to filter and classify flows.
+The included pre-defined rules are based on the https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml[IANA Service Name and Transport Protocol Port Number Registry].
 
 You can group flows by a combination of parameters: source/destination port, source/destination address, IP protocol, and exporter filter.
 Once set up, you can view classification groups on the home page.
@@ -66,7 +66,7 @@ Assume that you define the following rules:
 {page-component-title} receives the following flows, classified according to the rules defined above:
 
 [options="header"]
-[cols="1,3"]
+[cols="3,1"]
 |===
 | Flow
 | Classification

--- a/docs/modules/operation/pages/deep-dive/flows/classification-engine.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/classification-engine.adoc
@@ -2,8 +2,8 @@
 [[ga-flow-support-classification-engine]]
 = Flows Classification
 
-For improved flows management, {page-component-title} uses a classification engine that applies pre-defined and user-defined rules to filter and classify flows.
-The included pre-defined rules are based on the https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml[IANA Service Name and Transport Protocol Port Number Registry].
+For improved flows management, {page-component-title} uses a classification engine that applies predefined and user-defined rules to filter and classify flows.
+The included predefined rules are based on the https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml[IANA Service Name and Transport Protocol Port Number Registry].
 
 You can group flows by a combination of parameters: source/destination port, source/destination address, IP protocol, and exporter filter.
 Once set up, you can view classification groups on the home page.

--- a/docs/modules/operation/pages/deep-dive/flows/data-collection.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/data-collection.adoc
@@ -1,5 +1,5 @@
 [[ga-flow-support-data-collection]]
-= Data collection of flow applications
+= Data Collection of Flow Applications
 
 Flows are categorized in applications using the <<deep-dive/flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
 OpenNMS supports summing up the bytesIn/bytesOut data of flow records based on these flow applications and the collection of this data.

--- a/docs/modules/operation/pages/deep-dive/flows/distributed.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/distributed.adoc
@@ -1,6 +1,6 @@
 
 [[flows-remote]]
-= Using Minions as a flow collector
+= Using Minions as a Flow Collector
 
 Beyond a basic flows setup, you may want to add a Minion to collect flows data from hard-to-reach or remote locations.
 

--- a/docs/modules/operation/pages/deep-dive/flows/distributed.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/distributed.adoc
@@ -21,7 +21,7 @@ Make sure you do the following:
 This example enables a generic listener for the NetFlow v5 protocol on Minion.
 
 IMPORTANT: NetFlow v5 uses the generic UDP listener, but other protocols require a specific listener.
-See the examples in `$OPENNMS_HOME/etc/telemetryd-configuration.xml`, or <<reference:telemetryd/listeners/introduction.adoc#ref-listener, Telemetryd Listener Reference>> for details.
+See the examples in `$\{OPENNMS_HOME}/etc/telemetryd-configuration.xml`, or <<reference:telemetryd/listeners/introduction.adoc#ref-listener, Telemetryd Listener Reference>> for details.
 
 To enable and configure a listener for NetFlow v5 on Minion, connect to the Karaf Console and set the following properties:
 
@@ -36,7 +36,7 @@ config:property-set parsers.0.class-name org.opennms.netmgt.telemetry.protocols.
 config:update
 ----
 
-TIP: If using a configuration management, you can create and use the properties file as startup configuration in `$MINION_HOME/etc/org.opennms.features.telemetry.listeners-udp-8877.cfg`.
+TIP: If using a configuration management, you can create and use the properties file as startup configuration in `$\{MINION_HOME}/etc/org.opennms.features.telemetry.listeners-udp-8877.cfg`.
 
 [source, properties]
 ----

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/ipfix.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/ipfix.adoc
@@ -1,20 +1,20 @@
 [source, karaf]
 ----
-config:edit --alias ipfix --factory org.opennms.features.telemetry.listeners
+config:edit --alias ipfix --factory org.opennms.features.telemetry.adapters
 config:property-set name IPFIX<1>
 config:property-set adapters.0.name IPFIX-Adapter<2>
 config:property-set adapters.0.class-name org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapter<3>
 config:update
 ----
-
 <1> Queue name from which Sentinel will fetch messages.
+The Minion parser name for IPFIX must match this name.
 By default, for {page-component-title} components, the queue name convention is `IPFIX`.
 <2> Set a name for the IPFIX adapter.
 <3> Assign an adapter to enrich IPFIX messages.
 
 The configuration is persisted with the suffix specified as alias in `etc/org.opennms.features.telemetry.adapters-ipfix.cfg`.
 
-TIP: To process multiple protocols, increase the index `0` in the adapters name and class name accordingly for additional protocols.
+TIP: When processing multiple protocols from the same queue, include additional adapters by adding additional `name` and `class-name` properties, increasing the index `0` for each pair.
 
 .Run health-check to verify adapter configuration
 [source, karaf]
@@ -30,4 +30,3 @@ Verifying the health of the container
 ...
 Verifying Adapter IPFIX-Adapter (org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapter)   [ Success  ]
 ----
-

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/message-broker/activemq.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/message-broker/activemq.adoc
@@ -25,24 +25,21 @@ ssh -p 8301 admin@localhost
 config:edit org.opennms.sentinel.controller
 config:property-set location SENTINEL<1>
 config:property-set id 00000000-0000-0000-0000-000000ddba11<2>
-config:property-set http-url http://core-instance-ip:8980/opennms<3>
-config:property-set broker-url failover:tcp://my-activemq-ip:61616<4>
+config:property-set broker-url failover:tcp://my-activemq-ip:61616<3>
 config:update
 ----
-
-<1> A location string is used to assign the Sentinel to a monitoring location in your environment that has Minions.
-<2> Unique identifier used as a node label for monitoring the Sentinel instance within {page-component-title}.
-<3> URL that points to your core {page-component-title} instance.
-<4> URL that points to ActiveMQ broker.
+<1> A location string is used to assign the Sentinel to a monitoring location.
+This can be an existing location or a new location and does not impact the messages that this Sentinel will process.
+<2> Unique identifier you define to be used as a node label for monitoring the Sentinel instance within {page-component-title}.
+This can be a GUID or a hostname.
+<3> URL that points to ActiveMQ broker.
 
 .Configure the credentials and exit Karaf shell
 [source, karaf]
 ----
-opennms:scv-set opennms.http my-sentinel-user my-sentinel-password<1>
-opennms:scv-set opennms.broker my-sentinel-user my-sentinel-password<2>
+opennms:scv-set opennms.broker my-sentinel-user my-sentinel-password<1>
 ----
-<1> Set the credentials for the REST endpoint created in your {page-component-title} Core instance
-<2> Set the credentials for the ActiveMQ message broker
+<1> Set the credentials for the ActiveMQ message broker
 
 NOTE: The credentials are encrypted on disk in `$\{SENTINEL_HOME}/etc/scv.jce`.
 
@@ -69,7 +66,6 @@ Verifying installed bundles                    [ Success  ]
 Retrieving NodeDao                             [ Success  ]
 Connecting to JMS Broker                       [ Success  ]
 Connecting to ElasticSearch ReST API (Flows)   [ Success  ]
-Connecting to OpenNMS ReST API                 [ Success  ]
 
 => Everything is awesome
 ----

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/message-broker/activemq.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/message-broker/activemq.adoc
@@ -30,7 +30,7 @@ config:update
 ----
 <1> A location string is used to assign the Sentinel to a monitoring location.
 This can be an existing location or a new location and does not impact the messages that this Sentinel will process.
-<2> Unique identifier you define to be used as a node label for monitoring the Sentinel instance within {page-component-title}.
+<2> Unique identifier you define to use as a node label for monitoring the Sentinel instance within {page-component-title}.
 This can be a GUID or a hostname.
 <3> URL that points to ActiveMQ broker.
 

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/message-broker/kafka.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/message-broker/kafka.adoc
@@ -39,8 +39,9 @@ config:property-set location SENTINEL<1>
 config:property-set id 00000000-0000-0000-0000-000000ddba11<2>
 config:update
 ----
-<1> A location string is used to assign the Sentinel to a monitoring location. This can be an existing location or a new location and does not impact the messages that this Sentinel will process.
-<2> Unique identifier you define to be used as a node label for monitoring the Sentinel instance within {page-component-title}.
+<1> A location string is used to assign the Sentinel to a monitoring location.
+This can be an existing location or a new location and does not impact the messages that this Sentinel will process.
+<2> Unique identifier you define to use as a node label for monitoring the Sentinel instance within {page-component-title}.
 This can be a GUID or a hostname.
 
 .Configure Sentinel as Kafka consumer for flow messages

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/message-broker/kafka.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/message-broker/kafka.adoc
@@ -13,6 +13,18 @@ sentinel-kafka
 sentinel-flows
 ----
 
+.(Optional) Configure a custom topic prefix
+[source, console]
+----
+sudo vi etc/custom.system.properties
+----
+
+[source, custom.system.properties]
+----
+org.opennms.instance.id=OpenNMS<1>
+----
+<1> Replace `OpenNMS` with the same topic prefix that the target instance of {page-component-title} Core uses.
+
 .Connect to the Karaf shell via SSH
 [source, console]
 ----
@@ -25,47 +37,36 @@ ssh -p 8301 admin@localhost
 config:edit org.opennms.sentinel.controller
 config:property-set location SENTINEL<1>
 config:property-set id 00000000-0000-0000-0000-000000ddba11<2>
-config:property-set http-url http://core-instance-ip:8980/opennms<3>
 config:update
 ----
-
-<1> A location string is used to assign the Sentinel to a monitoring location in your environment that has Minions.
-<2> Unique identifier used as a node label for monitoring the Sentinel instance within {page-component-title}.
-<3> URL that points to your core {page-component-title} instance.
+<1> A location string is used to assign the Sentinel to a monitoring location. This can be an existing location or a new location and does not impact the messages that this Sentinel will process.
+<2> Unique identifier you define to be used as a node label for monitoring the Sentinel instance within {page-component-title}.
+This can be a GUID or a hostname.
 
 .Configure Sentinel as Kafka consumer for flow messages
 [source, karaf]
 ----
 config:edit org.opennms.core.ipc.sink.kafka.consumer<1>
 config:property-set bootstrap.servers my-kafka-ip-1:9092,my-kafka-ip-2:9092<2>
+config:property-set group.id OpenNMS<3>
 config:update
 ----
-
 <1> Edit the configuration for the flow consumer from Kafka.
 <2> Connect to the following Kafka nodes and adjust the IPs or FQDNs with the Kafka port (9092) accordingly.
+<3> (Optional) When using the same Kafka cluster for multiple {page-component-title} instances, the `group.id` value should be the same as the `org.opennms.instance.id` value in the `etc/custom.system.properties` file.
 
-.Configure Sentinel to generate and send events
+TIP: The complete set of configuration properties needed for your cluster depends on your Kafka deployment.
+Refer to the Kafka configuration that {page-component-title} Core and Minions use, as the properties required for those components will likely be similar to the properties needed in the Sentinel's configuration.
+
+
+.Configure Sentinel to generate and send events (sink) using the same set of properties from the previous step
 [source, karaf]
 ----
-config:edit org.opennms.core.ipc.sink.kafka<1>
-config:property-set bootstrap.servers my-kafka-ip-1:9092,my-kafka-ip-2:9092<2>
+config:edit org.opennms.core.ipc.sink.kafka
+config:property-set bootstrap.servers my-kafka-ip-1:9092,my-kafka-ip-2:9092
+config:property-set group.id OpenNMS
 config:update
 ----
-
-<1> Edit the configuration to send generated events from Sentinel via Kafka.
-<2> Connect to the following Kafka nodes and adjust the IPs or FQDNs with the Kafka port (9092) accordingly.
-
-TIP: To use a Kafka cluster with multiple {page-component-title} instances, customize the topic prefix by setting `group.id`, which is by default set to `OpenNMS`.
-     You can set a different topic prefix for each instance with `config:edit group.id my-group-id` for the consumer and sink.
-
-.Configure the credentials and exit Karaf shell
-[source, karaf]
-----
-opennms:scv-set opennms.http my-sentinel-user my-sentinel-password<1>
-----
-<1> Set the credentials for the REST endpoint created in your {page-component-title} Core instance.
-
-The credentials are encrypted on disk in `$\{SENTINEL_HOME}/etc/scv.jce`.
 
 Exit the Karaf Shell with kbd:[Ctrl+d]
 
@@ -91,7 +92,6 @@ Connecting to Kafka from Sink Producer         [ Success  ]
 Connecting to Kafka from Sink Consumer         [ Success  ]
 Retrieving NodeDao                             [ Success  ]
 Connecting to ElasticSearch ReST API (Flows)   [ Success  ]
-Connecting to OpenNMS ReST API                 [ Success  ]
 
 => Everything is awesome
 ----

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/netflow5.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/netflow5.adoc
@@ -6,15 +6,14 @@ config:property-set adapters.0.name Netflow-5-Adapter<2>
 config:property-set adapters.0.class-name org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5Adapter<3>
 config:update
 ----
-
-<1> Queue name from which Sentinel will fetch messages.
-By default for {page-component-title} components, the queue name convention is `Netflow-5`.
+<1> Queue name from which Sentinel will fetch messages. The Minion parser name for Netflow v5 must match this name.
+By default, for {page-component-title} components, the queue name convention is `Netflow-5`.
 <2> Set a name for the Netflow v5 adapter.
 <3> Assign an adapter to enrich Netflow v5 messages.
 
 The configuration is persisted with the suffix specified as alias in `etc/org.opennms.features.telemetry.adapters-netflow5.cfg`.
 
-TIP: To process multiple protocols, increase the index `0` in the adapters name and class name accordingly for additional protocols.
+TIP: When processing multiple protocols from the same queue, include additional adapters by adding additional `name` and `class-name` properties, increasing the index `0` for each pair.
 
 .Run health-check to verify adapter configuration
 [source, karaf]

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/netflow9.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/netflow9.adoc
@@ -6,15 +6,14 @@ config:property-set adapters.0.name Netflow-9-Adapter<2>
 config:property-set adapters.0.class-name org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter<3>
 config:update
 ----
-
-<1> Queue name from which Sentinel will fetch messages.
-By default for {page-component-title} components, the queue name convention is `Netflow-9`.
+<1> Queue name from which Sentinel will fetch messages. The Minion parser name for Netflow v9 must match this name.
+By default, for {page-component-title} components, the queue name convention is `Netflow-9`.
 <2> Set a name for the Netflow v9 adapter.
 <3> Assign an adapter to enrich Netflow v9 messages.
 
 The configuration is persisted with the suffix specified as alias in `etc/org.opennms.features.telemetry.adapters-netflow9.cfg`.
 
-TIP: To process multiple protocols, increase the index `0` in the adapters name and class name accordingly for additional protocols.
+TIP: When processing multiple protocols from the same queue, include additional adapters by adding additional `name` and `class-name` properties, increasing the index `0` for each pair.
 
 .Run health-check to verify adapter configuration
 [source, karaf]
@@ -30,4 +29,3 @@ Verifying the health of the container
 ...
 Verifying Adapter Netflow-9-Adapter (org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter)   [ Success  ]
 ----
-

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/netflow9.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/netflow9.adoc
@@ -6,7 +6,8 @@ config:property-set adapters.0.name Netflow-9-Adapter<2>
 config:property-set adapters.0.class-name org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter<3>
 config:update
 ----
-<1> Queue name from which Sentinel will fetch messages. The Minion parser name for Netflow v9 must match this name.
+<1> Queue name from which Sentinel will fetch messages.
+The Minion parser name for Netflow v9 must match this name.
 By default, for {page-component-title} components, the queue name convention is `Netflow-9`.
 <2> Set a name for the Netflow v9 adapter.
 <3> Assign an adapter to enrich Netflow v9 messages.

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/sentinel.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/sentinel.adoc
@@ -2,11 +2,11 @@
 [[flows-scaling]]
 = Scale Flow Processing with Sentinel
 
-When your flows data collection volume increases to the point that {page-component-title} is too busy processing flows, you can add Sentinel(s) to do the processing instead.
+When your flows data collection volume increases to the point that {page-component-title} is too busy processing flows, you can add one or more Sentinels to do the processing instead.
 Sentinel can do the following:
 
-* Persist network flow messages with Sentinel to Elasticsearch
 * Consume flow messages from Minions through a message broker (ActiveMQ or Apache Kafka)
+* Persist network flow messages to Elasticsearch
 * Generate and send events to the {page-component-title} core instance via message broker
 
 .Flow integration with Sentinel
@@ -18,12 +18,14 @@ Make sure you have the following:
 
 * xref:operation:deep-dive/flows/basic.adoc#flows-basic[Basic flows environment] set up
 * xref:deployment:sentinel/runtime/install.adoc#install-sentinel[Sentinel installed] on your system
-* PostgreSQL, Elasticsearch, and REST endpoint to {page-component-title} core instance running and reachable from the Sentinel node
-* Message broker (ActiveMQ or Apache Kafka) running and reachable from the Sentinel node
-* Credentials for authentication configured for the REST endpoint in the {page-component-title} core instance, message broker, Elasticsearch, and the PostgreSQL database
+* PostgreSQL, Elasticsearch, and REST endpoint to {page-component-title} core instance running and reachable from the Sentinel node(s)
+* Message broker (ActiveMQ or Apache Kafka) running and reachable from the Sentinel node(s)
+* Credentials for authentication configured for the message broker, Elasticsearch, and the PostgreSQL database
 
-NOTE: You must set configuration in the `etc` directory relative to the {page-component-title} Sentinel home directory.
-      Depending on your operating system, the home directory is `/usr/share/sentinel` for Debian/Ubuntu or `/opt/sentinel` for CentOS/RHEL.
+NOTE: You must set configuration in the `etc` directory relative to the {page-component-title} Sentinel home directory `$\{SENTINEL_HOME}`.
+Depending on your operating system, the home directory is `/usr/share/sentinel` for Debian/Ubuntu or `/opt/sentinel` for CentOS/RHEL.
+
+Repeat the following steps on each Sentinel node.
 
 == Configure access to PostgreSQL database
 
@@ -68,13 +70,16 @@ config:property-set connTimeout 30000<4>
 config:property-set readTimeout 60000<5>
 config:update
 ----
-
-<1> Add the URL to the Elasticsearch cluster.
-<2> Select an index strategy.
+<1> Replace with a URL to the Elasticsearch cluster.
+<2> Specify an index strategy.
 <3> Set number of replicas; 0 is a default.
 In production you should have at least 1.
 <4> Timeout, in milliseconds, Sentinel waits to connect to the Elasticsearch cluster.
 <5> Read timeout when data is fetched from the Elasticsearch cluster.
+
+Additional configuration properties are documented in <<deep-dive/elasticsearch/introduction.adoc#ga-elasticsearch-integration-configuration, General Elasticsearch configuration>>.
+Be sure to also set the `indexPrefix` property when using a single Elasticsearch cluster with multiple {page-component-title} instances.
+If you set the `indexPrefix` property, all Sentinel instances on the same {page-component-title} instance should use the same value.
 
 == Set up message broker
 

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/sflow.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/sflow.adoc
@@ -6,7 +6,8 @@ config:property-set adapters.0.name SFlow-Adapter<2>
 config:property-set adapters.0.class-name org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapter<3>
 config:update
 ----
-<1> Queue name from which Sentinel will fetch messages. The Minion parser name for sFlow must match this name.
+<1> Queue name from which Sentinel will fetch messages.
+The Minion parser name for sFlow must match this name.
 By default, for {page-component-title} components, the queue name convention is `SFlow`.
 <2> Set a name for the sFlow adapter.
 <3> Assign an adapter to enrich sFlow messages.

--- a/docs/modules/operation/pages/deep-dive/flows/sentinel/sflow.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/sentinel/sflow.adoc
@@ -1,20 +1,19 @@
 [source, karaf]
 ----
-config:edit --alias sflow --factory org.opennms.features.telemetry.listeners
+config:edit --alias sflow --factory org.opennms.features.telemetry.adapters
 config:property-set name SFlow<1>
 config:property-set adapters.0.name SFlow-Adapter<2>
 config:property-set adapters.0.class-name org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapter<3>
 config:update
 ----
-
-<1> Queue name from which Sentinel will fetch messages.
-By default for {page-component-title} components, the queue name convention is `SFlow`.
+<1> Queue name from which Sentinel will fetch messages. The Minion parser name for sFlow must match this name.
+By default, for {page-component-title} components, the queue name convention is `SFlow`.
 <2> Set a name for the sFlow adapter.
 <3> Assign an adapter to enrich sFlow messages.
 
 The configuration is persisted with the suffix specified as alias in `etc/org.opennms.features.telemetry.adapters-sflow.cfg`.
 
-TIP: To process multiple protocols, increase the index `0` in the adapters name and class name accordingly for additional protocols.
+TIP: When processing multiple protocols from the same queue, include additional adapters by adding additional `name` and `class-name` properties, increasing the index `0` for each pair.
 
 .Run health-check to verify adapter configuration
 [source, karaf]

--- a/docs/modules/operation/pages/deep-dive/flows/thresholding.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/thresholding.adoc
@@ -75,7 +75,7 @@ The following example defines thresholds for HTTPS traffic exceeding 4096000 byt
 ----
 
 [[ga-flow-support-thresholding-properties]]
-The properties for the step-size and the idle timeout can be specified in the file `$OPENNMS_HOME/etc/org.opennms.features.flows.persistence.elastic.cfg`.
+The properties for the step-size and the idle timeout can be specified in the file `$\{OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.elastic.cfg`.
 You can set the following properties:
 
 [options="header, autowidth" cols="1,3,2"]

--- a/docs/modules/operation/pages/deep-dive/flows/thresholding.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/thresholding.adoc
@@ -75,7 +75,7 @@ The following example defines thresholds for HTTPS traffic exceeding 4096000 byt
 ----
 
 [[ga-flow-support-thresholding-properties]]
-The properties for the step-size and the idle timeout can be specified in the file `$\{OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.elastic.cfg`.
+Specify the properties for the step size and the idle timeout in the file `$\{OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.elastic.cfg`.
 You can set the following properties:
 
 [options="header, autowidth" cols="1,3,2"]

--- a/docs/modules/operation/pages/deep-dive/flows/thresholding.adoc
+++ b/docs/modules/operation/pages/deep-dive/flows/thresholding.adoc
@@ -1,5 +1,5 @@
 [[ga-flow-support-thresholding]]
-= Thresholding flow applications
+= Thresholding Flow Applications
 
 Flows are categorized in applications using the <<deep-dive/flows/classification-engine.adoc#ga-flow-support-classification-engine, Classification Engine>>.
 OpenNMS supports summing up the bytesIn/bytesOut data of flow records based on these flow applications.

--- a/docs/modules/reference/pages/configuration/sentinel-features.adoc
+++ b/docs/modules/reference/pages/configuration/sentinel-features.adoc
@@ -1,4 +1,4 @@
-= Sentinel features
+= Sentinel Features
 
 The following list contains some features which may be installed manually:
 


### PR DESCRIPTION
Replaces https://github.com/OpenNMS/opennms/pull/6149 to target `foundation-2023` instead of `release-32.x`.  Includes changes from that PR as well as a couple other cleanup items in the Sentinel and Flows docs.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15708

