### PR TITLE
NMS-15732: Allowing relative redirects

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -354,6 +354,9 @@ org.opennms.netmgt.jetty.sendServerVersion=false
 # Provisioning web UI)
 org.eclipse.jetty.server.Request.maxFormKeys=2000
 
+# Allow relative redirects, see NMS-15732
+#org.opennms.netmgt.jetty.relativeRedirectAllowed=true
+
 ###### JETTY HTTPS SUPPORT ######
 # Details: http://www.opennms.org/index.php/Standalone_HTTPS_with_Jetty
 # If you want Jetty to provide an HTTPS listener, this is the port to listen on

--- a/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
+++ b/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
@@ -6,6 +6,7 @@
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="requestHeaderSize"><SystemProperty name="org.opennms.netmgt.jetty.requestHeaderSize" default="4000" /></Set>
     <Set name="sendServerVersion"><SystemProperty name="org.opennms.netmgt.jetty.sendServerVersion" default="false" /></Set>
+    <Set name="relativeRedirectAllowed"><SystemProperty name="org.opennms.netmgt.jetty.relativeRedirectAllowed" default="true" /></Set>
   </New>
 
   <Call name="addConnector">


### PR DESCRIPTION
The problem occurs on page where we use relative redirects. In the Response class these redirects are converted to absolute URLs including the scheme and since this class does not know that the current location is HTTPS it is converted to the HTTP URL. Firefox and some other browsers allow the call because it is immediatly redirected to the correspondig HTTPS page. Chrome seems more picky and does not allow to query the HTTP page. The fix is to allow relative redirects in our jetty configuration. In this case relative URLs will not be converted to absolute ones, so the scheme is not affected and stays the same. 

* JIRA: https://opennms.atlassian.net/browse/NMS-15732