### PR TITLE
NMS-15806: fix some bounds-checking on possible null values

### DIFF
--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/resource/TimeseriesResourceStorageDao.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/resource/TimeseriesResourceStorageDao.java
@@ -256,7 +256,7 @@ public class TimeseriesResourceStorageDao implements ResourceStorageDao {
         final String childEls[] = child.elements();
         final String parentEls[] = parent.elements();
 
-        if (childEls.length <= parentEls.length) {
+        if (childEls == null || parentEls == null || childEls.length <= parentEls.length) {
             return null;
         }
 

--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/samplewrite/MetaTagDataLoader.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/samplewrite/MetaTagDataLoader.java
@@ -145,14 +145,16 @@ public class MetaTagDataLoader extends CacheLoader<CollectionResource, Map<Strin
 
         String nodeCriteria = null;
         if (resource.getParent() != null) {
-            String[] resourcePathArray = resource.getParent().elements();
-            if (ResourceTypeUtils.FOREIGN_SOURCE_DIRECTORY.equals(resourcePathArray[0])
-                    && resourcePathArray.length == 3) {
-                // parent denotes nodeCriteria, form fs:fid
-                nodeCriteria = resourcePathArray[1] + ":" + resourcePathArray[2];
-            } else if (checkNumeric(resourcePathArray[0])) {
-                // parent denotes nodeId
-                nodeCriteria = resourcePathArray[0];
+            final String[] resourcePathArray = resource.getParent().elements();
+            if (resourcePathArray != null) {
+                if (ResourceTypeUtils.FOREIGN_SOURCE_DIRECTORY.equals(resourcePathArray[0])
+                        && resourcePathArray.length == 3) {
+                    // parent denotes nodeCriteria, form fs:fid
+                    nodeCriteria = resourcePathArray[1] + ":" + resourcePathArray[2];
+                } else if (checkNumeric(resourcePathArray[0])) {
+                    // parent denotes nodeId
+                    nodeCriteria = resourcePathArray[0];
+                }
             }
         }
         return nodeCriteria;


### PR DESCRIPTION
This PR resolves an `ArrayIndexOutOfBoundException` found when enabling the `rrd-status` feature (although it's actually a general issue with reading certain kinds of metadata).

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/${JIRA-ISSUE-NUMBER}

