### PR TITLE
NMS-15808: enlinkd enum refactor fix

### DIFF
--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -134,7 +134,7 @@
       <feature>opennms-dnsresolver-api</feature>
       <feature>dropwizard-metrics</feature>
       <feature>opennms-util</feature>
-      <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+      <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
       <bundle>mvn:com.google.code.gson/gson/${gsonVersion}</bundle>
       <bundle>mvn:org.mongodb/bson/${bsonVersion}</bundle>
       <bundle>mvn:org.apache.commons/commons-csv/${commonsCsvVersion}</bundle>

--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -113,7 +113,7 @@
         <feature>sentinel-thresholding-service</feature>
         <feature>opennms-util</feature>
 
-        <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
 
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.config/org.opennms.features.telemetry.config.api/${project.version}</bundle>
@@ -137,7 +137,7 @@
         <feature>sentinel-kvstore-api</feature>
         <feature>opennms-kafka</feature>
         <feature>rate-limited-logger</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java-util/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java-util/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.features.flows/org.opennms.features.flows.kafka-persistence/${project.version}</bundle>
         <bundle>wrap:mvn:org.apache.commons/commons-csv/${commonsCsvVersion}</bundle>
         <bundle>mvn:org.opennms.features.flows/org.opennms.features.flows.api/${project.version}</bundle>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -508,7 +508,7 @@
         <feature>opennms-distributed-core-api</feature>
         <feature>opennms-integration-api</feature>
         <feature>opennms-core-tracing</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.xml/${project.version}</bundle>
@@ -1028,7 +1028,7 @@
         <feature>rate-limited-logger</feature>
         <feature>opennms-collection-api</feature>
         <feature>opennms-situation-feedback-api</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.kafka/org.opennms.features.kafka.producer/${project.version}</bundle>
     </feature>
@@ -1036,7 +1036,7 @@
         <feature>opennms-kafka</feature>
         <feature>opennms-events-api</feature>
         <feature>opennms-model</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.kafka/org.opennms.features.kafka.consumer/${project.version}</bundle>
     </feature>
@@ -1047,7 +1047,7 @@
         <feature>opennms-collection-api</feature>
         <feature>opennms-thresholding-api</feature>
         <feature>opennms-osgi-jsr223</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:com.google.code.gson/gson/${gsonVersion}</bundle>
         <bundle>wrap:mvn:io.pkts/pkts-core/${pktsVersion}</bundle>
         <bundle>wrap:mvn:io.pkts/pkts-buffers/${pktsVersion}</bundle>
@@ -1070,7 +1070,7 @@
         <feature>opennms-dao</feature>
         <feature>opennms-telemetry-collection</feature>
         <feature>opennms-util</feature>
-        <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.registry/${project.version}</bundle>
@@ -1102,12 +1102,12 @@
     </feature>
     <feature name="opennms-telemetry-jti" version="${project.version}" description="OpenNMS :: Telemetry :: JTI">
         <feature>opennms-telemetry-collection</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.jti/org.opennms.features.telemetry.protocols.jti.adapter/${project.version}</bundle>
     </feature>
     <feature name="opennms-telemetry-nxos" version="${project.version}" description="OpenNMS :: Telemetry :: NX-OS">
         <feature>opennms-telemetry-collection</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.nxos/org.opennms.features.telemetry.protocols.nxos.adapter/${project.version}</bundle>
     </feature>
     <feature name="opennms-telemetry-graphite" version="${project.version}" description="OpenNMS :: Telemetry :: Graphite">
@@ -1118,7 +1118,7 @@
         <feature>opennms-telemetry-collection</feature>
         <feature>opennms-telemetry-openconfig-client</feature>
         <feature>opennms-rpc-utils</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.core.grpc/org.opennms.core.grpc.osgi/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.openconfig/org.opennms.features.openconfig.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.openconfig/org.opennms.features.openconfig.common/${project.version}</bundle>
@@ -1198,8 +1198,8 @@
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.listeners/${project.version}</bundle>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
-        <bundle>mvn:com.google.protobuf/protobuf-java-util/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java-util/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.flows/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.netflow/org.opennms.features.telemetry.protocols.netflow.parser/${project.version}</bundle>
@@ -1867,7 +1867,7 @@
     <feature name="opennms-core-ipc-twin-common" description="OpenNMS :: Core :: IPC :: Twin :: Common" version="${project.version}">
         <feature version="${guavaOsgiVersion}">guava</feature>
         <feature>json-patch</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.twin/org.opennms.core.ipc.twin.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.twin/org.opennms.core.ipc.twin.common/${project.version}</bundle>
     </feature>
@@ -1898,7 +1898,7 @@
         <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.twin.kafka/org.opennms.core.ipc.twin.kafka.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.sysprops/${project.version}</bundle>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
     </feature>
     <feature name="opennms-core-ipc-twin-kafka" version="${project.version}" description="OpenNMS :: Core :: IPC :: Twin :: Kafka :: Subscriber">
         <feature>opennms-core-ipc-twin-kafka-common</feature>

--- a/features/api-layer/dao-common/pom.xml
+++ b/features/api-layer/dao-common/pom.xml
@@ -78,5 +78,14 @@
             <artifactId>org.opennms.features.situation-feedback.api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.features.enlinkd</groupId>
+            <artifactId>org.opennms.features.enlinkd.service.api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/features/api-layer/dao-common/src/test/java/org/opennms/features/apilayer/utils/ModelMappersTest.java
+++ b/features/api-layer/dao-common/src/test/java/org/opennms/features/apilayer/utils/ModelMappersTest.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.opennms.integration.api.v1.model.Severity;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
+import org.opennms.integration.api.v1.ticketing.Ticket.State;
+import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
+
+public class ModelMappersTest {
+    @Test
+    public void testToSeverity() {
+        for (final var from : OnmsSeverity.values()) {
+            final var to = ModelMappers.toSeverity(from);
+            assertEquals("the severity enum names should match (" + from.toString() + "=" + to.toString() + ")", from.toString(), to.toString());
+        }
+    }
+
+    @Test
+    public void testFromSeverity() {
+        for (final var from : Severity.values()) {
+            final var to = ModelMappers.fromSeverity(from);
+            assertEquals("the severity enum names should match (" + from.toString() + "=" + to.toString() + ")", from.toString(), to.toString());
+        }
+    }
+
+    @Test
+    public void testToTicketState() {
+        // OPA's State object is a simplified one, containing only OPEN, CANCELLED, and CLOSED
+        final var noMapping = Arrays.asList(
+                "CREATE_PENDING",
+                "CREATE_FAILED",
+                "UPDATE_PENDING",
+                "UPDATE_FAILED",
+                "CLOSE_PENDING",
+                "CLOSE_FAILED",
+                "RESOLVED",
+                "RESOLVE_PENDING",
+                "RESOLVE_FAILED",
+                "CANCEL_PENDING",
+                "CANCEL_FAILED"
+        );
+
+        for (final var from : TroubleTicketState.values()) {
+            final var to = ModelMappers.toTicketState(from);
+            if (noMapping.contains(from.toString())) {
+                assertNull("this ticket state does not have an corresponding type in OPA", to);
+            } else {
+                assertEquals("the ticket state enum names should match (" + from.toString() + "=" + to.toString() + ")", from.toString(), to.toString());
+            }
+        }
+    }
+
+    @Test
+    public void testFromTicketState() {
+        for (final var from : State.values()) {
+            final var to = ModelMappers.fromTicketState(from);
+            assertEquals("the ticket state enum names should match (" + from.toString() + "=" + to.toString() + ")", from.toString(), to.toString());
+        }
+    }
+
+    @Test
+    public void testToTopologyProtocol() {
+        for (final var proto : ProtocolSupported.values()) {
+            final var from = OnmsTopologyProtocol.create(proto.toString());
+            final var to = ModelMappers.toTopologyProtocol(from);
+            assertEquals("the protocols should match (" + from.toString() + "=" + to.toString() + ")", from.toString(), to.toString());
+        }
+    }
+
+    @Test
+    public void testToOnmsTopologyProtocol() {
+        for (final var proto : ProtocolSupported.values()) {
+            final var from = TopologyProtocol.valueOf(proto.toString());
+            final var to = ModelMappers.toOnmsTopologyProtocol(from);
+            assertEquals("the protocols should match (" + from.toString() + "=" + to.toString() + ")", from.toString(), to.toString());
+        }
+    }
+
+    @Test
+    public void testAllToplogyProtocolsInProtocolSupported() {
+        for (final var from : TopologyProtocol.values()) {
+            if ("ALL".equals(from.toString())) {
+                // ALL is a special case that is not expected to be everywhere else
+                continue;
+            }
+            final var to = ProtocolSupported.valueOf(from.toString());
+            assertEquals("the protocols should match (" + from.toString() + "=" + to.toString() + ")", from.toString(), to.toString());
+        }
+    }
+}

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/model/OpennmsModelProtos.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/model/OpennmsModelProtos.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -18465,6 +18465,10 @@ public final class OpennmsModelProtos {
     org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyRef.Protocol getProtocol();
   }
   /**
+   * <pre>
+   * NOTE: if you change this, you must also update ALEC's copy as well 
+   * </pre>
+   *
    * Protobuf type {@code TopologyRef}
    */
   public  static final class TopologyRef extends
@@ -18578,6 +18582,18 @@ public final class OpennmsModelProtos {
        * <code>USERDEFINED = 5;</code>
        */
       USERDEFINED(5),
+      /**
+       * <code>NODES = 6;</code>
+       */
+      NODES(6),
+      /**
+       * <code>OSPFAREA = 7;</code>
+       */
+      OSPFAREA(7),
+      /**
+       * <code>NETWORKROUTER = 8;</code>
+       */
+      NETWORKROUTER(8),
       UNRECOGNIZED(-1),
       ;
 
@@ -18605,6 +18621,18 @@ public final class OpennmsModelProtos {
        * <code>USERDEFINED = 5;</code>
        */
       public static final int USERDEFINED_VALUE = 5;
+      /**
+       * <code>NODES = 6;</code>
+       */
+      public static final int NODES_VALUE = 6;
+      /**
+       * <code>OSPFAREA = 7;</code>
+       */
+      public static final int OSPFAREA_VALUE = 7;
+      /**
+       * <code>NETWORKROUTER = 8;</code>
+       */
+      public static final int NETWORKROUTER_VALUE = 8;
 
 
       public final int getNumber() {
@@ -18631,6 +18659,9 @@ public final class OpennmsModelProtos {
           case 3: return BRIDGE;
           case 4: return CDP;
           case 5: return USERDEFINED;
+          case 6: return NODES;
+          case 7: return OSPFAREA;
+          case 8: return NETWORKROUTER;
           default: return null;
         }
       }
@@ -18900,6 +18931,10 @@ public final class OpennmsModelProtos {
       return builder;
     }
     /**
+     * <pre>
+     * NOTE: if you change this, you must also update ALEC's copy as well 
+     * </pre>
+     *
      * Protobuf type {@code TopologyRef}
      */
     public static final class Builder extends
@@ -23041,99 +23076,101 @@ public final class OpennmsModelProtos {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\034opennms-kafka-producer.proto\"l\n\014NodeCr" +
-      "iteria\022\n\n\002id\030\001 \001(\004\022\026\n\016foreign_source\030\002 \001" +
-      "(\t\022\022\n\nforeign_id\030\003 \001(\t\022\022\n\nnode_label\030\004 \001" +
-      "(\t\022\020\n\010location\030\005 \001(\t\";\n\016EventParameter\022\014" +
-      "\n\004name\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\022\014\n\004type\030\003 \001(" +
-      "\t\"o\n\010SnmpInfo\022\n\n\002id\030\001 \001(\t\022\017\n\007version\030\002 \001" +
-      "(\t\022\020\n\010specific\030\003 \001(\r\022\017\n\007generic\030\004 \001(\r\022\021\n" +
-      "\tcommunity\030\005 \001(\t\022\020\n\010trap_oid\030\006 \001(\t\"\327\002\n\005E" +
-      "vent\022\n\n\002id\030\001 \001(\004\022\013\n\003uei\030\002 \001(\t\022\r\n\005label\030\003" +
-      " \001(\t\022\014\n\004time\030\004 \001(\004\022\016\n\006source\030\005 \001(\t\022\"\n\tpa" +
-      "rameter\030\006 \003(\0132\017.EventParameter\022\023\n\013create" +
-      "_time\030\007 \001(\004\022\023\n\013description\030\010 \001(\t\022\023\n\013log_" +
-      "message\030\t \001(\t\022\033\n\010severity\030\n \001(\0162\t.Severi" +
-      "ty\022\013\n\003log\030\013 \001(\010\022\017\n\007display\030\014 \001(\010\022$\n\rnode" +
-      "_criteria\030\r \001(\0132\r.NodeCriteria\022\022\n\nip_add" +
-      "ress\030\016 \001(\t\022\023\n\013dist_poller\030\017 \001(\t\022\033\n\010snmpI" +
-      "nfo\030\020 \001(\0132\t.SnmpInfo\"\271\005\n\005Alarm\022\n\n\002id\030\001 \001" +
-      "(\004\022\013\n\003uei\030\002 \001(\t\022$\n\rnode_criteria\030\003 \001(\0132\r" +
-      ".NodeCriteria\022\022\n\nip_address\030\004 \001(\t\022\024\n\014ser" +
-      "vice_name\030\005 \001(\t\022\025\n\rreduction_key\030\006 \001(\t\022\031" +
-      "\n\004type\030\007 \001(\0162\013.Alarm.Type\022\r\n\005count\030\010 \001(\004" +
-      "\022\033\n\010severity\030\t \001(\0162\t.Severity\022\030\n\020first_e" +
-      "vent_time\030\n \001(\004\022\023\n\013description\030\013 \001(\t\022\023\n\013" +
-      "log_message\030\014 \001(\t\022\020\n\010ack_user\030\r \001(\t\022\020\n\010a" +
-      "ck_time\030\016 \001(\004\022\032\n\nlast_event\030\017 \001(\0132\006.Even" +
-      "t\022\027\n\017last_event_time\030\020 \001(\004\022\020\n\010if_index\030\021" +
-      " \001(\r\022\035\n\025operator_instructions\030\022 \001(\t\022\021\n\tc" +
-      "lear_key\030\023 \001(\t\022\037\n\027managed_object_instanc" +
-      "e\030\024 \001(\t\022\033\n\023managed_object_type\030\025 \001(\t\022\034\n\014" +
-      "relatedAlarm\030\026 \003(\0132\006.Alarm\022\031\n\021trouble_ti" +
-      "cket_id\030\027 \001(\t\0221\n\024trouble_ticket_state\030\030 " +
-      "\001(\0162\023.TroubleTicketState\022\030\n\020last_update_" +
-      "time\030\031 \001(\004\"D\n\004Type\022\026\n\022PROBLEM_WITH_CLEAR" +
-      "\020\000\022\t\n\005CLEAR\020\001\022\031\n\025PROBLEM_WITHOUT_CLEAR\020\002" +
-      "\"\217\002\n\rAlarmFeedback\022\025\n\rsituation_key\030\001 \001(" +
-      "\t\022\035\n\025situation_fingerprint\030\002 \001(\t\022\021\n\talar" +
-      "m_key\030\003 \001(\t\0222\n\rfeedback_type\030\004 \001(\0162\033.Ala" +
-      "rmFeedback.FeedbackType\022\016\n\006reason\030\005 \001(\t\022" +
-      "\014\n\004user\030\006 \001(\t\022\021\n\ttimestamp\030\007 \001(\004\"P\n\014Feed" +
-      "backType\022\022\n\016FALSE_POSITIVE\020\000\022\022\n\016FALSE_NE" +
-      "GATIVE\020\001\022\013\n\007CORRECT\020\002\022\013\n\007UNKNOWN\020\003\"\275\001\n\013I" +
-      "pInterface\022\n\n\002id\030\001 \001(\004\022\022\n\nip_address\030\002 \001" +
-      "(\t\022\020\n\010if_index\030\003 \001(\r\022.\n\014primary_type\030\004 \001" +
-      "(\0162\030.IpInterface.PrimaryType\022\017\n\007service\030" +
-      "\005 \003(\t\";\n\013PrimaryType\022\013\n\007PRIMARY\020\000\022\r\n\tSEC" +
-      "ONDARY\020\001\022\020\n\014NOT_ELIGIBLE\020\002\"\317\001\n\rSnmpInter" +
-      "face\022\n\n\002id\030\001 \001(\004\022\020\n\010if_index\030\002 \001(\r\022\020\n\010if" +
-      "_descr\030\003 \001(\t\022\017\n\007if_type\030\004 \001(\r\022\017\n\007if_name" +
-      "\030\005 \001(\t\022\020\n\010if_speed\030\006 \001(\004\022\027\n\017if_phys_addr" +
-      "ess\030\007 \001(\t\022\027\n\017if_admin_status\030\010 \001(\r\022\026\n\016if" +
-      "_oper_status\030\t \001(\r\022\020\n\010if_alias\030\n \001(\t\"%\n\007" +
-      "HwAlias\022\r\n\005index\030\001 \001(\r\022\013\n\003oid\030\002 \001(\t\"\210\002\n\010" +
-      "HwEntity\022\032\n\022ent_physical_index\030\001 \001(\r\022\021\n\t" +
-      "entity_id\030\002 \001(\r\022\032\n\022ent_physical_class\030\003 " +
-      "\001(\t\022\032\n\022ent_physical_descr\030\004 \001(\t\022\033\n\023ent_p" +
-      "hysical_is_fru\030\005 \001(\010\022\031\n\021ent_physical_nam" +
-      "e\030\006 \001(\t\022 \n\030ent_physical_vendor_type\030\007 \001(" +
-      "\t\022\036\n\014ent_hw_alias\030\010 \003(\0132\010.HwAlias\022\033\n\010chi" +
-      "ldren\030\t \003(\0132\t.HwEntity\"\270\002\n\004Node\022\n\n\002id\030\001 " +
-      "\001(\004\022\026\n\016foreign_source\030\002 \001(\t\022\022\n\nforeign_i" +
-      "d\030\003 \001(\t\022\020\n\010location\030\004 \001(\t\022\020\n\010category\030\005 " +
-      "\003(\t\022\r\n\005label\030\006 \001(\t\022\023\n\013create_time\030\007 \001(\004\022" +
-      "\023\n\013sys_contact\030\010 \001(\t\022\027\n\017sys_description\030" +
-      "\t \001(\t\022\025\n\rsys_object_id\030\n \001(\t\022\"\n\014ip_inter" +
-      "face\030\013 \003(\0132\014.IpInterface\022&\n\016snmp_interfa" +
-      "ce\030\014 \003(\0132\016.SnmpInterface\022\037\n\014hw_inventory" +
-      "\030\r \001(\0132\t.HwEntity\"\222\001\n\013TopologyRef\022\n\n\002id\030" +
-      "\001 \001(\t\022\'\n\010protocol\030\002 \001(\0162\025.TopologyRef.Pr" +
-      "otocol\"N\n\010Protocol\022\010\n\004LLDP\020\000\022\010\n\004OSPF\020\001\022\010" +
-      "\n\004ISIS\020\002\022\n\n\006BRIDGE\020\003\022\007\n\003CDP\020\004\022\017\n\013USERDEF" +
-      "INED\020\005\",\n\017TopologySegment\022\031\n\003ref\030\001 \001(\0132\014" +
-      ".TopologyRef\"{\n\014TopologyPort\022\021\n\tvertex_i" +
-      "d\030\001 \001(\t\022\020\n\010if_index\030\002 \001(\004\022\017\n\007if_name\030\003 \001" +
-      "(\t\022\017\n\007address\030\004 \001(\t\022$\n\rnode_criteria\030\005 \001" +
-      "(\0132\r.NodeCriteria\"\227\002\n\014TopologyEdge\022\031\n\003re" +
-      "f\030\001 \001(\0132\014.TopologyRef\022#\n\nsourcePort\030\003 \001(" +
-      "\0132\r.TopologyPortH\000\022)\n\rsourceSegment\030\004 \001(" +
-      "\0132\020.TopologySegmentH\000\022\033\n\nsourceNode\030\005 \001(" +
-      "\0132\005.NodeH\000\022#\n\ntargetPort\030\006 \001(\0132\r.Topolog" +
-      "yPortH\001\022)\n\rtargetSegment\030\007 \001(\0132\020.Topolog" +
-      "ySegmentH\001\022\033\n\ntargetNode\030\010 \001(\0132\005.NodeH\001B" +
-      "\010\n\006sourceB\010\n\006target*g\n\010Severity\022\021\n\rINDET" +
-      "ERMINATE\020\000\022\013\n\007CLEARED\020\001\022\n\n\006NORMAL\020\002\022\013\n\007W" +
-      "ARNING\020\003\022\t\n\005MINOR\020\004\022\t\n\005MAJOR\020\005\022\014\n\010CRITIC" +
-      "AL\020\006*\212\002\n\022TroubleTicketState\022\010\n\004OPEN\020\000\022\022\n" +
-      "\016CREATE_PENDING\020\001\022\021\n\rCREATE_FAILED\020\002\022\022\n\016" +
-      "UPDATE_PENDING\020\003\022\021\n\rUPDATE_FAILED\020\004\022\n\n\006C" +
-      "LOSED\020\005\022\021\n\rCLOSE_PENDING\020\006\022\020\n\014CLOSE_FAIL" +
-      "ED\020\007\022\014\n\010RESOLVED\020\010\022\023\n\017RESOLVE_PENDING\020\t\022" +
-      "\022\n\016RESOLVE_FAILED\020\n\022\r\n\tCANCELLED\020\013\022\022\n\016CA" +
-      "NCEL_PENDING\020\014\022\021\n\rCANCEL_FAILED\020\rB?\n)org" +
-      ".opennms.features.kafka.producer.modelB\022" +
-      "OpennmsModelProtosb\006proto3"
+      "\n+src/main/proto/opennms-kafka-producer." +
+      "proto\"l\n\014NodeCriteria\022\n\n\002id\030\001 \001(\004\022\026\n\016for" +
+      "eign_source\030\002 \001(\t\022\022\n\nforeign_id\030\003 \001(\t\022\022\n" +
+      "\nnode_label\030\004 \001(\t\022\020\n\010location\030\005 \001(\t\";\n\016E" +
+      "ventParameter\022\014\n\004name\030\001 \001(\t\022\r\n\005value\030\002 \001" +
+      "(\t\022\014\n\004type\030\003 \001(\t\"o\n\010SnmpInfo\022\n\n\002id\030\001 \001(\t" +
+      "\022\017\n\007version\030\002 \001(\t\022\020\n\010specific\030\003 \001(\r\022\017\n\007g" +
+      "eneric\030\004 \001(\r\022\021\n\tcommunity\030\005 \001(\t\022\020\n\010trap_" +
+      "oid\030\006 \001(\t\"\327\002\n\005Event\022\n\n\002id\030\001 \001(\004\022\013\n\003uei\030\002" +
+      " \001(\t\022\r\n\005label\030\003 \001(\t\022\014\n\004time\030\004 \001(\004\022\016\n\006sou" +
+      "rce\030\005 \001(\t\022\"\n\tparameter\030\006 \003(\0132\017.EventPara" +
+      "meter\022\023\n\013create_time\030\007 \001(\004\022\023\n\013descriptio" +
+      "n\030\010 \001(\t\022\023\n\013log_message\030\t \001(\t\022\033\n\010severity" +
+      "\030\n \001(\0162\t.Severity\022\013\n\003log\030\013 \001(\010\022\017\n\007displa" +
+      "y\030\014 \001(\010\022$\n\rnode_criteria\030\r \001(\0132\r.NodeCri" +
+      "teria\022\022\n\nip_address\030\016 \001(\t\022\023\n\013dist_poller" +
+      "\030\017 \001(\t\022\033\n\010snmpInfo\030\020 \001(\0132\t.SnmpInfo\"\271\005\n\005" +
+      "Alarm\022\n\n\002id\030\001 \001(\004\022\013\n\003uei\030\002 \001(\t\022$\n\rnode_c" +
+      "riteria\030\003 \001(\0132\r.NodeCriteria\022\022\n\nip_addre" +
+      "ss\030\004 \001(\t\022\024\n\014service_name\030\005 \001(\t\022\025\n\rreduct" +
+      "ion_key\030\006 \001(\t\022\031\n\004type\030\007 \001(\0162\013.Alarm.Type" +
+      "\022\r\n\005count\030\010 \001(\004\022\033\n\010severity\030\t \001(\0162\t.Seve" +
+      "rity\022\030\n\020first_event_time\030\n \001(\004\022\023\n\013descri" +
+      "ption\030\013 \001(\t\022\023\n\013log_message\030\014 \001(\t\022\020\n\010ack_" +
+      "user\030\r \001(\t\022\020\n\010ack_time\030\016 \001(\004\022\032\n\nlast_eve" +
+      "nt\030\017 \001(\0132\006.Event\022\027\n\017last_event_time\030\020 \001(" +
+      "\004\022\020\n\010if_index\030\021 \001(\r\022\035\n\025operator_instruct" +
+      "ions\030\022 \001(\t\022\021\n\tclear_key\030\023 \001(\t\022\037\n\027managed" +
+      "_object_instance\030\024 \001(\t\022\033\n\023managed_object" +
+      "_type\030\025 \001(\t\022\034\n\014relatedAlarm\030\026 \003(\0132\006.Alar" +
+      "m\022\031\n\021trouble_ticket_id\030\027 \001(\t\0221\n\024trouble_" +
+      "ticket_state\030\030 \001(\0162\023.TroubleTicketState\022" +
+      "\030\n\020last_update_time\030\031 \001(\004\"D\n\004Type\022\026\n\022PRO" +
+      "BLEM_WITH_CLEAR\020\000\022\t\n\005CLEAR\020\001\022\031\n\025PROBLEM_" +
+      "WITHOUT_CLEAR\020\002\"\217\002\n\rAlarmFeedback\022\025\n\rsit" +
+      "uation_key\030\001 \001(\t\022\035\n\025situation_fingerprin" +
+      "t\030\002 \001(\t\022\021\n\talarm_key\030\003 \001(\t\0222\n\rfeedback_t" +
+      "ype\030\004 \001(\0162\033.AlarmFeedback.FeedbackType\022\016" +
+      "\n\006reason\030\005 \001(\t\022\014\n\004user\030\006 \001(\t\022\021\n\ttimestam" +
+      "p\030\007 \001(\004\"P\n\014FeedbackType\022\022\n\016FALSE_POSITIV" +
+      "E\020\000\022\022\n\016FALSE_NEGATIVE\020\001\022\013\n\007CORRECT\020\002\022\013\n\007" +
+      "UNKNOWN\020\003\"\275\001\n\013IpInterface\022\n\n\002id\030\001 \001(\004\022\022\n" +
+      "\nip_address\030\002 \001(\t\022\020\n\010if_index\030\003 \001(\r\022.\n\014p" +
+      "rimary_type\030\004 \001(\0162\030.IpInterface.PrimaryT" +
+      "ype\022\017\n\007service\030\005 \003(\t\";\n\013PrimaryType\022\013\n\007P" +
+      "RIMARY\020\000\022\r\n\tSECONDARY\020\001\022\020\n\014NOT_ELIGIBLE\020" +
+      "\002\"\317\001\n\rSnmpInterface\022\n\n\002id\030\001 \001(\004\022\020\n\010if_in" +
+      "dex\030\002 \001(\r\022\020\n\010if_descr\030\003 \001(\t\022\017\n\007if_type\030\004" +
+      " \001(\r\022\017\n\007if_name\030\005 \001(\t\022\020\n\010if_speed\030\006 \001(\004\022" +
+      "\027\n\017if_phys_address\030\007 \001(\t\022\027\n\017if_admin_sta" +
+      "tus\030\010 \001(\r\022\026\n\016if_oper_status\030\t \001(\r\022\020\n\010if_" +
+      "alias\030\n \001(\t\"%\n\007HwAlias\022\r\n\005index\030\001 \001(\r\022\013\n" +
+      "\003oid\030\002 \001(\t\"\210\002\n\010HwEntity\022\032\n\022ent_physical_" +
+      "index\030\001 \001(\r\022\021\n\tentity_id\030\002 \001(\r\022\032\n\022ent_ph" +
+      "ysical_class\030\003 \001(\t\022\032\n\022ent_physical_descr" +
+      "\030\004 \001(\t\022\033\n\023ent_physical_is_fru\030\005 \001(\010\022\031\n\021e" +
+      "nt_physical_name\030\006 \001(\t\022 \n\030ent_physical_v" +
+      "endor_type\030\007 \001(\t\022\036\n\014ent_hw_alias\030\010 \003(\0132\010" +
+      ".HwAlias\022\033\n\010children\030\t \003(\0132\t.HwEntity\"\270\002" +
+      "\n\004Node\022\n\n\002id\030\001 \001(\004\022\026\n\016foreign_source\030\002 \001" +
+      "(\t\022\022\n\nforeign_id\030\003 \001(\t\022\020\n\010location\030\004 \001(\t" +
+      "\022\020\n\010category\030\005 \003(\t\022\r\n\005label\030\006 \001(\t\022\023\n\013cre" +
+      "ate_time\030\007 \001(\004\022\023\n\013sys_contact\030\010 \001(\t\022\027\n\017s" +
+      "ys_description\030\t \001(\t\022\025\n\rsys_object_id\030\n " +
+      "\001(\t\022\"\n\014ip_interface\030\013 \003(\0132\014.IpInterface\022" +
+      "&\n\016snmp_interface\030\014 \003(\0132\016.SnmpInterface\022" +
+      "\037\n\014hw_inventory\030\r \001(\0132\t.HwEntity\"\276\001\n\013Top" +
+      "ologyRef\022\n\n\002id\030\001 \001(\t\022\'\n\010protocol\030\002 \001(\0162\025" +
+      ".TopologyRef.Protocol\"z\n\010Protocol\022\010\n\004LLD" +
+      "P\020\000\022\010\n\004OSPF\020\001\022\010\n\004ISIS\020\002\022\n\n\006BRIDGE\020\003\022\007\n\003C" +
+      "DP\020\004\022\017\n\013USERDEFINED\020\005\022\t\n\005NODES\020\006\022\014\n\010OSPF" +
+      "AREA\020\007\022\021\n\rNETWORKROUTER\020\010\",\n\017TopologySeg" +
+      "ment\022\031\n\003ref\030\001 \001(\0132\014.TopologyRef\"{\n\014Topol" +
+      "ogyPort\022\021\n\tvertex_id\030\001 \001(\t\022\020\n\010if_index\030\002" +
+      " \001(\004\022\017\n\007if_name\030\003 \001(\t\022\017\n\007address\030\004 \001(\t\022$" +
+      "\n\rnode_criteria\030\005 \001(\0132\r.NodeCriteria\"\227\002\n" +
+      "\014TopologyEdge\022\031\n\003ref\030\001 \001(\0132\014.TopologyRef" +
+      "\022#\n\nsourcePort\030\003 \001(\0132\r.TopologyPortH\000\022)\n" +
+      "\rsourceSegment\030\004 \001(\0132\020.TopologySegmentH\000" +
+      "\022\033\n\nsourceNode\030\005 \001(\0132\005.NodeH\000\022#\n\ntargetP" +
+      "ort\030\006 \001(\0132\r.TopologyPortH\001\022)\n\rtargetSegm" +
+      "ent\030\007 \001(\0132\020.TopologySegmentH\001\022\033\n\ntargetN" +
+      "ode\030\010 \001(\0132\005.NodeH\001B\010\n\006sourceB\010\n\006target*g" +
+      "\n\010Severity\022\021\n\rINDETERMINATE\020\000\022\013\n\007CLEARED" +
+      "\020\001\022\n\n\006NORMAL\020\002\022\013\n\007WARNING\020\003\022\t\n\005MINOR\020\004\022\t" +
+      "\n\005MAJOR\020\005\022\014\n\010CRITICAL\020\006*\212\002\n\022TroubleTicke" +
+      "tState\022\010\n\004OPEN\020\000\022\022\n\016CREATE_PENDING\020\001\022\021\n\r" +
+      "CREATE_FAILED\020\002\022\022\n\016UPDATE_PENDING\020\003\022\021\n\rU" +
+      "PDATE_FAILED\020\004\022\n\n\006CLOSED\020\005\022\021\n\rCLOSE_PEND" +
+      "ING\020\006\022\020\n\014CLOSE_FAILED\020\007\022\014\n\010RESOLVED\020\010\022\023\n" +
+      "\017RESOLVE_PENDING\020\t\022\022\n\016RESOLVE_FAILED\020\n\022\r" +
+      "\n\tCANCELLED\020\013\022\022\n\016CANCEL_PENDING\020\014\022\021\n\rCAN" +
+      "CEL_FAILED\020\rB?\n)org.opennms.features.kaf" +
+      "ka.producer.modelB\022OpennmsModelProtosb\006p" +
+      "roto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/features/kafka/producer/src/main/proto/opennms-kafka-producer.proto
+++ b/features/kafka/producer/src/main/proto/opennms-kafka-producer.proto
@@ -181,6 +181,7 @@ message Node {
   HwEntity hw_inventory = 13;
 }
 
+/* NOTE: if you change this, you must also update ALEC's copy as well */
 message TopologyRef {
   string id = 1;
   enum Protocol {
@@ -190,6 +191,9 @@ message TopologyRef {
     BRIDGE = 3;
     CDP = 4;
     USERDEFINED = 5;
+    NODES = 6;
+    OSPFAREA = 7;
+    NETWORKROUTER = 8;
   }
   Protocol protocol = 2;
 }

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/model/OpennmsModelProtosTest.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/model/OpennmsModelProtosTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.kafka.producer.model;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyRef.Protocol;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
+
+public class OpennmsModelProtosTest {
+    @Test
+    public void testTopologyProtocolToProtobuf() {
+        for (final var from : TopologyProtocol.values()) {
+            if (from == TopologyProtocol.ALL) {
+                // ALL is a special case that we don't expect to be on both sides, skip it
+                continue;
+            }
+
+            var to = OpennmsModelProtos.TopologyRef.Protocol.valueOf(from.toString());
+            assertEquals("expect protocols to match, but " +from.toString() + "!=" +to.toString() + ")", from.toString(), to.toString());
+        }
+    }
+
+    @Test
+    public void testProtobufToTopologyProtocol() {
+        for (final var from : OpennmsModelProtos.TopologyRef.Protocol.values()) {
+            if (from == Protocol.UNRECOGNIZED) {
+                // UNRECOGNIZED is a special case that we don't expect to be on both sides, skip it
+                continue;
+            }
+            final var to = TopologyProtocol.valueOf(from.toString());
+            assertEquals("expect protocols to match, but " +from.toString() + "!=" +to.toString() + ")", from.toString(), to.toString());
+        }
+    }
+}

--- a/features/telemetry/protocols/jti/adapter/pom.xml
+++ b/features/telemetry/protocols/jti/adapter/pom.xml
@@ -32,14 +32,14 @@
         </configuration>
       </plugin>
     <!-- Enable when you need to generate java source files from proto -->
-<!--                  <plugin>
+<!--            <plugin>
               <groupId>org.xolstice.maven.plugins</groupId>
               <artifactId>protobuf-maven-plugin</artifactId>
               <version>0.6.1</version>
               <configuration>
-                <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
+                <protocArtifact>com.google.protobuf:protoc:${protobufVersion}:exe:${os.detected.classifier}</protocArtifact>
                 <pluginId>grpc-java</pluginId>
-                <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.43.2:exe:${os.detected.classifier}</pluginArtifact>
+                <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.56.1:exe:${os.detected.classifier}</pluginArtifact>
               </configuration>
               <executions>
                 <execution>

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/CpuMemoryUtilizationOuterClass.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/CpuMemoryUtilizationOuterClass.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -73,6 +73,7 @@ public final class CpuMemoryUtilizationOuterClass {
   }
   /**
    * <pre>
+   *
    * The top level message is CpuMemoryUtilization
    * </pre>
    *
@@ -98,61 +99,6 @@ public final class CpuMemoryUtilizationOuterClass {
       return new CpuMemoryUtilization();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private CpuMemoryUtilization(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                utilization_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              utilization_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          utilization_ = java.util.Collections.unmodifiableList(utilization_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.internal_static_CpuMemoryUtilization_descriptor;
@@ -167,6 +113,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int UTILIZATION_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary> utilization_;
     /**
      * <code>repeated .CpuMemoryUtilizationSummary utilization = 1;</code>
@@ -223,7 +170,7 @@ public final class CpuMemoryUtilizationOuterClass {
       for (int i = 0; i < utilization_.size(); i++) {
         output.writeMessage(1, utilization_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -236,7 +183,7 @@ public final class CpuMemoryUtilizationOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, utilization_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -253,7 +200,7 @@ public final class CpuMemoryUtilizationOuterClass {
 
       if (!getUtilizationList()
           .equals(other.getUtilizationList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -268,7 +215,7 @@ public final class CpuMemoryUtilizationOuterClass {
         hash = (37 * hash) + UTILIZATION_FIELD_NUMBER;
         hash = (53 * hash) + getUtilizationList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -365,6 +312,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
     /**
      * <pre>
+     *
      * The top level message is CpuMemoryUtilization
      * </pre>
      *
@@ -389,29 +337,25 @@ public final class CpuMemoryUtilizationOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getUtilizationFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (utilizationBuilder_ == null) {
           utilization_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
+          utilization_ = null;
           utilizationBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -438,7 +382,13 @@ public final class CpuMemoryUtilizationOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization result) {
         if (utilizationBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             utilization_ = java.util.Collections.unmodifiableList(utilization_);
@@ -448,42 +398,12 @@ public final class CpuMemoryUtilizationOuterClass {
         } else {
           result.utilization_ = utilizationBuilder_.build();
         }
-        onBuilt();
-        return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization result) {
+        int from_bitField0_ = bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization) {
@@ -522,7 +442,7 @@ public final class CpuMemoryUtilizationOuterClass {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -537,17 +457,43 @@ public final class CpuMemoryUtilizationOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary.PARSER,
+                        extensionRegistry);
+                if (utilizationBuilder_ == null) {
+                  ensureUtilizationIsMutable();
+                  utilization_.add(m);
+                } else {
+                  utilizationBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilization) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -824,7 +770,18 @@ public final class CpuMemoryUtilizationOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CpuMemoryUtilization(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -1009,82 +966,6 @@ public final class CpuMemoryUtilizationOuterClass {
       return new CpuMemoryUtilizationSummary();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private CpuMemoryUtilizationSummary(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              name_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              size_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              bytesAllocated_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              utilization_ = input.readInt32();
-              break;
-            }
-            case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
-                applicationUtilization_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication>();
-                mutable_bitField0_ |= 0x00000010;
-              }
-              applicationUtilization_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000010) != 0)) {
-          applicationUtilization_ = java.util.Collections.unmodifiableList(applicationUtilization_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.internal_static_CpuMemoryUtilizationSummary_descriptor;
@@ -1100,7 +981,8 @@ public final class CpuMemoryUtilizationOuterClass {
 
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
     /**
      * <pre>
      * Name of the partition.
@@ -1160,7 +1042,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int SIZE_FIELD_NUMBER = 2;
-    private long size_;
+    private long size_ = 0L;
     /**
      * <pre>
      * The total size of the partition in bytes
@@ -1187,7 +1069,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int BYTES_ALLOCATED_FIELD_NUMBER = 3;
-    private long bytesAllocated_;
+    private long bytesAllocated_ = 0L;
     /**
      * <pre>
      * The amount of memory currently allocated from the partition in bytes
@@ -1214,7 +1096,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int UTILIZATION_FIELD_NUMBER = 4;
-    private int utilization_;
+    private int utilization_ = 0;
     /**
      * <pre>
      * The amount of memory that is currently allocated, expressed
@@ -1243,6 +1125,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int APPLICATION_UTILIZATION_FIELD_NUMBER = 5;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication> applicationUtilization_;
     /**
      * <pre>
@@ -1331,7 +1214,7 @@ public final class CpuMemoryUtilizationOuterClass {
       for (int i = 0; i < applicationUtilization_.size(); i++) {
         output.writeMessage(5, applicationUtilization_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -1359,7 +1242,7 @@ public final class CpuMemoryUtilizationOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(5, applicationUtilization_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -1396,7 +1279,7 @@ public final class CpuMemoryUtilizationOuterClass {
       }
       if (!getApplicationUtilizationList()
           .equals(other.getApplicationUtilizationList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -1429,7 +1312,7 @@ public final class CpuMemoryUtilizationOuterClass {
         hash = (37 * hash) + APPLICATION_UTILIZATION_FIELD_NUMBER;
         hash = (53 * hash) + getApplicationUtilizationList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -1551,37 +1434,29 @@ public final class CpuMemoryUtilizationOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getApplicationUtilizationFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         size_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         bytesAllocated_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         utilization_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
         if (applicationUtilizationBuilder_ == null) {
           applicationUtilization_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
         } else {
+          applicationUtilization_ = null;
           applicationUtilizationBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -1608,12 +1483,31 @@ public final class CpuMemoryUtilizationOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary(this);
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary result) {
+        if (applicationUtilizationBuilder_ == null) {
+          if (((bitField0_ & 0x00000010) != 0)) {
+            applicationUtilization_ = java.util.Collections.unmodifiableList(applicationUtilization_);
+            bitField0_ = (bitField0_ & ~0x00000010);
+          }
+          result.applicationUtilization_ = applicationUtilization_;
+        } else {
+          result.applicationUtilization_ = applicationUtilizationBuilder_.build();
+        }
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.name_ = name_;
           to_bitField0_ |= 0x00000001;
         }
-        result.name_ = name_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.size_ = size_;
           to_bitField0_ |= 0x00000002;
@@ -1626,52 +1520,9 @@ public final class CpuMemoryUtilizationOuterClass {
           result.utilization_ = utilization_;
           to_bitField0_ |= 0x00000008;
         }
-        if (applicationUtilizationBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) != 0)) {
-            applicationUtilization_ = java.util.Collections.unmodifiableList(applicationUtilization_);
-            bitField0_ = (bitField0_ & ~0x00000010);
-          }
-          result.applicationUtilization_ = applicationUtilization_;
-        } else {
-          result.applicationUtilization_ = applicationUtilizationBuilder_.build();
-        }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary) {
@@ -1685,8 +1536,8 @@ public final class CpuMemoryUtilizationOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary.getDefaultInstance()) return this;
         if (other.hasName()) {
-          bitField0_ |= 0x00000001;
           name_ = other.name_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasSize()) {
@@ -1724,7 +1575,7 @@ public final class CpuMemoryUtilizationOuterClass {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -1739,17 +1590,63 @@ public final class CpuMemoryUtilizationOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                name_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                size_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                bytesAllocated_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                utilization_ = input.readInt32();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 42: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication.PARSER,
+                        extensionRegistry);
+                if (applicationUtilizationBuilder_ == null) {
+                  ensureApplicationUtilizationIsMutable();
+                  applicationUtilization_.add(m);
+                } else {
+                  applicationUtilizationBuilder_.addMessage(m);
+                }
+                break;
+              } // case 42
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationSummary) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -1820,11 +1717,9 @@ public final class CpuMemoryUtilizationOuterClass {
        */
       public Builder setName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1837,8 +1732,8 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -1853,11 +1748,9 @@ public final class CpuMemoryUtilizationOuterClass {
        */
       public Builder setNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1897,8 +1790,9 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder setSize(long value) {
-        bitField0_ |= 0x00000002;
+
         size_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1952,8 +1846,9 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder setBytesAllocated(long value) {
-        bitField0_ |= 0x00000004;
+
         bytesAllocated_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2010,8 +1905,9 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder setUtilization(int value) {
-        bitField0_ |= 0x00000008;
+
         utilization_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2375,7 +2271,18 @@ public final class CpuMemoryUtilizationOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CpuMemoryUtilizationSummary(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -2531,75 +2438,6 @@ public final class CpuMemoryUtilizationOuterClass {
       return new CpuMemoryUtilizationPerApplication();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private CpuMemoryUtilizationPerApplication(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              name_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              bytesAllocated_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              allocations_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              frees_ = input.readUInt64();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              allocationsFailed_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.internal_static_CpuMemoryUtilizationPerApplication_descriptor;
@@ -2615,7 +2453,8 @@ public final class CpuMemoryUtilizationOuterClass {
 
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
     /**
      * <pre>
      * Application name
@@ -2675,7 +2514,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int BYTES_ALLOCATED_FIELD_NUMBER = 2;
-    private long bytesAllocated_;
+    private long bytesAllocated_ = 0L;
     /**
      * <pre>
      * Number of bytes allocated
@@ -2702,7 +2541,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int ALLOCATIONS_FIELD_NUMBER = 3;
-    private long allocations_;
+    private long allocations_ = 0L;
     /**
      * <pre>
      *  Number of allocations
@@ -2729,7 +2568,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int FREES_FIELD_NUMBER = 4;
-    private long frees_;
+    private long frees_ = 0L;
     /**
      * <pre>
      *  Number of frees
@@ -2756,7 +2595,7 @@ public final class CpuMemoryUtilizationOuterClass {
     }
 
     public static final int ALLOCATIONS_FAILED_FIELD_NUMBER = 5;
-    private long allocationsFailed_;
+    private long allocationsFailed_ = 0L;
     /**
      * <pre>
      * Number of allocations failed
@@ -2811,7 +2650,7 @@ public final class CpuMemoryUtilizationOuterClass {
       if (((bitField0_ & 0x00000010) != 0)) {
         output.writeUInt64(5, allocationsFailed_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -2839,7 +2678,7 @@ public final class CpuMemoryUtilizationOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(5, allocationsFailed_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -2879,7 +2718,7 @@ public final class CpuMemoryUtilizationOuterClass {
         if (getAllocationsFailed()
             != other.getAllocationsFailed()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -2914,7 +2753,7 @@ public final class CpuMemoryUtilizationOuterClass {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getAllocationsFailed());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -3035,32 +2874,23 @@ public final class CpuMemoryUtilizationOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         bytesAllocated_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         allocations_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         frees_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         allocationsFailed_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -3087,12 +2917,18 @@ public final class CpuMemoryUtilizationOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.name_ = name_;
           to_bitField0_ |= 0x00000001;
         }
-        result.name_ = name_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.bytesAllocated_ = bytesAllocated_;
           to_bitField0_ |= 0x00000002;
@@ -3109,43 +2945,9 @@ public final class CpuMemoryUtilizationOuterClass {
           result.allocationsFailed_ = allocationsFailed_;
           to_bitField0_ |= 0x00000010;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication) {
@@ -3159,8 +2961,8 @@ public final class CpuMemoryUtilizationOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication.getDefaultInstance()) return this;
         if (other.hasName()) {
-          bitField0_ |= 0x00000001;
           name_ = other.name_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasBytesAllocated()) {
@@ -3175,7 +2977,7 @@ public final class CpuMemoryUtilizationOuterClass {
         if (other.hasAllocationsFailed()) {
           setAllocationsFailed(other.getAllocationsFailed());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -3190,17 +2992,55 @@ public final class CpuMemoryUtilizationOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                name_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                bytesAllocated_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                allocations_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                frees_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 40: {
+                allocationsFailed_ = input.readUInt64();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass.CpuMemoryUtilizationPerApplication) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -3271,11 +3111,9 @@ public final class CpuMemoryUtilizationOuterClass {
        */
       public Builder setName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -3288,8 +3126,8 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -3304,11 +3142,9 @@ public final class CpuMemoryUtilizationOuterClass {
        */
       public Builder setNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -3348,8 +3184,9 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder setBytesAllocated(long value) {
-        bitField0_ |= 0x00000002;
+
         bytesAllocated_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3403,8 +3240,9 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder setAllocations(long value) {
-        bitField0_ |= 0x00000004;
+
         allocations_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -3458,8 +3296,9 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder setFrees(long value) {
-        bitField0_ |= 0x00000008;
+
         frees_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3513,8 +3352,9 @@ public final class CpuMemoryUtilizationOuterClass {
        * @return This builder for chaining.
        */
       public Builder setAllocationsFailed(long value) {
-        bitField0_ |= 0x00000010;
+
         allocationsFailed_ = value;
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3565,7 +3405,18 @@ public final class CpuMemoryUtilizationOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CpuMemoryUtilizationPerApplication(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/FirewallOuterClass.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/FirewallOuterClass.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -73,6 +73,7 @@ public final class FirewallOuterClass {
   }
   /**
    * <pre>
+   *
    * Top-level message
    * </pre>
    *
@@ -98,61 +99,6 @@ public final class FirewallOuterClass {
       return new Firewall();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private Firewall(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                firewallStats_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              firewallStats_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          firewallStats_ = java.util.Collections.unmodifiableList(firewallStats_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.internal_static_Firewall_descriptor;
@@ -167,6 +113,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int FIREWALL_STATS_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats> firewallStats_;
     /**
      * <code>repeated .FirewallStats firewall_stats = 1;</code>
@@ -229,7 +176,7 @@ public final class FirewallOuterClass {
       for (int i = 0; i < firewallStats_.size(); i++) {
         output.writeMessage(1, firewallStats_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -242,7 +189,7 @@ public final class FirewallOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, firewallStats_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -259,7 +206,7 @@ public final class FirewallOuterClass {
 
       if (!getFirewallStatsList()
           .equals(other.getFirewallStatsList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -274,7 +221,7 @@ public final class FirewallOuterClass {
         hash = (37 * hash) + FIREWALL_STATS_FIELD_NUMBER;
         hash = (53 * hash) + getFirewallStatsList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -371,6 +318,7 @@ public final class FirewallOuterClass {
     }
     /**
      * <pre>
+     *
      * Top-level message
      * </pre>
      *
@@ -395,29 +343,25 @@ public final class FirewallOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getFirewallStatsFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (firewallStatsBuilder_ == null) {
           firewallStats_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
+          firewallStats_ = null;
           firewallStatsBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -444,7 +388,13 @@ public final class FirewallOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall result) {
         if (firewallStatsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             firewallStats_ = java.util.Collections.unmodifiableList(firewallStats_);
@@ -454,42 +404,12 @@ public final class FirewallOuterClass {
         } else {
           result.firewallStats_ = firewallStatsBuilder_.build();
         }
-        onBuilt();
-        return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall result) {
+        int from_bitField0_ = bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall) {
@@ -528,7 +448,7 @@ public final class FirewallOuterClass {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -548,17 +468,43 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats.PARSER,
+                        extensionRegistry);
+                if (firewallStatsBuilder_ == null) {
+                  ensureFirewallStatsIsMutable();
+                  firewallStats_.add(m);
+                } else {
+                  firewallStatsBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.Firewall) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -835,7 +781,18 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Firewall(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -997,6 +954,7 @@ public final class FirewallOuterClass {
   }
   /**
    * <pre>
+   *
    * Firewall filter statistics
    * </pre>
    *
@@ -1026,108 +984,6 @@ public final class FirewallOuterClass {
       return new FirewallStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private FirewallStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              filterName_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              timestamp_ = input.readUInt64();
-              break;
-            }
-            case 26: {
-              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
-                memoryUsage_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage>();
-                mutable_bitField0_ |= 0x00000004;
-              }
-              memoryUsage_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage.PARSER, extensionRegistry));
-              break;
-            }
-            case 34: {
-              if (!((mutable_bitField0_ & 0x00000008) != 0)) {
-                counterStats_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats>();
-                mutable_bitField0_ |= 0x00000008;
-              }
-              counterStats_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats.PARSER, extensionRegistry));
-              break;
-            }
-            case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
-                policerStats_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats>();
-                mutable_bitField0_ |= 0x00000010;
-              }
-              policerStats_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats.PARSER, extensionRegistry));
-              break;
-            }
-            case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
-                hierarchicalPolicerStats_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats>();
-                mutable_bitField0_ |= 0x00000020;
-              }
-              hierarchicalPolicerStats_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000004) != 0)) {
-          memoryUsage_ = java.util.Collections.unmodifiableList(memoryUsage_);
-        }
-        if (((mutable_bitField0_ & 0x00000008) != 0)) {
-          counterStats_ = java.util.Collections.unmodifiableList(counterStats_);
-        }
-        if (((mutable_bitField0_ & 0x00000010) != 0)) {
-          policerStats_ = java.util.Collections.unmodifiableList(policerStats_);
-        }
-        if (((mutable_bitField0_ & 0x00000020) != 0)) {
-          hierarchicalPolicerStats_ = java.util.Collections.unmodifiableList(hierarchicalPolicerStats_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.internal_static_FirewallStats_descriptor;
@@ -1143,7 +999,8 @@ public final class FirewallOuterClass {
 
     private int bitField0_;
     public static final int FILTER_NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object filterName_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object filterName_ = "";
     /**
      * <code>required string filter_name = 1 [(.telemetry_options) = { ... }</code>
      * @return Whether the filterName field is set.
@@ -1191,7 +1048,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int TIMESTAMP_FIELD_NUMBER = 2;
-    private long timestamp_;
+    private long timestamp_ = 0L;
     /**
      * <pre>
      * The Unix timestamp (seconds since 00:00:00 UTC 1970-01-01) of
@@ -1222,6 +1079,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int MEMORY_USAGE_FIELD_NUMBER = 3;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage> memoryUsage_;
     /**
      * <code>repeated .MemoryUsage memory_usage = 3;</code>
@@ -1262,6 +1120,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int COUNTER_STATS_FIELD_NUMBER = 4;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats> counterStats_;
     /**
      * <code>repeated .CounterStats counter_stats = 4;</code>
@@ -1302,6 +1161,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int POLICER_STATS_FIELD_NUMBER = 5;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats> policerStats_;
     /**
      * <code>repeated .PolicerStats policer_stats = 5;</code>
@@ -1342,6 +1202,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int HIERARCHICAL_POLICER_STATS_FIELD_NUMBER = 6;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats> hierarchicalPolicerStats_;
     /**
      * <code>repeated .HierarchicalPolicerStats hierarchical_policer_stats = 6;</code>
@@ -1441,7 +1302,7 @@ public final class FirewallOuterClass {
       for (int i = 0; i < hierarchicalPolicerStats_.size(); i++) {
         output.writeMessage(6, hierarchicalPolicerStats_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -1473,7 +1334,7 @@ public final class FirewallOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(6, hierarchicalPolicerStats_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -1506,7 +1367,7 @@ public final class FirewallOuterClass {
           .equals(other.getPolicerStatsList())) return false;
       if (!getHierarchicalPolicerStatsList()
           .equals(other.getHierarchicalPolicerStatsList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -1542,7 +1403,7 @@ public final class FirewallOuterClass {
         hash = (37 * hash) + HIERARCHICAL_POLICER_STATS_FIELD_NUMBER;
         hash = (53 * hash) + getHierarchicalPolicerStatsList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -1639,6 +1500,7 @@ public final class FirewallOuterClass {
     }
     /**
      * <pre>
+     *
      * Firewall filter statistics
      * </pre>
      *
@@ -1663,54 +1525,48 @@ public final class FirewallOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getMemoryUsageFieldBuilder();
-          getCounterStatsFieldBuilder();
-          getPolicerStatsFieldBuilder();
-          getHierarchicalPolicerStatsFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         filterName_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         timestamp_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         if (memoryUsageBuilder_ == null) {
           memoryUsage_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000004);
         } else {
+          memoryUsage_ = null;
           memoryUsageBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000004);
         if (counterStatsBuilder_ == null) {
           counterStats_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000008);
         } else {
+          counterStats_ = null;
           counterStatsBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000008);
         if (policerStatsBuilder_ == null) {
           policerStats_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
         } else {
+          policerStats_ = null;
           policerStatsBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000010);
         if (hierarchicalPolicerStatsBuilder_ == null) {
           hierarchicalPolicerStats_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
         } else {
+          hierarchicalPolicerStats_ = null;
           hierarchicalPolicerStatsBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -1737,16 +1593,13 @@ public final class FirewallOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) != 0)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.filterName_ = filterName_;
-        if (((from_bitField0_ & 0x00000002) != 0)) {
-          result.timestamp_ = timestamp_;
-          to_bitField0_ |= 0x00000002;
-        }
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats result) {
         if (memoryUsageBuilder_ == null) {
           if (((bitField0_ & 0x00000004) != 0)) {
             memoryUsage_ = java.util.Collections.unmodifiableList(memoryUsage_);
@@ -1783,43 +1636,22 @@ public final class FirewallOuterClass {
         } else {
           result.hierarchicalPolicerStats_ = hierarchicalPolicerStatsBuilder_.build();
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.filterName_ = filterName_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.timestamp_ = timestamp_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ |= to_bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats) {
@@ -1833,8 +1665,8 @@ public final class FirewallOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats.getDefaultInstance()) return this;
         if (other.hasFilterName()) {
-          bitField0_ |= 0x00000001;
           filterName_ = other.filterName_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasTimestamp()) {
@@ -1944,7 +1776,7 @@ public final class FirewallOuterClass {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -1982,17 +1814,92 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                filterName_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                timestamp_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 26: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage.PARSER,
+                        extensionRegistry);
+                if (memoryUsageBuilder_ == null) {
+                  ensureMemoryUsageIsMutable();
+                  memoryUsage_.add(m);
+                } else {
+                  memoryUsageBuilder_.addMessage(m);
+                }
+                break;
+              } // case 26
+              case 34: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats.PARSER,
+                        extensionRegistry);
+                if (counterStatsBuilder_ == null) {
+                  ensureCounterStatsIsMutable();
+                  counterStats_.add(m);
+                } else {
+                  counterStatsBuilder_.addMessage(m);
+                }
+                break;
+              } // case 34
+              case 42: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats.PARSER,
+                        extensionRegistry);
+                if (policerStatsBuilder_ == null) {
+                  ensurePolicerStatsIsMutable();
+                  policerStats_.add(m);
+                } else {
+                  policerStatsBuilder_.addMessage(m);
+                }
+                break;
+              } // case 42
+              case 50: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats.PARSER,
+                        extensionRegistry);
+                if (hierarchicalPolicerStatsBuilder_ == null) {
+                  ensureHierarchicalPolicerStatsIsMutable();
+                  hierarchicalPolicerStats_.add(m);
+                } else {
+                  hierarchicalPolicerStatsBuilder_.addMessage(m);
+                }
+                break;
+              } // case 50
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.FirewallStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -2047,11 +1954,9 @@ public final class FirewallOuterClass {
        */
       public Builder setFilterName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         filterName_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2060,8 +1965,8 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearFilterName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         filterName_ = getDefaultInstance().getFilterName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -2072,11 +1977,9 @@ public final class FirewallOuterClass {
        */
       public Builder setFilterNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         filterName_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2122,8 +2025,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        bitField0_ |= 0x00000002;
+
         timestamp_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3136,7 +3040,18 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new FirewallStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -3219,6 +3134,7 @@ public final class FirewallOuterClass {
   }
   /**
    * <pre>
+   *
    * Memory usage
    * </pre>
    *
@@ -3244,60 +3160,6 @@ public final class FirewallOuterClass {
       return new MemoryUsage();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private MemoryUsage(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              name_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              allocated_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.internal_static_MemoryUsage_descriptor;
@@ -3313,7 +3175,8 @@ public final class FirewallOuterClass {
 
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
     /**
      * <pre>
      * The router has typically several types of memories (e.g. CPU's memory,
@@ -3382,7 +3245,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int ALLOCATED_FIELD_NUMBER = 2;
-    private long allocated_;
+    private long allocated_ = 0L;
     /**
      * <pre>
      * The amount of the memory allocated in bytes to the filter
@@ -3432,7 +3295,7 @@ public final class FirewallOuterClass {
       if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt64(2, allocated_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -3448,7 +3311,7 @@ public final class FirewallOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, allocated_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -3473,7 +3336,7 @@ public final class FirewallOuterClass {
         if (getAllocated()
             != other.getAllocated()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -3493,7 +3356,7 @@ public final class FirewallOuterClass {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getAllocated());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -3590,6 +3453,7 @@ public final class FirewallOuterClass {
     }
     /**
      * <pre>
+     *
      * Memory usage
      * </pre>
      *
@@ -3614,26 +3478,20 @@ public final class FirewallOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         allocated_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -3660,53 +3518,25 @@ public final class FirewallOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) != 0)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.name_ = name_;
-        if (((from_bitField0_ & 0x00000002) != 0)) {
-          result.allocated_ = allocated_;
-          to_bitField0_ |= 0x00000002;
-        }
-        result.bitField0_ = to_bitField0_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.name_ = name_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.allocated_ = allocated_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ |= to_bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage) {
@@ -3720,14 +3550,14 @@ public final class FirewallOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage.getDefaultInstance()) return this;
         if (other.hasName()) {
-          bitField0_ |= 0x00000001;
           name_ = other.name_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasAllocated()) {
           setAllocated(other.getAllocated());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -3745,17 +3575,40 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                name_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                allocated_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.MemoryUsage) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -3838,11 +3691,9 @@ public final class FirewallOuterClass {
        */
       public Builder setName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -3858,8 +3709,8 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -3877,11 +3728,9 @@ public final class FirewallOuterClass {
        */
       public Builder setNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -3921,8 +3770,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setAllocated(long value) {
-        bitField0_ |= 0x00000002;
+
         allocated_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3973,7 +3823,18 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MemoryUsage(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -4066,6 +3927,7 @@ public final class FirewallOuterClass {
   }
   /**
    * <pre>
+   *
    * Counter statistics
    * </pre>
    *
@@ -4091,65 +3953,6 @@ public final class FirewallOuterClass {
       return new CounterStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private CounterStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              name_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              packets_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              bytes_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.internal_static_CounterStats_descriptor;
@@ -4165,7 +3968,8 @@ public final class FirewallOuterClass {
 
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
     /**
      * <pre>
      * Counter name
@@ -4225,7 +4029,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int PACKETS_FIELD_NUMBER = 2;
-    private long packets_;
+    private long packets_ = 0L;
     /**
      * <pre>
      * The total number of packets seen by the counter
@@ -4252,7 +4056,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int BYTES_FIELD_NUMBER = 3;
-    private long bytes_;
+    private long bytes_ = 0L;
     /**
      * <pre>
      * The total number of bytes seen by the counter
@@ -4305,7 +4109,7 @@ public final class FirewallOuterClass {
       if (((bitField0_ & 0x00000004) != 0)) {
         output.writeUInt64(3, bytes_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -4325,7 +4129,7 @@ public final class FirewallOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(3, bytes_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -4355,7 +4159,7 @@ public final class FirewallOuterClass {
         if (getBytes()
             != other.getBytes()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -4380,7 +4184,7 @@ public final class FirewallOuterClass {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getBytes());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -4477,6 +4281,7 @@ public final class FirewallOuterClass {
     }
     /**
      * <pre>
+     *
      * Counter statistics
      * </pre>
      *
@@ -4501,28 +4306,21 @@ public final class FirewallOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         packets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         bytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -4549,12 +4347,18 @@ public final class FirewallOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.name_ = name_;
           to_bitField0_ |= 0x00000001;
         }
-        result.name_ = name_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.packets_ = packets_;
           to_bitField0_ |= 0x00000002;
@@ -4563,43 +4367,9 @@ public final class FirewallOuterClass {
           result.bytes_ = bytes_;
           to_bitField0_ |= 0x00000004;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats) {
@@ -4613,8 +4383,8 @@ public final class FirewallOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats.getDefaultInstance()) return this;
         if (other.hasName()) {
-          bitField0_ |= 0x00000001;
           name_ = other.name_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasPackets()) {
@@ -4623,7 +4393,7 @@ public final class FirewallOuterClass {
         if (other.hasBytes()) {
           setBytes(other.getBytes());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -4641,17 +4411,45 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                name_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                packets_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                bytes_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.CounterStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -4722,11 +4520,9 @@ public final class FirewallOuterClass {
        */
       public Builder setName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -4739,8 +4535,8 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -4755,11 +4551,9 @@ public final class FirewallOuterClass {
        */
       public Builder setNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -4799,8 +4593,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setPackets(long value) {
-        bitField0_ |= 0x00000002;
+
         packets_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -4854,8 +4649,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setBytes(long value) {
-        bitField0_ |= 0x00000004;
+
         bytes_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -4906,7 +4702,18 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CounterStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -5026,6 +4833,7 @@ public final class FirewallOuterClass {
   }
   /**
    * <pre>
+   *
    * Policer statistics
    * </pre>
    *
@@ -5051,78 +4859,6 @@ public final class FirewallOuterClass {
       return new PolicerStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private PolicerStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              name_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              outOfSpecPackets_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              outOfSpecBytes_ = input.readUInt64();
-              break;
-            }
-            case 34: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) != 0)) {
-                subBuilder = extendedPolicerStats_.toBuilder();
-              }
-              extendedPolicerStats_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(extendedPolicerStats_);
-                extendedPolicerStats_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000008;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.internal_static_PolicerStats_descriptor;
@@ -5138,7 +4874,8 @@ public final class FirewallOuterClass {
 
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
     /**
      * <pre>
      * Policer instance name
@@ -5198,7 +4935,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int OUT_OF_SPEC_PACKETS_FIELD_NUMBER = 2;
-    private long outOfSpecPackets_;
+    private long outOfSpecPackets_ = 0L;
     /**
      * <pre>
      * The total number of packets marked out-of-specification by the policer
@@ -5225,7 +4962,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int OUT_OF_SPEC_BYTES_FIELD_NUMBER = 3;
-    private long outOfSpecBytes_;
+    private long outOfSpecBytes_ = 0L;
     /**
      * <pre>
      * The total number of bytes marked out-of-specification by the policer
@@ -5319,7 +5056,7 @@ public final class FirewallOuterClass {
       if (((bitField0_ & 0x00000008) != 0)) {
         output.writeMessage(4, getExtendedPolicerStats());
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -5343,7 +5080,7 @@ public final class FirewallOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getExtendedPolicerStats());
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -5378,7 +5115,7 @@ public final class FirewallOuterClass {
         if (!getExtendedPolicerStats()
             .equals(other.getExtendedPolicerStats())) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -5407,7 +5144,7 @@ public final class FirewallOuterClass {
         hash = (37 * hash) + EXTENDED_POLICER_STATS_FIELD_NUMBER;
         hash = (53 * hash) + getExtendedPolicerStats().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -5504,6 +5241,7 @@ public final class FirewallOuterClass {
     }
     /**
      * <pre>
+     *
      * Policer statistics
      * </pre>
      *
@@ -5545,18 +5283,15 @@ public final class FirewallOuterClass {
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         outOfSpecPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         outOfSpecBytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        if (extendedPolicerStatsBuilder_ == null) {
-          extendedPolicerStats_ = null;
-        } else {
-          extendedPolicerStatsBuilder_.clear();
+        extendedPolicerStats_ = null;
+        if (extendedPolicerStatsBuilder_ != null) {
+          extendedPolicerStatsBuilder_.dispose();
+          extendedPolicerStatsBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -5583,12 +5318,18 @@ public final class FirewallOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.name_ = name_;
           to_bitField0_ |= 0x00000001;
         }
-        result.name_ = name_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.outOfSpecPackets_ = outOfSpecPackets_;
           to_bitField0_ |= 0x00000002;
@@ -5598,50 +5339,14 @@ public final class FirewallOuterClass {
           to_bitField0_ |= 0x00000004;
         }
         if (((from_bitField0_ & 0x00000008) != 0)) {
-          if (extendedPolicerStatsBuilder_ == null) {
-            result.extendedPolicerStats_ = extendedPolicerStats_;
-          } else {
-            result.extendedPolicerStats_ = extendedPolicerStatsBuilder_.build();
-          }
+          result.extendedPolicerStats_ = extendedPolicerStatsBuilder_ == null
+              ? extendedPolicerStats_
+              : extendedPolicerStatsBuilder_.build();
           to_bitField0_ |= 0x00000008;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats) {
@@ -5655,8 +5360,8 @@ public final class FirewallOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats.getDefaultInstance()) return this;
         if (other.hasName()) {
-          bitField0_ |= 0x00000001;
           name_ = other.name_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasOutOfSpecPackets()) {
@@ -5668,7 +5373,7 @@ public final class FirewallOuterClass {
         if (other.hasExtendedPolicerStats()) {
           mergeExtendedPolicerStats(other.getExtendedPolicerStats());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -5686,17 +5391,52 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                name_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                outOfSpecPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                outOfSpecBytes_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 34: {
+                input.readMessage(
+                    getExtendedPolicerStatsFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 34
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.PolicerStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -5767,11 +5507,9 @@ public final class FirewallOuterClass {
        */
       public Builder setName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -5784,8 +5522,8 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -5800,11 +5538,9 @@ public final class FirewallOuterClass {
        */
       public Builder setNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -5844,8 +5580,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setOutOfSpecPackets(long value) {
-        bitField0_ |= 0x00000002;
+
         outOfSpecPackets_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -5899,8 +5636,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setOutOfSpecBytes(long value) {
-        bitField0_ |= 0x00000004;
+
         outOfSpecBytes_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -5961,11 +5699,11 @@ public final class FirewallOuterClass {
             throw new NullPointerException();
           }
           extendedPolicerStats_ = value;
-          onChanged();
         } else {
           extendedPolicerStatsBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000008;
+        onChanged();
         return this;
       }
       /**
@@ -5979,11 +5717,11 @@ public final class FirewallOuterClass {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats.Builder builderForValue) {
         if (extendedPolicerStatsBuilder_ == null) {
           extendedPolicerStats_ = builderForValue.build();
-          onChanged();
         } else {
           extendedPolicerStatsBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000008;
+        onChanged();
         return this;
       }
       /**
@@ -5996,18 +5734,17 @@ public final class FirewallOuterClass {
       public Builder mergeExtendedPolicerStats(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats value) {
         if (extendedPolicerStatsBuilder_ == null) {
           if (((bitField0_ & 0x00000008) != 0) &&
-              extendedPolicerStats_ != null &&
-              extendedPolicerStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats.getDefaultInstance()) {
-            extendedPolicerStats_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats.newBuilder(extendedPolicerStats_).mergeFrom(value).buildPartial();
+            extendedPolicerStats_ != null &&
+            extendedPolicerStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats.getDefaultInstance()) {
+            getExtendedPolicerStatsBuilder().mergeFrom(value);
           } else {
             extendedPolicerStats_ = value;
           }
-          onChanged();
         } else {
           extendedPolicerStatsBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000008;
+        onChanged();
         return this;
       }
       /**
@@ -6018,13 +5755,13 @@ public final class FirewallOuterClass {
        * <code>optional .ExtendedPolicerStats extended_policer_stats = 4;</code>
        */
       public Builder clearExtendedPolicerStats() {
-        if (extendedPolicerStatsBuilder_ == null) {
-          extendedPolicerStats_ = null;
-          onChanged();
-        } else {
-          extendedPolicerStatsBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000008);
+        extendedPolicerStats_ = null;
+        if (extendedPolicerStatsBuilder_ != null) {
+          extendedPolicerStatsBuilder_.dispose();
+          extendedPolicerStatsBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -6107,7 +5844,18 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PolicerStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -6209,6 +5957,7 @@ public final class FirewallOuterClass {
   }
   /**
    * <pre>
+   *
    * Extended policer statistics when enhanced policer statistics are available
    * </pre>
    *
@@ -6233,69 +5982,6 @@ public final class FirewallOuterClass {
       return new ExtendedPolicerStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ExtendedPolicerStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              offeredPackets_ = input.readUInt64();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              offeredBytes_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              transmittedPackets_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              transmittedBytes_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.internal_static_ExtendedPolicerStats_descriptor;
@@ -6311,7 +5997,7 @@ public final class FirewallOuterClass {
 
     private int bitField0_;
     public static final int OFFERED_PACKETS_FIELD_NUMBER = 1;
-    private long offeredPackets_;
+    private long offeredPackets_ = 0L;
     /**
      * <pre>
      * The total number of packets subjected to policing
@@ -6338,7 +6024,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int OFFERED_BYTES_FIELD_NUMBER = 2;
-    private long offeredBytes_;
+    private long offeredBytes_ = 0L;
     /**
      * <pre>
      * The total number of bytes subjected to policing
@@ -6365,7 +6051,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int TRANSMITTED_PACKETS_FIELD_NUMBER = 3;
-    private long transmittedPackets_;
+    private long transmittedPackets_ = 0L;
     /**
      * <pre>
      * The total number of packets not discarded by the policer
@@ -6392,7 +6078,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int TRANSMITTED_BYTES_FIELD_NUMBER = 4;
-    private long transmittedBytes_;
+    private long transmittedBytes_ = 0L;
     /**
      * <pre>
      * The total number of bytes not discarded by the policer
@@ -6444,7 +6130,7 @@ public final class FirewallOuterClass {
       if (((bitField0_ & 0x00000008) != 0)) {
         output.writeUInt64(4, transmittedBytes_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -6469,7 +6155,7 @@ public final class FirewallOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(4, transmittedBytes_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -6504,7 +6190,7 @@ public final class FirewallOuterClass {
         if (getTransmittedBytes()
             != other.getTransmittedBytes()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -6535,7 +6221,7 @@ public final class FirewallOuterClass {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getTransmittedBytes());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -6632,6 +6318,7 @@ public final class FirewallOuterClass {
     }
     /**
      * <pre>
+     *
      * Extended policer statistics when enhanced policer statistics are available
      * </pre>
      *
@@ -6656,30 +6343,22 @@ public final class FirewallOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         offeredPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
         offeredBytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         transmittedPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         transmittedBytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -6706,6 +6385,12 @@ public final class FirewallOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -6724,43 +6409,9 @@ public final class FirewallOuterClass {
           result.transmittedBytes_ = transmittedBytes_;
           to_bitField0_ |= 0x00000008;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats) {
@@ -6785,7 +6436,7 @@ public final class FirewallOuterClass {
         if (other.hasTransmittedBytes()) {
           setTransmittedBytes(other.getTransmittedBytes());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -6800,17 +6451,50 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                offeredPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                offeredBytes_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                transmittedPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                transmittedBytes_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.ExtendedPolicerStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -6850,8 +6534,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setOfferedPackets(long value) {
-        bitField0_ |= 0x00000001;
+
         offeredPackets_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -6905,8 +6590,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setOfferedBytes(long value) {
-        bitField0_ |= 0x00000002;
+
         offeredBytes_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -6960,8 +6646,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setTransmittedPackets(long value) {
-        bitField0_ |= 0x00000004;
+
         transmittedPackets_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -7015,8 +6702,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setTransmittedBytes(long value) {
-        bitField0_ |= 0x00000008;
+
         transmittedBytes_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -7067,7 +6755,18 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ExtendedPolicerStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -7206,6 +6905,7 @@ public final class FirewallOuterClass {
   }
   /**
    * <pre>
+   *
    * Hierarchical policer statistics
    * </pre>
    *
@@ -7231,75 +6931,6 @@ public final class FirewallOuterClass {
       return new HierarchicalPolicerStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private HierarchicalPolicerStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              name_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              premiumPackets_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              premiumBytes_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              aggregatePackets_ = input.readUInt64();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              aggregateBytes_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.internal_static_HierarchicalPolicerStats_descriptor;
@@ -7315,7 +6946,8 @@ public final class FirewallOuterClass {
 
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
     /**
      * <pre>
      * Hierarchical policer instance name
@@ -7375,7 +7007,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int PREMIUM_PACKETS_FIELD_NUMBER = 2;
-    private long premiumPackets_;
+    private long premiumPackets_ = 0L;
     /**
      * <pre>
      * The total number of packets marked out-of-specification by
@@ -7404,7 +7036,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int PREMIUM_BYTES_FIELD_NUMBER = 3;
-    private long premiumBytes_;
+    private long premiumBytes_ = 0L;
     /**
      * <pre>
      * The total number of bytes marked out-of-specification by
@@ -7433,7 +7065,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int AGGREGATE_PACKETS_FIELD_NUMBER = 4;
-    private long aggregatePackets_;
+    private long aggregatePackets_ = 0L;
     /**
      * <pre>
      * The total number of packets marked out-of-specification by
@@ -7462,7 +7094,7 @@ public final class FirewallOuterClass {
     }
 
     public static final int AGGREGATE_BYTES_FIELD_NUMBER = 5;
-    private long aggregateBytes_;
+    private long aggregateBytes_ = 0L;
     /**
      * <pre>
      * The total number of bytes marked out-of-specification by
@@ -7523,7 +7155,7 @@ public final class FirewallOuterClass {
       if (((bitField0_ & 0x00000010) != 0)) {
         output.writeUInt64(5, aggregateBytes_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -7551,7 +7183,7 @@ public final class FirewallOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(5, aggregateBytes_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -7591,7 +7223,7 @@ public final class FirewallOuterClass {
         if (getAggregateBytes()
             != other.getAggregateBytes()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -7626,7 +7258,7 @@ public final class FirewallOuterClass {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getAggregateBytes());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -7723,6 +7355,7 @@ public final class FirewallOuterClass {
     }
     /**
      * <pre>
+     *
      * Hierarchical policer statistics
      * </pre>
      *
@@ -7747,32 +7380,23 @@ public final class FirewallOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         premiumPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         premiumBytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         aggregatePackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         aggregateBytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -7799,12 +7423,18 @@ public final class FirewallOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.name_ = name_;
           to_bitField0_ |= 0x00000001;
         }
-        result.name_ = name_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.premiumPackets_ = premiumPackets_;
           to_bitField0_ |= 0x00000002;
@@ -7821,43 +7451,9 @@ public final class FirewallOuterClass {
           result.aggregateBytes_ = aggregateBytes_;
           to_bitField0_ |= 0x00000010;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats) {
@@ -7871,8 +7467,8 @@ public final class FirewallOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats.getDefaultInstance()) return this;
         if (other.hasName()) {
-          bitField0_ |= 0x00000001;
           name_ = other.name_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasPremiumPackets()) {
@@ -7887,7 +7483,7 @@ public final class FirewallOuterClass {
         if (other.hasAggregateBytes()) {
           setAggregateBytes(other.getAggregateBytes());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -7905,17 +7501,55 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                name_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                premiumPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                premiumBytes_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                aggregatePackets_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 40: {
+                aggregateBytes_ = input.readUInt64();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.FirewallOuterClass.HierarchicalPolicerStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -7986,11 +7620,9 @@ public final class FirewallOuterClass {
        */
       public Builder setName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8003,8 +7635,8 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -8019,11 +7651,9 @@ public final class FirewallOuterClass {
        */
       public Builder setNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8066,8 +7696,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setPremiumPackets(long value) {
-        bitField0_ |= 0x00000002;
+
         premiumPackets_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -8125,8 +7756,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setPremiumBytes(long value) {
-        bitField0_ |= 0x00000004;
+
         premiumBytes_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -8184,8 +7816,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setAggregatePackets(long value) {
-        bitField0_ |= 0x00000008;
+
         aggregatePackets_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -8243,8 +7876,9 @@ public final class FirewallOuterClass {
        * @return This builder for chaining.
        */
       public Builder setAggregateBytes(long value) {
-        bitField0_ |= 0x00000010;
+
         aggregateBytes_ = value;
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -8296,7 +7930,18 @@ public final class FirewallOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new HierarchicalPolicerStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/LogicalPortOuterClass.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/LogicalPortOuterClass.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -73,6 +73,7 @@ public final class LogicalPortOuterClass {
   }
   /**
    * <pre>
+   *
    * Top-level message
    * </pre>
    *
@@ -98,61 +99,6 @@ public final class LogicalPortOuterClass {
       return new LogicalPort();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private LogicalPort(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                interfaceInfo_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              interfaceInfo_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          interfaceInfo_ = java.util.Collections.unmodifiableList(interfaceInfo_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.internal_static_LogicalPort_descriptor;
@@ -167,6 +113,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int INTERFACE_INFO_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo> interfaceInfo_;
     /**
      * <code>repeated .LogicalInterfaceInfo interface_info = 1;</code>
@@ -229,7 +176,7 @@ public final class LogicalPortOuterClass {
       for (int i = 0; i < interfaceInfo_.size(); i++) {
         output.writeMessage(1, interfaceInfo_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -242,7 +189,7 @@ public final class LogicalPortOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, interfaceInfo_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -259,7 +206,7 @@ public final class LogicalPortOuterClass {
 
       if (!getInterfaceInfoList()
           .equals(other.getInterfaceInfoList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -274,7 +221,7 @@ public final class LogicalPortOuterClass {
         hash = (37 * hash) + INTERFACE_INFO_FIELD_NUMBER;
         hash = (53 * hash) + getInterfaceInfoList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -371,6 +318,7 @@ public final class LogicalPortOuterClass {
     }
     /**
      * <pre>
+     *
      * Top-level message
      * </pre>
      *
@@ -395,29 +343,25 @@ public final class LogicalPortOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getInterfaceInfoFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (interfaceInfoBuilder_ == null) {
           interfaceInfo_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
+          interfaceInfo_ = null;
           interfaceInfoBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -444,7 +388,13 @@ public final class LogicalPortOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort result) {
         if (interfaceInfoBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             interfaceInfo_ = java.util.Collections.unmodifiableList(interfaceInfo_);
@@ -454,42 +404,12 @@ public final class LogicalPortOuterClass {
         } else {
           result.interfaceInfo_ = interfaceInfoBuilder_.build();
         }
-        onBuilt();
-        return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort result) {
+        int from_bitField0_ = bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort) {
@@ -528,7 +448,7 @@ public final class LogicalPortOuterClass {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -548,17 +468,43 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo.PARSER,
+                        extensionRegistry);
+                if (interfaceInfoBuilder_ == null) {
+                  ensureInterfaceInfoIsMutable();
+                  interfaceInfo_.add(m);
+                } else {
+                  interfaceInfoBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalPort) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -835,7 +781,18 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new LogicalPort(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -1038,6 +995,7 @@ public final class LogicalPortOuterClass {
   }
   /**
    * <pre>
+   *
    * Logical Interaface information
    * </pre>
    *
@@ -1064,110 +1022,6 @@ public final class LogicalPortOuterClass {
       return new LogicalInterfaceInfo();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private LogicalInterfaceInfo(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              ifName_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              initTime_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              snmpIfIndex_ = input.readUInt32();
-              break;
-            }
-            case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000008;
-              parentAeName_ = bs;
-              break;
-            }
-            case 42: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000010) != 0)) {
-                subBuilder = ingressStats_.toBuilder();
-              }
-              ingressStats_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(ingressStats_);
-                ingressStats_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000010;
-              break;
-            }
-            case 50: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) != 0)) {
-                subBuilder = egressStats_.toBuilder();
-              }
-              egressStats_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(egressStats_);
-                egressStats_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000020;
-              break;
-            }
-            case 58: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000040) != 0)) {
-                subBuilder = opState_.toBuilder();
-              }
-              opState_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(opState_);
-                opState_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000040;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.internal_static_LogicalInterfaceInfo_descriptor;
@@ -1183,7 +1037,8 @@ public final class LogicalPortOuterClass {
 
     private int bitField0_;
     public static final int IF_NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object ifName_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object ifName_ = "";
     /**
      * <pre>
      * Logical interface name (e.g. xe-0/0/0.0)
@@ -1243,7 +1098,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int INIT_TIME_FIELD_NUMBER = 2;
-    private long initTime_;
+    private long initTime_ = 0L;
     /**
      * <pre>
      * Time reset
@@ -1270,7 +1125,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int SNMP_IF_INDEX_FIELD_NUMBER = 3;
-    private int snmpIfIndex_;
+    private int snmpIfIndex_ = 0;
     /**
      * <pre>
      * Global Index
@@ -1297,7 +1152,8 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int PARENT_AE_NAME_FIELD_NUMBER = 4;
-    private volatile java.lang.Object parentAeName_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object parentAeName_ = "";
     /**
      * <pre>
      * Name of the aggregate bundle
@@ -1525,7 +1381,7 @@ public final class LogicalPortOuterClass {
       if (((bitField0_ & 0x00000040) != 0)) {
         output.writeMessage(7, getOpState());
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -1560,7 +1416,7 @@ public final class LogicalPortOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(7, getOpState());
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -1610,7 +1466,7 @@ public final class LogicalPortOuterClass {
         if (!getOpState()
             .equals(other.getOpState())) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -1650,7 +1506,7 @@ public final class LogicalPortOuterClass {
         hash = (37 * hash) + OP_STATE_FIELD_NUMBER;
         hash = (53 * hash) + getOpState().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -1747,6 +1603,7 @@ public final class LogicalPortOuterClass {
     }
     /**
      * <pre>
+     *
      * Logical Interaface information
      * </pre>
      *
@@ -1790,32 +1647,26 @@ public final class LogicalPortOuterClass {
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         ifName_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         initTime_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         snmpIfIndex_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
         parentAeName_ = "";
-        bitField0_ = (bitField0_ & ~0x00000008);
-        if (ingressStatsBuilder_ == null) {
-          ingressStats_ = null;
-        } else {
-          ingressStatsBuilder_.clear();
+        ingressStats_ = null;
+        if (ingressStatsBuilder_ != null) {
+          ingressStatsBuilder_.dispose();
+          ingressStatsBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000010);
-        if (egressStatsBuilder_ == null) {
-          egressStats_ = null;
-        } else {
-          egressStatsBuilder_.clear();
+        egressStats_ = null;
+        if (egressStatsBuilder_ != null) {
+          egressStatsBuilder_.dispose();
+          egressStatsBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000020);
-        if (opStateBuilder_ == null) {
-          opState_ = null;
-        } else {
-          opStateBuilder_.clear();
+        opState_ = null;
+        if (opStateBuilder_ != null) {
+          opStateBuilder_.dispose();
+          opStateBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -1842,12 +1693,18 @@ public final class LogicalPortOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.ifName_ = ifName_;
           to_bitField0_ |= 0x00000001;
         }
-        result.ifName_ = ifName_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.initTime_ = initTime_;
           to_bitField0_ |= 0x00000002;
@@ -1857,70 +1714,30 @@ public final class LogicalPortOuterClass {
           to_bitField0_ |= 0x00000004;
         }
         if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.parentAeName_ = parentAeName_;
           to_bitField0_ |= 0x00000008;
         }
-        result.parentAeName_ = parentAeName_;
         if (((from_bitField0_ & 0x00000010) != 0)) {
-          if (ingressStatsBuilder_ == null) {
-            result.ingressStats_ = ingressStats_;
-          } else {
-            result.ingressStats_ = ingressStatsBuilder_.build();
-          }
+          result.ingressStats_ = ingressStatsBuilder_ == null
+              ? ingressStats_
+              : ingressStatsBuilder_.build();
           to_bitField0_ |= 0x00000010;
         }
         if (((from_bitField0_ & 0x00000020) != 0)) {
-          if (egressStatsBuilder_ == null) {
-            result.egressStats_ = egressStats_;
-          } else {
-            result.egressStats_ = egressStatsBuilder_.build();
-          }
+          result.egressStats_ = egressStatsBuilder_ == null
+              ? egressStats_
+              : egressStatsBuilder_.build();
           to_bitField0_ |= 0x00000020;
         }
         if (((from_bitField0_ & 0x00000040) != 0)) {
-          if (opStateBuilder_ == null) {
-            result.opState_ = opState_;
-          } else {
-            result.opState_ = opStateBuilder_.build();
-          }
+          result.opState_ = opStateBuilder_ == null
+              ? opState_
+              : opStateBuilder_.build();
           to_bitField0_ |= 0x00000040;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo) {
@@ -1934,8 +1751,8 @@ public final class LogicalPortOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo.getDefaultInstance()) return this;
         if (other.hasIfName()) {
-          bitField0_ |= 0x00000001;
           ifName_ = other.ifName_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasInitTime()) {
@@ -1945,8 +1762,8 @@ public final class LogicalPortOuterClass {
           setSnmpIfIndex(other.getSnmpIfIndex());
         }
         if (other.hasParentAeName()) {
-          bitField0_ |= 0x00000008;
           parentAeName_ = other.parentAeName_;
+          bitField0_ |= 0x00000008;
           onChanged();
         }
         if (other.hasIngressStats()) {
@@ -1958,7 +1775,7 @@ public final class LogicalPortOuterClass {
         if (other.hasOpState()) {
           mergeOpState(other.getOpState());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -1989,17 +1806,71 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                ifName_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                initTime_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                snmpIfIndex_ = input.readUInt32();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 34: {
+                parentAeName_ = input.readBytes();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 34
+              case 42: {
+                input.readMessage(
+                    getIngressStatsFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 42
+              case 50: {
+                input.readMessage(
+                    getEgressStatsFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 50
+              case 58: {
+                input.readMessage(
+                    getOpStateFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000040;
+                break;
+              } // case 58
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.LogicalInterfaceInfo) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -2070,11 +1941,9 @@ public final class LogicalPortOuterClass {
        */
       public Builder setIfName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         ifName_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2087,8 +1956,8 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearIfName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         ifName_ = getDefaultInstance().getIfName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -2103,11 +1972,9 @@ public final class LogicalPortOuterClass {
        */
       public Builder setIfNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         ifName_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2147,8 +2014,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setInitTime(long value) {
-        bitField0_ |= 0x00000002;
+
         initTime_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2202,8 +2070,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setSnmpIfIndex(int value) {
-        bitField0_ |= 0x00000004;
+
         snmpIfIndex_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2288,11 +2157,9 @@ public final class LogicalPortOuterClass {
        */
       public Builder setParentAeName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
+        if (value == null) { throw new NullPointerException(); }
         parentAeName_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2305,8 +2172,8 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearParentAeName() {
-        bitField0_ = (bitField0_ & ~0x00000008);
         parentAeName_ = getDefaultInstance().getParentAeName();
+        bitField0_ = (bitField0_ & ~0x00000008);
         onChanged();
         return this;
       }
@@ -2321,11 +2188,9 @@ public final class LogicalPortOuterClass {
        */
       public Builder setParentAeNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
+        if (value == null) { throw new NullPointerException(); }
         parentAeName_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2372,11 +2237,11 @@ public final class LogicalPortOuterClass {
             throw new NullPointerException();
           }
           ingressStats_ = value;
-          onChanged();
         } else {
           ingressStatsBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000010;
+        onChanged();
         return this;
       }
       /**
@@ -2390,11 +2255,11 @@ public final class LogicalPortOuterClass {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats.Builder builderForValue) {
         if (ingressStatsBuilder_ == null) {
           ingressStats_ = builderForValue.build();
-          onChanged();
         } else {
           ingressStatsBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000010;
+        onChanged();
         return this;
       }
       /**
@@ -2407,18 +2272,17 @@ public final class LogicalPortOuterClass {
       public Builder mergeIngressStats(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats value) {
         if (ingressStatsBuilder_ == null) {
           if (((bitField0_ & 0x00000010) != 0) &&
-              ingressStats_ != null &&
-              ingressStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats.getDefaultInstance()) {
-            ingressStats_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats.newBuilder(ingressStats_).mergeFrom(value).buildPartial();
+            ingressStats_ != null &&
+            ingressStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats.getDefaultInstance()) {
+            getIngressStatsBuilder().mergeFrom(value);
           } else {
             ingressStats_ = value;
           }
-          onChanged();
         } else {
           ingressStatsBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000010;
+        onChanged();
         return this;
       }
       /**
@@ -2429,13 +2293,13 @@ public final class LogicalPortOuterClass {
        * <code>optional .IngressInterfaceStats ingress_stats = 5;</code>
        */
       public Builder clearIngressStats() {
-        if (ingressStatsBuilder_ == null) {
-          ingressStats_ = null;
-          onChanged();
-        } else {
-          ingressStatsBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000010);
+        ingressStats_ = null;
+        if (ingressStatsBuilder_ != null) {
+          ingressStatsBuilder_.dispose();
+          ingressStatsBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -2528,11 +2392,11 @@ public final class LogicalPortOuterClass {
             throw new NullPointerException();
           }
           egressStats_ = value;
-          onChanged();
         } else {
           egressStatsBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000020;
+        onChanged();
         return this;
       }
       /**
@@ -2546,11 +2410,11 @@ public final class LogicalPortOuterClass {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats.Builder builderForValue) {
         if (egressStatsBuilder_ == null) {
           egressStats_ = builderForValue.build();
-          onChanged();
         } else {
           egressStatsBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000020;
+        onChanged();
         return this;
       }
       /**
@@ -2563,18 +2427,17 @@ public final class LogicalPortOuterClass {
       public Builder mergeEgressStats(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats value) {
         if (egressStatsBuilder_ == null) {
           if (((bitField0_ & 0x00000020) != 0) &&
-              egressStats_ != null &&
-              egressStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats.getDefaultInstance()) {
-            egressStats_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats.newBuilder(egressStats_).mergeFrom(value).buildPartial();
+            egressStats_ != null &&
+            egressStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats.getDefaultInstance()) {
+            getEgressStatsBuilder().mergeFrom(value);
           } else {
             egressStats_ = value;
           }
-          onChanged();
         } else {
           egressStatsBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000020;
+        onChanged();
         return this;
       }
       /**
@@ -2585,13 +2448,13 @@ public final class LogicalPortOuterClass {
        * <code>optional .EgressInterfaceStats egress_stats = 6;</code>
        */
       public Builder clearEgressStats() {
-        if (egressStatsBuilder_ == null) {
-          egressStats_ = null;
-          onChanged();
-        } else {
-          egressStatsBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000020);
+        egressStats_ = null;
+        if (egressStatsBuilder_ != null) {
+          egressStatsBuilder_.dispose();
+          egressStatsBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -2684,11 +2547,11 @@ public final class LogicalPortOuterClass {
             throw new NullPointerException();
           }
           opState_ = value;
-          onChanged();
         } else {
           opStateBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000040;
+        onChanged();
         return this;
       }
       /**
@@ -2702,11 +2565,11 @@ public final class LogicalPortOuterClass {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState.Builder builderForValue) {
         if (opStateBuilder_ == null) {
           opState_ = builderForValue.build();
-          onChanged();
         } else {
           opStateBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000040;
+        onChanged();
         return this;
       }
       /**
@@ -2719,18 +2582,17 @@ public final class LogicalPortOuterClass {
       public Builder mergeOpState(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState value) {
         if (opStateBuilder_ == null) {
           if (((bitField0_ & 0x00000040) != 0) &&
-              opState_ != null &&
-              opState_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState.getDefaultInstance()) {
-            opState_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState.newBuilder(opState_).mergeFrom(value).buildPartial();
+            opState_ != null &&
+            opState_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState.getDefaultInstance()) {
+            getOpStateBuilder().mergeFrom(value);
           } else {
             opState_ = value;
           }
-          onChanged();
         } else {
           opStateBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000040;
+        onChanged();
         return this;
       }
       /**
@@ -2741,13 +2603,13 @@ public final class LogicalPortOuterClass {
        * <code>optional .OperationalState op_state = 7;</code>
        */
       public Builder clearOpState() {
-        if (opStateBuilder_ == null) {
-          opState_ = null;
-          onChanged();
-        } else {
-          opStateBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000040);
+        opState_ = null;
+        if (opStateBuilder_ != null) {
+          opStateBuilder_.dispose();
+          opStateBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -2830,7 +2692,18 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new LogicalInterfaceInfo(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -2956,6 +2829,7 @@ public final class LogicalPortOuterClass {
   }
   /**
    * <pre>
+   *
    *  Interface inbound/Ingress traffic statistics
    * </pre>
    *
@@ -2981,81 +2855,6 @@ public final class LogicalPortOuterClass {
       return new IngressInterfaceStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private IngressInterfaceStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              ifPackets_ = input.readUInt64();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              ifOctets_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              ifUcastPackets_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              ifMcastPackets_ = input.readUInt64();
-              break;
-            }
-            case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
-                ifFcStats_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting>();
-                mutable_bitField0_ |= 0x00000010;
-              }
-              ifFcStats_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000010) != 0)) {
-          ifFcStats_ = java.util.Collections.unmodifiableList(ifFcStats_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.internal_static_IngressInterfaceStats_descriptor;
@@ -3071,7 +2870,7 @@ public final class LogicalPortOuterClass {
 
     private int bitField0_;
     public static final int IF_PACKETS_FIELD_NUMBER = 1;
-    private long ifPackets_;
+    private long ifPackets_ = 0L;
     /**
      * <pre>
      * Count of packets
@@ -3098,7 +2897,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int IF_OCTETS_FIELD_NUMBER = 2;
-    private long ifOctets_;
+    private long ifOctets_ = 0L;
     /**
      * <pre>
      * Count of bytes
@@ -3125,7 +2924,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int IF_UCAST_PACKETS_FIELD_NUMBER = 3;
-    private long ifUcastPackets_;
+    private long ifUcastPackets_ = 0L;
     /**
      * <pre>
      * Count of unicast packets
@@ -3152,7 +2951,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int IF_MCAST_PACKETS_FIELD_NUMBER = 4;
-    private long ifMcastPackets_;
+    private long ifMcastPackets_ = 0L;
     /**
      * <pre>
      * Count of multicast packets
@@ -3179,6 +2978,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int IF_FC_STATS_FIELD_NUMBER = 5;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting> ifFcStats_;
     /**
      * <code>repeated .ForwardingClassAccounting if_fc_stats = 5;</code>
@@ -3259,7 +3059,7 @@ public final class LogicalPortOuterClass {
       for (int i = 0; i < ifFcStats_.size(); i++) {
         output.writeMessage(5, ifFcStats_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -3288,7 +3088,7 @@ public final class LogicalPortOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(5, ifFcStats_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -3325,7 +3125,7 @@ public final class LogicalPortOuterClass {
       }
       if (!getIfFcStatsList()
           .equals(other.getIfFcStatsList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -3360,7 +3160,7 @@ public final class LogicalPortOuterClass {
         hash = (37 * hash) + IF_FC_STATS_FIELD_NUMBER;
         hash = (53 * hash) + getIfFcStatsList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -3457,6 +3257,7 @@ public final class LogicalPortOuterClass {
     }
     /**
      * <pre>
+     *
      *  Interface inbound/Ingress traffic statistics
      * </pre>
      *
@@ -3481,37 +3282,29 @@ public final class LogicalPortOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getIfFcStatsFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         ifPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
         ifOctets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         ifUcastPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         ifMcastPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         if (ifFcStatsBuilder_ == null) {
           ifFcStats_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
         } else {
+          ifFcStats_ = null;
           ifFcStatsBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -3538,6 +3331,25 @@ public final class LogicalPortOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats(this);
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats result) {
+        if (ifFcStatsBuilder_ == null) {
+          if (((bitField0_ & 0x00000010) != 0)) {
+            ifFcStats_ = java.util.Collections.unmodifiableList(ifFcStats_);
+            bitField0_ = (bitField0_ & ~0x00000010);
+          }
+          result.ifFcStats_ = ifFcStats_;
+        } else {
+          result.ifFcStats_ = ifFcStatsBuilder_.build();
+        }
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -3556,52 +3368,9 @@ public final class LogicalPortOuterClass {
           result.ifMcastPackets_ = ifMcastPackets_;
           to_bitField0_ |= 0x00000008;
         }
-        if (ifFcStatsBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) != 0)) {
-            ifFcStats_ = java.util.Collections.unmodifiableList(ifFcStats_);
-            bitField0_ = (bitField0_ & ~0x00000010);
-          }
-          result.ifFcStats_ = ifFcStats_;
-        } else {
-          result.ifFcStats_ = ifFcStatsBuilder_.build();
-        }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats) {
@@ -3652,7 +3421,7 @@ public final class LogicalPortOuterClass {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -3676,17 +3445,63 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                ifPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                ifOctets_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                ifUcastPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                ifMcastPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 42: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting.PARSER,
+                        extensionRegistry);
+                if (ifFcStatsBuilder_ == null) {
+                  ensureIfFcStatsIsMutable();
+                  ifFcStats_.add(m);
+                } else {
+                  ifFcStatsBuilder_.addMessage(m);
+                }
+                break;
+              } // case 42
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.IngressInterfaceStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -3726,8 +3541,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setIfPackets(long value) {
-        bitField0_ |= 0x00000001;
+
         ifPackets_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -3781,8 +3597,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setIfOctets(long value) {
-        bitField0_ |= 0x00000002;
+
         ifOctets_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3836,8 +3653,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setIfUcastPackets(long value) {
-        bitField0_ |= 0x00000004;
+
         ifUcastPackets_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -3891,8 +3709,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setIfMcastPackets(long value) {
-        bitField0_ |= 0x00000008;
+
         ifMcastPackets_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -4183,7 +4002,18 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IngressInterfaceStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -4247,6 +4077,7 @@ public final class LogicalPortOuterClass {
   }
   /**
    * <pre>
+   *
    *  Interface outbound/Egress traffic statistics
    * </pre>
    *
@@ -4271,59 +4102,6 @@ public final class LogicalPortOuterClass {
       return new EgressInterfaceStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private EgressInterfaceStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              ifPackets_ = input.readUInt64();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              ifOctets_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.internal_static_EgressInterfaceStats_descriptor;
@@ -4339,7 +4117,7 @@ public final class LogicalPortOuterClass {
 
     private int bitField0_;
     public static final int IF_PACKETS_FIELD_NUMBER = 1;
-    private long ifPackets_;
+    private long ifPackets_ = 0L;
     /**
      * <pre>
      * Count of packets
@@ -4366,7 +4144,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int IF_OCTETS_FIELD_NUMBER = 2;
-    private long ifOctets_;
+    private long ifOctets_ = 0L;
     /**
      * <pre>
      * Count of bytes
@@ -4420,7 +4198,7 @@ public final class LogicalPortOuterClass {
       if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt64(2, ifOctets_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -4437,7 +4215,7 @@ public final class LogicalPortOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, ifOctets_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -4462,7 +4240,7 @@ public final class LogicalPortOuterClass {
         if (getIfOctets()
             != other.getIfOctets()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -4483,7 +4261,7 @@ public final class LogicalPortOuterClass {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getIfOctets());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -4580,6 +4358,7 @@ public final class LogicalPortOuterClass {
     }
     /**
      * <pre>
+     *
      *  Interface outbound/Egress traffic statistics
      * </pre>
      *
@@ -4604,26 +4383,20 @@ public final class LogicalPortOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         ifPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
         ifOctets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -4650,6 +4423,12 @@ public final class LogicalPortOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -4660,43 +4439,9 @@ public final class LogicalPortOuterClass {
           result.ifOctets_ = ifOctets_;
           to_bitField0_ |= 0x00000002;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats) {
@@ -4715,7 +4460,7 @@ public final class LogicalPortOuterClass {
         if (other.hasIfOctets()) {
           setIfOctets(other.getIfOctets());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -4736,17 +4481,40 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                ifPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                ifOctets_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.EgressInterfaceStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -4786,8 +4554,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setIfPackets(long value) {
-        bitField0_ |= 0x00000001;
+
         ifPackets_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -4841,8 +4610,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setIfOctets(long value) {
-        bitField0_ |= 0x00000002;
+
         ifOctets_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -4893,7 +4663,18 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new EgressInterfaceStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -4948,6 +4729,7 @@ public final class LogicalPortOuterClass {
   }
   /**
    * <pre>
+   *
    *  Interface operational State details
    * </pre>
    *
@@ -4973,55 +4755,6 @@ public final class LogicalPortOuterClass {
       return new OperationalState();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private OperationalState(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              operationalStatus_ = bs;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.internal_static_OperationalState_descriptor;
@@ -5037,7 +4770,8 @@ public final class LogicalPortOuterClass {
 
     private int bitField0_;
     public static final int OPERATIONAL_STATUS_FIELD_NUMBER = 1;
-    private volatile java.lang.Object operationalStatus_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object operationalStatus_ = "";
     /**
      * <pre>
      * If the link is up/down
@@ -5113,7 +4847,7 @@ public final class LogicalPortOuterClass {
       if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, operationalStatus_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -5125,7 +4859,7 @@ public final class LogicalPortOuterClass {
       if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, operationalStatus_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -5145,7 +4879,7 @@ public final class LogicalPortOuterClass {
         if (!getOperationalStatus()
             .equals(other.getOperationalStatus())) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -5160,7 +4894,7 @@ public final class LogicalPortOuterClass {
         hash = (37 * hash) + OPERATIONAL_STATUS_FIELD_NUMBER;
         hash = (53 * hash) + getOperationalStatus().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -5257,6 +4991,7 @@ public final class LogicalPortOuterClass {
     }
     /**
      * <pre>
+     *
      *  Interface operational State details
      * </pre>
      *
@@ -5281,24 +5016,19 @@ public final class LogicalPortOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         operationalStatus_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -5325,49 +5055,21 @@ public final class LogicalPortOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) != 0)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.operationalStatus_ = operationalStatus_;
-        result.bitField0_ = to_bitField0_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.operationalStatus_ = operationalStatus_;
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState) {
@@ -5381,11 +5083,11 @@ public final class LogicalPortOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState.getDefaultInstance()) return this;
         if (other.hasOperationalStatus()) {
-          bitField0_ |= 0x00000001;
           operationalStatus_ = other.operationalStatus_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -5400,17 +5102,35 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                operationalStatus_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.OperationalState) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -5481,11 +5201,9 @@ public final class LogicalPortOuterClass {
        */
       public Builder setOperationalStatus(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         operationalStatus_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -5498,8 +5216,8 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearOperationalStatus() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         operationalStatus_ = getDefaultInstance().getOperationalStatus();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -5514,11 +5232,9 @@ public final class LogicalPortOuterClass {
        */
       public Builder setOperationalStatusBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         operationalStatus_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -5555,7 +5271,18 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OperationalState(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -5667,6 +5394,7 @@ public final class LogicalPortOuterClass {
   }
   /**
    * <pre>
+   *
    *  Interface forwarding class accounting
    * </pre>
    *
@@ -5692,70 +5420,6 @@ public final class LogicalPortOuterClass {
       return new ForwardingClassAccounting();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ForwardingClassAccounting(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              ifFamily_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              fcNumber_ = input.readUInt32();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              ifPackets_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              ifOctets_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.internal_static_ForwardingClassAccounting_descriptor;
@@ -5771,7 +5435,8 @@ public final class LogicalPortOuterClass {
 
     private int bitField0_;
     public static final int IF_FAMILY_FIELD_NUMBER = 1;
-    private volatile java.lang.Object ifFamily_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object ifFamily_ = "";
     /**
      * <pre>
      * Interface protocol
@@ -5831,7 +5496,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int FC_NUMBER_FIELD_NUMBER = 2;
-    private int fcNumber_;
+    private int fcNumber_ = 0;
     /**
      * <pre>
      * Forwarding class number
@@ -5858,7 +5523,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int IF_PACKETS_FIELD_NUMBER = 3;
-    private long ifPackets_;
+    private long ifPackets_ = 0L;
     /**
      * <pre>
      * Count of packets
@@ -5885,7 +5550,7 @@ public final class LogicalPortOuterClass {
     }
 
     public static final int IF_OCTETS_FIELD_NUMBER = 4;
-    private long ifOctets_;
+    private long ifOctets_ = 0L;
     /**
      * <pre>
      * Count of bytes
@@ -5937,7 +5602,7 @@ public final class LogicalPortOuterClass {
       if (((bitField0_ & 0x00000008) != 0)) {
         output.writeUInt64(4, ifOctets_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -5961,7 +5626,7 @@ public final class LogicalPortOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(4, ifOctets_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -5996,7 +5661,7 @@ public final class LogicalPortOuterClass {
         if (getIfOctets()
             != other.getIfOctets()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -6025,7 +5690,7 @@ public final class LogicalPortOuterClass {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getIfOctets());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -6122,6 +5787,7 @@ public final class LogicalPortOuterClass {
     }
     /**
      * <pre>
+     *
      *  Interface forwarding class accounting
      * </pre>
      *
@@ -6146,30 +5812,22 @@ public final class LogicalPortOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         ifFamily_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         fcNumber_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
         ifPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         ifOctets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -6196,12 +5854,18 @@ public final class LogicalPortOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.ifFamily_ = ifFamily_;
           to_bitField0_ |= 0x00000001;
         }
-        result.ifFamily_ = ifFamily_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.fcNumber_ = fcNumber_;
           to_bitField0_ |= 0x00000002;
@@ -6214,43 +5878,9 @@ public final class LogicalPortOuterClass {
           result.ifOctets_ = ifOctets_;
           to_bitField0_ |= 0x00000008;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting) {
@@ -6264,8 +5894,8 @@ public final class LogicalPortOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting.getDefaultInstance()) return this;
         if (other.hasIfFamily()) {
-          bitField0_ |= 0x00000001;
           ifFamily_ = other.ifFamily_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasFcNumber()) {
@@ -6277,7 +5907,7 @@ public final class LogicalPortOuterClass {
         if (other.hasIfOctets()) {
           setIfOctets(other.getIfOctets());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -6292,17 +5922,50 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                ifFamily_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                fcNumber_ = input.readUInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                ifPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                ifOctets_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LogicalPortOuterClass.ForwardingClassAccounting) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -6373,11 +6036,9 @@ public final class LogicalPortOuterClass {
        */
       public Builder setIfFamily(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         ifFamily_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -6390,8 +6051,8 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearIfFamily() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         ifFamily_ = getDefaultInstance().getIfFamily();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -6406,11 +6067,9 @@ public final class LogicalPortOuterClass {
        */
       public Builder setIfFamilyBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         ifFamily_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -6450,8 +6109,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setFcNumber(int value) {
-        bitField0_ |= 0x00000002;
+
         fcNumber_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -6505,8 +6165,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setIfPackets(long value) {
-        bitField0_ |= 0x00000004;
+
         ifPackets_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -6560,8 +6221,9 @@ public final class LogicalPortOuterClass {
        * @return This builder for chaining.
        */
       public Builder setIfOctets(long value) {
-        bitField0_ |= 0x00000008;
+
         ifOctets_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -6612,7 +6274,18 @@ public final class LogicalPortOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ForwardingClassAccounting(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/LspMon.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/LspMon.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -534,65 +534,6 @@ public final class LspMon {
       return new key();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private key(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              name_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              instanceIdentifier_ = input.readInt32();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              timeStampg_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.internal_static_key_descriptor;
@@ -608,7 +549,8 @@ public final class LspMon {
 
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
     /**
      * <code>required string name = 1;</code>
      * @return Whether the name field is set.
@@ -656,7 +598,7 @@ public final class LspMon {
     }
 
     public static final int INSTANCE_IDENTIFIER_FIELD_NUMBER = 2;
-    private int instanceIdentifier_;
+    private int instanceIdentifier_ = 0;
     /**
      * <code>required int32 instance_identifier = 2;</code>
      * @return Whether the instanceIdentifier field is set.
@@ -675,7 +617,7 @@ public final class LspMon {
     }
 
     public static final int TIME_STAMPG_FIELD_NUMBER = 3;
-    private long timeStampg_;
+    private long timeStampg_ = 0L;
     /**
      * <code>required uint64 time_stampg = 3;</code>
      * @return Whether the timeStampg field is set.
@@ -728,7 +670,7 @@ public final class LspMon {
       if (((bitField0_ & 0x00000004) != 0)) {
         output.writeUInt64(3, timeStampg_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -748,7 +690,7 @@ public final class LspMon {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(3, timeStampg_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -778,7 +720,7 @@ public final class LspMon {
         if (getTimeStampg()
             != other.getTimeStampg()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -802,7 +744,7 @@ public final class LspMon {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getTimeStampg());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -923,28 +865,21 @@ public final class LspMon {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         instanceIdentifier_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
         timeStampg_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -971,12 +906,18 @@ public final class LspMon {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.name_ = name_;
           to_bitField0_ |= 0x00000001;
         }
-        result.name_ = name_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.instanceIdentifier_ = instanceIdentifier_;
           to_bitField0_ |= 0x00000002;
@@ -985,43 +926,9 @@ public final class LspMon {
           result.timeStampg_ = timeStampg_;
           to_bitField0_ |= 0x00000004;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key) {
@@ -1035,8 +942,8 @@ public final class LspMon {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key.getDefaultInstance()) return this;
         if (other.hasName()) {
-          bitField0_ |= 0x00000001;
           name_ = other.name_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasInstanceIdentifier()) {
@@ -1045,7 +952,7 @@ public final class LspMon {
         if (other.hasTimeStampg()) {
           setTimeStampg(other.getTimeStampg());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -1069,17 +976,45 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                name_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                instanceIdentifier_ = input.readInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                timeStampg_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -1134,11 +1069,9 @@ public final class LspMon {
        */
       public Builder setName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1147,8 +1080,8 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -1159,11 +1092,9 @@ public final class LspMon {
        */
       public Builder setNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1191,8 +1122,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setInstanceIdentifier(int value) {
-        bitField0_ |= 0x00000002;
+
         instanceIdentifier_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1230,8 +1162,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setTimeStampg(long value) {
-        bitField0_ |= 0x00000004;
+
         timeStampg_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -1278,7 +1211,18 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new key(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -1352,73 +1296,6 @@ public final class LspMon {
       return new lsp_monitor_data_event();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private lsp_monitor_data_event(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              int rawValue = input.readEnum();
-                @SuppressWarnings("deprecation")
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event value = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(1, rawValue);
-              } else {
-                bitField0_ |= 0x00000001;
-                eventIdentifier_ = rawValue;
-              }
-              break;
-            }
-            case 16: {
-              int rawValue = input.readEnum();
-                @SuppressWarnings("deprecation")
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode value = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(2, rawValue);
-              } else {
-                bitField0_ |= 0x00000002;
-                subcode_ = rawValue;
-              }
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.internal_static_lsp_monitor_data_event_descriptor;
@@ -1434,7 +1311,7 @@ public final class LspMon {
 
     private int bitField0_;
     public static final int EVENT_IDENTIFIER_FIELD_NUMBER = 1;
-    private int eventIdentifier_;
+    private int eventIdentifier_ = 0;
     /**
      * <code>required .lsp_event event_identifier = 1;</code>
      * @return Whether the eventIdentifier field is set.
@@ -1447,13 +1324,12 @@ public final class LspMon {
      * @return The eventIdentifier.
      */
     @java.lang.Override public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event getEventIdentifier() {
-      @SuppressWarnings("deprecation")
-      org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event result = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event.valueOf(eventIdentifier_);
+      org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event result = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event.forNumber(eventIdentifier_);
       return result == null ? org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event.INITIATED : result;
     }
 
     public static final int SUBCODE_FIELD_NUMBER = 2;
-    private int subcode_;
+    private int subcode_ = 1;
     /**
      * <code>optional .event_subcode subcode = 2;</code>
      * @return Whether the subcode field is set.
@@ -1466,8 +1342,7 @@ public final class LspMon {
      * @return The subcode.
      */
     @java.lang.Override public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode getSubcode() {
-      @SuppressWarnings("deprecation")
-      org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode result = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode.valueOf(subcode_);
+      org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode result = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode.forNumber(subcode_);
       return result == null ? org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode.ADMISSION_CONTROL_FAILURE : result;
     }
 
@@ -1495,7 +1370,7 @@ public final class LspMon {
       if (((bitField0_ & 0x00000002) != 0)) {
         output.writeEnum(2, subcode_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -1512,7 +1387,7 @@ public final class LspMon {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(2, subcode_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -1535,7 +1410,7 @@ public final class LspMon {
       if (hasSubcode()) {
         if (subcode_ != other.subcode_) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -1554,7 +1429,7 @@ public final class LspMon {
         hash = (37 * hash) + SUBCODE_FIELD_NUMBER;
         hash = (53 * hash) + subcode_;
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -1675,26 +1550,20 @@ public final class LspMon {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         eventIdentifier_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000001);
         subcode_ = 1;
-        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -1721,53 +1590,25 @@ public final class LspMon {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) != 0)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.eventIdentifier_ = eventIdentifier_;
-        if (((from_bitField0_ & 0x00000002) != 0)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.subcode_ = subcode_;
-        result.bitField0_ = to_bitField0_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.eventIdentifier_ = eventIdentifier_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.subcode_ = subcode_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ |= to_bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event) {
@@ -1786,7 +1627,7 @@ public final class LspMon {
         if (other.hasSubcode()) {
           setSubcode(other.getSubcode());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -1804,17 +1645,54 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                int tmpRaw = input.readEnum();
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event tmpValue =
+                    org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event.forNumber(tmpRaw);
+                if (tmpValue == null) {
+                  mergeUnknownVarintField(1, tmpRaw);
+                } else {
+                  eventIdentifier_ = tmpRaw;
+                  bitField0_ |= 0x00000001;
+                }
+                break;
+              } // case 8
+              case 16: {
+                int tmpRaw = input.readEnum();
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode tmpValue =
+                    org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode.forNumber(tmpRaw);
+                if (tmpValue == null) {
+                  mergeUnknownVarintField(2, tmpRaw);
+                } else {
+                  subcode_ = tmpRaw;
+                  bitField0_ |= 0x00000002;
+                }
+                break;
+              } // case 16
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -1833,8 +1711,7 @@ public final class LspMon {
        */
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event getEventIdentifier() {
-        @SuppressWarnings("deprecation")
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event result = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event.valueOf(eventIdentifier_);
+        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event result = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event.forNumber(eventIdentifier_);
         return result == null ? org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_event.INITIATED : result;
       }
       /**
@@ -1876,8 +1753,7 @@ public final class LspMon {
        */
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode getSubcode() {
-        @SuppressWarnings("deprecation")
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode result = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode.valueOf(subcode_);
+        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode result = org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode.forNumber(subcode_);
         return result == null ? org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.event_subcode.ADMISSION_CONTROL_FAILURE : result;
       }
       /**
@@ -1937,7 +1813,18 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new lsp_monitor_data_event(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -2012,60 +1899,6 @@ public final class LspMon {
       return new ero_type_entry();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ero_type_entry(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              ip_ = input.readUInt32();
-              break;
-            }
-            case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
-              flags_ = bs;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.internal_static_ero_type_entry_descriptor;
@@ -2081,7 +1914,7 @@ public final class LspMon {
 
     private int bitField0_;
     public static final int IP_FIELD_NUMBER = 1;
-    private int ip_;
+    private int ip_ = 0;
     /**
      * <code>required uint32 ip = 1;</code>
      * @return Whether the ip field is set.
@@ -2100,7 +1933,8 @@ public final class LspMon {
     }
 
     public static final int FLAGS_FIELD_NUMBER = 2;
-    private volatile java.lang.Object flags_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object flags_ = "";
     /**
      * <code>optional string flags = 2;</code>
      * @return Whether the flags field is set.
@@ -2171,7 +2005,7 @@ public final class LspMon {
       if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, flags_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -2187,7 +2021,7 @@ public final class LspMon {
       if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, flags_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -2212,7 +2046,7 @@ public final class LspMon {
         if (!getFlags()
             .equals(other.getFlags())) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -2231,7 +2065,7 @@ public final class LspMon {
         hash = (37 * hash) + FLAGS_FIELD_NUMBER;
         hash = (53 * hash) + getFlags().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -2348,26 +2182,20 @@ public final class LspMon {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         ip_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000001);
         flags_ = "";
-        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -2394,6 +2222,12 @@ public final class LspMon {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -2401,46 +2235,12 @@ public final class LspMon {
           to_bitField0_ |= 0x00000001;
         }
         if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.flags_ = flags_;
           to_bitField0_ |= 0x00000002;
         }
-        result.flags_ = flags_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry) {
@@ -2457,11 +2257,11 @@ public final class LspMon {
           setIp(other.getIp());
         }
         if (other.hasFlags()) {
-          bitField0_ |= 0x00000002;
           flags_ = other.flags_;
+          bitField0_ |= 0x00000002;
           onChanged();
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -2479,17 +2279,40 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                ip_ = input.readUInt32();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 18: {
+                flags_ = input.readBytes();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 18
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -2517,8 +2340,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setIp(int value) {
-        bitField0_ |= 0x00000001;
+
         ip_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2583,11 +2407,9 @@ public final class LspMon {
        */
       public Builder setFlags(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
+        if (value == null) { throw new NullPointerException(); }
         flags_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2596,8 +2418,8 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder clearFlags() {
-        bitField0_ = (bitField0_ & ~0x00000002);
         flags_ = getDefaultInstance().getFlags();
+        bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
         return this;
       }
@@ -2608,11 +2430,9 @@ public final class LspMon {
        */
       public Builder setFlagsBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
+        if (value == null) { throw new NullPointerException(); }
         flags_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2649,7 +2469,18 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ero_type_entry(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -2720,61 +2551,6 @@ public final class LspMon {
       return new ero_ipv4_type();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ero_ipv4_type(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                entry_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              entry_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          entry_ = java.util.Collections.unmodifiableList(entry_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.internal_static_ero_ipv4_type_descriptor;
@@ -2789,6 +2565,7 @@ public final class LspMon {
     }
 
     public static final int ENTRY_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry> entry_;
     /**
      * <code>repeated .ero_type_entry entry = 1;</code>
@@ -2851,7 +2628,7 @@ public final class LspMon {
       for (int i = 0; i < entry_.size(); i++) {
         output.writeMessage(1, entry_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -2864,7 +2641,7 @@ public final class LspMon {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, entry_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -2881,7 +2658,7 @@ public final class LspMon {
 
       if (!getEntryList()
           .equals(other.getEntryList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -2896,7 +2673,7 @@ public final class LspMon {
         hash = (37 * hash) + ENTRY_FIELD_NUMBER;
         hash = (53 * hash) + getEntryList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -3013,29 +2790,25 @@ public final class LspMon {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getEntryFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (entryBuilder_ == null) {
           entry_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
+          entry_ = null;
           entryBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -3062,7 +2835,13 @@ public final class LspMon {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type result) {
         if (entryBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             entry_ = java.util.Collections.unmodifiableList(entry_);
@@ -3072,42 +2851,12 @@ public final class LspMon {
         } else {
           result.entry_ = entryBuilder_.build();
         }
-        onBuilt();
-        return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type result) {
+        int from_bitField0_ = bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type) {
@@ -3146,7 +2895,7 @@ public final class LspMon {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -3166,17 +2915,43 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_type_entry.PARSER,
+                        extensionRegistry);
+                if (entryBuilder_ == null) {
+                  ensureEntryIsMutable();
+                  entry_.add(m);
+                } else {
+                  entryBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -3453,7 +3228,18 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ero_ipv4_type(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -3575,69 +3361,6 @@ public final class LspMon {
       return new rro_type_entry();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private rro_type_entry(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              nodeid_ = input.readUInt32();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              flags_ = input.readUInt32();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              intfAddr_ = input.readUInt32();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              label_ = input.readUInt32();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.internal_static_rro_type_entry_descriptor;
@@ -3653,7 +3376,7 @@ public final class LspMon {
 
     private int bitField0_;
     public static final int NODEID_FIELD_NUMBER = 1;
-    private int nodeid_;
+    private int nodeid_ = 0;
     /**
      * <pre>
      * node-id or loopback
@@ -3680,7 +3403,7 @@ public final class LspMon {
     }
 
     public static final int FLAGS_FIELD_NUMBER = 2;
-    private int flags_;
+    private int flags_ = 0;
     /**
      * <pre>
      * contains flags
@@ -3707,7 +3430,7 @@ public final class LspMon {
     }
 
     public static final int INTF_ADDR_FIELD_NUMBER = 3;
-    private int intfAddr_;
+    private int intfAddr_ = 0;
     /**
      * <pre>
      * interface-ip
@@ -3734,7 +3457,7 @@ public final class LspMon {
     }
 
     public static final int LABEL_FIELD_NUMBER = 4;
-    private int label_;
+    private int label_ = 0;
     /**
      * <pre>
      * may be using PHP
@@ -3786,7 +3509,7 @@ public final class LspMon {
       if (((bitField0_ & 0x00000008) != 0)) {
         output.writeUInt32(4, label_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -3811,7 +3534,7 @@ public final class LspMon {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt32Size(4, label_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -3846,7 +3569,7 @@ public final class LspMon {
         if (getLabel()
             != other.getLabel()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -3873,7 +3596,7 @@ public final class LspMon {
         hash = (37 * hash) + LABEL_FIELD_NUMBER;
         hash = (53 * hash) + getLabel();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -3990,30 +3713,22 @@ public final class LspMon {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         nodeid_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000001);
         flags_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
         intfAddr_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
         label_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -4040,6 +3755,12 @@ public final class LspMon {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -4058,43 +3779,9 @@ public final class LspMon {
           result.label_ = label_;
           to_bitField0_ |= 0x00000008;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry) {
@@ -4119,7 +3806,7 @@ public final class LspMon {
         if (other.hasLabel()) {
           setLabel(other.getLabel());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -4134,17 +3821,50 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                nodeid_ = input.readUInt32();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                flags_ = input.readUInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                intfAddr_ = input.readUInt32();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                label_ = input.readUInt32();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -4184,8 +3904,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setNodeid(int value) {
-        bitField0_ |= 0x00000001;
+
         nodeid_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -4239,8 +3960,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setFlags(int value) {
-        bitField0_ |= 0x00000002;
+
         flags_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -4294,8 +4016,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setIntfAddr(int value) {
-        bitField0_ |= 0x00000004;
+
         intfAddr_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -4349,8 +4072,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setLabel(int value) {
-        bitField0_ |= 0x00000008;
+
         label_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -4401,7 +4125,18 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new rro_type_entry(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -4472,61 +4207,6 @@ public final class LspMon {
       return new rro_ipv4_type();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private rro_ipv4_type(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                rroEntry_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              rroEntry_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          rroEntry_ = java.util.Collections.unmodifiableList(rroEntry_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.internal_static_rro_ipv4_type_descriptor;
@@ -4541,6 +4221,7 @@ public final class LspMon {
     }
 
     public static final int RRO_ENTRY_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry> rroEntry_;
     /**
      * <code>repeated .rro_type_entry rro_entry = 1;</code>
@@ -4597,7 +4278,7 @@ public final class LspMon {
       for (int i = 0; i < rroEntry_.size(); i++) {
         output.writeMessage(1, rroEntry_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -4610,7 +4291,7 @@ public final class LspMon {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, rroEntry_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -4627,7 +4308,7 @@ public final class LspMon {
 
       if (!getRroEntryList()
           .equals(other.getRroEntryList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -4642,7 +4323,7 @@ public final class LspMon {
         hash = (37 * hash) + RRO_ENTRY_FIELD_NUMBER;
         hash = (53 * hash) + getRroEntryList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -4759,29 +4440,25 @@ public final class LspMon {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getRroEntryFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (rroEntryBuilder_ == null) {
           rroEntry_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
+          rroEntry_ = null;
           rroEntryBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -4808,7 +4485,13 @@ public final class LspMon {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type result) {
         if (rroEntryBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             rroEntry_ = java.util.Collections.unmodifiableList(rroEntry_);
@@ -4818,42 +4501,12 @@ public final class LspMon {
         } else {
           result.rroEntry_ = rroEntryBuilder_.build();
         }
-        onBuilt();
-        return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type result) {
+        int from_bitField0_ = bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type) {
@@ -4892,7 +4545,7 @@ public final class LspMon {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -4907,17 +4560,43 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_type_entry.PARSER,
+                        extensionRegistry);
+                if (rroEntryBuilder_ == null) {
+                  ensureRroEntryIsMutable();
+                  rroEntry_.add(m);
+                } else {
+                  rroEntryBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -5194,7 +4873,18 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new rro_ipv4_type(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -5325,96 +5015,6 @@ public final class LspMon {
       return new lsp_monitor_data_property();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private lsp_monitor_data_property(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              bandwidth_ = input.readUInt64();
-              break;
-            }
-            case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
-              pathName_ = bs;
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              metric_ = input.readInt32();
-              break;
-            }
-            case 37: {
-              bitField0_ |= 0x00000008;
-              maxAvgBw_ = input.readFloat();
-              break;
-            }
-            case 42: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000010) != 0)) {
-                subBuilder = ero_.toBuilder();
-              }
-              ero_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(ero_);
-                ero_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000010;
-              break;
-            }
-            case 50: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) != 0)) {
-                subBuilder = rro_.toBuilder();
-              }
-              rro_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(rro_);
-                rro_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000020;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.internal_static_lsp_monitor_data_property_descriptor;
@@ -5430,7 +5030,7 @@ public final class LspMon {
 
     private int bitField0_;
     public static final int BANDWIDTH_FIELD_NUMBER = 1;
-    private long bandwidth_;
+    private long bandwidth_ = 0L;
     /**
      * <code>optional uint64 bandwidth = 1;</code>
      * @return Whether the bandwidth field is set.
@@ -5449,7 +5049,8 @@ public final class LspMon {
     }
 
     public static final int PATH_NAME_FIELD_NUMBER = 2;
-    private volatile java.lang.Object pathName_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object pathName_ = "";
     /**
      * <code>optional string path_name = 2;</code>
      * @return Whether the pathName field is set.
@@ -5497,7 +5098,7 @@ public final class LspMon {
     }
 
     public static final int METRIC_FIELD_NUMBER = 3;
-    private int metric_;
+    private int metric_ = 0;
     /**
      * <code>optional int32 metric = 3;</code>
      * @return Whether the metric field is set.
@@ -5516,7 +5117,7 @@ public final class LspMon {
     }
 
     public static final int MAX_AVG_BW_FIELD_NUMBER = 4;
-    private float maxAvgBw_;
+    private float maxAvgBw_ = 0F;
     /**
      * <code>optional float max_avg_bw = 4;</code>
      * @return Whether the maxAvgBw field is set.
@@ -5624,7 +5225,7 @@ public final class LspMon {
       if (((bitField0_ & 0x00000020) != 0)) {
         output.writeMessage(6, getRro());
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -5656,7 +5257,7 @@ public final class LspMon {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(6, getRro());
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -5702,7 +5303,7 @@ public final class LspMon {
         if (!getRro()
             .equals(other.getRro())) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -5739,7 +5340,7 @@ public final class LspMon {
         hash = (37 * hash) + RRO_FIELD_NUMBER;
         hash = (53 * hash) + getRro().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -5878,26 +5479,21 @@ public final class LspMon {
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         bandwidth_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
         pathName_ = "";
-        bitField0_ = (bitField0_ & ~0x00000002);
         metric_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
         maxAvgBw_ = 0F;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        if (eroBuilder_ == null) {
-          ero_ = null;
-        } else {
-          eroBuilder_.clear();
+        ero_ = null;
+        if (eroBuilder_ != null) {
+          eroBuilder_.dispose();
+          eroBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000010);
-        if (rroBuilder_ == null) {
-          rro_ = null;
-        } else {
-          rroBuilder_.clear();
+        rro_ = null;
+        if (rroBuilder_ != null) {
+          rroBuilder_.dispose();
+          rroBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -5924,6 +5520,12 @@ public final class LspMon {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -5931,9 +5533,9 @@ public final class LspMon {
           to_bitField0_ |= 0x00000001;
         }
         if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.pathName_ = pathName_;
           to_bitField0_ |= 0x00000002;
         }
-        result.pathName_ = pathName_;
         if (((from_bitField0_ & 0x00000004) != 0)) {
           result.metric_ = metric_;
           to_bitField0_ |= 0x00000004;
@@ -5943,58 +5545,20 @@ public final class LspMon {
           to_bitField0_ |= 0x00000008;
         }
         if (((from_bitField0_ & 0x00000010) != 0)) {
-          if (eroBuilder_ == null) {
-            result.ero_ = ero_;
-          } else {
-            result.ero_ = eroBuilder_.build();
-          }
+          result.ero_ = eroBuilder_ == null
+              ? ero_
+              : eroBuilder_.build();
           to_bitField0_ |= 0x00000010;
         }
         if (((from_bitField0_ & 0x00000020) != 0)) {
-          if (rroBuilder_ == null) {
-            result.rro_ = rro_;
-          } else {
-            result.rro_ = rroBuilder_.build();
-          }
+          result.rro_ = rroBuilder_ == null
+              ? rro_
+              : rroBuilder_.build();
           to_bitField0_ |= 0x00000020;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property) {
@@ -6011,8 +5575,8 @@ public final class LspMon {
           setBandwidth(other.getBandwidth());
         }
         if (other.hasPathName()) {
-          bitField0_ |= 0x00000002;
           pathName_ = other.pathName_;
+          bitField0_ |= 0x00000002;
           onChanged();
         }
         if (other.hasMetric()) {
@@ -6027,7 +5591,7 @@ public final class LspMon {
         if (other.hasRro()) {
           mergeRro(other.getRro());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -6047,17 +5611,64 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                bandwidth_ = input.readUInt64();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 18: {
+                pathName_ = input.readBytes();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 18
+              case 24: {
+                metric_ = input.readInt32();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 37: {
+                maxAvgBw_ = input.readFloat();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 37
+              case 42: {
+                input.readMessage(
+                    getEroFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 42
+              case 50: {
+                input.readMessage(
+                    getRroFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 50
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -6085,8 +5696,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setBandwidth(long value) {
-        bitField0_ |= 0x00000001;
+
         bandwidth_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -6151,11 +5763,9 @@ public final class LspMon {
        */
       public Builder setPathName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
+        if (value == null) { throw new NullPointerException(); }
         pathName_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -6164,8 +5774,8 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder clearPathName() {
-        bitField0_ = (bitField0_ & ~0x00000002);
         pathName_ = getDefaultInstance().getPathName();
+        bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
         return this;
       }
@@ -6176,11 +5786,9 @@ public final class LspMon {
        */
       public Builder setPathNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
+        if (value == null) { throw new NullPointerException(); }
         pathName_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -6208,8 +5816,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setMetric(int value) {
-        bitField0_ |= 0x00000004;
+
         metric_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -6247,8 +5856,9 @@ public final class LspMon {
        * @return This builder for chaining.
        */
       public Builder setMaxAvgBw(float value) {
-        bitField0_ |= 0x00000008;
+
         maxAvgBw_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -6293,11 +5903,11 @@ public final class LspMon {
             throw new NullPointerException();
           }
           ero_ = value;
-          onChanged();
         } else {
           eroBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000010;
+        onChanged();
         return this;
       }
       /**
@@ -6307,11 +5917,11 @@ public final class LspMon {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type.Builder builderForValue) {
         if (eroBuilder_ == null) {
           ero_ = builderForValue.build();
-          onChanged();
         } else {
           eroBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000010;
+        onChanged();
         return this;
       }
       /**
@@ -6320,31 +5930,30 @@ public final class LspMon {
       public Builder mergeEro(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type value) {
         if (eroBuilder_ == null) {
           if (((bitField0_ & 0x00000010) != 0) &&
-              ero_ != null &&
-              ero_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type.getDefaultInstance()) {
-            ero_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type.newBuilder(ero_).mergeFrom(value).buildPartial();
+            ero_ != null &&
+            ero_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.ero_ipv4_type.getDefaultInstance()) {
+            getEroBuilder().mergeFrom(value);
           } else {
             ero_ = value;
           }
-          onChanged();
         } else {
           eroBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000010;
+        onChanged();
         return this;
       }
       /**
        * <code>optional .ero_ipv4_type ero = 5;</code>
        */
       public Builder clearEro() {
-        if (eroBuilder_ == null) {
-          ero_ = null;
-          onChanged();
-        } else {
-          eroBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000010);
+        ero_ = null;
+        if (eroBuilder_ != null) {
+          eroBuilder_.dispose();
+          eroBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -6413,11 +6022,11 @@ public final class LspMon {
             throw new NullPointerException();
           }
           rro_ = value;
-          onChanged();
         } else {
           rroBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000020;
+        onChanged();
         return this;
       }
       /**
@@ -6427,11 +6036,11 @@ public final class LspMon {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type.Builder builderForValue) {
         if (rroBuilder_ == null) {
           rro_ = builderForValue.build();
-          onChanged();
         } else {
           rroBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000020;
+        onChanged();
         return this;
       }
       /**
@@ -6440,31 +6049,30 @@ public final class LspMon {
       public Builder mergeRro(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type value) {
         if (rroBuilder_ == null) {
           if (((bitField0_ & 0x00000020) != 0) &&
-              rro_ != null &&
-              rro_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type.getDefaultInstance()) {
-            rro_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type.newBuilder(rro_).mergeFrom(value).buildPartial();
+            rro_ != null &&
+            rro_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.rro_ipv4_type.getDefaultInstance()) {
+            getRroBuilder().mergeFrom(value);
           } else {
             rro_ = value;
           }
-          onChanged();
         } else {
           rroBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000020;
+        onChanged();
         return this;
       }
       /**
        * <code>optional .rro_ipv4_type rro = 6;</code>
        */
       public Builder clearRro() {
-        if (rroBuilder_ == null) {
-          rro_ = null;
-          onChanged();
-        } else {
-          rroBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000020);
+        rro_ = null;
+        if (rroBuilder_ != null) {
+          rroBuilder_.dispose();
+          rroBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -6535,7 +6143,18 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new lsp_monitor_data_property(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -6626,88 +6245,6 @@ public final class LspMon {
       return new lsp_mon();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private lsp_mon(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) != 0)) {
-                subBuilder = keyField_.toBuilder();
-              }
-              keyField_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(keyField_);
-                keyField_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000001;
-              break;
-            }
-            case 18: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) != 0)) {
-                subBuilder = eventField_.toBuilder();
-              }
-              eventField_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(eventField_);
-                eventField_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000002;
-              break;
-            }
-            case 26: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) != 0)) {
-                subBuilder = propertyField_.toBuilder();
-              }
-              propertyField_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(propertyField_);
-                propertyField_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000004;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.internal_static_lsp_mon_descriptor;
@@ -6843,7 +6380,7 @@ public final class LspMon {
       if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getPropertyField());
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -6864,7 +6401,7 @@ public final class LspMon {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getPropertyField());
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -6894,7 +6431,7 @@ public final class LspMon {
         if (!getPropertyField()
             .equals(other.getPropertyField())) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -6917,7 +6454,7 @@ public final class LspMon {
         hash = (37 * hash) + PROPERTY_FIELD_FIELD_NUMBER;
         hash = (53 * hash) + getPropertyField().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -7053,24 +6590,22 @@ public final class LspMon {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (keyFieldBuilder_ == null) {
-          keyField_ = null;
-        } else {
-          keyFieldBuilder_.clear();
+        bitField0_ = 0;
+        keyField_ = null;
+        if (keyFieldBuilder_ != null) {
+          keyFieldBuilder_.dispose();
+          keyFieldBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000001);
-        if (eventFieldBuilder_ == null) {
-          eventField_ = null;
-        } else {
-          eventFieldBuilder_.clear();
+        eventField_ = null;
+        if (eventFieldBuilder_ != null) {
+          eventFieldBuilder_.dispose();
+          eventFieldBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000002);
-        if (propertyFieldBuilder_ == null) {
-          propertyField_ = null;
-        } else {
-          propertyFieldBuilder_.clear();
+        propertyField_ = null;
+        if (propertyFieldBuilder_ != null) {
+          propertyFieldBuilder_.dispose();
+          propertyFieldBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -7097,69 +6632,35 @@ public final class LspMon {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_mon buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_mon result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_mon(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) != 0)) {
-          if (keyFieldBuilder_ == null) {
-            result.keyField_ = keyField_;
-          } else {
-            result.keyField_ = keyFieldBuilder_.build();
-          }
-          to_bitField0_ |= 0x00000001;
-        }
-        if (((from_bitField0_ & 0x00000002) != 0)) {
-          if (eventFieldBuilder_ == null) {
-            result.eventField_ = eventField_;
-          } else {
-            result.eventField_ = eventFieldBuilder_.build();
-          }
-          to_bitField0_ |= 0x00000002;
-        }
-        if (((from_bitField0_ & 0x00000004) != 0)) {
-          if (propertyFieldBuilder_ == null) {
-            result.propertyField_ = propertyField_;
-          } else {
-            result.propertyField_ = propertyFieldBuilder_.build();
-          }
-          to_bitField0_ |= 0x00000004;
-        }
-        result.bitField0_ = to_bitField0_;
+        if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_mon result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.keyField_ = keyFieldBuilder_ == null
+              ? keyField_
+              : keyFieldBuilder_.build();
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.eventField_ = eventFieldBuilder_ == null
+              ? eventField_
+              : eventFieldBuilder_.build();
+          to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.propertyField_ = propertyFieldBuilder_ == null
+              ? propertyField_
+              : propertyFieldBuilder_.build();
+          to_bitField0_ |= 0x00000004;
+        }
+        result.bitField0_ |= to_bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_mon) {
@@ -7181,7 +6682,7 @@ public final class LspMon {
         if (other.hasPropertyField()) {
           mergePropertyField(other.getPropertyField());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -7212,17 +6713,51 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_mon parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                input.readMessage(
+                    getKeyFieldFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 18: {
+                input.readMessage(
+                    getEventFieldFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 18
+              case 26: {
+                input.readMessage(
+                    getPropertyFieldFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 26
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_mon) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -7257,11 +6792,11 @@ public final class LspMon {
             throw new NullPointerException();
           }
           keyField_ = value;
-          onChanged();
         } else {
           keyFieldBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -7271,11 +6806,11 @@ public final class LspMon {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key.Builder builderForValue) {
         if (keyFieldBuilder_ == null) {
           keyField_ = builderForValue.build();
-          onChanged();
         } else {
           keyFieldBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
@@ -7284,31 +6819,30 @@ public final class LspMon {
       public Builder mergeKeyField(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key value) {
         if (keyFieldBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0) &&
-              keyField_ != null &&
-              keyField_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key.getDefaultInstance()) {
-            keyField_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key.newBuilder(keyField_).mergeFrom(value).buildPartial();
+            keyField_ != null &&
+            keyField_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.key.getDefaultInstance()) {
+            getKeyFieldBuilder().mergeFrom(value);
           } else {
             keyField_ = value;
           }
-          onChanged();
         } else {
           keyFieldBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000001;
+        onChanged();
         return this;
       }
       /**
        * <code>required .key key_field = 1;</code>
        */
       public Builder clearKeyField() {
-        if (keyFieldBuilder_ == null) {
-          keyField_ = null;
-          onChanged();
-        } else {
-          keyFieldBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000001);
+        keyField_ = null;
+        if (keyFieldBuilder_ != null) {
+          keyFieldBuilder_.dispose();
+          keyFieldBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -7377,11 +6911,11 @@ public final class LspMon {
             throw new NullPointerException();
           }
           eventField_ = value;
-          onChanged();
         } else {
           eventFieldBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000002;
+        onChanged();
         return this;
       }
       /**
@@ -7391,11 +6925,11 @@ public final class LspMon {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event.Builder builderForValue) {
         if (eventFieldBuilder_ == null) {
           eventField_ = builderForValue.build();
-          onChanged();
         } else {
           eventFieldBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000002;
+        onChanged();
         return this;
       }
       /**
@@ -7404,31 +6938,30 @@ public final class LspMon {
       public Builder mergeEventField(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event value) {
         if (eventFieldBuilder_ == null) {
           if (((bitField0_ & 0x00000002) != 0) &&
-              eventField_ != null &&
-              eventField_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event.getDefaultInstance()) {
-            eventField_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event.newBuilder(eventField_).mergeFrom(value).buildPartial();
+            eventField_ != null &&
+            eventField_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_event.getDefaultInstance()) {
+            getEventFieldBuilder().mergeFrom(value);
           } else {
             eventField_ = value;
           }
-          onChanged();
         } else {
           eventFieldBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000002;
+        onChanged();
         return this;
       }
       /**
        * <code>optional .lsp_monitor_data_event event_field = 2;</code>
        */
       public Builder clearEventField() {
-        if (eventFieldBuilder_ == null) {
-          eventField_ = null;
-          onChanged();
-        } else {
-          eventFieldBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000002);
+        eventField_ = null;
+        if (eventFieldBuilder_ != null) {
+          eventFieldBuilder_.dispose();
+          eventFieldBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -7497,11 +7030,11 @@ public final class LspMon {
             throw new NullPointerException();
           }
           propertyField_ = value;
-          onChanged();
         } else {
           propertyFieldBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000004;
+        onChanged();
         return this;
       }
       /**
@@ -7511,11 +7044,11 @@ public final class LspMon {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property.Builder builderForValue) {
         if (propertyFieldBuilder_ == null) {
           propertyField_ = builderForValue.build();
-          onChanged();
         } else {
           propertyFieldBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000004;
+        onChanged();
         return this;
       }
       /**
@@ -7524,31 +7057,30 @@ public final class LspMon {
       public Builder mergePropertyField(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property value) {
         if (propertyFieldBuilder_ == null) {
           if (((bitField0_ & 0x00000004) != 0) &&
-              propertyField_ != null &&
-              propertyField_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property.getDefaultInstance()) {
-            propertyField_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property.newBuilder(propertyField_).mergeFrom(value).buildPartial();
+            propertyField_ != null &&
+            propertyField_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspMon.lsp_monitor_data_property.getDefaultInstance()) {
+            getPropertyFieldBuilder().mergeFrom(value);
           } else {
             propertyField_ = value;
           }
-          onChanged();
         } else {
           propertyFieldBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000004;
+        onChanged();
         return this;
       }
       /**
        * <code>optional .lsp_monitor_data_property property_field = 3;</code>
        */
       public Builder clearPropertyField() {
-        if (propertyFieldBuilder_ == null) {
-          propertyField_ = null;
-          onChanged();
-        } else {
-          propertyFieldBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000004);
+        propertyField_ = null;
+        if (propertyFieldBuilder_ != null) {
+          propertyFieldBuilder_.dispose();
+          propertyFieldBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -7619,7 +7151,18 @@ public final class LspMon {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new lsp_mon(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/LspStatsOuterClass.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/LspStatsOuterClass.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -93,6 +93,7 @@ public final class LspStatsOuterClass {
   }
   /**
    * <pre>
+   *
    * Top-level message
    * </pre>
    *
@@ -118,61 +119,6 @@ public final class LspStatsOuterClass {
       return new LspStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private LspStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                lspStatsRecords_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              lspStatsRecords_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          lspStatsRecords_ = java.util.Collections.unmodifiableList(lspStatsRecords_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.internal_static_LspStats_descriptor;
@@ -187,6 +133,7 @@ public final class LspStatsOuterClass {
     }
 
     public static final int LSP_STATS_RECORDS_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord> lspStatsRecords_;
     /**
      * <pre>
@@ -269,7 +216,7 @@ public final class LspStatsOuterClass {
       for (int i = 0; i < lspStatsRecords_.size(); i++) {
         output.writeMessage(1, lspStatsRecords_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -282,7 +229,7 @@ public final class LspStatsOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, lspStatsRecords_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -299,7 +246,7 @@ public final class LspStatsOuterClass {
 
       if (!getLspStatsRecordsList()
           .equals(other.getLspStatsRecordsList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -314,7 +261,7 @@ public final class LspStatsOuterClass {
         hash = (37 * hash) + LSP_STATS_RECORDS_FIELD_NUMBER;
         hash = (53 * hash) + getLspStatsRecordsList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -411,6 +358,7 @@ public final class LspStatsOuterClass {
     }
     /**
      * <pre>
+     *
      * Top-level message
      * </pre>
      *
@@ -435,29 +383,25 @@ public final class LspStatsOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getLspStatsRecordsFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (lspStatsRecordsBuilder_ == null) {
           lspStatsRecords_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
+          lspStatsRecords_ = null;
           lspStatsRecordsBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -484,7 +428,13 @@ public final class LspStatsOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats result) {
         if (lspStatsRecordsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             lspStatsRecords_ = java.util.Collections.unmodifiableList(lspStatsRecords_);
@@ -494,42 +444,12 @@ public final class LspStatsOuterClass {
         } else {
           result.lspStatsRecords_ = lspStatsRecordsBuilder_.build();
         }
-        onBuilt();
-        return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats result) {
+        int from_bitField0_ = bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats) {
@@ -568,7 +488,7 @@ public final class LspStatsOuterClass {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -588,17 +508,43 @@ public final class LspStatsOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord.PARSER,
+                        extensionRegistry);
+                if (lspStatsRecordsBuilder_ == null) {
+                  ensureLspStatsRecordsIsMutable();
+                  lspStatsRecords_.add(m);
+                } else {
+                  lspStatsRecordsBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -947,7 +893,18 @@ public final class LspStatsOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new LspStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -1132,6 +1089,7 @@ public final class LspStatsOuterClass {
   }
   /**
    * <pre>
+   *
    * LSP statistics record
    * </pre>
    *
@@ -1158,86 +1116,6 @@ public final class LspStatsOuterClass {
       return new LspStatsRecord();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private LspStatsRecord(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              name_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              instanceIdentifier_ = input.readUInt32();
-              break;
-            }
-            case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000004;
-              counterName_ = bs;
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              packets_ = input.readUInt64();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              bytes_ = input.readUInt64();
-              break;
-            }
-            case 48: {
-              bitField0_ |= 0x00000020;
-              packetRate_ = input.readUInt64();
-              break;
-            }
-            case 56: {
-              bitField0_ |= 0x00000040;
-              byteRate_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.internal_static_LspStatsRecord_descriptor;
@@ -1253,7 +1131,8 @@ public final class LspStatsOuterClass {
 
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
     /**
      * <pre>
      * Name of the LSP
@@ -1313,7 +1192,7 @@ public final class LspStatsOuterClass {
     }
 
     public static final int INSTANCE_IDENTIFIER_FIELD_NUMBER = 2;
-    private int instanceIdentifier_;
+    private int instanceIdentifier_ = 0;
     /**
      * <pre>
      * Instance Identifier for cases when RPD creates multiple instances
@@ -1340,7 +1219,8 @@ public final class LspStatsOuterClass {
     }
 
     public static final int COUNTER_NAME_FIELD_NUMBER = 3;
-    private volatile java.lang.Object counterName_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object counterName_ = "";
     /**
      * <pre>
      * Name of the counter. This is useful when an LSP has multiple counters.
@@ -1406,7 +1286,7 @@ public final class LspStatsOuterClass {
     }
 
     public static final int PACKETS_FIELD_NUMBER = 4;
-    private long packets_;
+    private long packets_ = 0L;
     /**
      * <pre>
      * The total number of packets
@@ -1433,7 +1313,7 @@ public final class LspStatsOuterClass {
     }
 
     public static final int BYTES_FIELD_NUMBER = 5;
-    private long bytes_;
+    private long bytes_ = 0L;
     /**
      * <pre>
      * The total number of bytes
@@ -1460,7 +1340,7 @@ public final class LspStatsOuterClass {
     }
 
     public static final int PACKET_RATE_FIELD_NUMBER = 6;
-    private long packetRate_;
+    private long packetRate_ = 0L;
     /**
      * <pre>
      * Packet rate computed over the most recent 3 second interval
@@ -1487,7 +1367,7 @@ public final class LspStatsOuterClass {
     }
 
     public static final int BYTE_RATE_FIELD_NUMBER = 7;
-    private long byteRate_;
+    private long byteRate_ = 0L;
     /**
      * <pre>
      * Byte rate computed over the most recent 3 second interval
@@ -1560,7 +1440,7 @@ public final class LspStatsOuterClass {
       if (((bitField0_ & 0x00000040) != 0)) {
         output.writeUInt64(7, byteRate_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -1595,7 +1475,7 @@ public final class LspStatsOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(7, byteRate_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -1645,7 +1525,7 @@ public final class LspStatsOuterClass {
         if (getByteRate()
             != other.getByteRate()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -1688,7 +1568,7 @@ public final class LspStatsOuterClass {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getByteRate());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -1785,6 +1665,7 @@ public final class LspStatsOuterClass {
     }
     /**
      * <pre>
+     *
      * LSP statistics record
      * </pre>
      *
@@ -1809,36 +1690,25 @@ public final class LspStatsOuterClass {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         instanceIdentifier_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
         counterName_ = "";
-        bitField0_ = (bitField0_ & ~0x00000004);
         packets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         bytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000010);
         packetRate_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
         byteRate_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -1865,20 +1735,26 @@ public final class LspStatsOuterClass {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.name_ = name_;
           to_bitField0_ |= 0x00000001;
         }
-        result.name_ = name_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.instanceIdentifier_ = instanceIdentifier_;
           to_bitField0_ |= 0x00000002;
         }
         if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.counterName_ = counterName_;
           to_bitField0_ |= 0x00000004;
         }
-        result.counterName_ = counterName_;
         if (((from_bitField0_ & 0x00000008) != 0)) {
           result.packets_ = packets_;
           to_bitField0_ |= 0x00000008;
@@ -1895,43 +1771,9 @@ public final class LspStatsOuterClass {
           result.byteRate_ = byteRate_;
           to_bitField0_ |= 0x00000040;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord) {
@@ -1945,16 +1787,16 @@ public final class LspStatsOuterClass {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord.getDefaultInstance()) return this;
         if (other.hasName()) {
-          bitField0_ |= 0x00000001;
           name_ = other.name_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasInstanceIdentifier()) {
           setInstanceIdentifier(other.getInstanceIdentifier());
         }
         if (other.hasCounterName()) {
-          bitField0_ |= 0x00000004;
           counterName_ = other.counterName_;
+          bitField0_ |= 0x00000004;
           onChanged();
         }
         if (other.hasPackets()) {
@@ -1969,7 +1811,7 @@ public final class LspStatsOuterClass {
         if (other.hasByteRate()) {
           setByteRate(other.getByteRate());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -1993,17 +1835,65 @@ public final class LspStatsOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                name_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                instanceIdentifier_ = input.readUInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 26: {
+                counterName_ = input.readBytes();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 26
+              case 32: {
+                packets_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 40: {
+                bytes_ = input.readUInt64();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              case 48: {
+                packetRate_ = input.readUInt64();
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 48
+              case 56: {
+                byteRate_ = input.readUInt64();
+                bitField0_ |= 0x00000040;
+                break;
+              } // case 56
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.LspStatsOuterClass.LspStatsRecord) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -2074,11 +1964,9 @@ public final class LspStatsOuterClass {
        */
       public Builder setName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2091,8 +1979,8 @@ public final class LspStatsOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -2107,11 +1995,9 @@ public final class LspStatsOuterClass {
        */
       public Builder setNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         name_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2151,8 +2037,9 @@ public final class LspStatsOuterClass {
        * @return This builder for chaining.
        */
       public Builder setInstanceIdentifier(int value) {
-        bitField0_ |= 0x00000002;
+
         instanceIdentifier_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2245,11 +2132,9 @@ public final class LspStatsOuterClass {
        */
       public Builder setCounterName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
+        if (value == null) { throw new NullPointerException(); }
         counterName_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2264,8 +2149,8 @@ public final class LspStatsOuterClass {
        * @return This builder for chaining.
        */
       public Builder clearCounterName() {
-        bitField0_ = (bitField0_ & ~0x00000004);
         counterName_ = getDefaultInstance().getCounterName();
+        bitField0_ = (bitField0_ & ~0x00000004);
         onChanged();
         return this;
       }
@@ -2282,11 +2167,9 @@ public final class LspStatsOuterClass {
        */
       public Builder setCounterNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000004;
+        if (value == null) { throw new NullPointerException(); }
         counterName_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2326,8 +2209,9 @@ public final class LspStatsOuterClass {
        * @return This builder for chaining.
        */
       public Builder setPackets(long value) {
-        bitField0_ |= 0x00000008;
+
         packets_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2381,8 +2265,9 @@ public final class LspStatsOuterClass {
        * @return This builder for chaining.
        */
       public Builder setBytes(long value) {
-        bitField0_ |= 0x00000010;
+
         bytes_ = value;
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -2436,8 +2321,9 @@ public final class LspStatsOuterClass {
        * @return This builder for chaining.
        */
       public Builder setPacketRate(long value) {
-        bitField0_ |= 0x00000020;
+
         packetRate_ = value;
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -2491,8 +2377,9 @@ public final class LspStatsOuterClass {
        * @return This builder for chaining.
        */
       public Builder setByteRate(long value) {
-        bitField0_ |= 0x00000040;
+
         byteRate_ = value;
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -2543,7 +2430,18 @@ public final class LspStatsOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new LspStatsRecord(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/Port.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/Port.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -94,61 +94,6 @@ public final class Port {
       return new GPort();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private GPort(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                interfaceStats_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              interfaceStats_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          interfaceStats_ = java.util.Collections.unmodifiableList(interfaceStats_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.internal_static_GPort_descriptor;
@@ -163,6 +108,7 @@ public final class Port {
     }
 
     public static final int INTERFACE_STATS_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos> interfaceStats_;
     /**
      * <code>repeated .InterfaceInfos interface_stats = 1;</code>
@@ -225,7 +171,7 @@ public final class Port {
       for (int i = 0; i < interfaceStats_.size(); i++) {
         output.writeMessage(1, interfaceStats_.get(i));
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -238,7 +184,7 @@ public final class Port {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, interfaceStats_.get(i));
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -255,7 +201,7 @@ public final class Port {
 
       if (!getInterfaceStatsList()
           .equals(other.getInterfaceStatsList())) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -270,7 +216,7 @@ public final class Port {
         hash = (37 * hash) + INTERFACE_STATS_FIELD_NUMBER;
         hash = (53 * hash) + getInterfaceStatsList().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -387,29 +333,25 @@ public final class Port {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getInterfaceStatsFieldBuilder();
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         if (interfaceStatsBuilder_ == null) {
           interfaceStats_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
+          interfaceStats_ = null;
           interfaceStatsBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
 
@@ -436,7 +378,13 @@ public final class Port {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort(this);
-        int from_bitField0_ = bitField0_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort result) {
         if (interfaceStatsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             interfaceStats_ = java.util.Collections.unmodifiableList(interfaceStats_);
@@ -446,42 +394,12 @@ public final class Port {
         } else {
           result.interfaceStats_ = interfaceStatsBuilder_.build();
         }
-        onBuilt();
-        return result;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort result) {
+        int from_bitField0_ = bitField0_;
       }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort) {
@@ -520,7 +438,7 @@ public final class Port {
             }
           }
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -540,17 +458,43 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos.PARSER,
+                        extensionRegistry);
+                if (interfaceStatsBuilder_ == null) {
+                  ensureInterfaceStatsIsMutable();
+                  interfaceStats_.add(m);
+                } else {
+                  interfaceStatsBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.GPort) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -827,7 +771,18 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GPort(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -1142,134 +1097,6 @@ public final class Port {
       return new InterfaceInfos();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private InterfaceInfos(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              ifName_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              initTime_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              snmpIfIndex_ = input.readUInt32();
-              break;
-            }
-            case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000008;
-              parentAeName_ = bs;
-              break;
-            }
-            case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
-                egressQueueInfo_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats>();
-                mutable_bitField0_ |= 0x00000010;
-              }
-              egressQueueInfo_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats.PARSER, extensionRegistry));
-              break;
-            }
-            case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
-                ingressQueueInfo_ = new java.util.ArrayList<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats>();
-                mutable_bitField0_ |= 0x00000020;
-              }
-              ingressQueueInfo_.add(
-                  input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats.PARSER, extensionRegistry));
-              break;
-            }
-            case 58: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000010) != 0)) {
-                subBuilder = ingressStats_.toBuilder();
-              }
-              ingressStats_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(ingressStats_);
-                ingressStats_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000010;
-              break;
-            }
-            case 66: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) != 0)) {
-                subBuilder = egressStats_.toBuilder();
-              }
-              egressStats_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(egressStats_);
-                egressStats_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000020;
-              break;
-            }
-            case 74: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000040) != 0)) {
-                subBuilder = ingressErrors_.toBuilder();
-              }
-              ingressErrors_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(ingressErrors_);
-                ingressErrors_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000040;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000010) != 0)) {
-          egressQueueInfo_ = java.util.Collections.unmodifiableList(egressQueueInfo_);
-        }
-        if (((mutable_bitField0_ & 0x00000020) != 0)) {
-          ingressQueueInfo_ = java.util.Collections.unmodifiableList(ingressQueueInfo_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.internal_static_InterfaceInfos_descriptor;
@@ -1285,7 +1112,8 @@ public final class Port {
 
     private int bitField0_;
     public static final int IF_NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object ifName_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object ifName_ = "";
     /**
      * <pre>
      * e.g., xe-0/0/0
@@ -1345,7 +1173,7 @@ public final class Port {
     }
 
     public static final int INIT_TIME_FIELD_NUMBER = 2;
-    private long initTime_;
+    private long initTime_ = 0L;
     /**
      * <pre>
      * time when if/stats last reset
@@ -1372,7 +1200,7 @@ public final class Port {
     }
 
     public static final int SNMP_IF_INDEX_FIELD_NUMBER = 3;
-    private int snmpIfIndex_;
+    private int snmpIfIndex_ = 0;
     /**
      * <pre>
      * Global Index
@@ -1399,7 +1227,8 @@ public final class Port {
     }
 
     public static final int PARENT_AE_NAME_FIELD_NUMBER = 4;
-    private volatile java.lang.Object parentAeName_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object parentAeName_ = "";
     /**
      * <pre>
      * name of parent for ae interface, if applicable
@@ -1459,6 +1288,7 @@ public final class Port {
     }
 
     public static final int EGRESS_QUEUE_INFO_FIELD_NUMBER = 5;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats> egressQueueInfo_;
     /**
      * <pre>
@@ -1519,6 +1349,7 @@ public final class Port {
     }
 
     public static final int INGRESS_QUEUE_INFO_FIELD_NUMBER = 6;
+    @SuppressWarnings("serial")
     private java.util.List<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats> ingressQueueInfo_;
     /**
      * <pre>
@@ -1753,7 +1584,7 @@ public final class Port {
       if (((bitField0_ & 0x00000040) != 0)) {
         output.writeMessage(9, getIngressErrors());
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -1796,7 +1627,7 @@ public final class Port {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(9, getIngressErrors());
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -1850,7 +1681,7 @@ public final class Port {
         if (!getIngressErrors()
             .equals(other.getIngressErrors())) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -1898,7 +1729,7 @@ public final class Port {
         hash = (37 * hash) + INGRESS_ERRORS_FIELD_NUMBER;
         hash = (53 * hash) + getIngressErrors().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -2036,44 +1867,40 @@ public final class Port {
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         ifName_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         initTime_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         snmpIfIndex_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
         parentAeName_ = "";
-        bitField0_ = (bitField0_ & ~0x00000008);
         if (egressQueueInfoBuilder_ == null) {
           egressQueueInfo_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
         } else {
+          egressQueueInfo_ = null;
           egressQueueInfoBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000010);
         if (ingressQueueInfoBuilder_ == null) {
           ingressQueueInfo_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
         } else {
+          ingressQueueInfo_ = null;
           ingressQueueInfoBuilder_.clear();
         }
-        if (ingressStatsBuilder_ == null) {
-          ingressStats_ = null;
-        } else {
-          ingressStatsBuilder_.clear();
+        bitField0_ = (bitField0_ & ~0x00000020);
+        ingressStats_ = null;
+        if (ingressStatsBuilder_ != null) {
+          ingressStatsBuilder_.dispose();
+          ingressStatsBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000040);
-        if (egressStatsBuilder_ == null) {
-          egressStats_ = null;
-        } else {
-          egressStatsBuilder_.clear();
+        egressStats_ = null;
+        if (egressStatsBuilder_ != null) {
+          egressStatsBuilder_.dispose();
+          egressStatsBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000080);
-        if (ingressErrorsBuilder_ == null) {
-          ingressErrors_ = null;
-        } else {
-          ingressErrorsBuilder_.clear();
+        ingressErrors_ = null;
+        if (ingressErrorsBuilder_ != null) {
+          ingressErrorsBuilder_.dispose();
+          ingressErrorsBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000100);
         return this;
       }
 
@@ -2100,24 +1927,13 @@ public final class Port {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) != 0)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.ifName_ = ifName_;
-        if (((from_bitField0_ & 0x00000002) != 0)) {
-          result.initTime_ = initTime_;
-          to_bitField0_ |= 0x00000002;
-        }
-        if (((from_bitField0_ & 0x00000004) != 0)) {
-          result.snmpIfIndex_ = snmpIfIndex_;
-          to_bitField0_ |= 0x00000004;
-        }
-        if (((from_bitField0_ & 0x00000008) != 0)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.parentAeName_ = parentAeName_;
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos result) {
         if (egressQueueInfoBuilder_ == null) {
           if (((bitField0_ & 0x00000010) != 0)) {
             egressQueueInfo_ = java.util.Collections.unmodifiableList(egressQueueInfo_);
@@ -2136,67 +1952,48 @@ public final class Port {
         } else {
           result.ingressQueueInfo_ = ingressQueueInfoBuilder_.build();
         }
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.ifName_ = ifName_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.initTime_ = initTime_;
+          to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.snmpIfIndex_ = snmpIfIndex_;
+          to_bitField0_ |= 0x00000004;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.parentAeName_ = parentAeName_;
+          to_bitField0_ |= 0x00000008;
+        }
         if (((from_bitField0_ & 0x00000040) != 0)) {
-          if (ingressStatsBuilder_ == null) {
-            result.ingressStats_ = ingressStats_;
-          } else {
-            result.ingressStats_ = ingressStatsBuilder_.build();
-          }
+          result.ingressStats_ = ingressStatsBuilder_ == null
+              ? ingressStats_
+              : ingressStatsBuilder_.build();
           to_bitField0_ |= 0x00000010;
         }
         if (((from_bitField0_ & 0x00000080) != 0)) {
-          if (egressStatsBuilder_ == null) {
-            result.egressStats_ = egressStats_;
-          } else {
-            result.egressStats_ = egressStatsBuilder_.build();
-          }
+          result.egressStats_ = egressStatsBuilder_ == null
+              ? egressStats_
+              : egressStatsBuilder_.build();
           to_bitField0_ |= 0x00000020;
         }
         if (((from_bitField0_ & 0x00000100) != 0)) {
-          if (ingressErrorsBuilder_ == null) {
-            result.ingressErrors_ = ingressErrors_;
-          } else {
-            result.ingressErrors_ = ingressErrorsBuilder_.build();
-          }
+          result.ingressErrors_ = ingressErrorsBuilder_ == null
+              ? ingressErrors_
+              : ingressErrorsBuilder_.build();
           to_bitField0_ |= 0x00000040;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos) {
@@ -2210,8 +2007,8 @@ public final class Port {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos.getDefaultInstance()) return this;
         if (other.hasIfName()) {
-          bitField0_ |= 0x00000001;
           ifName_ = other.ifName_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasInitTime()) {
@@ -2221,8 +2018,8 @@ public final class Port {
           setSnmpIfIndex(other.getSnmpIfIndex());
         }
         if (other.hasParentAeName()) {
-          bitField0_ |= 0x00000008;
           parentAeName_ = other.parentAeName_;
+          bitField0_ |= 0x00000008;
           onChanged();
         }
         if (egressQueueInfoBuilder_ == null) {
@@ -2286,7 +2083,7 @@ public final class Port {
         if (other.hasIngressErrors()) {
           mergeIngressErrors(other.getIngressErrors());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -2317,17 +2114,97 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                ifName_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                initTime_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                snmpIfIndex_ = input.readUInt32();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 34: {
+                parentAeName_ = input.readBytes();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 34
+              case 42: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats.PARSER,
+                        extensionRegistry);
+                if (egressQueueInfoBuilder_ == null) {
+                  ensureEgressQueueInfoIsMutable();
+                  egressQueueInfo_.add(m);
+                } else {
+                  egressQueueInfoBuilder_.addMessage(m);
+                }
+                break;
+              } // case 42
+              case 50: {
+                org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats m =
+                    input.readMessage(
+                        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats.PARSER,
+                        extensionRegistry);
+                if (ingressQueueInfoBuilder_ == null) {
+                  ensureIngressQueueInfoIsMutable();
+                  ingressQueueInfo_.add(m);
+                } else {
+                  ingressQueueInfoBuilder_.addMessage(m);
+                }
+                break;
+              } // case 50
+              case 58: {
+                input.readMessage(
+                    getIngressStatsFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000040;
+                break;
+              } // case 58
+              case 66: {
+                input.readMessage(
+                    getEgressStatsFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000080;
+                break;
+              } // case 66
+              case 74: {
+                input.readMessage(
+                    getIngressErrorsFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000100;
+                break;
+              } // case 74
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceInfos) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -2398,11 +2275,9 @@ public final class Port {
        */
       public Builder setIfName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         ifName_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2415,8 +2290,8 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder clearIfName() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         ifName_ = getDefaultInstance().getIfName();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -2431,11 +2306,9 @@ public final class Port {
        */
       public Builder setIfNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         ifName_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2475,8 +2348,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setInitTime(long value) {
-        bitField0_ |= 0x00000002;
+
         initTime_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2530,8 +2404,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setSnmpIfIndex(int value) {
-        bitField0_ |= 0x00000004;
+
         snmpIfIndex_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2616,11 +2491,9 @@ public final class Port {
        */
       public Builder setParentAeName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
+        if (value == null) { throw new NullPointerException(); }
         parentAeName_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2633,8 +2506,8 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder clearParentAeName() {
-        bitField0_ = (bitField0_ & ~0x00000008);
         parentAeName_ = getDefaultInstance().getParentAeName();
+        bitField0_ = (bitField0_ & ~0x00000008);
         onChanged();
         return this;
       }
@@ -2649,11 +2522,9 @@ public final class Port {
        */
       public Builder setParentAeNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
+        if (value == null) { throw new NullPointerException(); }
         parentAeName_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3324,11 +3195,11 @@ public final class Port {
             throw new NullPointerException();
           }
           ingressStats_ = value;
-          onChanged();
         } else {
           ingressStatsBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000040;
+        onChanged();
         return this;
       }
       /**
@@ -3342,11 +3213,11 @@ public final class Port {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.Builder builderForValue) {
         if (ingressStatsBuilder_ == null) {
           ingressStats_ = builderForValue.build();
-          onChanged();
         } else {
           ingressStatsBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000040;
+        onChanged();
         return this;
       }
       /**
@@ -3359,18 +3230,17 @@ public final class Port {
       public Builder mergeIngressStats(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats value) {
         if (ingressStatsBuilder_ == null) {
           if (((bitField0_ & 0x00000040) != 0) &&
-              ingressStats_ != null &&
-              ingressStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.getDefaultInstance()) {
-            ingressStats_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.newBuilder(ingressStats_).mergeFrom(value).buildPartial();
+            ingressStats_ != null &&
+            ingressStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.getDefaultInstance()) {
+            getIngressStatsBuilder().mergeFrom(value);
           } else {
             ingressStats_ = value;
           }
-          onChanged();
         } else {
           ingressStatsBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000040;
+        onChanged();
         return this;
       }
       /**
@@ -3381,13 +3251,13 @@ public final class Port {
        * <code>optional .InterfaceStats ingress_stats = 7;</code>
        */
       public Builder clearIngressStats() {
-        if (ingressStatsBuilder_ == null) {
-          ingressStats_ = null;
-          onChanged();
-        } else {
-          ingressStatsBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000040);
+        ingressStats_ = null;
+        if (ingressStatsBuilder_ != null) {
+          ingressStatsBuilder_.dispose();
+          ingressStatsBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -3480,11 +3350,11 @@ public final class Port {
             throw new NullPointerException();
           }
           egressStats_ = value;
-          onChanged();
         } else {
           egressStatsBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000080;
+        onChanged();
         return this;
       }
       /**
@@ -3498,11 +3368,11 @@ public final class Port {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.Builder builderForValue) {
         if (egressStatsBuilder_ == null) {
           egressStats_ = builderForValue.build();
-          onChanged();
         } else {
           egressStatsBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000080;
+        onChanged();
         return this;
       }
       /**
@@ -3515,18 +3385,17 @@ public final class Port {
       public Builder mergeEgressStats(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats value) {
         if (egressStatsBuilder_ == null) {
           if (((bitField0_ & 0x00000080) != 0) &&
-              egressStats_ != null &&
-              egressStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.getDefaultInstance()) {
-            egressStats_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.newBuilder(egressStats_).mergeFrom(value).buildPartial();
+            egressStats_ != null &&
+            egressStats_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.getDefaultInstance()) {
+            getEgressStatsBuilder().mergeFrom(value);
           } else {
             egressStats_ = value;
           }
-          onChanged();
         } else {
           egressStatsBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000080;
+        onChanged();
         return this;
       }
       /**
@@ -3537,13 +3406,13 @@ public final class Port {
        * <code>optional .InterfaceStats egress_stats = 8;</code>
        */
       public Builder clearEgressStats() {
-        if (egressStatsBuilder_ == null) {
-          egressStats_ = null;
-          onChanged();
-        } else {
-          egressStatsBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000080);
+        egressStats_ = null;
+        if (egressStatsBuilder_ != null) {
+          egressStatsBuilder_.dispose();
+          egressStatsBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -3636,11 +3505,11 @@ public final class Port {
             throw new NullPointerException();
           }
           ingressErrors_ = value;
-          onChanged();
         } else {
           ingressErrorsBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000100;
+        onChanged();
         return this;
       }
       /**
@@ -3654,11 +3523,11 @@ public final class Port {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors.Builder builderForValue) {
         if (ingressErrorsBuilder_ == null) {
           ingressErrors_ = builderForValue.build();
-          onChanged();
         } else {
           ingressErrorsBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000100;
+        onChanged();
         return this;
       }
       /**
@@ -3671,18 +3540,17 @@ public final class Port {
       public Builder mergeIngressErrors(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors value) {
         if (ingressErrorsBuilder_ == null) {
           if (((bitField0_ & 0x00000100) != 0) &&
-              ingressErrors_ != null &&
-              ingressErrors_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors.getDefaultInstance()) {
-            ingressErrors_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors.newBuilder(ingressErrors_).mergeFrom(value).buildPartial();
+            ingressErrors_ != null &&
+            ingressErrors_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors.getDefaultInstance()) {
+            getIngressErrorsBuilder().mergeFrom(value);
           } else {
             ingressErrors_ = value;
           }
-          onChanged();
         } else {
           ingressErrorsBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000100;
+        onChanged();
         return this;
       }
       /**
@@ -3693,13 +3561,13 @@ public final class Port {
        * <code>optional .IngressInterfaceErrors ingress_errors = 9;</code>
        */
       public Builder clearIngressErrors() {
-        if (ingressErrorsBuilder_ == null) {
-          ingressErrors_ = null;
-          onChanged();
-        } else {
-          ingressErrorsBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000100);
+        ingressErrors_ = null;
+        if (ingressErrorsBuilder_ != null) {
+          ingressErrorsBuilder_.dispose();
+          ingressErrorsBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -3782,7 +3650,18 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new InterfaceInfos(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -3961,84 +3840,6 @@ public final class Port {
       return new InterfaceStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private InterfaceStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              ifPkts_ = input.readUInt64();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              ifOctets_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              if1SecPkts_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              if1SecOctets_ = input.readUInt64();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              ifUcPkts_ = input.readUInt64();
-              break;
-            }
-            case 48: {
-              bitField0_ |= 0x00000020;
-              ifMcPkts_ = input.readUInt64();
-              break;
-            }
-            case 56: {
-              bitField0_ |= 0x00000040;
-              ifBcPkts_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.internal_static_InterfaceStats_descriptor;
@@ -4054,7 +3855,7 @@ public final class Port {
 
     private int bitField0_;
     public static final int IF_PKTS_FIELD_NUMBER = 1;
-    private long ifPkts_;
+    private long ifPkts_ = 0L;
     /**
      * <pre>
      * Counter: the total number of packets sent/rcvd by this interface
@@ -4081,7 +3882,7 @@ public final class Port {
     }
 
     public static final int IF_OCTETS_FIELD_NUMBER = 2;
-    private long ifOctets_;
+    private long ifOctets_ = 0L;
     /**
      * <pre>
      * Counter: the total number of bytes sent/rcvd by this interface
@@ -4108,7 +3909,7 @@ public final class Port {
     }
 
     public static final int IF_1SEC_PKTS_FIELD_NUMBER = 3;
-    private long if1SecPkts_;
+    private long if1SecPkts_ = 0L;
     /**
      * <pre>
      * Rate: the rate at which packets are sent/rcvd by this interface (in packets/sec)
@@ -4135,7 +3936,7 @@ public final class Port {
     }
 
     public static final int IF_1SEC_OCTETS_FIELD_NUMBER = 4;
-    private long if1SecOctets_;
+    private long if1SecOctets_ = 0L;
     /**
      * <pre>
      * Rate: the rate at which bytes are sent/rcvd by this interface
@@ -4162,7 +3963,7 @@ public final class Port {
     }
 
     public static final int IF_UC_PKTS_FIELD_NUMBER = 5;
-    private long ifUcPkts_;
+    private long ifUcPkts_ = 0L;
     /**
      * <pre>
      * Counter: total no of unicast packets sent/rcvd by this interface
@@ -4189,7 +3990,7 @@ public final class Port {
     }
 
     public static final int IF_MC_PKTS_FIELD_NUMBER = 6;
-    private long ifMcPkts_;
+    private long ifMcPkts_ = 0L;
     /**
      * <pre>
      * Counter: total no of multicast packets sent/rcvd by this interface
@@ -4216,7 +4017,7 @@ public final class Port {
     }
 
     public static final int IF_BC_PKTS_FIELD_NUMBER = 7;
-    private long ifBcPkts_;
+    private long ifBcPkts_ = 0L;
     /**
      * <pre>
      * Counter: total no of broadcast packets sent/rcvd by this interface
@@ -4305,7 +4106,7 @@ public final class Port {
       if (((bitField0_ & 0x00000040) != 0)) {
         output.writeUInt64(7, ifBcPkts_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -4342,7 +4143,7 @@ public final class Port {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(7, ifBcPkts_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -4392,7 +4193,7 @@ public final class Port {
         if (getIfBcPkts()
             != other.getIfBcPkts()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -4438,7 +4239,7 @@ public final class Port {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getIfBcPkts());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -4555,36 +4356,25 @@ public final class Port {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         ifPkts_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
         ifOctets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         if1SecPkts_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         if1SecOctets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         ifUcPkts_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000010);
         ifMcPkts_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
         ifBcPkts_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -4611,6 +4401,12 @@ public final class Port {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -4641,43 +4437,9 @@ public final class Port {
           result.ifBcPkts_ = ifBcPkts_;
           to_bitField0_ |= 0x00000040;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats) {
@@ -4711,7 +4473,7 @@ public final class Port {
         if (other.hasIfBcPkts()) {
           setIfBcPkts(other.getIfBcPkts());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -4747,17 +4509,65 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                ifPkts_ = input.readUInt64();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                ifOctets_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                if1SecPkts_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                if1SecOctets_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 40: {
+                ifUcPkts_ = input.readUInt64();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              case 48: {
+                ifMcPkts_ = input.readUInt64();
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 48
+              case 56: {
+                ifBcPkts_ = input.readUInt64();
+                bitField0_ |= 0x00000040;
+                break;
+              } // case 56
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.InterfaceStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -4797,8 +4607,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfPkts(long value) {
-        bitField0_ |= 0x00000001;
+
         ifPkts_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -4852,8 +4663,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfOctets(long value) {
-        bitField0_ |= 0x00000002;
+
         ifOctets_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -4907,8 +4719,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIf1SecPkts(long value) {
-        bitField0_ |= 0x00000004;
+
         if1SecPkts_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -4962,8 +4775,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIf1SecOctets(long value) {
-        bitField0_ |= 0x00000008;
+
         if1SecOctets_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -5017,8 +4831,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfUcPkts(long value) {
-        bitField0_ |= 0x00000010;
+
         ifUcPkts_ = value;
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -5072,8 +4887,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfMcPkts(long value) {
-        bitField0_ |= 0x00000020;
+
         ifMcPkts_ = value;
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -5127,8 +4943,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfBcPkts(long value) {
-        bitField0_ |= 0x00000040;
+
         ifBcPkts_ = value;
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -5179,7 +4996,18 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new InterfaceStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -5415,99 +5243,6 @@ public final class Port {
       return new IngressInterfaceErrors();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private IngressInterfaceErrors(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              ifInErrors_ = input.readUInt64();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              ifInQdrops_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              ifInFrameErrors_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              ifInDiscards_ = input.readUInt64();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              ifInRunts_ = input.readUInt64();
-              break;
-            }
-            case 48: {
-              bitField0_ |= 0x00000020;
-              ifInL3Incompletes_ = input.readUInt64();
-              break;
-            }
-            case 56: {
-              bitField0_ |= 0x00000040;
-              ifInL2ChanErrors_ = input.readUInt64();
-              break;
-            }
-            case 64: {
-              bitField0_ |= 0x00000080;
-              ifInL2MismatchTimeouts_ = input.readUInt64();
-              break;
-            }
-            case 72: {
-              bitField0_ |= 0x00000100;
-              ifInFifoErrors_ = input.readUInt64();
-              break;
-            }
-            case 80: {
-              bitField0_ |= 0x00000200;
-              ifInResourceErrors_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.internal_static_IngressInterfaceErrors_descriptor;
@@ -5523,7 +5258,7 @@ public final class Port {
 
     private int bitField0_;
     public static final int IF_IN_ERRORS_FIELD_NUMBER = 1;
-    private long ifInErrors_;
+    private long ifInErrors_ = 0L;
     /**
      * <pre>
      * Counter: the number of packets that contained errors
@@ -5550,7 +5285,7 @@ public final class Port {
     }
 
     public static final int IF_IN_QDROPS_FIELD_NUMBER = 2;
-    private long ifInQdrops_;
+    private long ifInQdrops_ = 0L;
     /**
      * <pre>
      * Counter: the number of packets dropped by the input queue of the I/O Manager ASIC
@@ -5577,7 +5312,7 @@ public final class Port {
     }
 
     public static final int IF_IN_FRAME_ERRORS_FIELD_NUMBER = 3;
-    private long ifInFrameErrors_;
+    private long ifInFrameErrors_ = 0L;
     /**
      * <pre>
      * Counter: the number of packets which were misaligned
@@ -5604,7 +5339,7 @@ public final class Port {
     }
 
     public static final int IF_IN_DISCARDS_FIELD_NUMBER = 4;
-    private long ifInDiscards_;
+    private long ifInDiscards_ = 0L;
     /**
      * <pre>
      * Counter: the number of non-errorpackets which were chosen to be discarded
@@ -5631,7 +5366,7 @@ public final class Port {
     }
 
     public static final int IF_IN_RUNTS_FIELD_NUMBER = 5;
-    private long ifInRunts_;
+    private long ifInRunts_ = 0L;
     /**
      * <pre>
      * Counter: the number of runt packets
@@ -5658,7 +5393,7 @@ public final class Port {
     }
 
     public static final int IF_IN_L3_INCOMPLETES_FIELD_NUMBER = 6;
-    private long ifInL3Incompletes_;
+    private long ifInL3Incompletes_ = 0L;
     /**
      * <pre>
      * Counter: the number of packets that fail Layer 3 sanity checks of the header
@@ -5685,7 +5420,7 @@ public final class Port {
     }
 
     public static final int IF_IN_L2CHAN_ERRORS_FIELD_NUMBER = 7;
-    private long ifInL2ChanErrors_;
+    private long ifInL2ChanErrors_ = 0L;
     /**
      * <pre>
      * Counter: the number of packets for which the software could not find a valid logical interface
@@ -5712,7 +5447,7 @@ public final class Port {
     }
 
     public static final int IF_IN_L2_MISMATCH_TIMEOUTS_FIELD_NUMBER = 8;
-    private long ifInL2MismatchTimeouts_;
+    private long ifInL2MismatchTimeouts_ = 0L;
     /**
      * <pre>
      * Counter: the number of malform or short packets
@@ -5739,7 +5474,7 @@ public final class Port {
     }
 
     public static final int IF_IN_FIFO_ERRORS_FIELD_NUMBER = 9;
-    private long ifInFifoErrors_;
+    private long ifInFifoErrors_ = 0L;
     /**
      * <pre>
      * Counter: the number of FIFO errors
@@ -5766,7 +5501,7 @@ public final class Port {
     }
 
     public static final int IF_IN_RESOURCE_ERRORS_FIELD_NUMBER = 10;
-    private long ifInResourceErrors_;
+    private long ifInResourceErrors_ = 0L;
     /**
      * <pre>
      * Counter: the number of resourceerrors
@@ -5836,7 +5571,7 @@ public final class Port {
       if (((bitField0_ & 0x00000200) != 0)) {
         output.writeUInt64(10, ifInResourceErrors_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -5885,7 +5620,7 @@ public final class Port {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(10, ifInResourceErrors_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -5950,7 +5685,7 @@ public final class Port {
         if (getIfInResourceErrors()
             != other.getIfInResourceErrors()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -6011,7 +5746,7 @@ public final class Port {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getIfInResourceErrors());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -6128,42 +5863,28 @@ public final class Port {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         ifInErrors_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000001);
         ifInQdrops_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         ifInFrameErrors_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         ifInDiscards_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         ifInRunts_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000010);
         ifInL3Incompletes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
         ifInL2ChanErrors_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000040);
         ifInL2MismatchTimeouts_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000080);
         ifInFifoErrors_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000100);
         ifInResourceErrors_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
 
@@ -6190,6 +5911,12 @@ public final class Port {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -6232,43 +5959,9 @@ public final class Port {
           result.ifInResourceErrors_ = ifInResourceErrors_;
           to_bitField0_ |= 0x00000200;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors) {
@@ -6311,7 +6004,7 @@ public final class Port {
         if (other.hasIfInResourceErrors()) {
           setIfInResourceErrors(other.getIfInResourceErrors());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -6326,17 +6019,80 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                ifInErrors_ = input.readUInt64();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                ifInQdrops_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                ifInFrameErrors_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                ifInDiscards_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 40: {
+                ifInRunts_ = input.readUInt64();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              case 48: {
+                ifInL3Incompletes_ = input.readUInt64();
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 48
+              case 56: {
+                ifInL2ChanErrors_ = input.readUInt64();
+                bitField0_ |= 0x00000040;
+                break;
+              } // case 56
+              case 64: {
+                ifInL2MismatchTimeouts_ = input.readUInt64();
+                bitField0_ |= 0x00000080;
+                break;
+              } // case 64
+              case 72: {
+                ifInFifoErrors_ = input.readUInt64();
+                bitField0_ |= 0x00000100;
+                break;
+              } // case 72
+              case 80: {
+                ifInResourceErrors_ = input.readUInt64();
+                bitField0_ |= 0x00000200;
+                break;
+              } // case 80
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.IngressInterfaceErrors) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -6376,8 +6132,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInErrors(long value) {
-        bitField0_ |= 0x00000001;
+
         ifInErrors_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -6431,8 +6188,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInQdrops(long value) {
-        bitField0_ |= 0x00000002;
+
         ifInQdrops_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -6486,8 +6244,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInFrameErrors(long value) {
-        bitField0_ |= 0x00000004;
+
         ifInFrameErrors_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -6541,8 +6300,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInDiscards(long value) {
-        bitField0_ |= 0x00000008;
+
         ifInDiscards_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -6596,8 +6356,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInRunts(long value) {
-        bitField0_ |= 0x00000010;
+
         ifInRunts_ = value;
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -6651,8 +6412,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInL3Incompletes(long value) {
-        bitField0_ |= 0x00000020;
+
         ifInL3Incompletes_ = value;
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -6706,8 +6468,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInL2ChanErrors(long value) {
-        bitField0_ |= 0x00000040;
+
         ifInL2ChanErrors_ = value;
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -6761,8 +6524,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInL2MismatchTimeouts(long value) {
-        bitField0_ |= 0x00000080;
+
         ifInL2MismatchTimeouts_ = value;
+        bitField0_ |= 0x00000080;
         onChanged();
         return this;
       }
@@ -6816,8 +6580,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInFifoErrors(long value) {
-        bitField0_ |= 0x00000100;
+
         ifInFifoErrors_ = value;
+        bitField0_ |= 0x00000100;
         onChanged();
         return this;
       }
@@ -6871,8 +6636,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setIfInResourceErrors(long value) {
-        bitField0_ |= 0x00000200;
+
         ifInResourceErrors_ = value;
+        bitField0_ |= 0x00000200;
         onChanged();
         return this;
       }
@@ -6923,7 +6689,18 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IngressInterfaceErrors(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -7189,109 +6966,6 @@ public final class Port {
       return new QueueStats();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private QueueStats(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              queueNumber_ = input.readUInt32();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              packets_ = input.readUInt64();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              bytes_ = input.readUInt64();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              tailDropPackets_ = input.readUInt64();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              rlDropPackets_ = input.readUInt64();
-              break;
-            }
-            case 48: {
-              bitField0_ |= 0x00000020;
-              rlDropBytes_ = input.readUInt64();
-              break;
-            }
-            case 56: {
-              bitField0_ |= 0x00000040;
-              redDropPackets_ = input.readUInt64();
-              break;
-            }
-            case 64: {
-              bitField0_ |= 0x00000080;
-              redDropBytes_ = input.readUInt64();
-              break;
-            }
-            case 72: {
-              bitField0_ |= 0x00000100;
-              avgBufferOccupancy_ = input.readUInt64();
-              break;
-            }
-            case 80: {
-              bitField0_ |= 0x00000200;
-              curBufferOccupancy_ = input.readUInt64();
-              break;
-            }
-            case 88: {
-              bitField0_ |= 0x00000400;
-              peakBufferOccupancy_ = input.readUInt64();
-              break;
-            }
-            case 96: {
-              bitField0_ |= 0x00000800;
-              allocatedBufferSize_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.internal_static_QueueStats_descriptor;
@@ -7307,7 +6981,7 @@ public final class Port {
 
     private int bitField0_;
     public static final int QUEUE_NUMBER_FIELD_NUMBER = 1;
-    private int queueNumber_;
+    private int queueNumber_ = 0;
     /**
      * <code>optional uint32 queue_number = 1 [(.telemetry_options) = { ... }</code>
      * @return Whether the queueNumber field is set.
@@ -7326,7 +7000,7 @@ public final class Port {
     }
 
     public static final int PACKETS_FIELD_NUMBER = 2;
-    private long packets_;
+    private long packets_ = 0L;
     /**
      * <pre>
      * Counter: the total number of packets that have been added to this queue
@@ -7353,7 +7027,7 @@ public final class Port {
     }
 
     public static final int BYTES_FIELD_NUMBER = 3;
-    private long bytes_;
+    private long bytes_ = 0L;
     /**
      * <pre>
      * Counter: the total number of bytes that have been added to this queue
@@ -7380,7 +7054,7 @@ public final class Port {
     }
 
     public static final int TAIL_DROP_PACKETS_FIELD_NUMBER = 4;
-    private long tailDropPackets_;
+    private long tailDropPackets_ = 0L;
     /**
      * <pre>
      * Counter: the total number of tail dropped packets
@@ -7407,7 +7081,7 @@ public final class Port {
     }
 
     public static final int RL_DROP_PACKETS_FIELD_NUMBER = 5;
-    private long rlDropPackets_;
+    private long rlDropPackets_ = 0L;
     /**
      * <pre>
      * Counter: the total number of rate-limitd packets
@@ -7434,7 +7108,7 @@ public final class Port {
     }
 
     public static final int RL_DROP_BYTES_FIELD_NUMBER = 6;
-    private long rlDropBytes_;
+    private long rlDropBytes_ = 0L;
     /**
      * <pre>
      * Counter: the total number of rate-limited bytes
@@ -7461,7 +7135,7 @@ public final class Port {
     }
 
     public static final int RED_DROP_PACKETS_FIELD_NUMBER = 7;
-    private long redDropPackets_;
+    private long redDropPackets_ = 0L;
     /**
      * <pre>
      * Counter: the total number of red-dropped packets
@@ -7488,7 +7162,7 @@ public final class Port {
     }
 
     public static final int RED_DROP_BYTES_FIELD_NUMBER = 8;
-    private long redDropBytes_;
+    private long redDropBytes_ = 0L;
     /**
      * <pre>
      * Counter: the total number of red-dropped bytes
@@ -7515,7 +7189,7 @@ public final class Port {
     }
 
     public static final int AVG_BUFFER_OCCUPANCY_FIELD_NUMBER = 9;
-    private long avgBufferOccupancy_;
+    private long avgBufferOccupancy_ = 0L;
     /**
      * <pre>
      * Average: avg queue depth,TAQL:time-average-queue-len, in packets, details TBD
@@ -7542,7 +7216,7 @@ public final class Port {
     }
 
     public static final int CUR_BUFFER_OCCUPANCY_FIELD_NUMBER = 10;
-    private long curBufferOccupancy_;
+    private long curBufferOccupancy_ = 0L;
     /**
      * <pre>
      * Gauge: current queue depth, in packets
@@ -7569,7 +7243,7 @@ public final class Port {
     }
 
     public static final int PEAK_BUFFER_OCCUPANCY_FIELD_NUMBER = 11;
-    private long peakBufferOccupancy_;
+    private long peakBufferOccupancy_ = 0L;
     /**
      * <pre>
      * Peak: the max measured queue depth, in packets, across all measurements since bo ot.
@@ -7596,7 +7270,7 @@ public final class Port {
     }
 
     public static final int ALLOCATED_BUFFER_SIZE_FIELD_NUMBER = 12;
-    private long allocatedBufferSize_;
+    private long allocatedBufferSize_ = 0L;
     /**
      * <pre>
      * allocated buffer size
@@ -7672,7 +7346,7 @@ public final class Port {
       if (((bitField0_ & 0x00000800) != 0)) {
         output.writeUInt64(12, allocatedBufferSize_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -7729,7 +7403,7 @@ public final class Port {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(12, allocatedBufferSize_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -7804,7 +7478,7 @@ public final class Port {
         if (getAllocatedBufferSize()
             != other.getAllocatedBufferSize()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -7874,7 +7548,7 @@ public final class Port {
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getAllocatedBufferSize());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -7991,46 +7665,30 @@ public final class Port {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         queueNumber_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000001);
         packets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000002);
         bytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         tailDropPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000008);
         rlDropPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000010);
         rlDropBytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
         redDropPackets_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000040);
         redDropBytes_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000080);
         avgBufferOccupancy_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000100);
         curBufferOccupancy_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000200);
         peakBufferOccupancy_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000400);
         allocatedBufferSize_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000800);
         return this;
       }
 
@@ -8057,6 +7715,12 @@ public final class Port {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -8107,43 +7771,9 @@ public final class Port {
           result.allocatedBufferSize_ = allocatedBufferSize_;
           to_bitField0_ |= 0x00000800;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats) {
@@ -8192,7 +7822,7 @@ public final class Port {
         if (other.hasAllocatedBufferSize()) {
           setAllocatedBufferSize(other.getAllocatedBufferSize());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -8207,17 +7837,90 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                queueNumber_ = input.readUInt32();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                packets_ = input.readUInt64();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                bytes_ = input.readUInt64();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                tailDropPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              case 40: {
+                rlDropPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              case 48: {
+                rlDropBytes_ = input.readUInt64();
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 48
+              case 56: {
+                redDropPackets_ = input.readUInt64();
+                bitField0_ |= 0x00000040;
+                break;
+              } // case 56
+              case 64: {
+                redDropBytes_ = input.readUInt64();
+                bitField0_ |= 0x00000080;
+                break;
+              } // case 64
+              case 72: {
+                avgBufferOccupancy_ = input.readUInt64();
+                bitField0_ |= 0x00000100;
+                break;
+              } // case 72
+              case 80: {
+                curBufferOccupancy_ = input.readUInt64();
+                bitField0_ |= 0x00000200;
+                break;
+              } // case 80
+              case 88: {
+                peakBufferOccupancy_ = input.readUInt64();
+                bitField0_ |= 0x00000400;
+                break;
+              } // case 88
+              case 96: {
+                allocatedBufferSize_ = input.readUInt64();
+                bitField0_ |= 0x00000800;
+                break;
+              } // case 96
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port.QueueStats) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -8245,8 +7948,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setQueueNumber(int value) {
-        bitField0_ |= 0x00000001;
+
         queueNumber_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8296,8 +8000,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setPackets(long value) {
-        bitField0_ |= 0x00000002;
+
         packets_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -8351,8 +8056,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setBytes(long value) {
-        bitField0_ |= 0x00000004;
+
         bytes_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -8406,8 +8112,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setTailDropPackets(long value) {
-        bitField0_ |= 0x00000008;
+
         tailDropPackets_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -8461,8 +8168,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setRlDropPackets(long value) {
-        bitField0_ |= 0x00000010;
+
         rlDropPackets_ = value;
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -8516,8 +8224,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setRlDropBytes(long value) {
-        bitField0_ |= 0x00000020;
+
         rlDropBytes_ = value;
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -8571,8 +8280,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setRedDropPackets(long value) {
-        bitField0_ |= 0x00000040;
+
         redDropPackets_ = value;
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -8626,8 +8336,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setRedDropBytes(long value) {
-        bitField0_ |= 0x00000080;
+
         redDropBytes_ = value;
+        bitField0_ |= 0x00000080;
         onChanged();
         return this;
       }
@@ -8681,8 +8392,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setAvgBufferOccupancy(long value) {
-        bitField0_ |= 0x00000100;
+
         avgBufferOccupancy_ = value;
+        bitField0_ |= 0x00000100;
         onChanged();
         return this;
       }
@@ -8736,8 +8448,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setCurBufferOccupancy(long value) {
-        bitField0_ |= 0x00000200;
+
         curBufferOccupancy_ = value;
+        bitField0_ |= 0x00000200;
         onChanged();
         return this;
       }
@@ -8791,8 +8504,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setPeakBufferOccupancy(long value) {
-        bitField0_ |= 0x00000400;
+
         peakBufferOccupancy_ = value;
+        bitField0_ |= 0x00000400;
         onChanged();
         return this;
       }
@@ -8846,8 +8560,9 @@ public final class Port {
        * @return This builder for chaining.
        */
       public Builder setAllocatedBufferSize(long value) {
-        bitField0_ |= 0x00000800;
+
         allocatedBufferSize_ = value;
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -8898,7 +8613,18 @@ public final class Port {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new QueueStats(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/TelemetryTop.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/proto/TelemetryTop.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -114,69 +114,6 @@ public final class TelemetryTop {
       return new TelemetryFieldOptions();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private TelemetryFieldOptions(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              isKey_ = input.readBool();
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              isTimestamp_ = input.readBool();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              isCounter_ = input.readBool();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              isGauge_ = input.readBool();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.internal_static_TelemetryFieldOptions_descriptor;
@@ -192,7 +129,7 @@ public final class TelemetryTop {
 
     private int bitField0_;
     public static final int IS_KEY_FIELD_NUMBER = 1;
-    private boolean isKey_;
+    private boolean isKey_ = false;
     /**
      * <code>optional bool is_key = 1;</code>
      * @return Whether the isKey field is set.
@@ -211,7 +148,7 @@ public final class TelemetryTop {
     }
 
     public static final int IS_TIMESTAMP_FIELD_NUMBER = 2;
-    private boolean isTimestamp_;
+    private boolean isTimestamp_ = false;
     /**
      * <code>optional bool is_timestamp = 2;</code>
      * @return Whether the isTimestamp field is set.
@@ -230,7 +167,7 @@ public final class TelemetryTop {
     }
 
     public static final int IS_COUNTER_FIELD_NUMBER = 3;
-    private boolean isCounter_;
+    private boolean isCounter_ = false;
     /**
      * <code>optional bool is_counter = 3;</code>
      * @return Whether the isCounter field is set.
@@ -249,7 +186,7 @@ public final class TelemetryTop {
     }
 
     public static final int IS_GAUGE_FIELD_NUMBER = 4;
-    private boolean isGauge_;
+    private boolean isGauge_ = false;
     /**
      * <code>optional bool is_gauge = 4;</code>
      * @return Whether the isGauge field is set.
@@ -293,7 +230,7 @@ public final class TelemetryTop {
       if (((bitField0_ & 0x00000008) != 0)) {
         output.writeBool(4, isGauge_);
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -318,7 +255,7 @@ public final class TelemetryTop {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(4, isGauge_);
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -353,7 +290,7 @@ public final class TelemetryTop {
         if (getIsGauge()
             != other.getIsGauge()) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -384,7 +321,7 @@ public final class TelemetryTop {
         hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
             getIsGauge());
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -501,30 +438,22 @@ public final class TelemetryTop {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryFieldOptions.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         isKey_ = false;
-        bitField0_ = (bitField0_ & ~0x00000001);
         isTimestamp_ = false;
-        bitField0_ = (bitField0_ & ~0x00000002);
         isCounter_ = false;
-        bitField0_ = (bitField0_ & ~0x00000004);
         isGauge_ = false;
-        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -551,6 +480,12 @@ public final class TelemetryTop {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryFieldOptions buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryFieldOptions result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryFieldOptions(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryFieldOptions result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -569,43 +504,9 @@ public final class TelemetryTop {
           result.isGauge_ = isGauge_;
           to_bitField0_ |= 0x00000008;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryFieldOptions) {
@@ -630,7 +531,7 @@ public final class TelemetryTop {
         if (other.hasIsGauge()) {
           setIsGauge(other.getIsGauge());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -645,17 +546,50 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryFieldOptions parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 8: {
+                isKey_ = input.readBool();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 8
+              case 16: {
+                isTimestamp_ = input.readBool();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                isCounter_ = input.readBool();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 32: {
+                isGauge_ = input.readBool();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryFieldOptions) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -683,8 +617,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setIsKey(boolean value) {
-        bitField0_ |= 0x00000001;
+
         isKey_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -722,8 +657,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setIsTimestamp(boolean value) {
-        bitField0_ |= 0x00000002;
+
         isTimestamp_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -761,8 +697,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setIsCounter(boolean value) {
-        bitField0_ |= 0x00000004;
+
         isCounter_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -800,8 +737,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setIsGauge(boolean value) {
-        bitField0_ |= 0x00000008;
+
         isGauge_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -848,7 +786,18 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TelemetryFieldOptions(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -1100,117 +1049,6 @@ public final class TelemetryTop {
       return new TelemetryStream();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private TelemetryStream(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              systemId_ = bs;
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              componentId_ = input.readUInt32();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              subComponentId_ = input.readUInt32();
-              break;
-            }
-            case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000008;
-              sensorName_ = bs;
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              sequenceNumber_ = input.readUInt32();
-              break;
-            }
-            case 48: {
-              bitField0_ |= 0x00000020;
-              timestamp_ = input.readUInt64();
-              break;
-            }
-            case 56: {
-              bitField0_ |= 0x00000040;
-              versionMajor_ = input.readUInt32();
-              break;
-            }
-            case 64: {
-              bitField0_ |= 0x00000080;
-              versionMinor_ = input.readUInt32();
-              break;
-            }
-            case 802: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000100) != 0)) {
-                subBuilder = ietf_.toBuilder();
-              }
-              ietf_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(ietf_);
-                ietf_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000100;
-              break;
-            }
-            case 810: {
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000200) != 0)) {
-                subBuilder = enterprise_.toBuilder();
-              }
-              enterprise_ = input.readMessage(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(enterprise_);
-                enterprise_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000200;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.internal_static_TelemetryStream_descriptor;
@@ -1226,7 +1064,8 @@ public final class TelemetryTop {
 
     private int bitField0_;
     public static final int SYSTEM_ID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object systemId_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object systemId_ = "";
     /**
      * <pre>
      * router name or export IP address
@@ -1286,7 +1125,7 @@ public final class TelemetryTop {
     }
 
     public static final int COMPONENT_ID_FIELD_NUMBER = 2;
-    private int componentId_;
+    private int componentId_ = 0;
     /**
      * <pre>
      * line card / RE (slot number)
@@ -1313,7 +1152,7 @@ public final class TelemetryTop {
     }
 
     public static final int SUB_COMPONENT_ID_FIELD_NUMBER = 3;
-    private int subComponentId_;
+    private int subComponentId_ = 0;
     /**
      * <pre>
      * PFE (if applicable)
@@ -1340,7 +1179,8 @@ public final class TelemetryTop {
     }
 
     public static final int SENSOR_NAME_FIELD_NUMBER = 4;
-    private volatile java.lang.Object sensorName_;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object sensorName_ = "";
     /**
      * <pre>
      * configured sensor name
@@ -1400,7 +1240,7 @@ public final class TelemetryTop {
     }
 
     public static final int SEQUENCE_NUMBER_FIELD_NUMBER = 5;
-    private int sequenceNumber_;
+    private int sequenceNumber_ = 0;
     /**
      * <pre>
      * sequence number, monotonically increasesing for each
@@ -1429,7 +1269,7 @@ public final class TelemetryTop {
     }
 
     public static final int TIMESTAMP_FIELD_NUMBER = 6;
-    private long timestamp_;
+    private long timestamp_ = 0L;
     /**
      * <pre>
      * timestamp (milliseconds since 00:00:00 UTC 1/1/1970)
@@ -1456,7 +1296,7 @@ public final class TelemetryTop {
     }
 
     public static final int VERSION_MAJOR_FIELD_NUMBER = 7;
-    private int versionMajor_;
+    private int versionMajor_ = 0;
     /**
      * <pre>
      * major version
@@ -1483,7 +1323,7 @@ public final class TelemetryTop {
     }
 
     public static final int VERSION_MINOR_FIELD_NUMBER = 8;
-    private int versionMinor_;
+    private int versionMinor_ = 0;
     /**
      * <pre>
      * minor version
@@ -1621,7 +1461,7 @@ public final class TelemetryTop {
       if (((bitField0_ & 0x00000200) != 0)) {
         output.writeMessage(101, getEnterprise());
       }
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -1668,7 +1508,7 @@ public final class TelemetryTop {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(101, getEnterprise());
       }
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -1733,7 +1573,7 @@ public final class TelemetryTop {
         if (!getEnterprise()
             .equals(other.getEnterprise())) return false;
       }
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
 
@@ -1785,7 +1625,7 @@ public final class TelemetryTop {
         hash = (37 * hash) + ENTERPRISE_FIELD_NUMBER;
         hash = (53 * hash) + getEnterprise().hashCode();
       }
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -1920,34 +1760,25 @@ public final class TelemetryTop {
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        bitField0_ = 0;
         systemId_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         componentId_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
         subComponentId_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
         sensorName_ = "";
-        bitField0_ = (bitField0_ & ~0x00000008);
         sequenceNumber_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000010);
         timestamp_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
         versionMajor_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000040);
         versionMinor_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000080);
-        if (ietfBuilder_ == null) {
-          ietf_ = null;
-        } else {
-          ietfBuilder_.clear();
+        ietf_ = null;
+        if (ietfBuilder_ != null) {
+          ietfBuilder_.dispose();
+          ietfBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000100);
-        if (enterpriseBuilder_ == null) {
-          enterprise_ = null;
-        } else {
-          enterpriseBuilder_.clear();
+        enterprise_ = null;
+        if (enterpriseBuilder_ != null) {
+          enterpriseBuilder_.dispose();
+          enterpriseBuilder_ = null;
         }
-        bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
 
@@ -1974,12 +1805,18 @@ public final class TelemetryTop {
       @java.lang.Override
       public org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream buildPartial() {
         org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream result = new org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream result) {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.systemId_ = systemId_;
           to_bitField0_ |= 0x00000001;
         }
-        result.systemId_ = systemId_;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.componentId_ = componentId_;
           to_bitField0_ |= 0x00000002;
@@ -1989,9 +1826,9 @@ public final class TelemetryTop {
           to_bitField0_ |= 0x00000004;
         }
         if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.sensorName_ = sensorName_;
           to_bitField0_ |= 0x00000008;
         }
-        result.sensorName_ = sensorName_;
         if (((from_bitField0_ & 0x00000010) != 0)) {
           result.sequenceNumber_ = sequenceNumber_;
           to_bitField0_ |= 0x00000010;
@@ -2009,58 +1846,20 @@ public final class TelemetryTop {
           to_bitField0_ |= 0x00000080;
         }
         if (((from_bitField0_ & 0x00000100) != 0)) {
-          if (ietfBuilder_ == null) {
-            result.ietf_ = ietf_;
-          } else {
-            result.ietf_ = ietfBuilder_.build();
-          }
+          result.ietf_ = ietfBuilder_ == null
+              ? ietf_
+              : ietfBuilder_.build();
           to_bitField0_ |= 0x00000100;
         }
         if (((from_bitField0_ & 0x00000200) != 0)) {
-          if (enterpriseBuilder_ == null) {
-            result.enterprise_ = enterprise_;
-          } else {
-            result.enterprise_ = enterpriseBuilder_.build();
-          }
+          result.enterprise_ = enterpriseBuilder_ == null
+              ? enterprise_
+              : enterpriseBuilder_.build();
           to_bitField0_ |= 0x00000200;
         }
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
+        result.bitField0_ |= to_bitField0_;
       }
 
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream) {
@@ -2074,8 +1873,8 @@ public final class TelemetryTop {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream.getDefaultInstance()) return this;
         if (other.hasSystemId()) {
-          bitField0_ |= 0x00000001;
           systemId_ = other.systemId_;
+          bitField0_ |= 0x00000001;
           onChanged();
         }
         if (other.hasComponentId()) {
@@ -2085,8 +1884,8 @@ public final class TelemetryTop {
           setSubComponentId(other.getSubComponentId());
         }
         if (other.hasSensorName()) {
-          bitField0_ |= 0x00000008;
           sensorName_ = other.sensorName_;
+          bitField0_ |= 0x00000008;
           onChanged();
         }
         if (other.hasSequenceNumber()) {
@@ -2107,7 +1906,7 @@ public final class TelemetryTop {
         if (other.hasEnterprise()) {
           mergeEnterprise(other.getEnterprise());
         }
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -2135,17 +1934,84 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                systemId_ = input.readBytes();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 16: {
+                componentId_ = input.readUInt32();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 16
+              case 24: {
+                subComponentId_ = input.readUInt32();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 24
+              case 34: {
+                sensorName_ = input.readBytes();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 34
+              case 40: {
+                sequenceNumber_ = input.readUInt32();
+                bitField0_ |= 0x00000010;
+                break;
+              } // case 40
+              case 48: {
+                timestamp_ = input.readUInt64();
+                bitField0_ |= 0x00000020;
+                break;
+              } // case 48
+              case 56: {
+                versionMajor_ = input.readUInt32();
+                bitField0_ |= 0x00000040;
+                break;
+              } // case 56
+              case 64: {
+                versionMinor_ = input.readUInt32();
+                bitField0_ |= 0x00000080;
+                break;
+              } // case 64
+              case 802: {
+                input.readMessage(
+                    getIetfFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000100;
+                break;
+              } // case 802
+              case 810: {
+                input.readMessage(
+                    getEnterpriseFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000200;
+                break;
+              } // case 810
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.TelemetryStream) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       private int bitField0_;
@@ -2216,11 +2082,9 @@ public final class TelemetryTop {
        */
       public Builder setSystemId(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         systemId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2233,8 +2097,8 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder clearSystemId() {
-        bitField0_ = (bitField0_ & ~0x00000001);
         systemId_ = getDefaultInstance().getSystemId();
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
@@ -2249,11 +2113,9 @@ public final class TelemetryTop {
        */
       public Builder setSystemIdBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
+        if (value == null) { throw new NullPointerException(); }
         systemId_ = value;
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -2293,8 +2155,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setComponentId(int value) {
-        bitField0_ |= 0x00000002;
+
         componentId_ = value;
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2348,8 +2211,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setSubComponentId(int value) {
-        bitField0_ |= 0x00000004;
+
         subComponentId_ = value;
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2434,11 +2298,9 @@ public final class TelemetryTop {
        */
       public Builder setSensorName(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
+        if (value == null) { throw new NullPointerException(); }
         sensorName_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2451,8 +2313,8 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder clearSensorName() {
-        bitField0_ = (bitField0_ & ~0x00000008);
         sensorName_ = getDefaultInstance().getSensorName();
+        bitField0_ = (bitField0_ & ~0x00000008);
         onChanged();
         return this;
       }
@@ -2467,11 +2329,9 @@ public final class TelemetryTop {
        */
       public Builder setSensorNameBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000008;
+        if (value == null) { throw new NullPointerException(); }
         sensorName_ = value;
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2514,8 +2374,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setSequenceNumber(int value) {
-        bitField0_ |= 0x00000010;
+
         sequenceNumber_ = value;
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -2570,8 +2431,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        bitField0_ |= 0x00000020;
+
         timestamp_ = value;
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -2625,8 +2487,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setVersionMajor(int value) {
-        bitField0_ |= 0x00000040;
+
         versionMajor_ = value;
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -2680,8 +2543,9 @@ public final class TelemetryTop {
        * @return This builder for chaining.
        */
       public Builder setVersionMinor(int value) {
-        bitField0_ |= 0x00000080;
+
         versionMinor_ = value;
+        bitField0_ |= 0x00000080;
         onChanged();
         return this;
       }
@@ -2730,11 +2594,11 @@ public final class TelemetryTop {
             throw new NullPointerException();
           }
           ietf_ = value;
-          onChanged();
         } else {
           ietfBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000100;
+        onChanged();
         return this;
       }
       /**
@@ -2744,11 +2608,11 @@ public final class TelemetryTop {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors.Builder builderForValue) {
         if (ietfBuilder_ == null) {
           ietf_ = builderForValue.build();
-          onChanged();
         } else {
           ietfBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000100;
+        onChanged();
         return this;
       }
       /**
@@ -2757,31 +2621,30 @@ public final class TelemetryTop {
       public Builder mergeIetf(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors value) {
         if (ietfBuilder_ == null) {
           if (((bitField0_ & 0x00000100) != 0) &&
-              ietf_ != null &&
-              ietf_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors.getDefaultInstance()) {
-            ietf_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors.newBuilder(ietf_).mergeFrom(value).buildPartial();
+            ietf_ != null &&
+            ietf_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors.getDefaultInstance()) {
+            getIetfBuilder().mergeFrom(value);
           } else {
             ietf_ = value;
           }
-          onChanged();
         } else {
           ietfBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000100;
+        onChanged();
         return this;
       }
       /**
        * <code>optional .IETFSensors ietf = 100;</code>
        */
       public Builder clearIetf() {
-        if (ietfBuilder_ == null) {
-          ietf_ = null;
-          onChanged();
-        } else {
-          ietfBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000100);
+        ietf_ = null;
+        if (ietfBuilder_ != null) {
+          ietfBuilder_.dispose();
+          ietfBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -2850,11 +2713,11 @@ public final class TelemetryTop {
             throw new NullPointerException();
           }
           enterprise_ = value;
-          onChanged();
         } else {
           enterpriseBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000200;
+        onChanged();
         return this;
       }
       /**
@@ -2864,11 +2727,11 @@ public final class TelemetryTop {
           org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors.Builder builderForValue) {
         if (enterpriseBuilder_ == null) {
           enterprise_ = builderForValue.build();
-          onChanged();
         } else {
           enterpriseBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000200;
+        onChanged();
         return this;
       }
       /**
@@ -2877,31 +2740,30 @@ public final class TelemetryTop {
       public Builder mergeEnterprise(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors value) {
         if (enterpriseBuilder_ == null) {
           if (((bitField0_ & 0x00000200) != 0) &&
-              enterprise_ != null &&
-              enterprise_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors.getDefaultInstance()) {
-            enterprise_ =
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors.newBuilder(enterprise_).mergeFrom(value).buildPartial();
+            enterprise_ != null &&
+            enterprise_ != org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors.getDefaultInstance()) {
+            getEnterpriseBuilder().mergeFrom(value);
           } else {
             enterprise_ = value;
           }
-          onChanged();
         } else {
           enterpriseBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000200;
+        onChanged();
         return this;
       }
       /**
        * <code>optional .EnterpriseSensors enterprise = 101;</code>
        */
       public Builder clearEnterprise() {
-        if (enterpriseBuilder_ == null) {
-          enterprise_ = null;
-          onChanged();
-        } else {
-          enterpriseBuilder_.clear();
-        }
         bitField0_ = (bitField0_ & ~0x00000200);
+        enterprise_ = null;
+        if (enterpriseBuilder_ != null) {
+          enterpriseBuilder_.dispose();
+          enterpriseBuilder_ = null;
+        }
+        onChanged();
         return this;
       }
       /**
@@ -2972,7 +2834,18 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TelemetryStream(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -3020,48 +2893,6 @@ public final class TelemetryTop {
       return new IETFSensors();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private IETFSensors(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.internal_static_IETFSensors_descriptor;
@@ -3097,7 +2928,7 @@ public final class TelemetryTop {
         .ExtendableMessage<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors>.ExtensionWriter
           extensionWriter = newExtensionWriter();
       extensionWriter.writeUntil(536870912, output);
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -3107,7 +2938,7 @@ public final class TelemetryTop {
 
       size = 0;
       size += extensionsSerializedSize();
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -3122,7 +2953,7 @@ public final class TelemetryTop {
       }
       org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors other = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors) obj;
 
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       if (!getExtensionFields().equals(other.getExtensionFields()))
         return false;
       return true;
@@ -3136,7 +2967,7 @@ public final class TelemetryTop {
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
       hash = hashFields(hash, getExtensionFields());
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -3254,18 +3085,13 @@ public final class TelemetryTop {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
@@ -3301,65 +3127,6 @@ public final class TelemetryTop {
       }
 
       @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public <Type> Builder setExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors, Type> extension,
-          Type value) {
-        return super.setExtension(extension, value);
-      }
-      @java.lang.Override
-      public <Type> Builder setExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors, java.util.List<Type>> extension,
-          int index, Type value) {
-        return super.setExtension(extension, index, value);
-      }
-      @java.lang.Override
-      public <Type> Builder addExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors, java.util.List<Type>> extension,
-          Type value) {
-        return super.addExtension(extension, value);
-      }
-      @java.lang.Override
-      public <Type> Builder clearExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors, ?> extension) {
-        return super.clearExtension(extension);
-      }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors) {
           return mergeFrom((org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors)other);
@@ -3372,7 +3139,7 @@ public final class TelemetryTop {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors.getDefaultInstance()) return this;
         this.mergeExtensionFields(other);
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -3390,17 +3157,30 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.IETFSensors) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       @java.lang.Override
@@ -3436,7 +3216,18 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IETFSensors(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -3484,48 +3275,6 @@ public final class TelemetryTop {
       return new EnterpriseSensors();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private EnterpriseSensors(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.internal_static_EnterpriseSensors_descriptor;
@@ -3561,7 +3310,7 @@ public final class TelemetryTop {
         .ExtendableMessage<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors>.ExtensionWriter
           extensionWriter = newExtensionWriter();
       extensionWriter.writeUntil(536870912, output);
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -3571,7 +3320,7 @@ public final class TelemetryTop {
 
       size = 0;
       size += extensionsSerializedSize();
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -3586,7 +3335,7 @@ public final class TelemetryTop {
       }
       org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors other = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors) obj;
 
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       if (!getExtensionFields().equals(other.getExtensionFields()))
         return false;
       return true;
@@ -3600,7 +3349,7 @@ public final class TelemetryTop {
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
       hash = hashFields(hash, getExtensionFields());
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -3718,18 +3467,13 @@ public final class TelemetryTop {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
@@ -3765,65 +3509,6 @@ public final class TelemetryTop {
       }
 
       @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public <Type> Builder setExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors, Type> extension,
-          Type value) {
-        return super.setExtension(extension, value);
-      }
-      @java.lang.Override
-      public <Type> Builder setExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors, java.util.List<Type>> extension,
-          int index, Type value) {
-        return super.setExtension(extension, index, value);
-      }
-      @java.lang.Override
-      public <Type> Builder addExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors, java.util.List<Type>> extension,
-          Type value) {
-        return super.addExtension(extension, value);
-      }
-      @java.lang.Override
-      public <Type> Builder clearExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors, ?> extension) {
-        return super.clearExtension(extension);
-      }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors) {
           return mergeFrom((org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors)other);
@@ -3836,7 +3521,7 @@ public final class TelemetryTop {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors.getDefaultInstance()) return this;
         this.mergeExtensionFields(other);
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -3854,17 +3539,30 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.EnterpriseSensors) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       @java.lang.Override
@@ -3900,7 +3598,18 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new EnterpriseSensors(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 
@@ -3948,48 +3657,6 @@ public final class TelemetryTop {
       return new JuniperNetworksSensors();
     }
 
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private JuniperNetworksSensors(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
       return org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.internal_static_JuniperNetworksSensors_descriptor;
@@ -4025,7 +3692,7 @@ public final class TelemetryTop {
         .ExtendableMessage<org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors>.ExtensionWriter
           extensionWriter = newExtensionWriter();
       extensionWriter.writeUntil(536870912, output);
-      unknownFields.writeTo(output);
+      getUnknownFields().writeTo(output);
     }
 
     @java.lang.Override
@@ -4035,7 +3702,7 @@ public final class TelemetryTop {
 
       size = 0;
       size += extensionsSerializedSize();
-      size += unknownFields.getSerializedSize();
+      size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
     }
@@ -4050,7 +3717,7 @@ public final class TelemetryTop {
       }
       org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors other = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors) obj;
 
-      if (!unknownFields.equals(other.unknownFields)) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       if (!getExtensionFields().equals(other.getExtensionFields()))
         return false;
       return true;
@@ -4064,7 +3731,7 @@ public final class TelemetryTop {
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
       hash = hashFields(hash, getExtensionFields());
-      hash = (29 * hash) + unknownFields.hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
@@ -4182,18 +3849,13 @@ public final class TelemetryTop {
 
       // Construct using org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors.newBuilder()
       private Builder() {
-        maybeForceBuilderInitialization();
+
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+
       }
       @java.lang.Override
       public Builder clear() {
@@ -4229,65 +3891,6 @@ public final class TelemetryTop {
       }
 
       @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public <Type> Builder setExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors, Type> extension,
-          Type value) {
-        return super.setExtension(extension, value);
-      }
-      @java.lang.Override
-      public <Type> Builder setExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors, java.util.List<Type>> extension,
-          int index, Type value) {
-        return super.setExtension(extension, index, value);
-      }
-      @java.lang.Override
-      public <Type> Builder addExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors, java.util.List<Type>> extension,
-          Type value) {
-        return super.addExtension(extension, value);
-      }
-      @java.lang.Override
-      public <Type> Builder clearExtension(
-          com.google.protobuf.GeneratedMessage.GeneratedExtension<
-              org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors, ?> extension) {
-        return super.clearExtension(extension);
-      }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors) {
           return mergeFrom((org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors)other);
@@ -4300,7 +3903,7 @@ public final class TelemetryTop {
       public Builder mergeFrom(org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors other) {
         if (other == org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors.getDefaultInstance()) return this;
         this.mergeExtensionFields(other);
-        this.mergeUnknownFields(other.unknownFields);
+        this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
       }
@@ -4318,17 +3921,30 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors parsedMessage = null;
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop.JuniperNetworksSensors) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
+          onChanged();
+        } // finally
         return this;
       }
       @java.lang.Override
@@ -4364,7 +3980,18 @@ public final class TelemetryTop {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new JuniperNetworksSensors(input, extensionRegistry);
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
       }
     };
 

--- a/features/topologies/service/api/src/main/java/org/opennms/netmgt/topologies/service/api/OnmsTopologyProtocol.java
+++ b/features/topologies/service/api/src/main/java/org/opennms/netmgt/topologies/service/api/OnmsTopologyProtocol.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -50,6 +50,10 @@ public class OnmsTopologyProtocol {
     }
 
     public String getId() {
+        return m_id;
+    }
+
+    public String toString() {
         return m_id;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1644,7 +1644,7 @@
     <gsonVersion>2.9.1</gsonVersion>
     <guavaVersion>31.1-jre</guavaVersion>
     <guavaOsgiVersion>31.1</guavaOsgiVersion>
-    <guavagRPCVersion>28.2-jre</guavagRPCVersion>
+    <guavagRPCVersion>30.1-jre</guavagRPCVersion>
     <gwtVersion>2.9.0</gwtVersion>
     <gwtPluginVersion>${gwtVersion}</gwtPluginVersion>
     <h2databaseVersion>1.4.197</h2databaseVersion>
@@ -1726,7 +1726,7 @@
     <paxSwissboxVersion>1.8.3</paxSwissboxVersion>
     <paxWebVersion>7.3.23</paxWebVersion>
     <pktsVersion>3.0.10</pktsVersion>
-    <protobufVersion>3.16.3</protobufVersion>
+    <protobufVersion>3.22.5</protobufVersion>
     <protobuf2Version>2.6.1</protobuf2Version>
     <postgresqlVersion>42.5.4</postgresqlVersion>
     <powermockVersion>2.0.9</powermockVersion>


### PR DESCRIPTION
Note: this PR looks like a lot has changed, but actually the only real difference is that I got rid of `org.opennms.netmgt.enlinkd.service.api.ProtocolSupported` and changed everything that relied upon it to use the `TopologyProtocol` from OPA (1.6 and up) instead. I also cleaned up the Karaf feature files to use a single feature that defines the `protobuf` dependency.

These changes get rid of one of the places where code is duplicated. :)

Unfortunately, the updates _also_ needed to get put into the `opennms-kafka-producer.proto` file, which is a part of both Horizon _and_ ALEC.

Long-term, we should ideally move the proto file (and its generated classes) to OPA, and let everything rely on a single copy everywhere, and just use the enum generated as part of the protobuf file instead rather than reproducing it in multiple places, but that will have to be an OPA 2.0 thing since `TopologyProtocol` pre-existed in OPA and is relied upon already.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15808