### PR TITLE
NMS-15809: Avoid errors in postinstall scripts when directories are empty

### DIFF
--- a/debian/opennms-server.postinst
+++ b/debian/opennms-server.postinst
@@ -20,8 +20,10 @@ case "$1" in
         fi
 
         if [ -d "/usr/share/opennms/data" ]; then
-            find /usr/share/opennms/data/* -maxdepth 0 -name tmp -o -name history.txt -prune -o -print0 | xargs --no-run-if-empty -0 rm -rf
-            find /usr/share/opennms/data/tmp/* -maxdepth 0 -name README -prune -o -print0 | xargs --no-run-if-empty -0 rm -rf
+            find /usr/share/opennms/data/ -maxdepth 1 -mindepth 1 -name tmp -o -name history.txt -prune -o -print0 | xargs --no-run-if-empty -0 rm -rf
+            if [ -d "/usr/share/opennms/data/tmp" ]; then
+                find /usr/share/opennms/data/tmp/ -maxdepth 1 -mindepth 1 -name README -prune -o -print0 | xargs --no-run-if-empty -0 rm -rf
+            fi
         fi
 
         /usr/share/opennms/bin/update-package-permissions opennms-server

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -258,9 +258,9 @@ ROOT_INST="${RPM_INSTALL_PREFIX0}"
 
 # Clean out the data directory
 if [ -d "${ROOT_INST}/data" ]; then
-    find "$ROOT_INST/data/"* -maxdepth 0 -name tmp -prune -o -print0 | xargs -0 rm -rf
+    find "$ROOT_INST/data/" -maxdepth 1 -mindepth 1 -name tmp -prune -o -print0 | xargs -0 rm -rf
     if [ -d "${ROOT_INST}/data/tmp"  ]; then
-        find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
+        find "$ROOT_INST/data/tmp/" -maxdepth 1 -mindepth 1 -name README -prune -o -print0 | xargs -0 rm -rf
     fi
 fi
 

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -963,9 +963,9 @@ done
 
 printf -- "- cleaning up \$OPENNMS_HOME/data... "
 if [ -d "$ROOT_INST/data" ]; then
-	find "$ROOT_INST/data/"* -maxdepth 0 -name tmp -o -name history.txt -prune -o -print0 | xargs -0 rm -rf
+	find "$ROOT_INST/data/" -maxdepth 1 -mindepth 1 -name tmp -prune -o -print0 | xargs -0 rm -rf
 	if [ -d "$ROOT_INST/data/tmp" ]; then
-		find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
+		find "$ROOT_INST/data/tmp/" -maxdepth 1 -mindepth 1 -name README -prune -o -print0 | xargs -0 rm -rf
 	fi
 fi
 echo "done"

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -963,7 +963,7 @@ done
 
 printf -- "- cleaning up \$OPENNMS_HOME/data... "
 if [ -d "$ROOT_INST/data" ]; then
-	find "$ROOT_INST/data/" -maxdepth 1 -mindepth 1 -name tmp -prune -o -print0 | xargs -0 rm -rf
+	find "$ROOT_INST/data/" -maxdepth 1 -mindepth 1 -name tmp -o -name history.txt -prune -o -print0 | xargs -0 rm -rf
 	if [ -d "$ROOT_INST/data/tmp" ]; then
 		find "$ROOT_INST/data/tmp/" -maxdepth 1 -mindepth 1 -name README -prune -o -print0 | xargs -0 rm -rf
 	fi

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -204,9 +204,9 @@ ROOT_INST="${RPM_INSTALL_PREFIX0}"
 
 # Clean out the data directory
 if [ -d "${ROOT_INST}/data" ]; then
-    find "$ROOT_INST/data/"* -maxdepth 0 -name tmp -prune -o -print0 | xargs -0 rm -rf
+    find "$ROOT_INST/data/" -maxdepth 1 -mindepth 1 -name tmp -prune -o -print0 | xargs -0 rm -rf
     if [ -d "${ROOT_INST}/data/tmp"  ]; then
-        find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
+        find "$ROOT_INST/data/tmp/" -maxdepth 1 -mindepth 1 -name README -prune -o -print0 | xargs -0 rm -rf
     fi
 fi
 


### PR DESCRIPTION
JIRA: https://opennms.atlassian.net/browse/NMS-15809

If /data or /data/tmp are present but empty, find throws an error when searching 'directory/*'. Instead, increase the -maxdepth argument and add a -mindepth argument to achieve the same result without risking a 'No such file or directory' error.