### PR TITLE
NMS-15780: Admin Password Change Prompt

### DIFF
--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/OpenNMSAuthSuccessHandler.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/OpenNMSAuthSuccessHandler.java
@@ -45,33 +45,62 @@ import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.util.StringUtils;
 
 public class OpenNMSAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    // username/password combination that triggers the password gate, which prompts
+    // user to change the default "admin" password
+    public static final String PASSWORD_GATE_USERNAME = "admin";
+    public static final String PASSWORD_GATE_PASSWORD = "admin";
+
     protected final Logger logger = LoggerFactory.getLogger(OpenNMSAuthSuccessHandler.class);
     private final RequestCache requestCache = new HttpSessionRequestCache();
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
-        final DefaultSavedRequest savedRequest = (DefaultSavedRequest) this.requestCache.getRequest(request, response);
-
         // changing JSESSIONID to prevent Session Fixation attacks, see NMS-15310
         request.changeSessionId();
 
-        if (savedRequest == null) {
-            this.getRedirectStrategy().sendRedirect(request, response, createTargetURL(request, response));
-            super.clearAuthenticationAttributes(request);
+        // check for admin/admin
+        boolean defaultAdminLogin = isDefaultAdminLogin(request.getParameter("j_username"), request.getParameter("j_password"));
+
+        if (defaultAdminLogin) {
+            handleDefaultAdminLogin(request, response);
         } else {
-            String targetUrlParameter = this.getTargetUrlParameter();
-            if (!this.isAlwaysUseDefaultTargetUrl() && (targetUrlParameter == null || !StringUtils.hasText(request.getParameter(targetUrlParameter)))) {
-                this.clearAuthenticationAttributes(request);
-                final String targetUrl = Util.calculateUrlBase(request, savedRequest.getServletPath() + (savedRequest.getQueryString() == null ? "" : "?" + savedRequest.getQueryString()));
-                this.logger.debug("Redirecting to DefaultSavedRequest Url: " + targetUrl);
-                this.getRedirectStrategy().sendRedirect(request, response, targetUrl);
-            } else {
-                this.requestCache.removeRequest(request, response);
+            final DefaultSavedRequest savedRequest = (DefaultSavedRequest) this.requestCache.getRequest(request, response);
+
+            if (savedRequest == null) {
+                super.clearAuthenticationAttributes(request);
                 this.getRedirectStrategy().sendRedirect(request, response, createTargetURL(request, response));
+            } else {
+                String targetUrlParameter = this.getTargetUrlParameter();
+
+                if (!this.isAlwaysUseDefaultTargetUrl() && (targetUrlParameter == null || !StringUtils.hasText(request.getParameter(targetUrlParameter)))) {
+                    this.clearAuthenticationAttributes(request);
+                    final String targetUrl = Util.calculateUrlBase(request, savedRequest.getServletPath() + (savedRequest.getQueryString() == null ? "" : "?" + savedRequest.getQueryString()));
+                    this.logger.debug("Redirecting to DefaultSavedRequest Url: " + targetUrl);
+                    this.getRedirectStrategy().sendRedirect(request, response, targetUrl);
+                } else {
+                    this.requestCache.removeRequest(request, response);
+                    this.getRedirectStrategy().sendRedirect(request, response, createTargetURL(request, response));
+                }
             }
         }
     }
+
+    /**
+     * 'admin' user is logged in successfully, but with default "admin" password, redirect to password gate page.
+     */
+    private void handleDefaultAdminLogin(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        final String targetUrl = Util.calculateUrlBase(request, "/account/selfService/passwordGate.jsp");
+        this.logger.debug("User used default admin password. Redirecting to Password Gate, url: " + targetUrl);
+        super.clearAuthenticationAttributes(request);
+        this.getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
     private String createTargetURL(HttpServletRequest request, HttpServletResponse response) {
         return Util.calculateUrlBase(request, determineTargetUrl(request, response));
+    }
+
+    private boolean isDefaultAdminLogin(String username, String password) {
+        return username != null && username.equals(PASSWORD_GATE_USERNAME) &&
+            password != null && password.equals(PASSWORD_GATE_PASSWORD);
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/account/selfService/AbstractBasePasswordChangeActionServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/account/selfService/AbstractBasePasswordChangeActionServlet.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.account.selfService;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.opennms.netmgt.config.UserFactory;
+import org.opennms.netmgt.config.UserManager;
+import org.opennms.netmgt.config.users.Password;
+import org.opennms.netmgt.config.users.User;
+import org.opennms.web.api.Authentication;
+
+/**
+ * Base servlet class for changing a user's password.
+ */
+public abstract class AbstractBasePasswordChangeActionServlet extends HttpServlet {
+    public static final String PASSWORD_REGEX = "((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%&.*+-]).{12,128})";
+    public static final String SAME_CHARACTER_REGEX = "(.)\\1{5}";
+
+    protected void initUserFactory(String servletName) throws ServletException {
+        try {
+            UserFactory.init();
+        } catch (Throwable e) {
+            throw new ServletException(servletName + ": Error initializing user factory." + e);
+        }
+    }
+
+    protected void readonlyUserCheck(HttpServletRequest request, User user) throws ServletException {
+        if (!request.isUserInRole(Authentication.ROLE_ADMIN) && user.getRoles().contains(Authentication.ROLE_READONLY)) {
+            throw new ServletException("User " + user.getUserId() + " is read-only");
+        }
+    }
+
+    protected boolean validatePassword(final String password) {
+        boolean isPasswordComplexityValid = Pattern.compile(this.PASSWORD_REGEX)
+            .matcher(password)
+            .matches();
+
+        boolean isPasswordWithSameCharacters = Pattern.compile(this.SAME_CHARACTER_REGEX)
+            .matcher(password)
+            .matches();
+
+        return isPasswordComplexityValid && !isPasswordWithSameCharacters;
+    }
+
+    protected void verifyAndChangePassword(UserManager userFactory, HttpSession userSession, User user,
+                                           HttpServletRequest request, HttpServletResponse response,
+                                           String currentPassword, String newPassword,
+                                           String redoUrl) throws IOException, ServletException {
+        if (!userFactory.comparePasswords(user.getUserId(), currentPassword)) {
+            // passwords don't match, have user redo
+            RequestDispatcher dispatcher = this.getServletContext().getRequestDispatcher("/account/selfService/passwordGate.jsp?action=redo");
+            dispatcher.forward(request, response);
+        } else {
+            if (this.validatePassword(newPassword)) {
+                final Password pass = new Password();
+                pass.setEncryptedPassword(userFactory.encryptedPassword(newPassword, true));
+                pass.setSalt(true);
+                user.setPassword(pass);
+
+                userSession.setAttribute("user.newPassword.jsp", user);
+
+                try {
+                    userFactory.saveUser(user.getUserId(), user);
+                } catch (Throwable e) {
+                    throw new ServletException("Error saving user " + user.getUserId(), e);
+                }
+
+                // forward the request for proper display
+                RequestDispatcher dispatcher = this.getServletContext().getRequestDispatcher("/account/selfService/passwordChanged.jsp");
+                dispatcher.forward(request, response);
+            } else {
+                throw new ServletException("Error saving user " + user.getUserId() + ":::Password complexity is not correct! Please use at least 12 characters, consisting of 1 special character, 1 upper case letter, 1 lower case letter and 1 number. Identical strings with 6 or more characters in a row are also not allowed.");
+            }
+        }
+    }
+}

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -225,6 +225,10 @@
           <beans:constructor-arg name="httpMethod" value="POST"/>
         </beans:bean>
         <beans:bean class="org.springframework.security.web.util.matcher.AntPathRequestMatcher">
+          <beans:constructor-arg name="pattern" value="/admin/account/selfService/passwordGateAction"/>
+          <beans:constructor-arg name="httpMethod" value="POST"/>
+        </beans:bean>
+        <beans:bean class="org.springframework.security.web.util.matcher.AntPathRequestMatcher">
           <beans:constructor-arg name="pattern" value="/event/**"/>
           <beans:constructor-arg name="httpMethod" value="POST"/>
         </beans:bean>

--- a/opennms-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/web.xml
@@ -762,6 +762,11 @@
     <servlet-name>newPasswordAction</servlet-name>
     <servlet-class>org.opennms.web.account.selfService.NewPasswordActionServlet</servlet-class>
   </servlet>
+  <!-- servlet for self-service password gate action -->
+  <servlet>
+    <servlet-name>passwordGateAction</servlet-name>
+    <servlet-class>org.opennms.web.account.selfService.PasswordGateActionServlet</servlet-class>
+  </servlet>
 
   <!-- Servlet mappings for user account self-service -->
   <servlet-mapping>
@@ -771,6 +776,10 @@
   <servlet-mapping>
     <servlet-name>newPasswordAction</servlet-name>
     <url-pattern>/account/selfService/newPasswordAction</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>passwordGateAction</servlet-name>
+    <url-pattern>/account/selfService/passwordGateAction</url-pattern>
   </servlet-mapping>
   <servlet>
     <servlet-name>nodeLabelChange</servlet-name>
@@ -1279,6 +1288,4 @@
   <welcome-file-list>
     <welcome-file>frontPage.jsp</welcome-file>
   </welcome-file-list>
-
 </web-app>
-

--- a/opennms-webapp/src/main/webapp/account/selfService/newPassword.jsp
+++ b/opennms-webapp/src/main/webapp/account/selfService/newPassword.jsp
@@ -26,7 +26,6 @@
  *     http://www.opennms.org/
  *     http://www.opennms.com/
  *******************************************************************************/
-
 --%>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
@@ -46,30 +45,28 @@
 </jsp:include>
 
 <script type="text/javascript">
-  function verifyGoForm()
-  {
-    if (document.goForm.pass1.value == document.goForm.pass2.value)
-    {
-      let newPassword=document.goForm.pass1.value
-      const passwordRegex=/${fn:escapeXml(NewPasswordActionServlet.PASSWORD_REGEX)}/;
-      const sameCharacterRegex=/${fn:escapeXml(NewPasswordActionServlet.SAME_CHARACTER_REGEX)}/;
+  function verifyGoForm() {
+    if (document.goForm.pass1.value == document.goForm.pass2.value) {
+      let newPassword = document.goForm.pass1.value
+      const passwordRegex = /${fn:escapeXml(NewPasswordActionServlet.PASSWORD_REGEX)}/;
+      const sameCharacterRegex = /${fn:escapeXml(NewPasswordActionServlet.SAME_CHARACTER_REGEX)}/;
 
-      if(newPassword.match(passwordRegex) && !newPassword.match(sameCharacterRegex) )
-      {
-        document.goForm.currentPassword.value=document.goForm.oldpass.value;
-        document.goForm.newPassword.value=document.goForm.pass1.value;
+      if (newPassword.match(passwordRegex) && !newPassword.match(sameCharacterRegex)) {
+        document.goForm.currentPassword.value = document.goForm.oldpass.value;
+        document.goForm.newPassword.value = document.goForm.pass1.value;
         return true;
       } else {
         alert("Password complexity is not correct! Please use at least 12 characters, consisting of 1 special character, 1 upper case letter, 1 lower case letter and 1 number. Identical strings with more than 6 characters in a row are also not allowed.");
+        return false;
       }
     }
     else
     {
       alert("The two new password fields do not match!");
+      return false;
     }
   }
 </script>
-
 
 <div class="row">
   <div class="col-md-4">

--- a/opennms-webapp/src/main/webapp/account/selfService/passwordGate.jsp
+++ b/opennms-webapp/src/main/webapp/account/selfService/passwordGate.jsp
@@ -1,0 +1,226 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2006-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+--%>
+
+<jsp:include page="/includes/bootstrap.jsp" flush="false">
+  <jsp:param name="title" value="Password Gate" />
+  <jsp:param name="quiet" value="true" />
+</jsp:include>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
+
+<%@ page
+  language="java"
+  contentType="text/html"
+  session="true"
+  import="org.opennms.web.account.selfService.PasswordGateActionServlet"
+%>
+
+<style type="text/css">
+  .login-page {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-image: url('images/wallpapers/background_dark.png');
+    background-size: cover;
+  }
+
+  .form-content-wrapper {
+    margin-left: 10%;
+    padding-left: 6px;
+  }
+
+  .form-input-wrapper {
+    max-width: 300px;
+  }
+
+  .form-group {
+    margin-bottom: 1.25rem;
+  }
+
+  .form-group.buttons {
+    margin-top: 1.5rem;
+  }
+
+  .login-form {
+    max-width: 480px;
+  }
+
+  .card {
+    background-color: transparent;
+    border-color: transparent;
+    margin-left: 10%;
+    margin-top: 10%;
+  }
+
+  input.form-control {
+    font-size: 12px;
+    padding: 10px;
+    color: black;
+    width: 225px;
+    height: 32px;
+    border-radius: 5px;
+    outline: none;
+    border:2px solid rgba(97, 215, 231, 0.829);
+    background-color: rgba(255, 255, 255, 0.623);
+  }
+
+  button {
+    color: black;
+    padding: 7px;
+    padding-left: 28px;
+    padding-right: 28px;
+    font-size: 11px;
+    border-radius: 30px;
+    background-image: linear-gradient(to right, rgb(67, 194, 233), rgb(137, 230, 194));
+    border: none;
+  }
+
+  button:hover {
+    background-image: linear-gradient(to right, rgb(61, 168, 200), rgb(116, 187, 160));
+  }
+
+  .btn {
+    border-radius: 1.25rem;
+    color: #000;
+    font-size: 11px;
+  }
+
+  .btn-primary, .btn-secondary {
+    min-width: 80px;
+  }
+
+  .btn-secondary {
+    margin-left: 4px;
+    background-image: linear-gradient(to right, rgb(84, 142, 131), rgb(104, 156, 139));
+  }
+
+  .horizon {
+    margin-left: 20%;
+  }
+
+  label.pg-text, span.pg-text {
+    color: #fff;
+  }
+</style>
+
+<%
+  // Spring Security remembers the requested URL and redirects after a successful login.
+  // If the session_expired parameter is set, it is known that this is a Javascript redirect.
+  // In this case, we remove the remembered request attribute so the user is forwarded to the login page instead.
+  if (request.getParameter("session_expired") != null
+    && request.getParameter("session_expired").equals("true")
+    && session != null) {
+    session.removeAttribute("SPRING_SECURITY_SAVED_REQUEST");
+  }
+%>
+<script type="text/javascript">
+  function verifyGoForm(event) {
+    if (event.submitter.id === 'btn_skip') {
+        return true;
+    }
+
+    if (document.goForm.pass1.value == document.goForm.pass2.value) {
+      let newPassword = document.goForm.pass1.value
+      const passwordRegex = /${fn:escapeXml(PasswordGateActionServlet.PASSWORD_REGEX)}/;
+      const sameCharacterRegex = /${fn:escapeXml(PasswordGateActionServlet.SAME_CHARACTER_REGEX)}/;
+
+      if (newPassword.match(passwordRegex) && !newPassword.match(sameCharacterRegex)) {
+        document.goForm.currentPassword.value = document.goForm.oldpass.value;
+        document.goForm.newPassword.value = document.goForm.pass1.value;
+        return true;
+      } else {
+        alert("Password complexity is not correct! Please use at least 12 characters, consisting of 1 special character, 1 upper case letter, 1 lower case letter and 1 number. Identical strings with 6 or more characters in a row are also not allowed.");
+        return false;
+      }
+    } else {
+      alert("The two new password fields do not match!");
+      return false;
+    }
+  }
+
+  window.onload = function() {
+    var oldPass = document.getElementById("loginForm:input_oldpass") || document.getElementById("input_oldpass");
+    var pass1 = document.getElementById("loginForm:input_pass1") || document.getElementById("input_pass1");
+    var pass2 = document.getElementById("loginForm:input_pass2") || document.getElementById("input_pass2");
+
+    oldPass.value = '';
+    pass1.value = '';
+    pass2.value = '';
+  }
+</script>
+
+<div class="login-page">
+    <div class="card login-form rounded">
+        <div style="padding-bottom: 36px; padding-top: 60px">
+            <img src="images/opennms_horizon_title.svg" class="horizon" width="185px" />
+        </div>
+        <div class="form-content-wrapper">
+            <form role="form" method="post" name="goForm" onSubmit="return verifyGoForm(event);" action="account/selfService/passwordGateAction">
+                <div class="form-content">
+                    <div class="form-group">
+                        <span class="pg-text">You landed here because you have not changed your "admin" password from the default value.
+                        It is highly recommended that you do so.
+                        You may also click "Skip" to skip this step for now.</span>
+                    </div>
+                    <div class="form-input-wrapper">
+                        <div class="form-group">
+                            <label class="col-form-label pg-text" for="input_oldpass">Current Password</label>
+                            <input type="password" class="form-control <% if ("redo".equals(request.getParameter("action"))) { %>is-invalid<% } %>" id="input_oldpass" name="oldpass" autocomplete="off">
+                        </div>
+                        <div class="form-group">
+                            <label class="col-form-label pg-text" for="input_pass1">New Password</label>
+                            <input type="password" class="form-control" name="pass1" id="input_pass1" autocomplete="off">
+                        </div>
+                        <div class="form-group">
+                            <label class="col-form-label pg-text" for="input_pass2">Confirm New Password</label>
+                            <input type="password" class="form-control" name="pass2" id="input_pass2" autocomplete="off">
+                        </div>
+                        <div class="form-group buttons">
+                            <button type="submit" class="btn btn-primary">Change Password</button>
+                            <button type="submit" id="btn_skip" name="btn_skip" formaction="account/selfService/passwordGateAction?skip=1" class="btn btn-secondary">Skip</button>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                        <input type="hidden" name="currentPassword" value="">
+                        <input type="hidden" name="newPassword" value="">
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="" style="position: absolute; bottom: 0px; right: 10px; font-size: 3em; padding: 20pt 20pt 5pt 20pt">
+        <div style="padding-bottom: 20px; padding-top: 20px">
+            <img src="images/opennms-logo-light.svg" class="" width="180px" />
+        </div>
+    </div>
+</div>

--- a/opennms-webapp/src/main/webapp/login.jsp
+++ b/opennms-webapp/src/main/webapp/login.jsp
@@ -35,7 +35,6 @@
 <jsp:include page="/includes/mobile-app-promo.jsp" flush="false" />
 
 <style type="text/css">
-
   .login-page {
     position: absolute;
     top: 0;
@@ -127,6 +126,7 @@
     background-color: #ffe5e7;
     border-color: #f15b65;
   }
+
   p {
     margin-bottom:0px;
   }
@@ -162,9 +162,9 @@
         <div class="form-content">
           <div class="form-group">
             <input type="text" id="input_j_username" name="j_username"
-            <%-- This is deprecated and requires a custom AuthenticationFailureHandler to function properly --%>
-                   <c:if test="${not empty param.login_error}">value='<c:out value="${SPRING_SECURITY_LAST_USERNAME}"/>'</c:if>
-                   placeholder="Username" autofocus="autofocus" autocomplete="username" required/>
+              <%-- This is deprecated and requires a custom AuthenticationFailureHandler to function properly --%>
+              <c:if test="${not empty param.login_error}">value='<c:out value="${SPRING_SECURITY_LAST_USERNAME}"/>'</c:if>
+              placeholder="Username" autofocus="autofocus" autocomplete="username" required/>
           </div>
 
           <div class="form-group">
@@ -173,7 +173,7 @@
 
           <c:if test="${not empty param.session_expired}">
             <div id="login-expired" class="alert alert-warning">
-              <strong>Session expired</strong> <br> Please log back in.
+              <strong>Session expired</strong> <br /> Please log back in.
             </div>
           </c:if>
 
@@ -199,6 +199,4 @@
           <img src="images/opennms-logo-light.svg" class="" width="180px" />
        </div>
   </div>
-
 </div>
-

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -124,6 +124,11 @@ public abstract class AbstractOpenNMSSeleniumHelper {
     public static final String BASIC_AUTH_USERNAME = "admin";
     public static final String BASIC_AUTH_PASSWORD = "admin";
 
+    // username/password combination that triggers the password gate, which prompts
+    // user to change the default "admin" password
+    public static final String PASSWORD_GATE_USERNAME = "admin";
+    public static final String PASSWORD_GATE_PASSWORD = "admin";
+
     public static final String REQUISITION_NAME   = "SeleniumTestGroup";
     public static final String USER_NAME          = "SmokeTestUser";
     public static final String GROUP_NAME         = "SmokeTestGroup";
@@ -286,7 +291,9 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         wait.until((WebDriver driver) -> {
             return ! driver.getCurrentUrl().contains("login.jsp");
         });
+
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='content']")));
+
         invokeWithImplicitWait(0, () -> {
             try {
                 // Make sure that the 'login-attempt-failed' element is not present
@@ -297,9 +304,20 @@ public abstract class AbstractOpenNMSSeleniumHelper {
             }
         });
 
+        // login with "admin/admin" will result in the passwordGate page, click "Skip" to continue
+        if (BASIC_AUTH_USERNAME.equals(PASSWORD_GATE_USERNAME) && BASIC_AUTH_PASSWORD.equals(PASSWORD_GATE_PASSWORD)) {
+            clickElement(By.id("btn_skip"));
+
+            wait.until((WebDriver driver) -> {
+                return !driver.getCurrentUrl().contains("passwordGate.jsp");
+            });
+        }
+
+        // close the Usage Statistics Sharing dialog if present
         invokeWithImplicitWait(0, () -> {
             try {
                 WebElement element = findElementById("usage-statistics-sharing-modal");
+
                 if (element.isDisplayed()) { // usage statistics modal is visible
                     findElementById("usage-statistics-sharing-notice-dismiss").click(); // close modal
                 }


### PR DESCRIPTION
Initial implementation of a password change prompt when the default admin user logs in with username `admin`, password `admin`.

- Update login page to check for “admin/admin” and redirect to Password Gate page

- Implement Password Gate page which allows user to either change password or skip

- Clicking “skip” will respect navigating to original target page (if it wasn’t just the login page)

- Refactored password change servlets to abstract base class since they contain much of the same functionality

- Fix integration and smoke tests to click “Skip” so they all still work

- Doesn’t include smoke test for this functionality and UI/UX will need review

Target branch is a feature branch. When smoke test and any UX changes have been implemented and merge to feature branch, will open a separate PR to merge to `develop`.


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15780

