### PR TITLE
nms-15802 Add preselect auth to page in page sequence

### DIFF
--- a/docs/modules/reference/pages/service-assurance/monitors/PageSequenceMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/PageSequenceMonitor.adoc
@@ -124,7 +124,7 @@ In case of an HTTPS request, this is also the virtual domain to send as part of 
 Colon-separated credentials such as USERNAME:PASSWORD.
 | n/a
 
-| preselect-auth
+| preemptive-auth
 | Preselect authentication method. 
 When specified, allows only basic authentication.
 User name and password must be provided in the `user-info` attribute.
@@ -211,10 +211,10 @@ WARNING: You need to delete existing RRD files and let them be recreated with th
 When authentication is required, the first HTTP request receives a "401 Unauthorized" response with possible authentication methods. 
 The second request is sent using the selected authentication method.
 
-Using the `preselect-auth` attribute lets you use a specific authentication on the first request.
+Using the `preemptive-auth` attribute lets you use a specific authentication on the first request.
 
 Some servers do not tell you which authentication methods they support. 
-In these cases, using the `preselect-auth` attribute is the only option.
+In these cases, using the `preemptive-auth` attribute is the only option.
 
 == Examples
 

--- a/docs/modules/reference/pages/service-assurance/monitors/PageSequenceMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/PageSequenceMonitor.adoc
@@ -124,6 +124,10 @@ In case of an HTTPS request, this is also the virtual domain to send as part of 
 Colon-separated credentials such as USERNAME:PASSWORD.
 | n/a
 
+| preselect-auth
+| Preselect authentication method. At the time allows only "basic" what corresponds to Basic Authentication and requires that user name and password are provided in the attribute `user-info`
+| n/a
+
 | host
 | Set host field in HTTP header.
 | IP interface address of the service
@@ -200,6 +204,13 @@ To collect response times for individual pages in a sequence, add a ds-name attr
 The response time for each page will be stored in the same RRD file specified for the service via the rrd-base-name parameter under the specified data source name.
 
 WARNING: You need to delete existing RRD files and let them be recreated with the new list of data sources when you add a ds-name attribute to a page in a sequence that is already storing response-time data.
+
+== Preselect authentication
+When authentication is required, the first HTTP request receives a "401 Unauthorized" response with possible authentication methods. The second request is sent using the selected authentication method.
+
+Using the `preselect-auth` attribute allows you to use a specific authentication right on the first request.
+
+Some servers do not tell you which authentication methods are supported. In these cases, using the `preselect-auth` attribute is the only option.
 
 == Examples
 

--- a/docs/modules/reference/pages/service-assurance/monitors/PageSequenceMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/PageSequenceMonitor.adoc
@@ -125,7 +125,9 @@ Colon-separated credentials such as USERNAME:PASSWORD.
 | n/a
 
 | preselect-auth
-| Preselect authentication method. At the time allows only "basic" what corresponds to Basic Authentication and requires that user name and password are provided in the attribute `user-info`
+| Preselect authentication method. 
+When specified, allows only basic authentication.
+User name and password must be provided in the `user-info` attribute.
 | n/a
 
 | host
@@ -206,11 +208,13 @@ The response time for each page will be stored in the same RRD file specified fo
 WARNING: You need to delete existing RRD files and let them be recreated with the new list of data sources when you add a ds-name attribute to a page in a sequence that is already storing response-time data.
 
 == Preselect authentication
-When authentication is required, the first HTTP request receives a "401 Unauthorized" response with possible authentication methods. The second request is sent using the selected authentication method.
+When authentication is required, the first HTTP request receives a "401 Unauthorized" response with possible authentication methods. 
+The second request is sent using the selected authentication method.
 
-Using the `preselect-auth` attribute allows you to use a specific authentication right on the first request.
+Using the `preselect-auth` attribute lets you to use a specific authentication on the first request.
 
-Some servers do not tell you which authentication methods are supported. In these cases, using the `preselect-auth` attribute is the only option.
+Some servers do not tell you which authentication methods they support. 
+In these cases, using the `preselect-auth` attribute is the only option.
 
 == Examples
 

--- a/docs/modules/reference/pages/service-assurance/monitors/PageSequenceMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/PageSequenceMonitor.adoc
@@ -211,7 +211,7 @@ WARNING: You need to delete existing RRD files and let them be recreated with th
 When authentication is required, the first HTTP request receives a "401 Unauthorized" response with possible authentication methods. 
 The second request is sent using the selected authentication method.
 
-Using the `preselect-auth` attribute lets you to use a specific authentication on the first request.
+Using the `preselect-auth` attribute lets you use a specific authentication on the first request.
 
 Some servers do not tell you which authentication methods they support. 
 In these cases, using the `preselect-auth` attribute is the only option.

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitor.java
@@ -376,13 +376,13 @@ public class PageSequenceMonitor extends AbstractServiceMonitor {
                     }
                 }
 
-                String preselectAuth = getPreselectAuth();
-                if (preselectAuth!=null) {
-                    switch (preselectAuth.toLowerCase()) {
+                String preemptiveAuth = getPreemptiveAuth();
+                if (preemptiveAuth!=null) {
+                    switch (preemptiveAuth.toLowerCase()) {
                         case "basic":
                             clientWrapper.addRequestInterceptor((request, context) -> {
                                 if (userInfo == null) {
-                                    LOG.warn("preselectAuth=\"basic\" but user-info is empty");
+                                    LOG.warn("preemptiveAuth=\"basic\" but user-info is empty");
                                     return;
                                 }
                                 final Header[] headers = request.getHeaders("Authorization");
@@ -394,7 +394,7 @@ public class PageSequenceMonitor extends AbstractServiceMonitor {
                             });
                             break;
                         default:
-                            LOG.warn("Illegal value found for preselect-auth: {}", preselectAuth);
+                            LOG.warn("Illegal value found for preselect-auth: {}", preemptiveAuth);
                     }
                 }
                 
@@ -560,8 +560,8 @@ public class PageSequenceMonitor extends AbstractServiceMonitor {
             return m_page.getUserInfo();
         }
 
-        private String getPreselectAuth() {
-            return m_page.getPreselectAuth();
+        private String getPreemptiveAuth() {
+            return m_page.getPreemptiveAuth();
         }
 
         private String getScheme() {

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitorIT.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitorIT.java
@@ -392,7 +392,7 @@ public class PageSequenceMonitorIT {
         assertNull(status1.getReason());
 
         final Map<String, Object> params2 = new HashMap<>(m_params);
-        String wrongUserInfo = "admin:wrong";
+        String wrongUserInfo = "admin:passwort";
         params2.put("page-sequence", "" +
                 "<?xml version=\"1.0\"?>" +
                 "<page-sequence>\n" +

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitorIT.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitorIT.java
@@ -392,7 +392,7 @@ public class PageSequenceMonitorIT {
         assertNull(status1.getReason());
 
         final Map<String, Object> params2 = new HashMap<>(m_params);
-        String wrongUserInfo = "admin:passwort";
+        String wrongUserInfo = "admin:wrong";
         params2.put("page-sequence", "" +
                 "<?xml version=\"1.0\"?>" +
                 "<page-sequence>\n" +

--- a/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/pagesequence/Page.java
+++ b/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/pagesequence/Page.java
@@ -59,7 +59,7 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name="page")
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlType(propOrder={"method","httpVersion","userAgent","virtualHost","scheme","userInfo","preselectAuth","host","requireIPv6","requireIPv4","disableSslVerification","port","path","query","fragment","failureMatch","failureMessage","successMatch","locationMatch","responseRange","dsName", "parameters", "headers", "sessionVariables"})
+@XmlType(propOrder={"m_method","m_httpVersion","m_userAgent","m_virtualHost","m_scheme","m_userInfo","m_preselectAuth","m_host","m_requireIPv6","m_requireIPv4","m_disableSslVerification","m_port","m_path","m_query","m_fragment","m_failureMatch","m_failureMessage","m_successMatch","m_locationMatch","m_responseRange","m_dsName","m_parameters","m_headers","m_sessionVariables"})
 public class Page implements Serializable {
     private static final long serialVersionUID = -568663444768205075L;
 

--- a/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/pagesequence/Page.java
+++ b/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/pagesequence/Page.java
@@ -59,7 +59,31 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name="page")
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlType(propOrder={"m_method","m_httpVersion","m_userAgent","m_virtualHost","m_scheme","m_userInfo","m_preselectAuth","m_host","m_requireIPv6","m_requireIPv4","m_disableSslVerification","m_port","m_path","m_query","m_fragment","m_failureMatch","m_failureMessage","m_successMatch","m_locationMatch","m_responseRange","m_dsName","m_parameters","m_headers","m_sessionVariables"})
+@XmlType(propOrder={
+        "m_method",
+        "m_httpVersion",
+        "m_userAgent",
+        "m_virtualHost",
+        "m_scheme",
+        "m_userInfo",
+        "m_preemptiveAuth",
+        "m_host",
+        "m_requireIPv6",
+        "m_requireIPv4",
+        "m_disableSslVerification",
+        "m_port",
+        "m_path",
+        "m_query",
+        "m_fragment",
+        "m_failureMatch",
+        "m_failureMessage",
+        "m_successMatch",
+        "m_locationMatch",
+        "m_responseRange",
+        "m_dsName",
+        "m_parameters",
+        "m_headers",
+        "m_sessionVariables"})
 public class Page implements Serializable {
     private static final long serialVersionUID = -568663444768205075L;
 
@@ -81,8 +105,8 @@ public class Page implements Serializable {
     @XmlAttribute(name="user-info")
     private String m_userInfo;
 
-    @XmlAttribute(name="preselect-auth")
-    private String m_preselectAuth = null;
+    @XmlAttribute(name="preemptive-auth")
+    private String m_preemptiveAuth = null;
 
     @XmlAttribute(name="host")
     private String m_host = "${ipaddr}";
@@ -192,12 +216,12 @@ public class Page implements Serializable {
         m_scheme = scheme == null? null : scheme.intern();
     }
 
-    public String getPreselectAuth() {
-        return m_preselectAuth;
+    public String getPreemptiveAuth() {
+        return m_preemptiveAuth;
     }
 
-    public void setPreselectAuth(String m_forceAuth) {
-        this.m_preselectAuth = m_forceAuth;
+    public void setPreemptiveAuth(String m_preemptiveAuth) {
+        this.m_preemptiveAuth = m_preemptiveAuth;
     }
 
     public String getUserInfo() {
@@ -417,7 +441,7 @@ public class Page implements Serializable {
         result = prime * result + ((m_successMatch == null) ? 0 : m_successMatch.hashCode());
         result = prime * result + ((m_userAgent == null) ? 0 : m_userAgent.hashCode());
         result = prime * result + ((m_userInfo == null) ? 0 : m_userInfo.hashCode());
-        result = prime * result + ((m_preselectAuth == null) ? 0 : m_preselectAuth.hashCode());
+        result = prime * result + ((m_preemptiveAuth == null) ? 0 : m_preemptiveAuth.hashCode());
         result = prime * result + ((m_virtualHost == null) ? 0 : m_virtualHost.hashCode());
         return result;
     }
@@ -581,11 +605,11 @@ public class Page implements Serializable {
         } else if (!m_userInfo.equals(other.m_userInfo)) {
             return false;
         }
-        if (m_preselectAuth == null) {
-            if (other.m_preselectAuth != null) {
+        if (m_preemptiveAuth == null) {
+            if (other.m_preemptiveAuth != null) {
                 return false;
             }
-        } else if (!m_preselectAuth.equals(other.m_preselectAuth)) {
+        } else if (!m_preemptiveAuth.equals(other.m_preemptiveAuth)) {
             return false;
         }
         if (m_virtualHost == null) {
@@ -604,7 +628,7 @@ public class Page implements Serializable {
                 + m_userInfo + ", host=" + m_host + ", requireIPv6=" + m_requireIPv6 + ", requireIPv4=" + m_requireIPv4 + ", disableSslVerification=" + m_disableSslVerification + ", port="
                 + m_port + ", path=" + m_path + ", query=" + m_query + ", fragment=" + m_fragment + ", failureMatch=" + m_failureMatch + ", failureMessage=" + m_failureMessage
                 + ", successMatch=" + m_successMatch + ", locationMatch=" + m_locationMatch + ", responseRange=" + m_responseRange + ", dsName=" + m_dsName + ", parameters=" + m_parameters
-                + ", sessionVariables=" + m_sessionVariables + ", preselectAuth=" + m_preselectAuth + "]";
+                + ", sessionVariables=" + m_sessionVariables + ", preemptiveAuth=" + m_preemptiveAuth + "]";
     }
 
 

--- a/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/pagesequence/Page.java
+++ b/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/pagesequence/Page.java
@@ -59,9 +59,9 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name="page")
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlType(propOrder={"m_method","m_httpVersion","m_userAgent","m_virtualHost","m_scheme","m_userInfo","m_host","m_requireIPv6","m_requireIPv4","m_disableSslVerification","m_port","m_path","m_query","m_fragment","m_failureMatch","m_failureMessage","m_successMatch","m_locationMatch","m_responseRange","m_dsName", "m_parameters", "m_headers", "m_sessionVariables"})
+@XmlType(propOrder={"method","httpVersion","userAgent","virtualHost","scheme","userInfo","preselectAuth","host","requireIPv6","requireIPv4","disableSslVerification","port","path","query","fragment","failureMatch","failureMessage","successMatch","locationMatch","responseRange","dsName", "parameters", "headers", "sessionVariables"})
 public class Page implements Serializable {
-    private static final long serialVersionUID = -8690979689322573975L;
+    private static final long serialVersionUID = -568663444768205075L;
 
     @XmlAttribute(name="method")
     private String m_method = "GET";
@@ -80,6 +80,9 @@ public class Page implements Serializable {
 
     @XmlAttribute(name="user-info")
     private String m_userInfo;
+
+    @XmlAttribute(name="preselect-auth")
+    private String m_preselectAuth = null;
 
     @XmlAttribute(name="host")
     private String m_host = "${ipaddr}";
@@ -187,6 +190,14 @@ public class Page implements Serializable {
 
     public void setScheme(final String scheme) {
         m_scheme = scheme == null? null : scheme.intern();
+    }
+
+    public String getPreselectAuth() {
+        return m_preselectAuth;
+    }
+
+    public void setPreselectAuth(String m_forceAuth) {
+        this.m_preselectAuth = m_forceAuth;
     }
 
     public String getUserInfo() {
@@ -406,6 +417,7 @@ public class Page implements Serializable {
         result = prime * result + ((m_successMatch == null) ? 0 : m_successMatch.hashCode());
         result = prime * result + ((m_userAgent == null) ? 0 : m_userAgent.hashCode());
         result = prime * result + ((m_userInfo == null) ? 0 : m_userInfo.hashCode());
+        result = prime * result + ((m_preselectAuth == null) ? 0 : m_preselectAuth.hashCode());
         result = prime * result + ((m_virtualHost == null) ? 0 : m_virtualHost.hashCode());
         return result;
     }
@@ -569,6 +581,13 @@ public class Page implements Serializable {
         } else if (!m_userInfo.equals(other.m_userInfo)) {
             return false;
         }
+        if (m_preselectAuth == null) {
+            if (other.m_preselectAuth != null) {
+                return false;
+            }
+        } else if (!m_preselectAuth.equals(other.m_preselectAuth)) {
+            return false;
+        }
         if (m_virtualHost == null) {
             if (other.m_virtualHost != null) {
                 return false;
@@ -585,7 +604,7 @@ public class Page implements Serializable {
                 + m_userInfo + ", host=" + m_host + ", requireIPv6=" + m_requireIPv6 + ", requireIPv4=" + m_requireIPv4 + ", disableSslVerification=" + m_disableSslVerification + ", port="
                 + m_port + ", path=" + m_path + ", query=" + m_query + ", fragment=" + m_fragment + ", failureMatch=" + m_failureMatch + ", failureMessage=" + m_failureMessage
                 + ", successMatch=" + m_successMatch + ", locationMatch=" + m_locationMatch + ", responseRange=" + m_responseRange + ", dsName=" + m_dsName + ", parameters=" + m_parameters
-                + ", sessionVariables=" + m_sessionVariables + "]";
+                + ", sessionVariables=" + m_sessionVariables + ", preselectAuth=" + m_preselectAuth + "]";
     }
 
 

--- a/opennms-config-jaxb/src/main/resources/xsds/page-sequence.xsd
+++ b/opennms-config-jaxb/src/main/resources/xsds/page-sequence.xsd
@@ -48,7 +48,7 @@
       <attribute name="virtual-host" type="string" use="optional" />
       <attribute name="scheme" type="string" use="optional" default="http" />
       <attribute name="user-info" type="string" use="optional" />
-      <attribute name="preselect-auth" type="string" use="optional" />
+      <attribute name="preemptive-auth" type="string" use="optional" />
       <attribute name="host" type="string" use="optional" default="${ipaddr}" />
       <attribute name="requireIPv6" type="boolean" use="optional" default="false" />
       <attribute name="requireIPv4" type="boolean" use="optional" default="false" />

--- a/opennms-config-jaxb/src/main/resources/xsds/page-sequence.xsd
+++ b/opennms-config-jaxb/src/main/resources/xsds/page-sequence.xsd
@@ -48,6 +48,7 @@
       <attribute name="virtual-host" type="string" use="optional" />
       <attribute name="scheme" type="string" use="optional" default="http" />
       <attribute name="user-info" type="string" use="optional" />
+      <attribute name="preselect-auth" type="string" use="optional" />
       <attribute name="host" type="string" use="optional" default="${ipaddr}" />
       <attribute name="requireIPv6" type="boolean" use="optional" default="false" />
       <attribute name="requireIPv4" type="boolean" use="optional" default="false" />


### PR DESCRIPTION
When authentication is required, the first HTTP request receives a "401 Unauthorized" response with possible authentication methods. The second request is sent using the selected authentication method.
Using the `preselect-auth` attribute allows you to use a specific authentication right on the first request.
Some servers do not tell you which authentication methods are supported. In these cases, using the `preselect-auth` attribute is the only option.

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15802

