### PR TITLE
NMS-15869: Exclude 'scv.jce' from filtered resources

### DIFF
--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -226,6 +226,11 @@
         <configuration>
           <encoding>UTF-8</encoding>
           <escapeString>\</escapeString>
+          <nonFilteredFileExtensions>
+            <nonFilteredFileExtension>dat</nonFilteredFileExtension>
+            <nonFilteredFileExtension>jce</nonFilteredFileExtension>
+            <nonFilteredFileExtension>raw</nonFilteredFileExtension>
+          </nonFilteredFileExtensions>
         </configuration>
       </plugin>
     </plugins>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -275,8 +275,9 @@
          <configuration>
            <encoding>UTF-8</encoding>
            <nonFilteredFileExtensions>
-             <nonFilteredFileExtension>raw</nonFilteredFileExtension>
              <nonFilteredFileExtension>dat</nonFilteredFileExtension>
+             <nonFilteredFileExtension>jce</nonFilteredFileExtension>
+             <nonFilteredFileExtension>raw</nonFilteredFileExtension>
            </nonFilteredFileExtensions>
          </configuration>
         <!-- Copy some default configuration for $OPENNMS_HOME/etc/ which is used by some system tests -->


### PR DESCRIPTION
Developer build (on Mac) failing due to `MalformedInputException: Length = 1` error while executing the Maven `resource` or `copy-resources` goal and copying `scv.jce`, which is a binary file.

Seems to be caused by this file not being excluded from Maven filtering, probably due to trying to read this binary file using UTF-8 encoding. Solution is to exclude file from the filtering process. 

Occurring in `develop` branch; targeting `foundation-2023` since it's a bug fix.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15869

