### PR TITLE
NMS-15866: Smoke test for admin password gate

### DIFF
--- a/opennms-webapp/src/main/webapp/account/selfService/passwordGate.jsp
+++ b/opennms-webapp/src/main/webapp/account/selfService/passwordGate.jsp
@@ -205,7 +205,7 @@
                             <input type="password" class="form-control" name="pass2" id="input_pass2" autocomplete="off">
                         </div>
                         <div class="form-group buttons">
-                            <button type="submit" class="btn btn-primary">Change Password</button>
+                            <button type="submit" id="btn_change_password" name="btn_change_password" class="btn btn-primary">Change Password</button>
                             <button type="submit" id="btn_skip" name="btn_skip" formaction="account/selfService/passwordGateAction?skip=1" class="btn btn-secondary">Skip</button>
                         </div>
                     </div>

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -167,10 +167,12 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         protected void failed(final Throwable e, final Description description) {
             final String testName = description.getMethodName();
             final WebDriver driver = getDriver();
+
             if (driver == null) {
                 LOG.warn("Test {} failed... no web driver was set.", testName);
                 return;
             }
+
             LOG.debug("Test {} failed... attempting to take screenshot.", testName);
 
             // Reset the implicit wait since we can't trust the last value
@@ -178,10 +180,12 @@ public abstract class AbstractOpenNMSSeleniumHelper {
 
             if (driver instanceof TakesScreenshot) {
                 final TakesScreenshot shot = (TakesScreenshot)driver;
+
                 try {
                     final Path from = shot.getScreenshotAs(OutputType.FILE).toPath();
                     final Path to = Paths.get("target", "screenshots", description.getClassName() + "." + testName + ".png");
                     LOG.debug("Screenshot saved to: {}", from);
+
                     try {
                         Files.createDirectories(to.getParent());
                         Files.move(from, to, StandardCopyOption.REPLACE_EXISTING);
@@ -195,10 +199,12 @@ public abstract class AbstractOpenNMSSeleniumHelper {
             } else {
                 LOG.debug("Driver can't take screenshots.");
             }
+
             try {
                 LOG.debug("Attempting to dump DOM.");
                 final String domText = driver.findElement(By.tagName("html")).getAttribute("innerHTML");
                 final Path to = Paths.get("target", "contents", description.getClassName() + "." + testName + ".html");
+
                 try {
                     Files.createDirectories(to.getParent());
                     Files.write(to, domText.getBytes(StandardCharsets.UTF_8));
@@ -279,53 +285,58 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         }
     }
 
+    /**
+     * Standard login for smoke tests. Navigate to login page, log in as default admin user,
+     * skip the password gate page and then close the Usage Statistics Sharing dialog if present.
+     */
     public void login() {
-        getDriver().get(getBaseUrlInternal() + "opennms/login.jsp");
+        login(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, true, true, true);
+    }
+
+    /**
+     * Perform a login with given credentials and various options.
+     *
+     * If login username/password is "admin/admin", this results in going to the Admin Password Gate page.
+     * 'skip' will skip having to change the password and continue to the main page.
+     *
+     * @param username Username to use for the login
+     * @param password Password to use for the login
+     * @param skip If true, clicks Skip on the password gate page to avoid having to change the admin password
+     * @param closeUsageStatsSharing If true, close the Usage Statistics Sharing dialog if it appears
+     * @param navigateToLoginPage If true, navigate to the login page. Set to false to navigate
+     *     to a different page before calling this method, e.g. to test that redirect after login works.
+     */
+    public void login(final String username, final String password, final boolean skip, final boolean closeUsageStatsSharing,
+                      final boolean navigateToLoginPage) {
+        LOG.debug("Login: username={}, skip={}, closeUsageStatsSharing={}, navigateToLoginPage={}",
+            username, skip, closeUsageStatsSharing, navigateToLoginPage);
+
+        if (navigateToLoginPage) {
+            getDriver().get(getBaseUrlInternal() + "opennms/login.jsp");
+        }
 
         waitForLogin();
 
-        enterText(By.name("j_username"), BASIC_AUTH_USERNAME);
-        enterText(By.name("j_password"), BASIC_AUTH_PASSWORD);
+        enterText(By.name("j_username"), username);
+        enterText(By.name("j_password"), password);
         clickElement(By.name("Login"));
 
         wait.until((WebDriver driver) -> {
             return ! driver.getCurrentUrl().contains("login.jsp");
         });
 
+        // bootstrap header, exists in all JSP-based OpenNMS pages
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='content']")));
 
-        invokeWithImplicitWait(0, () -> {
-            try {
-                // Make sure that the 'login-attempt-failed' element is not present
-                findElementById("login-attempt-failed");
-                fail("Login failed: " + findElementById("login-attempt-failed-reason").getText());
-            } catch (NoSuchElementException e) {
-                // This is expected
-            }
-        });
+        ensureLoginSuccess();
 
-        // login with "admin/admin" will result in the passwordGate page, click "Skip" to continue
-        if (BASIC_AUTH_USERNAME.equals(PASSWORD_GATE_USERNAME) && BASIC_AUTH_PASSWORD.equals(PASSWORD_GATE_PASSWORD)) {
-            clickElement(By.id("btn_skip"));
-
-            wait.until((WebDriver driver) -> {
-                return !driver.getCurrentUrl().contains("passwordGate.jsp");
-            });
+        if (skip) {
+            skipPasswordGate(username, password);
         }
 
-        // close the Usage Statistics Sharing dialog if present
-        invokeWithImplicitWait(0, () -> {
-            try {
-                WebElement element = findElementById("usage-statistics-sharing-modal");
-
-                if (element.isDisplayed()) { // usage statistics modal is visible
-                    findElementById("usage-statistics-sharing-notice-dismiss").click(); // close modal
-                }
-            } catch (NoSuchElementException e) {
-                // "usage-statistics-sharing-notice-dismiss" is not visible or does not exist.
-                // No further action required
-            }
-        });
+        if (closeUsageStatsSharing) {
+            closeUsageStatisticsSharingDialog();
+        }
     }
 
     private void invokeWithImplicitWait(int implicitWait, Runnable runnable) {
@@ -340,8 +351,10 @@ public abstract class AbstractOpenNMSSeleniumHelper {
     }
 
     protected void logout() {
+        LOG.debug("Logout started");
         getElementWithoutWaiting(By.name("headerLogoutForm")).submit();
         waitForLogin();
+        LOG.debug("Logout complete");
     }
 
     private void waitForLogin() {
@@ -363,6 +376,50 @@ public abstract class AbstractOpenNMSSeleniumHelper {
     public void clearElement(final By by) {
         sleepQuietly(200);
         waitForElement(by).clear();
+    }
+
+    protected void ensureLoginSuccess() {
+        invokeWithImplicitWait(0, () -> {
+            try {
+                // Make sure that the 'login-attempt-failed' element is not present
+                findElementById("login-attempt-failed");
+                fail("Login failed: " + findElementById("login-attempt-failed-reason").getText());
+            } catch (NoSuchElementException e) {
+                // This is expected
+            }
+        });
+    }
+
+    /**
+     * Logging in with "admin/admin" will result in navigating to the passwordGate page,
+     * this clicks "Skip" to continue.
+     */
+    protected void skipPasswordGate(final String username, final String password) {
+        if (username.equals(PASSWORD_GATE_USERNAME) && password.equals(PASSWORD_GATE_PASSWORD)) {
+            clickElement(By.id("btn_skip"));
+
+            wait.until((WebDriver driver) -> {
+                return !driver.getCurrentUrl().contains("passwordGate.jsp");
+            });
+        }
+    }
+
+    /**
+     * Close the Usage Statistics Sharing dialog if present.
+     */
+    protected void closeUsageStatisticsSharingDialog() {
+        invokeWithImplicitWait(0, () -> {
+            try {
+                WebElement element = findElementById("usage-statistics-sharing-modal");
+
+                if (element.isDisplayed()) { // usage statistics modal is visible
+                    findElementById("usage-statistics-sharing-notice-dismiss").click(); // close modal
+                }
+            } catch (NoSuchElementException e) {
+                // "usage-statistics-sharing-notice-dismiss" is not visible or does not exist.
+                // No further action required
+            }
+        });
     }
 
     public void assertElementDoesNotExist(final By by) {
@@ -427,7 +484,7 @@ public abstract class AbstractOpenNMSSeleniumHelper {
     }
 
     protected String handleAlert(final String expectedText) {
-        LOG.debug("handleAlerm: expectedText={}", expectedText);
+        LOG.debug("handleAlert: expectedText={}", expectedText);
         try {
             final Alert alert = getDriver().switchTo().alert();
             final String alertText = alert.getText();
@@ -1117,17 +1174,37 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         }
     }
 
+    /**
+     * Do an Http request with standard admin credentials and return status code.
+     */
     public static Integer doRequest(final HttpRequestBase request) throws ClientProtocolException, IOException, InterruptedException {
-        return getRequest(request).getStatus();
+        return getRequest(request, createBasicCredentials()).getStatus();
     }
 
+    /**
+     * Do an Http request, overriding credentials, and return status code.
+     */
+    public static Integer doRequest(final HttpRequestBase request, UsernamePasswordCredentials credentials) throws ClientProtocolException, IOException, InterruptedException {
+        return getRequest(request, credentials).getStatus();
+    }
+
+    /**
+     * Do an Http request using standard admin credentials.
+     */
     protected static ResponseData getRequest(final HttpRequestBase request) throws ClientProtocolException, IOException, InterruptedException {
+        return getRequest(request, createBasicCredentials());
+    }
+
+    /**
+     * Do an Http request with the given credentials.
+     */
+    protected static ResponseData getRequest(final HttpRequestBase request, UsernamePasswordCredentials credentials) throws ClientProtocolException, IOException, InterruptedException {
         final CountDownLatch waitForCompletion = new CountDownLatch(1);
 
         final URI uri = request.getURI();
         final HttpHost targetHost = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
         CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        credsProvider.setCredentials(new AuthScope(targetHost.getHostName(), targetHost.getPort()), new UsernamePasswordCredentials(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD));
+        credsProvider.setCredentials(new AuthScope(targetHost.getHostName(), targetHost.getPort()), credentials);
         AuthCache authCache = new BasicAuthCache();
         // Generate BASIC scheme object and add it to the local auth cache
         BasicScheme basicAuth = new BasicScheme();
@@ -1174,6 +1251,10 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         waitForCompletion.await();
         client.close();
         return result;
+    }
+
+    protected static UsernamePasswordCredentials createBasicCredentials() {
+        return new UsernamePasswordCredentials(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
     }
 
     public long getNodesInDatabase(final String foreignSource) {
@@ -1424,10 +1505,17 @@ public abstract class AbstractOpenNMSSeleniumHelper {
     }
 
     protected void sendPut(final String urlFragment, final String body, final Integer expectedResponse) throws ClientProtocolException, IOException, InterruptedException {
+        sendPut(urlFragment, body, expectedResponse, createBasicCredentials());
+    }
+
+    protected void sendPut(final String urlFragment, final String body, final Integer expectedResponse,
+                           final UsernamePasswordCredentials credentials) throws ClientProtocolException, IOException, InterruptedException {
         LOG.debug("sendPut: url={}, expectedResponse={}, body={}", urlFragment, expectedResponse, body);
         final HttpPut put = new HttpPut(buildUrlExternal(urlFragment));
         put.setEntity(new StringEntity(body, ContentType.APPLICATION_FORM_URLENCODED));
-        final Integer response = doRequest(put);
+
+        final Integer response = doRequest(put, credentials);
+
         if (expectedResponse == null) {
             if (response == null || (response != 303 && response != 200 && response != 201 && response != 202)) {
                 throw new RuntimeException("Bad response code! (" + response + "; expected 200, 201, 202, or 303)");

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminPasswordGateIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminPasswordGateIT.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2011-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests the Admin Password Gate functionality, when user enters the default 'admin' password.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class AdminPasswordGateIT extends OpenNMSSeleniumIT {
+    private static final Logger LOG = LoggerFactory.getLogger(AdminPasswordGateIT.class);
+
+    private static final String ALTERNATE_ADMIN_PASSWORD = "Admin!admin1";
+
+    @Before
+    public void setUp() throws Exception {
+        driver.get(getBaseUrlInternal() + "opennms/login.jsp");
+    }
+
+    /**
+     * Tests:
+     * - logging in as "admin/admin", then getting the Password Change gate.
+     * - skipping the gate, changing password to something else
+     * - login and skipping with redirect.
+     *
+     * Resets password back to the standard admin password.
+     * Since we change the password, it's easier to do all these tests within the same test method,
+     * otherwise there are issues when the AbstractOpenNMSSeleniumHelper.m_watcher TestWatcher Rule
+     * fires.
+     */
+    @Test
+    public void testAdminPasswordGate() {
+        // login with "admin/admin", do not skip past the password gate
+        LOG.debug("Test admin login and password change.");
+        login(PASSWORD_GATE_USERNAME, PASSWORD_GATE_PASSWORD, false, false, true);
+
+        if (!driver.getCurrentUrl().contains("passwordGate.jsp")) {
+            fail("Failed to get password gate page after 'admin/admin' login attempt.");
+        }
+
+        // Change the admin password
+        enterText(By.name("oldpass"), PASSWORD_GATE_PASSWORD);
+        enterText(By.name("pass1"), ALTERNATE_ADMIN_PASSWORD);
+        enterText(By.name("pass2"), ALTERNATE_ADMIN_PASSWORD);
+        clickElement(By.name("btn_change_password"));
+
+        wait.until((WebDriver driver) -> {
+            return driver.getCurrentUrl().contains("passwordGateAction");
+        });
+
+        final WebElement element = findElementByXpath("//h3[contains(@class, 'alert-success') and text()='Password successfully changed.']");
+        assertNotNull(element);
+
+        // logout, then login with "admin/newPassword", should go directly to main page
+        LOG.debug("Test admin login with new password.");
+        logout();
+
+        login(PASSWORD_GATE_USERNAME, ALTERNATE_ADMIN_PASSWORD, true, true, true);
+        assertTrue(driver.getCurrentUrl().contains("index.jsp"));
+
+        // should be on main index.jsp page, verify some elements in that page
+        final WebElement contentMiddleElement = getDriver().findElement(By.id("index-contentmiddle"));
+        assertNotNull(contentMiddleElement);
+
+        final WebElement statusOverviewElement = findElementByXpath("//div[contains(@class, 'card-header')]//span[text()='Status Overview']");
+        assertNotNull(statusOverviewElement);
+
+        // Now reset password back to "admin" using Rest API
+        LOG.debug("Resetting password back to default via Rest API");
+        final String url = "/rest/users/admin";
+        final String body = "password=admin&hashPassword=true";
+
+        try {
+            final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(PASSWORD_GATE_USERNAME, ALTERNATE_ADMIN_PASSWORD);
+            sendPut(url, body, 204, credentials);
+        } catch (Exception e) {
+            fail("Failed to reset password to 'admin': " + e.getMessage());
+        }
+
+        // login with "admin/admin", should succeed but display passwordGate page, which is skipped
+        LOG.debug("Confirm logout/login with default password");
+        logout();
+        login(PASSWORD_GATE_USERNAME, PASSWORD_GATE_PASSWORD, true, true, true);
+
+        assertTrue(driver.getCurrentUrl().contains("index.jsp"));
+
+        // logout and try to go to a non-login page
+        // user will be redirected to login page, login with "admin/admin"
+        // will get password gate page, click Skip, then should redirect to original page
+        LOG.debug("Logout and login to the node page, confirm that skipping the password gate redirects there");
+        logout();
+        nodePage();
+
+        // waiting until redirecting back to login page
+        wait.until((WebDriver driver) -> {
+            return driver.getCurrentUrl().contains("login.jsp");
+        });
+
+        // login and skip, should redirect to node page
+        login(PASSWORD_GATE_USERNAME, PASSWORD_GATE_PASSWORD, true, true, false);
+        assertTrue(driver.getCurrentUrl().contains("element/nodeList.htm"));
+    }
+}


### PR DESCRIPTION
Smoke test for the Admin Password Gate functionality.

Put several tests within the same test method, otherwise there are issues when the `AbstractOpenNMSSeleniumHelper TestWatcher Rule` runs.

Tests:

- logging in as "admin/admin", then getting the Password Change gate.
- skipping the gate, changing password to something else
- logout/login with new password
- resetting the password back to the standard admin password using the Rest API
- logout, then attempting to go to node page, being redirected to login then passwordGate, clicking Skip, then being redirected to node page

Had to make various changes in `AbstractOpenNMSSeleniumHelper` to be able to pass in custom credentials, clicking Skip button, etc. as well as some refactoring. Adding some debug log messages to make it a bit easier to debug any failing tests.

Note, this is targeting a Horizon 33 feature branch. Will open a separate PR when merging this entire feature back into `develop`.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15866

