### PR TITLE
NMS-15866: Add SuppressWarnings to suppress Sonar 'password' alerts

### DIFF
--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/OpenNMSAuthSuccessHandler.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/OpenNMSAuthSuccessHandler.java
@@ -44,9 +44,11 @@ import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.util.StringUtils;
 
+@SuppressWarnings("java:S2068")
 public class OpenNMSAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     // username/password combination that triggers the password gate, which prompts
     // user to change the default "admin" password
+
     public static final String PASSWORD_GATE_USERNAME = "admin";
     public static final String PASSWORD_GATE_PASSWORD = "admin";
 

--- a/opennms-webapp/src/main/java/org/opennms/web/account/selfService/AbstractBasePasswordChangeActionServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/account/selfService/AbstractBasePasswordChangeActionServlet.java
@@ -45,6 +45,7 @@ import org.opennms.web.api.Authentication;
 /**
  * Base servlet class for changing a user's password.
  */
+@SuppressWarnings("java:S2068")
 public abstract class AbstractBasePasswordChangeActionServlet extends HttpServlet {
     public static final String PASSWORD_REGEX = "((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%&.*+-]).{12,128})";
     public static final String SAME_CHARACTER_REGEX = "(.)\\1{5}";
@@ -64,11 +65,11 @@ public abstract class AbstractBasePasswordChangeActionServlet extends HttpServle
     }
 
     protected boolean validatePassword(final String password) {
-        boolean isPasswordComplexityValid = Pattern.compile(this.PASSWORD_REGEX)
+        boolean isPasswordComplexityValid = Pattern.compile(PASSWORD_REGEX)
             .matcher(password)
             .matches();
 
-        boolean isPasswordWithSameCharacters = Pattern.compile(this.SAME_CHARACTER_REGEX)
+        boolean isPasswordWithSameCharacters = Pattern.compile(SAME_CHARACTER_REGEX)
             .matcher(password)
             .matches();
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -115,6 +115,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+@SuppressWarnings("java:S2068")
 public abstract class AbstractOpenNMSSeleniumHelper {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractOpenNMSSeleniumHelper.class);
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminPasswordGateIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminPasswordGateIT.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Tests the Admin Password Gate functionality, when user enters the default 'admin' password.
  */
+@SuppressWarnings("java:S2068")
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AdminPasswordGateIT extends OpenNMSSeleniumIT {
     private static final Logger LOG = LoggerFactory.getLogger(AdminPasswordGateIT.class);


### PR DESCRIPTION
Follow-up to NMS-15866, adding `@SuppressWarnings` to suppress Sonar alerts for variables containing the word `password` in code having to do with Admin Password Gate functionality and smoke tests.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15866

