### PR TITLE
NMS-16025: modified tpl and adoc for issue

### DIFF
--- a/docs/modules/reference/pages/configuration/core-docker.adoc
+++ b/docs/modules/reference/pages/configuration/core-docker.adoc
@@ -83,7 +83,7 @@
 | `OPENNMS_CASSANDRA_PORT`      | _Cassandra_ server port                                                           | optional | `9042`
 | `OPENNMS_CASSANDRA_USERNAME`  | Username with access to _Cassandra_                                               | optional | `cassandra`
 | `OPENNMS_CASSANDRA_PASSWORD`  | Password for user with access to _Cassandra_                                      | optional | `cassandra`
-| `OPENNMS_CASSANDRA_DATACENTER`  | data center DC set for  _Cassandra_                                             | optional | `datacenter1`
+| `OPENNMS_CASSANDRA_DATACENTER`  | Data center DC set for  _Cassandra_                                             | optional | `datacenter1`
 |===
 
 == Directory Conventions

--- a/docs/modules/reference/pages/configuration/core-docker.adoc
+++ b/docs/modules/reference/pages/configuration/core-docker.adoc
@@ -83,6 +83,7 @@
 | `OPENNMS_CASSANDRA_PORT`      | _Cassandra_ server port                                                           | optional | `9042`
 | `OPENNMS_CASSANDRA_USERNAME`  | Username with access to _Cassandra_                                               | optional | `cassandra`
 | `OPENNMS_CASSANDRA_PASSWORD`  | Password for user with access to _Cassandra_                                      | optional | `cassandra`
+| `OPENNMS_CASSANDRA_DATACENTER`  | data center DC set for  _Cassandra_                                             | optional | `datacenter1`
 |===
 
 == Directory Conventions

--- a/opennms-container/core/container-fs/confd/templates/newts.properties.tpl
+++ b/opennms-container/core/container-fs/confd/templates/newts.properties.tpl
@@ -9,3 +9,4 @@ org.opennms.newts.config.keyspace={{getv (print $cassandraPath "keyspace") "newt
 org.opennms.newts.config.port={{getv (print $cassandraPath "port") "9042"}}
 org.opennms.newts.config.username={{getv (print $cassandraPath "username") "cassandra"}}
 org.opennms.newts.config.password={{getv (print $cassandraPath "password") "cassandra"}}
+org.opennms.newts.config.datacenter={{getv (print $cassandraPath "datacenter") "datacenter1"}}


### PR DESCRIPTION
### All Contributors
additional property in core docker container to allow cassanrda setting of lab name
changes to tpl and adoc file to match.
See also issue in stack play https://github.com/opennms-forge/stack-play/issues/25


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16025

* https://github.com/opennms-forge/stack-play/issues/25 

