### PR TITLE
NMS-16034: fix validation triggered by karaf jar(s) in newer JDKs

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -439,6 +439,8 @@ doStart(){
 		# this is a JRE, try to use ECJ for Jetty compilation instead
 		APP_VM_PARMS=("-Dorg.apache.jasper.compiler.disablejsr199=true" "${APP_VM_PARMS[@]}")
 	fi
+	# work around some jar files that are not compatible with updated JDK validation
+	APP_VM_PARMS=("-Djdk.util.zip.disableZip64ExtraFieldValidation=true" "${APP_VM_PARMS[@]}")
 
 	CMD=("${JAVA_CMD[@]}" "-Dopennms.pidfile=${OPENNMS_PIDFILE}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}")
 	if [ "$SYSTEMD" = 1 ]; then

--- a/opennms-container/horizon/container-fs/entrypoint.sh
+++ b/opennms-container/horizon/container-fs/entrypoint.sh
@@ -141,6 +141,7 @@ start() {
   -Dcom.sun.management.jmxremote.access.file=/opt/opennms/etc/jmxremote.access
   -DisThreadContextMapInheritable=true
   -Djdk.attach.allowAttachSelf=true
+  -Djdk.util.zip.disableZip64ExtraFieldValidation=true
   -Dgroovy.use.classvalue=true
   -Djava.io.tmpdir=/opt/opennms/data/tmp
   -Djava.locale.providers=CLDR,COMPAT

--- a/opennms-container/minion/container-fs/entrypoint.sh
+++ b/opennms-container/minion/container-fs/entrypoint.sh
@@ -15,7 +15,7 @@ CONFD_CONFIG_DIR="/opt/minion/confd"
 CONFD_BIN="/usr/local/bin/confd"
 CONFD_CONFIG_FILE="${CONFD_CONFIG_DIR}/confd.toml"
 
-export KARAF_OPTS="-Djava.locale.providers=CLDR,COMPAT"
+export KARAF_OPTS="-Djava.locale.providers=CLDR,COMPAT -Djdk.util.zip.disableZip64ExtraFieldValidation=true"
 
 # Error codes
 E_ILLEGAL_ARGS=126

--- a/opennms-container/sentinel/assets/entrypoint.sh
+++ b/opennms-container/sentinel/assets/entrypoint.sh
@@ -14,7 +14,7 @@ umask 002
 SENTINEL_OVERLAY_ETC="/opt/sentinel-etc-overlay"
 SENTINEL_OVERLAY="/opt/sentinel-overlay"
 
-export KARAF_OPTS="-Djava.locale.providers=CLDR,COMPAT"
+export KARAF_OPTS="-Djava.locale.providers=CLDR,COMPAT -Djdk.util.zip.disableZip64ExtraFieldValidation=true"
 
 # Error codes
 E_ILLEGAL_ARGS=126


### PR DESCRIPTION
See [the release notes for JDK 11.0.20](https://www.oracle.com/java/technologies/javase/11-0-20-relnotes.html) for details.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16034

