### PR TITLE
NMS-16037: Initial Structured/Hierarchical Node page

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -337,6 +337,11 @@
                                 <property name="locationMatch" value="nodelist"/>
                             </bean>
                             <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
+                                <property name="name" value="Nodes (Preview)"/>
+                                <property name="url" value="ui/index.html#/nodes"/>
+                                <property name="locationMatch" value="configurationManagement"/>
+                            </bean>
+                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
                                 <property name="name" value="Assets"/>
                                 <property name="url" value="asset/index.jsp"/>
                                 <property name="locationMatch" value="asset"/>

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "build": "vue-tsc --noEmit && vite build --base=/opennms/ui/",
     "build:dev": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --minify false",
     "watch": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --watch",
+    "watch:dev": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --minify false --watch",
     "serve": "vite preview",
     "test": "vitest run",
     "lint": "eslint --ignore-path ../.gitignore --ext .ts,.vue .",

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -261,7 +261,7 @@ const sortStates: Record<string, SORT> = reactive({
   lastBackup: SORT.NONE,
   lastUpdated: SORT.NONE
 })
-const { arrivedState, directions } = useScroll(tableWrap, {
+const { arrivedState, directions } = useScroll(tableWrap.value as HTMLElement, {
   offset: { bottom: 300 }
 })
 

--- a/ui/src/components/Nodes/NodeHierarchyPanel.vue
+++ b/ui/src/components/Nodes/NodeHierarchyPanel.vue
@@ -1,0 +1,197 @@
+<template>
+  <div class="button-panel">
+      <FeatherButton primary class="category-btn" @click="onClearAll">Clear All</FeatherButton>
+  </div>
+  <FeatherExpansionPanel>
+    <template v-slot:title>
+      <div v-if="selectedCategoryCount">
+        <span>{{ `Categories (${selectedCategoryCount})` }}</span>
+        <FeatherButton icon="Clear" @click="onClearCategories">
+          <FeatherIcon :icon="clearIcon"> </FeatherIcon>
+        </FeatherButton>
+      </div>
+      <div v-else>Categories</div>
+    </template>
+    <FeatherList class="category-list">
+      <FeatherListItem
+        v-for="cat of categories"
+        :selected="isCategorySelected(cat)"
+        :key="cat.name"
+        @click="onCategoryClick(cat)">
+        {{ cat.name }}
+      </FeatherListItem>
+    </FeatherList>
+  </FeatherExpansionPanel>
+  <FeatherExpansionPanel>
+    <template v-slot:title>
+      <div v-if="selectedFlowCount">
+        <span>{{ `Flows (${selectedFlowCount})` }}</span>
+        <FeatherButton icon="Clear" @click="onClearFlows">
+          <FeatherIcon :icon="clearIcon"> </FeatherIcon>
+        </FeatherButton>
+      </div>
+      <div v-else>Flows</div>
+    </template>
+    <FeatherList class="category-list">
+      <FeatherListItem
+        v-for="flow of flowTypes"
+        :selected="isFlowSelected(flow)"
+        :key="flow"
+        @click="onFlowClick(flow)">
+        {{ flow }}
+      </FeatherListItem>
+    </FeatherList>
+  </FeatherExpansionPanel>
+  <FeatherExpansionPanel>
+    <template v-slot:title>
+      <div v-if="selectedLocationCount">
+        <span>{{ `Locations (${selectedLocationCount})` }}</span>
+        <FeatherButton icon="Clear" @click="onClearLocations">
+          <FeatherIcon :icon="clearIcon"> </FeatherIcon>
+        </FeatherButton>
+      </div>
+      <div v-else>Locations</div>
+    </template>
+    <FeatherList class="category-list">
+      <FeatherListItem
+        v-for="loc of locations"
+        :selected="isLocationSelected(loc)"
+        :key="loc.name"
+        @click="onLocationClick(loc)">
+        {{ loc.name }}
+      </FeatherListItem>
+    </FeatherList>
+  </FeatherExpansionPanel>
+</template>
+
+<script setup lang="ts">
+import ClearIcon from '@featherds/icon/action/Cancel'
+import { FeatherButton } from '@featherds/button'
+import { FeatherExpansionPanel } from '@featherds/expansion'
+import { FeatherIcon } from '@featherds/icon'
+import { FeatherList, FeatherListItem } from '@featherds/list'
+import { useStore } from 'vuex'
+import { Category, MonitoringLocation } from '@/types'
+
+const store = useStore()
+const clearIcon = ref(ClearIcon)
+const categories = computed<Category[]>(() => store.state.hierarchyModule.categories)
+const selectedCategories = computed<Category[]>(() => store.state.hierarchyModule.selectedCategories)
+const flowTypes = computed<string[]>(() => ['Ingress', 'Egress'])
+const selectedFlows = computed<string[]>(() => store.state.hierarchyModule.selectedFlows)
+
+const locations = computed<MonitoringLocation[]>(() => store.state.hierarchyModule.monitoringLocations)
+const selectedLocations = computed<MonitoringLocation[]>(() => store.state.hierarchyModule.selectedMonitoringLocations)
+const selectedCategoryCount = computed<number>(() => selectedCategories.value?.length || 0)
+const selectedFlowCount = computed<number>(() => selectedFlows.value?.length || 0)
+const selectedLocationCount = computed<number>(() => selectedLocations.value?.length || 0)
+
+const isCategorySelected = (cat: Category) => {
+  return selectedCategories.value.some(c => c.id === cat.id)
+}
+
+const isFlowSelected = (flow: string) => {
+  return selectedFlows.value.some(f => f === flow)
+}
+
+const isLocationSelected = (loc: MonitoringLocation) => {
+  return selectedLocations.value.some(x => x.name === loc.name)
+}
+
+const onClearCategories = () => {
+  store.dispatch('hierarchyModule/setSelectedCategories', [])
+}
+
+const onClearFlows = () => {
+  store.dispatch('hierarchyModule/setSelectedFlows', [])
+}
+
+const onClearLocations = () => {
+  store.dispatch('hierarchyModule/setSelectedMonitoringLocations', [])
+}
+
+const onClearAll = () => {
+  onClearCategories()
+  onClearFlows()
+  onClearLocations()
+}
+
+/**
+* Create a new array of selected items in a hierarchy filter by taking existing items and adding/removing the selected item.
+* @param item the item clicked
+* @param isSelected predicate for determining whether the item was previously selected
+* @param existingItems array of existing values
+* @param deselector function for determining the item that should be deselected
+* @param dispatchName dispatch name within the 'hierarchymodule' for setting the new selected item
+*/
+const onSelectionClick = <T,>(item: T, isSelected: boolean, existingItems: T[],
+  deselector: ((existingItem: T, clickedItem: T) => boolean), dispatchName: string) => {
+
+  let newSelection: T[] = []
+
+  if (isSelected) {
+    // deselect clicked item
+    newSelection = existingItems.filter(c => deselector(c, item))
+  } else {
+    // add clicked item to selection
+    newSelection = [...existingItems, item]
+  }
+
+  store.dispatch(`hierarchyModule/${dispatchName}`, newSelection)
+}
+
+const onCategoryClick = (cat: Category) => {
+  onSelectionClick(cat, isCategorySelected(cat), selectedCategories.value, c => c.id !== cat.id, 'setSelectedCategories')
+}
+
+const onFlowClick = (flow: string) => {
+  onSelectionClick(flow, isFlowSelected(flow), selectedFlows.value, f => f !== flow, 'setSelectedFlows')
+}
+
+const onLocationClick = (loc: MonitoringLocation) => {
+  onSelectionClick(loc, isLocationSelected(loc), selectedLocations.value, x => x.name !== loc.name, 'setSelectedMonitoringLocations')
+}
+
+onMounted(() => {
+  store.dispatch('hierarchyModule/getCategories', true)
+  store.dispatch('hierarchyModule/getMonitoringLocations', true)
+})
+</script>
+
+<style lang="scss" scoped>
+@import "@featherds/styles/themes/variables";
+@import "@featherds/styles/mixins/elevation";
+@import "@featherds/styles/mixins/typography";
+
+.button-panel {
+  margin-bottom: 4px;
+}
+
+.category-list {
+  @include elevation(2);
+  background: var($surface);
+  overflow-y: auto;
+
+  .title {
+    @include headline3
+  }
+}
+.category-btn {
+  margin-bottom: 4px;
+  margin-right: 4px;
+}
+</style>
+
+<style lang="scss">
+.category-list {
+  .feather-list-item-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.drawer-container .content {
+  top: var(--feather-header-height);
+}
+</style>

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="card">
     <div class="feather-row">
-      <div class="feather-col-12">
-        <BreadCrumbs :items="breadcrumbs" />
-      </div>
-    </div>
-    <div class="feather-row">
-      <div class="feather-col-3">
+      <div class="feather-col-4">
         <FeatherInput
           @update:modelValue="searchFilterHandler"
           label="Search node label"
@@ -49,7 +44,35 @@
                 v-on:sort-changed="sortChanged"
                 >Foreign Id</FeatherSortHeader
               >
-            </tr>
+              <FeatherSortHeader
+                scope="col"
+                property="sysContact"
+                :sort="sortStates.sysContact"
+                v-on:sort-changed="sortChanged"
+                >Sys Contact</FeatherSortHeader
+              >
+               <FeatherSortHeader
+                scope="col"
+                property="sysLocation"
+                :sort="sortStates.sysLocation"
+                v-on:sort-changed="sortChanged"
+                >Sys Location</FeatherSortHeader
+              >
+              <FeatherSortHeader
+                scope="col"
+                property="sysDescription"
+                :sort="sortStates.sysDescription"
+                v-on:sort-changed="sortChanged"
+                >Sys Description</FeatherSortHeader
+              >
+              <FeatherSortHeader
+                scope="col"
+                property="flows"
+                :sort="sortStates.flows"
+                v-on:sort-changed="sortChanged"
+                >Flows</FeatherSortHeader
+              >
+             </tr>
           </thead>
           <tbody>
             <tr
@@ -57,11 +80,21 @@
               :key="node.id"
             >
               <td>
-                <router-link :to="`/node/${node.id}`">{{ node.label }}</router-link>
+                <a
+                  :href="computeNodeLink(node.id)"
+                  @click="onNodeLinkClick(node.id)"
+                  target="_blank">
+                  {{ node.label }}
+                </a>
+                <!-- <router-link :to="`/node/${node.id}`">{{ node.label }}</router-link> -->
               </td>
               <td>{{ node.location }}</td>
               <td>{{ node.foreignSource }}</td>
               <td>{{ node.foreignId }}</td>
+              <td>{{ node.sysContact }}</td>
+              <td>{{ node.sysLocation }}</td>
+              <td>{{ node.sysDescription }}</td>
+              <td>{{ displayFlows(node) }}</td>
             </tr>
           </tbody>
         </table>
@@ -87,17 +120,34 @@ import { QueryParameters, UpdateModelFunction } from '@/types'
 import useQueryParameters from '@/composables/useQueryParams'
 import { FeatherInput } from '@featherds/input'
 import { FeatherSortHeader, SORT } from '@featherds/table'
-import { FeatherSortObject } from '@/types'
-import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
-import { BreadCrumb } from '@/types'
+import { Category, FeatherSortObject, MonitoringLocation, Node } from '@/types'
+import { MainMenu } from '@/types/mainMenu'
+import { isNumber } from '@/lib/utils'
 
 const store = useStore()
 const sortStates: any = reactive({
   label: SORT.ASCENDING,
   location: SORT.NONE,
   foreignSource: SORT.NONE,
-  foreignId: SORT.NONE
+  foreignId: SORT.NONE,
+  sysContact: SORT.NONE,
+  sysLocation: SORT.NONE,
+  sysDescription: SORT.NONE,
+  flows: SORT.NONE
 })
+
+const currentSearch = ref('')
+const nodes = computed(() => store.state.nodesModule.nodes)
+const mainMenu = computed<MainMenu>(() => store.state.menuModule.mainMenu)
+const selectedCategories = computed<Category[]>(() => store.state.hierarchyModule.selectedCategories)
+const selectedFlows = computed<string[]>(() => store.state.hierarchyModule.selectedFlows)
+const selectedLocations = computed<MonitoringLocation[]>(() => store.state.hierarchyModule.selectedMonitoringLocations)
+
+const { queryParameters, updateQueryParameters, sort } = useQueryParameters({
+  limit: 10,
+  offset: 0,
+  orderBy: 'label'
+}, 'nodesModule/getNodes')
 
 const sortChanged = (sortObj: FeatherSortObject) => {
   for (const key in sortStates) {
@@ -107,35 +157,107 @@ const sortChanged = (sortObj: FeatherSortObject) => {
   sort(sortObj)
 }
 
-const { queryParameters, updateQueryParameters, sort } = useQueryParameters({
-  limit: 10,
-  offset: 0,
-  orderBy: 'label'
-}, 'nodesModule/getNodes')
+const buildQueryParams = (searchVal: string) => {
+  // search query
+  let searchQuery = ''
+
+  if (searchVal.length > 0) {
+    const star = searchVal.endsWith('*') ? '' : '*'
+    searchQuery = `node.label==${searchVal}${star}`
+  }
+
+  // category query
+  const categoryItems = selectedCategories.value.map(cat => `category.id==${cat.id}`)
+
+  let categoryQuery = ''
+
+  if (categoryItems.length === 1) {
+    categoryQuery = `${categoryItems[0]}`
+  } else if (categoryItems.length > 1) {
+    categoryQuery = `(${categoryItems.join(',')})`
+  }
+
+  // flows query
+  const hasIngress = selectedFlows.value.some(f => f === 'Ingress')
+  const hasEgress = selectedFlows.value.some(f => f === 'Egress')
+
+  const flowItems = [
+    hasIngress ? 'lastIngressFlow=gt=0' : '',
+    hasEgress ? 'lastEgressFlow=gt=0' : ''
+  ].filter(x => x)
+
+  let flowsQuery = ''
+
+  if (flowItems.length === 1) {
+    flowsQuery = `${flowItems[0]}`
+  } else if (flowItems.length > 1) {
+    flowsQuery = `(${flowItems.join(',')})`
+  }
+
+  // monitoring locations query
+  const locationItems = selectedLocations.value.map(loc => `node.location.locationName==${loc.name}`)
+  let locationQuery = ''
+
+  if (locationItems.length === 1) {
+    locationQuery = `${locationItems[0]}`
+  } else if (locationItems.length > 1) {
+    locationQuery = `(${locationItems.join(',')})`
+  }
+
+  // TODO: filter on regex to screen out bad FIQL characters like ',', ';', etc.
+  // and/or restrict characters in the FeatherInput above
+  let query = [searchQuery, categoryQuery, flowsQuery, locationQuery].filter(s => s.length > 0).join(';')
+
+  return query
+}
+
+const displayFlows = (node: Node) => {
+  const hasIngress = node.lastIngressFlow && isNumber(node.lastIngressFlow)
+  const hasEgress = node.lastEgressFlow && isNumber(node.lastEgressFlow)
+
+  if (hasIngress && hasEgress) {
+    return 'I/E'
+  } else if (hasEgress) {
+    return 'E'
+  } else if (hasIngress) {
+    return 'I'
+  }
+
+  return ''
+}
 
 const searchFilterHandler: UpdateModelFunction = (val = '') => {
-  const searchQueryParam: QueryParameters = { _s: `node.label==${val}*` }
+  currentSearch.value = val
+  updateQuery(val)
+}
+
+const updateQuery = (val?: string) => {
+  const searchQuery = buildQueryParams(val || currentSearch.value)
+  const searchQueryParam: QueryParameters = { _s: searchQuery }
   const updatedParams = { ...queryParameters.value, ...searchQueryParam }
+
   store.dispatch('nodesModule/getNodes', updatedParams)
   queryParameters.value = updatedParams
 }
-const nodes = computed(() => store.state.nodesModule.nodes)
 
-const homeUrl = computed<string>(() => store.state.menuModule.mainMenu?.homeUrl)
+const computeNodeLink = (nodeId: number) => {
+  return `${mainMenu.value.baseHref}${mainMenu.value.baseNodeUrl}${nodeId}`
+}
 
-const breadcrumbs: BreadCrumb[] = [
-  { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
-  { label: 'Nodes', to: '/', position: 'last' }
-]
+const onNodeLinkClick = (nodeId: number) => {
+  window.location.assign(computeNodeLink(nodeId))
+}
+
+watch([selectedCategories, selectedFlows, selectedLocations], () => {
+  updateQuery()
+})
 </script>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 @import "@featherds/table/scss/table";
 @import "@featherds/styles/mixins/elevation";
 @import "@featherds/styles/mixins/typography";
+
 .card {
   @include elevation(2);
   background: var($surface);
@@ -145,4 +267,3 @@ table {
   @include table;
 }
 </style>
-

--- a/ui/src/containers/NodeDetails.vue
+++ b/ui/src/containers/NodeDetails.vue
@@ -4,8 +4,9 @@
       <BreadCrumbs :items="items" />
     </div>
   </div>
-  <div class="feather-row" style="flex-wrap: inherit;">
-    <span>This page has been deprecated. Please choose "Nodes" from the main menu instead.</span>
+  <div class="feather-row" style="flex-wrap: inherit; padding: 4px;">
+    <!-- <span>This page has been deprecated. Please choose "Nodes" from the main menu instead.</span> -->
+    <span>Temp node details page for node: {{ props.id }}</span>
     <!--
     <div class="feather-col-6">
       <NodeAvailabilityGraphVue />
@@ -29,6 +30,12 @@ import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
 import { BreadCrumb } from '@/types'
 
 const store = useStore()
+
+const props = defineProps({
+  id: {
+    type: Number
+  }
+})
 
 const homeUrl = computed<string>(() => store.state.menuModule.mainMenu?.homeUrl)
 

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -1,18 +1,47 @@
 <template>
   <div class="feather-row">
     <div class="feather-col-12">
-      <span>This page has been deprecated. Please choose "Nodes" from the main menu instead.</span>
-      <!--
-      <NodesTable />
-      -->
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+  <div class="feather-row">
+    <div class="feather-col-12">
+      <div class="card">
+        <div class="feather-row">
+          <div class="feather-col-2">
+            <NodeHierarchyPanel />
+          </div>
+          <div :class="`feather-col-10`">
+            <NodesTable />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
   
 <script setup lang="ts">
-//import NodesTable from '@/components/Nodes/NodesTable.vue'
+import { useStore } from 'vuex'
+import NodesTable from '@/components/Nodes/NodesTable.vue'
+import NodeHierarchyPanel from '@/components/Nodes/NodeHierarchyPanel.vue'
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import { BreadCrumb } from '@/types'
+
+const store = useStore()
+
+const homeUrl = computed<string>(() => store.state.menuModule.mainMenu?.homeUrl)
+
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Nodes', to: '#', position: 'last' }
+  ]
+})
+
 </script>
   
-<style scoped>
+<style lang="scss" scoped>
+@import "@featherds/styles/themes/variables";
+
 </style>
   

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -3,8 +3,8 @@ import { Plugin } from '@/types'
 import DeviceConfigBackup from '@/containers/DeviceConfigBackup.vue'
 import Home from '@/containers/Home.vue'
 import FileEditor from '@/containers/FileEditor.vue'
-import Resources from '@/components/Resources/Resources.vue'
 import Graphs from '@/components/Resources/Graphs.vue'
+import Resources from '@/components/Resources/Resources.vue'
 import useRole from '@/composables/useRole'
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
@@ -113,6 +113,16 @@ const router = createRouter({
           component: () => import('@/components/Map/MapNodesGrid.vue')
         }
       ]
+    },
+    {
+      path: '/nodes',
+      name: 'Nodes',
+      component: () => import('@/containers/Nodes.vue')
+    },
+    {
+      path: '/node/:id',
+      name: 'Node Details',
+      component: () => import('@/containers/NodeDetails.vue')
     },
     {
       path: '/resource-graphs',

--- a/ui/src/services/categoryService.ts
+++ b/ui/src/services/categoryService.ts
@@ -1,0 +1,25 @@
+import { rest } from './axiosInstances'
+import {
+  CategoryApiResponse
+} from '@/types'
+
+const endpoint = '/categories'
+
+const getCategories = async (): Promise<CategoryApiResponse | false> => {
+  try {
+    const resp = await rest.get(endpoint)
+
+    // no content from server
+    if (resp.status === 204) {
+      return { category: [], totalCount: 0, count: 0, offset: 0 }
+    }
+
+    return resp.data
+  } catch (err) {
+    return false
+  }
+}
+
+export {
+  getCategories
+}

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -6,6 +6,8 @@ import {
   getNodeSnmpInterfaces,
   getNodeAvailabilityPercentage
 } from './nodeService'
+import { getCategories } from './categoryService'
+import { getMonitoringLocations } from './monitoringLocationService'
 import { getProvisionDService, putProvisionDService, populateProvisionD } from './configurationService'
 import {
   getGraphNodesNodes,
@@ -61,6 +63,8 @@ export default {
   getNodeIpInterfaces,
   getNodeSnmpInterfaces,
   getNodeAvailabilityPercentage,
+  getCategories,
+  getMonitoringLocations,
   getLog,
   getLogs,
   getFile,

--- a/ui/src/services/monitoringLocationService.ts
+++ b/ui/src/services/monitoringLocationService.ts
@@ -1,0 +1,22 @@
+import { v2 } from './axiosInstances'
+import { MonitoringLocationApiResponse } from '@/types'
+
+const endpoint = '/monitoringLocations'
+
+export const getMonitoringLocations = async (): Promise<MonitoringLocationApiResponse| false> => {
+  try {
+    const resp = await v2.get(endpoint)
+
+    const data = resp.data as MonitoringLocationApiResponse
+
+    // map these to typed fields for clarity in calling code
+    data.location.forEach(loc => {
+      loc.name = loc['location-name']
+      loc.area = loc['monitoring-area']
+    })
+
+    return data
+  } catch (err) {
+    return false
+  }
+}

--- a/ui/src/store/hierarchy/actions.ts
+++ b/ui/src/store/hierarchy/actions.ts
@@ -1,0 +1,39 @@
+import API from '@/services'
+import { Category, VuexContext } from '@/types'
+
+const getCategories = async (context: VuexContext) => {
+  const resp = await API.getCategories()
+
+  if (resp) {
+    context.commit('SAVE_CATEGORY_COUNT', resp.totalCount)
+    context.commit('SAVE_CATEGORIES_TO_STATE', resp.category)
+  }
+}
+
+const getMonitoringLocations = async (context: VuexContext) => {
+  const resp = await API.getMonitoringLocations()
+
+  if (resp) {
+    context.commit('SAVE_LOCATIONS_TO_STATE', resp.location)
+  }
+}
+
+const setSelectedCategories = async (context: VuexContext, categories: Category[]) => {
+  context.commit('SAVE_SELECTED_CATEGORIES_TO_STATE', categories)
+}
+
+const setSelectedFlows = async (context: VuexContext, flows: string[]) => {
+  context.commit('SAVE_SELECTED_FLOWS_TO_STATE', flows)
+}
+
+const setSelectedMonitoringLocations = async (context: VuexContext, locations: string[]) => {
+  context.commit('SAVE_SELECTED_MONITORING_LOCATIONS_TO_STATE', locations)
+}
+
+export default {
+  getCategories,
+  getMonitoringLocations,
+  setSelectedCategories,
+  setSelectedFlows,
+  setSelectedMonitoringLocations
+}

--- a/ui/src/store/hierarchy/index.ts
+++ b/ui/src/store/hierarchy/index.ts
@@ -1,0 +1,10 @@
+import state from './state'
+import mutations from './mutations'
+import actions from './actions'
+
+export default {
+  state,
+  actions,
+  mutations,
+  namespaced: true
+}

--- a/ui/src/store/hierarchy/mutations.ts
+++ b/ui/src/store/hierarchy/mutations.ts
@@ -1,0 +1,35 @@
+import { Category, MonitoringLocation } from '@/types'
+import { State } from './state'
+
+const SAVE_CATEGORY_COUNT = (state: State, count: number) => {
+  state.categoryCount = count
+}
+
+const SAVE_CATEGORIES_TO_STATE = (state: State, categories: Category[]) => {
+  state.categories = [...categories]
+}
+
+const SAVE_SELECTED_CATEGORIES_TO_STATE = (state: State, categories: Category[]) => {
+  state.selectedCategories = [...categories]
+}
+
+const SAVE_SELECTED_FLOWS_TO_STATE = (state: State, flows: string[]) => {
+  state.selectedFlows = [...flows]
+}
+
+const SAVE_LOCATIONS_TO_STATE = (state: State, locations: MonitoringLocation[]) => {
+  state.monitoringLocations = [...locations]
+}
+
+const SAVE_SELECTED_MONITORING_LOCATIONS_TO_STATE = (state: State, locations: MonitoringLocation[]) => {
+  state.selectedMonitoringLocations = [...locations]
+}
+
+export default {
+  SAVE_CATEGORY_COUNT,
+  SAVE_CATEGORIES_TO_STATE,
+  SAVE_SELECTED_CATEGORIES_TO_STATE,
+  SAVE_SELECTED_FLOWS_TO_STATE,
+  SAVE_LOCATIONS_TO_STATE,
+  SAVE_SELECTED_MONITORING_LOCATIONS_TO_STATE
+}

--- a/ui/src/store/hierarchy/state.ts
+++ b/ui/src/store/hierarchy/state.ts
@@ -1,0 +1,21 @@
+import { Category, MonitoringLocation } from '@/types'
+
+export interface State {
+  categories: Category[]
+  categoryCount: number
+  selectedCategories: Category[]
+  selectedFlows: string[]
+  monitoringLocations: MonitoringLocation[]
+  selectedMonitoringLocations: MonitoringLocation[]
+}
+
+const state: State = {
+  categories: [],
+  categoryCount: 0,
+  selectedCategories: [],
+  selectedFlows: [],
+  monitoringLocations: [],
+  selectedMonitoringLocations: []
+}
+
+export default state

--- a/ui/src/store/index.ts
+++ b/ui/src/store/index.ts
@@ -3,6 +3,7 @@ import { createStore } from 'vuex'
 // store modules
 import searchModule from './search'
 import nodesModule from './nodes'
+import hierarchyModule from './hierarchy'
 import ipInterfacesModule from './ipInterfaces'
 import eventsModule from './events'
 import ifServicesModule from './ifServices'
@@ -26,6 +27,7 @@ export default createStore({
   modules: {
     searchModule,
     nodesModule,
+    hierarchyModule,
     ipInterfacesModule,
     eventsModule,
     ifServicesModule,

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,7 +1,6 @@
 import { Commit, Dispatch } from 'vuex'
 import { SORT } from '@featherds/table'
 
-
 export interface VuexContext {
   commit: Commit
   dispatch: Dispatch
@@ -49,6 +48,9 @@ export interface ApiResponse {
   totalCount: number
 }
 
+export interface CategoryApiResponse extends ApiResponse {
+  category: Category[]
+}
 export interface NodeApiResponse extends ApiResponse {
   node: Node[]
 }
@@ -80,6 +82,10 @@ export interface IfServiceApiResponse extends ApiResponse {
   'monitored-service': IfService[]
 }
 
+export interface MonitoringLocationApiResponse extends ApiResponse {
+  location: MonitoringLocation[]
+}
+
 export interface Node {
   location: string
   type: string
@@ -95,8 +101,8 @@ export interface Node {
   createTime: number
   foreignId: string
   foreignSource: string
-  lastEgressFlow: any
-  lastIngressFlow: any
+  lastEgressFlow: number      // timestamp
+  lastIngressFlow: number
   labelSource: string
   lastCapabilitiesScan: string
   primaryInterface: number
@@ -151,6 +157,18 @@ export interface Event {
   source: string
   time: number
   uei: string
+}
+
+export interface MonitoringLocation {
+  tags: string[]
+  geolocation: string
+  longitude: number
+  latitude: number
+  priority: number
+  'location-name': string
+  'monitoring-area': string
+  name: string    // mapped from 'location-name' after API GET call response
+  area: string    // mapped from 'monitoring-area' after API GET call response
 }
 
 export interface SnmpInterface {


### PR DESCRIPTION
Create initial Structured/Hierarchical Node page, for applying various hierarchical filters to a node list.

This is targeting an epic feature branch. Will put up another PR for merge to `develop` when this feature is more complete.

This task is for an initial page, additional features will be added in subsequent tasks.

- Revive the Vue Node List page
- Add to menubar as "Nodes (Preview)"
- Point node links to legacy node details page
- Add node hierarchy/filter panel
- Include Categories, Flows, Locations as initial items to filter on
- All selections within a section are "or"/unions for now
- Expansion / Accordion style components to select items, display count and allow clearing
- Node list will be filtered on hierarchy items as well as Node Label search 

Known issues to be fixed in future PRs:

- There are some issues with pagination which will be fixed in a future PR
- `NodesTable.buildQueryParams` will be moved out of the component and refactored

<img width="1546" alt="Screenshot 2023-08-01 at 16 48 41" src="https://github.com/OpenNMS/opennms/assets/1933710/4a1e6f71-ea39-438f-9e12-699d481c0fda">


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16037

