### PR TITLE
NMS-16077: Clarify newts polling interval configuration

### DIFF
--- a/docs/modules/deployment/pages/time-series-storage/newts/newts.adoc
+++ b/docs/modules/deployment/pages/time-series-storage/newts/newts.adoc
@@ -60,7 +60,7 @@ org.opennms.newts.query.heartbeat=45000 <2>
 ----
 <1> The shortest collection interval configured for any collectable or pollable service, in milliseconds (in this case, 30 seconds).
 <2> The communication interval for the Newts service, in milliseconds.
-Should be set to 1.5 times the `minimum_step` value.
+Should be set to 1.5 times the `maximum` value of collection interval configured for any collectable or pollable service, in milliseconds (in this case, 45 seconds).
 
 . Initialize the Newts schema in Cassandra:
 +

--- a/docs/modules/deployment/pages/time-series-storage/newts/newts.adoc
+++ b/docs/modules/deployment/pages/time-series-storage/newts/newts.adoc
@@ -60,7 +60,7 @@ org.opennms.newts.query.heartbeat=45000 <2>
 ----
 <1> The shortest collection interval configured for any collectable or pollable service, in milliseconds (in this case, 30 seconds).
 <2> The communication interval for the Newts service, in milliseconds.
-Should be set to 1.5 times the `maximum` value of collection interval configured for any collectable or pollable service, in milliseconds (in this case, 45 seconds).
+Should be set to 1.5 times the `maximum` value of the collection interval configured for any collectable or pollable service, in milliseconds (in this case, 45 seconds).
 
 . Initialize the Newts schema in Cassandra:
 +


### PR DESCRIPTION
The documentation regarging configuration of horizon to use newts states: Configure Horizon to Use Newts 

(Optional) If your Horizon data collection or polling intervals have been modified, set the query minimum and heartbeat rates:

org.opennms.newts.query.minimum_step=30000 
org.opennms.newts.query.heartbeat=45000 
The shortest collection interval configured for any collectable or pollable service, in milliseconds (in this case, 30 seconds).The communication interval for the Newts service, in milliseconds. Should be set to 1.5 times the minimum_step value.

This might create problems in cases where different polling intervals have been set for different services. For e.g. ICMP has polling every 60seconds while SNMP has polling set to every 300seconds(5 minutes). Following the documentation the minimum_step would be 60000 and heartbeat would be 90000 (both in ms). This would cause the SNMP graphs to not be populated.


The documentation should be modified to define heartbeat to be 1.5 times that maximum value of step configured for any service. In the example above that would be 450seconds(7.5 minutes) or 450000 ms.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### Contribution Checklist

* Please [make an issue in the OpenNMS issue tracker](https://opennms.atlassian.net/) if there isn't one already.<br />Once there is an issue, please:
  1. update the title of this PR to be in the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the Jira link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
  4. once you've created this PR, please link to it in a comment in the Jira issue
  Don't worry if this sounds like a lot, we can help you get things set up properly.
* **If this code is likely to affect the UI, did you name your branch with `-smoke` in it to trigger smoke tests?**
* If this is a new or updated feature, is there documentation for the new behavior?
* If this is new code, are there unit and/or integration tests?
* If this PR targets a `foundation-*` branch, does it try to avoid changing files in `$OPENNMS_HOME/etc/`?

### What's Next?

A PR should be assigned at least 2 reviewers.  If you know that someone would be a good person to review your code, feel free to add them.

If you need help making additions or changes to the documentation related to your changes, please let us know.

In any case, if anything is unclear or you want help getting your PR ready for merge, please don't hesitate to say something in the comments here,
or in [the #opennms-development chat channel](https://chat.opennms.com/opennms/channels/opennms-development).

Once reviewer(s) accept the PR and the branch passes continuous integration, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the OGP) you are welcome to merge the PR when you're ready.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16077

