### PR TITLE
NMS-16057: Node filter, suppress SQL exception details

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -63,6 +63,7 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.events.api.EventProxyException;
 import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.filter.api.FilterParseException;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsCategoryCollection;
 import org.opennms.netmgt.model.OnmsGeolocation;
@@ -133,7 +134,15 @@ public class NodeRestService extends OnmsRestService {
             }
             crit = filterForNodeIds(builder, nodeIds).toCriteria();
         } else if (params.getFirst("filterRule") != null) {
-            final Set<Integer> filteredNodeIds = m_filterDao.getNodeMap(params.getFirst("filterRule")).keySet();
+            Set<Integer> filteredNodeIds = null;
+
+            try {
+                filteredNodeIds = m_filterDao.getNodeMap(params.getFirst("filterRule")).keySet();
+            } catch (FilterParseException fpe) {
+                // do not rethrow, the exception may contain the actual SQL query which should not be seen by consumers
+                throw getException(Status.BAD_REQUEST, "Invalid 'filterRule' in request.");
+            }
+
             if (filteredNodeIds.size() < 1) {
                 // The "in" criteria fails if the list of node ids is empty
                 final OnmsNodeList coll = new OnmsNodeList(Collections.emptyList());


### PR DESCRIPTION
Backport to `foundation-2021`. Prevent SQL query being returned in response to an invalid node filter Rest API call.

Original PR: https://github.com/OpenNMS/opennms/pull/6506

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16057

