### PR TITLE
NMS-16089: backport JAXB updates to foundation-2019

### DIFF
--- a/core/test-api/xml/src/main/java/org/opennms/core/test/xml/XmlTest.java
+++ b/core/test-api/xml/src/main/java/org/opennms/core/test/xml/XmlTest.java
@@ -243,7 +243,7 @@ abstract public class XmlTest<T> {
         });
         try {
             final InputSource inputSource = new InputSource(getSampleXmlInputStream());
-            final XMLFilter filter = JaxbUtils.getXMLFilterForClass(getSampleClass());
+            final XMLFilter filter = JaxbUtils.getXMLFilterForClass(getSampleClass(), false);
             final SAXSource source = new SAXSource(filter, inputSource);
             @SuppressWarnings("unchecked")
             T obj = (T) unmarshaller.unmarshal(source);


### PR DESCRIPTION
This PR backports a number of small improvements to JAXB handling to foundation 2019.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16089