### PR TITLE
NMS-16090: fix min and max java version

### DIFF
--- a/container/shared/src/main/resources/etc/container.init
+++ b/container/shared/src/main/resources/etc/container.init
@@ -23,7 +23,7 @@ if [ -f /etc/rc.d/init.d/functions ]; then
 fi
 
 if [ -z "$JAVA_HOME" ]; then
-	JAVA_HOME="$("$CONTAINER_HOME/bin/find-java.sh" 1.8.0 11.9.9999)"
+	JAVA_HOME="$("$CONTAINER_HOME/bin/find-java.sh" 11.0 17.9999)"
 fi
 
 if [ -r "$SYSCONFDIR/$NAME" ]; then


### PR DESCRIPTION
Set the minimum and maximum JDK version to the same range as in Horizon Core.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16090

