### PR TITLE
build(deps): bump jasperreports from 6.3.0 to 6.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1685,7 +1685,7 @@
     <jackson2Version>2.14.2</jackson2Version>
     <snakeyamlVersion>1.33</snakeyamlVersion>
     <jacocoVersion>0.8.8</jacocoVersion>
-    <jasperreportsVersion>6.3.0</jasperreportsVersion>
+    <jasperreportsVersion>6.20.0</jasperreportsVersion>
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <javaxMailVersion>1.4.7</javaxMailVersion>
     <jcifsVersion>1.3.19</jcifsVersion>


### PR DESCRIPTION
Backport of Jasper upgrade that went into H32

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16105

