### PR TITLE
NMS-16103: Node structure UI updates, selectable columns

### DIFF
--- a/ui/src/components/Device/DCBGroupFilters.vue
+++ b/ui/src/components/Device/DCBGroupFilters.vue
@@ -60,9 +60,9 @@ import { FeatherButton } from '@featherds/button'
 import { FeatherIcon } from '@featherds/icon'
 import ArrowDown from '@featherds/icon/navigation/ArrowDropDown'
 import { useStore } from 'vuex'
+import { DeviceConfigQueryParams } from '@/types/deviceConfig'
 
 const store = useStore()
-import { DeviceConfigQueryParams } from '@/types/deviceConfig'
 
 const vendorOptions = computed<string[]>(() => store.state.deviceModule.vendorOptions)
 const backupStatusOptions = computed<string[]>(() => store.state.deviceModule.backupStatusOptions)

--- a/ui/src/components/Nodes/ColumnSelectDropdown.vue
+++ b/ui/src/components/Nodes/ColumnSelectDropdown.vue
@@ -1,0 +1,78 @@
+<template>
+  <FeatherDropdown>
+    <template v-slot:trigger="{ attrs, on }">
+      <FeatherButton
+        icon="Select Columns"
+        v-bind="attrs"
+        v-on="on"
+      >
+        <FeatherIcon :icon="settingsIcon" class="node-actions-icon" />
+      </FeatherButton>
+    </template>
+    <div class="node-actions-reset">
+      <FeatherButton secondary @click="resetToDefault">Default</FeatherButton>
+    </div>
+    <FeatherDropdownItem
+      v-for="col in columns"
+      :key="col.id"
+      >
+        <div class="column-select-item-wrapper">
+          <FeatherCheckbox
+            class="checkbox"
+            @update:modelValue="selectColumn(col)"
+            :modelValue="col.selected"
+          >{{ col.label }}</FeatherCheckbox>
+        </div>
+    </FeatherDropdownItem>
+  </FeatherDropdown>
+</template>
+
+<script setup lang="ts">
+import { FeatherButton } from '@featherds/button'
+import { FeatherCheckbox } from '@featherds/checkbox'
+import { FeatherDropdown, FeatherDropdownItem } from '@featherds/dropdown'
+import { FeatherIcon } from '@featherds/icon'
+import Settings from '@featherds/icon/action/Settings'
+import { markRaw } from 'vue'
+import { useStore } from 'vuex'
+import { NodeColumnSelectionItem } from '@/types'
+
+const store = useStore()
+const settingsIcon = markRaw(Settings)
+
+const columns = computed<NodeColumnSelectionItem[]>(() => store.state.nodeStructureModule.columns)
+
+const selectColumn = (col: NodeColumnSelectionItem) => {
+  const newItem = {
+    ...col,
+    selected: !col.selected
+  }
+
+  store.dispatch('nodeStructureModule/updateNodeColumnSelection', newItem)
+  return false
+}
+
+const resetToDefault = () => {
+  store.dispatch('nodeStructureModule/resetColumnSelectionToDefault')
+  return false
+}
+</script>
+
+<style lang="scss" scoped>
+.focus-icon {
+  cursor: pointer;
+}
+
+button.btn.btn-icon .node-actions-icon {
+  font-size: 1.1rem;
+}
+
+.column-select-item-wrapper {
+  padding-left: 0.5em;
+}
+
+.node-actions-reset {
+  padding-left: 0.5em;
+  margin-bottom: 1em;
+}
+</style>

--- a/ui/src/components/Nodes/FlowTooltipCell.vue
+++ b/ui/src/components/Nodes/FlowTooltipCell.vue
@@ -1,0 +1,43 @@
+<template>
+  <FeatherTooltip
+    :title="flowTooltipTitle(node)"
+    :alignment="PointerAlignment.center"
+    :placement="PopoverPlacement.top"
+    v-slot="{ attrs, on }">
+    <div v-if="hasIngressFlow(node) || hasEgressFlow(node)" v-bind="attrs" v-on="on">
+      <font-awesome-icon v-if="hasIngressFlow(node)" :icon="'fa-solid fa-long-arrow-left'"></font-awesome-icon>
+      <br v-if="hasIngressFlow(node) && hasEgressFlow(node)" style="height: 40px" />
+      <font-awesome-icon v-if="hasEgressFlow(node)" :icon="'fa-solid fa-long-arrow-right'"></font-awesome-icon>
+    </div>
+  </FeatherTooltip>
+</template>
+
+<script setup lang="ts">
+import { PropType } from 'vue'
+import { FeatherTooltip, PointerAlignment, PopoverPlacement } from '@featherds/tooltip'
+import { hasIngressFlow, hasEgressFlow } from './utils'
+import { Node } from '@/types'
+
+defineProps({
+  node: {
+    required: true,
+    type: Object as PropType<Node>
+  }
+})
+
+const flowTooltipTitle = (node: Node) => {
+  if (hasIngressFlow(node) && hasEgressFlow(node)) {
+    return 'Has Ingress/Egress Flows'
+  } else if (hasIngressFlow(node)) {
+    return 'Has Ingress Flows'
+  } else if (hasEgressFlow(node)) {
+    return 'Has Egress Flows'
+  }
+
+  return ''
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/ui/src/components/Nodes/NodeActionsDropdown.vue
+++ b/ui/src/components/Nodes/NodeActionsDropdown.vue
@@ -1,0 +1,116 @@
+<template>
+  <FeatherDropdown>
+    <template v-slot:trigger="{ attrs, on }">
+      <FeatherButton
+        icon="Node Actions"
+        v-bind="attrs"
+        v-on="on"
+      >
+        <FeatherIcon :icon="menu" class="node-actions-icon" />
+      </FeatherButton>
+    </template>
+    <FeatherDropdownItem @click="triggerNodeInfo(node)">
+      <span class="node-menu-item">Info...</span>
+    </FeatherDropdownItem>
+    <FeatherDropdownItem
+      v-for="linkItem in linkItems"
+      :key="linkItem.name"
+      @click="onNodeLink(linkItem.name, node)">
+      <span class="node-menu-item">{{ linkItem.label }}</span>
+    </FeatherDropdownItem>
+  </FeatherDropdown>
+</template>
+
+<script setup lang="ts">
+import { FeatherButton } from '@featherds/button'
+import { FeatherDropdown, FeatherDropdownItem } from '@featherds/dropdown'
+import { FeatherIcon } from '@featherds/icon'
+import MoreVert from '@featherds/icon/navigation/MoreVert'
+import { markRaw, PropType } from 'vue'
+import { Node } from '@/types'
+
+const props = defineProps({
+  baseHref: {
+    required: true,
+    type: String
+  },
+  node: {
+    required: true,
+    type: Object as PropType<Node>
+  },
+  triggerNodeInfo: {
+    required: true,
+    type: Function as PropType<(node: Node) => void>
+  }
+})
+
+const menu = markRaw(MoreVert)
+
+const linkItems = [
+  { name: 'events', label: 'Events' },
+  { name: 'alarms', label: 'Alarms' },
+  { name: 'view-outages', label: 'Outages' },
+  { name: 'assets', label: 'Assets' },
+  { name: 'metadata', label: 'Metadata' },
+  { name: 'hardware', label: 'Hardware Info' },
+  { name: 'availability', label: 'Availability' },
+  { name: 'graphs', label: 'Resource Graphs' },
+  { name: 'rescan', label: 'Rescan' },
+  { name: 'admin', label: 'Admin' },
+  { name: 'updateSnmp', label: 'Update SNMP' },
+  { name: 'schedule-outage', label: 'Schedule an Outage' },
+  { name: 'topology', label: 'View in Topology' }
+]
+
+const onNodeLink = (name: string, node: Node) => {
+  const link = mapLink(name, node)
+  window.location.assign(`${props.baseHref}${link}`)
+}
+
+const mapLink = (name: string, node: Node) => {
+  switch (name) {
+    case 'events':
+      return `event/list?filter=node%3D${node.id}`
+    case 'alarms':
+      return `alarm/list.htm?filter=node%3D${node.id}`
+    case 'view-outages':
+      return `outage/list.htm?filter=node%3D${node.id}`
+    case 'assets':
+      return `asset/modify.jsp?node=${node.id}`
+    case 'metadata':
+      return `element/node-metadata.jsp?node=${node.id}`
+    case 'hardware':
+      return `hardware/list.jsp?node=${node.id}`
+    case 'availability':
+      return `element/availability.jsp?node=${node.id}`
+    case 'graphs':
+      return `graph/chooseresource.jsp?node=${node.id}&reports=all`
+    case 'rescan':
+      return `element/rescan.jsp?node=${node.id}`
+    case 'admin':
+      return `admin/nodemanagement/index.jsp?node=${node.id}`
+    case 'updateSnmp':
+      // TODO: Get IP Address
+      return `admin/updateSnmp.jsp?node=${node.id}&ipaddr=0.0.0.0`
+    case 'schedule-outage':
+      return `admin/sched-outages/editoutage.jsp?newName=${node.label}&addNew=true&nodeID=${node.id}`
+    case 'topology':
+      return `topology?provider=Enhanced+Linkd&szl=1&focus-vertices=${node.id}`
+    default: return ''
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.focus-icon {
+  cursor: pointer;
+}
+
+.node-menu-item {
+  padding: 1em;
+}
+
+button.btn.btn-icon .node-actions-icon {
+  font-size: 1.1rem;
+}
+</style>

--- a/ui/src/components/Nodes/NodeDetailsDialog.vue
+++ b/ui/src/components/Nodes/NodeDetailsDialog.vue
@@ -1,0 +1,56 @@
+<template>
+  <FeatherDialog :modelValue="visible" relative :labels="labels" @update:modelValue="$emit('close')">
+    <div class="content">
+      <div class="feather-row" v-for="item in nodeItems" :key="item.label">
+        <div class="feather-col-4">
+          <span class="label">{{ item.label }}</span>
+        </div>
+        <div class="feather-col-8">
+          {{ item.text }}
+        </div>
+      </div>
+    </div>
+  </FeatherDialog>
+</template>
+
+<script setup lang="ts">
+import { PropType } from 'vue'
+import { FeatherDialog } from '@featherds/dialog'
+import { Node } from '@/types'
+
+const props = defineProps({
+  visible: {
+    required: true,
+    type: Boolean
+  },
+  node: {
+    required: false,
+    type: Object as PropType<Node>
+  }
+})
+
+const labels = reactive({
+  title: 'Node Details',
+  close: 'Close'
+})
+
+const nodeItems = computed(() => {
+  return [
+    { label: 'Node ID', text: props.node?.id },
+    { label: 'Node Label', text: props.node?.label },
+    { label: 'FS:FID', text: `${props.node?.foreignSource}:${props.node?.foreignId}` }
+  ]
+})
+</script>
+
+<style scoped lang="scss">
+.content {
+  min-height: 300px;
+  min-width: 550px;
+  position: relative;
+}
+
+.label {
+  font-weight: bold;
+}
+</style>

--- a/ui/src/components/Nodes/NodeTooltipCell.vue
+++ b/ui/src/components/Nodes/NodeTooltipCell.vue
@@ -1,0 +1,31 @@
+<template>
+  <td :class="text ? 'focus-cell' : ''">
+    <FeatherTooltip
+      :title="text"
+      :alignment="PointerAlignment.left"
+      :placement="PopoverPlacement.top"
+      v-if="text"
+      v-slot="{ attrs, on }">
+        <span v-bind="attrs" v-on="on">{{ ellipsify(text, 30) }}</span>
+    </FeatherTooltip>
+  </td>
+</template>
+
+<script setup lang="ts">
+import { FeatherTooltip, PointerAlignment, PopoverPlacement } from '@featherds/tooltip'
+import { ellipsify } from '@/lib/utils'
+
+defineProps({
+  text: {
+    required: true,
+    type: String
+  }
+})
+
+</script>
+
+<style lang="scss" scoped>
+.focus-cell {
+  cursor: pointer;
+}
+</style>

--- a/ui/src/components/Nodes/utils.ts
+++ b/ui/src/components/Nodes/utils.ts
@@ -75,17 +75,10 @@ export const buildNodeStructureQuery = (
   return query
 }
 
-export const shouldDisplayFlows = (node: Node) => {
-  const hasIngress = node.lastIngressFlow && isNumber(node.lastIngressFlow)
-  const hasEgress = node.lastEgressFlow && isNumber(node.lastEgressFlow)
+export const hasIngressFlow = (node: Node) => {
+  return node.lastIngressFlow && isNumber(node.lastIngressFlow)
+}
 
-  if (hasIngress && hasEgress) {
-    return 'I/E'
-  } else if (hasEgress) {
-    return 'E'
-  } else if (hasIngress) {
-    return 'I'
-  }
-
-  return ''
+export const hasEgressFlow = (node: Node) => {
+  return node.lastEgressFlow && isNumber(node.lastEgressFlow)
 }

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -43,4 +43,3 @@ const breadcrumbs = computed<BreadCrumb[]>(() => {
 @import "@featherds/styles/themes/variables";
 
 </style>
-

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -8,3 +8,11 @@ export const isNumber = (value: any) => {
 export const isString = (value: any) => {
   return value !== null && (typeof(value) === 'string' || value instanceof String)
 }
+
+export const ellipsify = (text: string, count: number) => {
+  if (text && count && text.length > count) {
+    return text.substring(0, count) + '...'
+  }
+
+  return text
+}

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -30,6 +30,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 // TODO: Move to separate fil
 // See: https://fontawesome.com/docs/web/use-with/vue/ and following
 import {
+  faArrowLeftLong,
+  faArrowRightLong,
   faBell,
   faBellSlash,
   faCalendar,
@@ -48,6 +50,8 @@ import {
   faUsers
 } from '@fortawesome/free-solid-svg-icons'
 const icons = [
+  faArrowLeftLong,
+  faArrowRightLong,
   faBell,
   faBellSlash,
   faCalendar,

--- a/ui/src/store/nodeStructure/actions.ts
+++ b/ui/src/store/nodeStructure/actions.ts
@@ -1,5 +1,5 @@
 import API from '@/services'
-import { Category, SetOperator, VuexContext } from '@/types'
+import { Category, NodeColumnSelectionItem, SetOperator, VuexContext } from '@/types'
 
 const getCategories = async (context: VuexContext) => {
   const resp = await API.getCategories()
@@ -18,6 +18,10 @@ const getMonitoringLocations = async (context: VuexContext) => {
   }
 }
 
+const resetColumnSelectionToDefault = async (context: VuexContext) => {
+  context.commit('RESET_NODE_COLUMN_SELECTION')
+}
+
 const setSelectedCategories = async (context: VuexContext, categories: Category[]) => {
   context.commit('SAVE_SELECTED_CATEGORIES_TO_STATE', categories)
 }
@@ -34,11 +38,17 @@ const setSelectedMonitoringLocations = async (context: VuexContext, locations: s
   context.commit('SAVE_SELECTED_MONITORING_LOCATIONS_TO_STATE', locations)
 }
 
+const updateNodeColumnSelection = async (context: VuexContext, column: NodeColumnSelectionItem) => {
+  context.commit('UPDATE_NODE_COLUMN_SELECTION', column)
+}
+
 export default {
   getCategories,
   getMonitoringLocations,
+  resetColumnSelectionToDefault,
   setSelectedCategories,
   setCategoryMode,
   setSelectedFlows,
-  setSelectedMonitoringLocations
+  setSelectedMonitoringLocations,
+  updateNodeColumnSelection
 }

--- a/ui/src/store/nodeStructure/mutations.ts
+++ b/ui/src/store/nodeStructure/mutations.ts
@@ -1,5 +1,5 @@
-import { Category, MonitoringLocation, SetOperator } from '@/types'
-import { State } from './state'
+import { Category, MonitoringLocation, NodeColumnSelectionItem, SetOperator } from '@/types'
+import { State, defaultColumns } from './state'
 
 const SAVE_CATEGORY_COUNT = (state: State, count: number) => {
   state.categoryCount = count
@@ -25,16 +25,36 @@ const SAVE_LOCATIONS_TO_STATE = (state: State, locations: MonitoringLocation[]) 
   state.monitoringLocations = [...locations]
 }
 
+const RESET_NODE_COLUMN_SELECTION = (state: State) => {
+  state.columns = [...defaultColumns]
+}
+
+const UPDATE_NODE_COLUMN_SELECTION = (state: State, column: NodeColumnSelectionItem) => {
+  const newColumns = [...state.columns].map(c => {
+    if (c.id === column.id) {
+      return {
+        ...c,
+        selected: column.selected
+      }
+    }
+    return c
+  })
+
+  state.columns = [...newColumns]
+}
+
 const SAVE_SELECTED_MONITORING_LOCATIONS_TO_STATE = (state: State, locations: MonitoringLocation[]) => {
   state.selectedMonitoringLocations = [...locations]
 }
 
 export default {
+  RESET_NODE_COLUMN_SELECTION,
   SAVE_CATEGORY_COUNT,
   SAVE_CATEGORIES_TO_STATE,
   SAVE_SELECTED_CATEGORIES_TO_STATE,
   SAVE_CATEGORY_MODE,
   SAVE_SELECTED_FLOWS_TO_STATE,
   SAVE_LOCATIONS_TO_STATE,
-  SAVE_SELECTED_MONITORING_LOCATIONS_TO_STATE
+  SAVE_SELECTED_MONITORING_LOCATIONS_TO_STATE,
+  UPDATE_NODE_COLUMN_SELECTION
 }

--- a/ui/src/store/nodeStructure/state.ts
+++ b/ui/src/store/nodeStructure/state.ts
@@ -1,4 +1,16 @@
-import { Category, MonitoringLocation, SetOperator } from '@/types'
+import { Category, MonitoringLocation, NodeColumnSelectionItem, SetOperator } from '@/types'
+
+export const defaultColumns: NodeColumnSelectionItem[] = [
+  { id: 'id', label: 'ID', selected: false, order: 0 },
+  { id: 'label', label: 'Node Label', selected: true, order: 1 },
+  { id: 'location', label: 'Location', selected: true, order: 2 },
+  { id: 'foreignSource', label: 'Foreign Source', selected: true, order: 3 },
+  { id: 'foreignId', label: 'Foreign ID', selected: true, order: 4 },
+  { id: 'sysContact', label: 'Sys Contact', selected: true, order: 5 },
+  { id: 'sysLocation', label: 'Sys Location', selected: true, order: 6 },
+  { id: 'sysDescription', label: 'Sys Description', selected: true, order: 7 },
+  { id: 'flows', label: 'Flows', selected: true, order: 8 }
+]
 
 export interface State {
   categories: Category[]
@@ -7,7 +19,8 @@ export interface State {
   categoryMode: SetOperator
   selectedFlows: string[]
   monitoringLocations: MonitoringLocation[]
-  selectedMonitoringLocations: MonitoringLocation[]
+  selectedMonitoringLocations: MonitoringLocation[],
+  columns: NodeColumnSelectionItem[]
 }
 
 const state: State = {
@@ -17,7 +30,8 @@ const state: State = {
   categoryMode: SetOperator.Union,
   selectedFlows: [],
   monitoringLocations: [],
-  selectedMonitoringLocations: []
+  selectedMonitoringLocations: [],
+  columns: defaultColumns
 }
 
 export default state

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -113,6 +113,13 @@ export interface Node {
   sysLocation: string
 }
 
+export interface NodeColumnSelectionItem {
+  id: string
+  label: string
+  selected: boolean
+  order: number // 0-based
+}
+
 export interface MapNode {
   id: string
   coordinates: [number, number]


### PR DESCRIPTION
NMS-16103: Node Structure UX improvements, selectable columns

- horizontal table scroll, highlight on mouseover
- added "Filtering" and "Metadata Search" headings
- dropdown to select which columns to display, and a button to reset them to the default
- start of support for ordering columns, will do rest in subsequent task
- refactored some functionality into smaller Vue components
- vertical ellipse menu for node actions (links to other pages, etc.)
- node details dialog, will add more in subsequent tasks
- using buttons instead of radio group for "Any / All" switch
- add metadata search autocomplete, even though it's non-functional for now (want this in to get UX feedback)
- truncate long text and provide tooltip
- flows icons
- title and move Search input to right

There's enough functionality here that can probably merge feature branch to `develop` once this has been merged.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16103

