### PR TITLE
Ranger/guava osgi version cleanup smoke

### DIFF
--- a/container/extender/pom.xml
+++ b/container/extender/pom.xml
@@ -18,6 +18,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1511,7 +1511,7 @@
         <bundle>mvn:com.google.code.gson/gson/${jestGsonVersion}</bundle>
         <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/${httpcoreVersion}</bundle>
         <bundle>mvn:org.opennms.features.jest/org.opennms.features.jest.client/${project.version}</bundle>
-        <bundle>mvn:io.searchbox/jest-complete-osgi/${jestVersion}</bundle>
+        <bundle>mvn:org.opennms.dependencies/jest-complete-osgi/${project.version}</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcoreVersion}</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclientVersion}</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpasyncclient-osgi/${httpasyncclientVersion}</bundle>

--- a/core/api/pom.xml
+++ b/core/api/pom.xml
@@ -25,6 +25,7 @@
               org.opennms.core.config.api.*;version="${project.version}",
               org.opennms.core.network;version="${project.version}"
             </Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/cache/pom.xml
+++ b/core/cache/pom.xml
@@ -21,6 +21,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/grpc/common/pom.xml
+++ b/core/grpc/common/pom.xml
@@ -25,6 +25,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/health/impl/pom.xml
+++ b/core/health/impl/pom.xml
@@ -19,6 +19,7 @@
                 <configuration>
                     <instructions>
                         <Export-Package>org.opennms.core.health.impl</Export-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/grpc/client/pom.xml
+++ b/core/ipc/grpc/client/pom.xml
@@ -25,6 +25,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/grpc/server/pom.xml
+++ b/core/ipc/grpc/server/pom.xml
@@ -24,6 +24,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/osgi/pom.xml
+++ b/core/ipc/osgi/pom.xml
@@ -25,6 +25,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/rpc/camel/pom.xml
+++ b/core/ipc/rpc/camel/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/rpc/common/pom.xml
+++ b/core/ipc/rpc/common/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/rpc/kafka/pom.xml
+++ b/core/ipc/rpc/kafka/pom.xml
@@ -30,6 +30,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/rpc/shell-commands/pom.xml
+++ b/core/ipc/rpc/shell-commands/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/sink/common/pom.xml
+++ b/core/ipc/sink/common/pom.xml
@@ -32,6 +32,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Bundle-Activator>org.opennms.core.ipc.sink.offheap.Activator</Bundle-Activator>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/sink/kafka/client/pom.xml
+++ b/core/ipc/sink/kafka/client/pom.xml
@@ -30,6 +30,7 @@
             -->
             <Import-Package>
               !org.opennms.core.ipc.sink.kafka.server,
+              ${guavaImportPackage},
               *
             </Import-Package>
           </instructions>

--- a/core/ipc/sink/kafka/server/pom.xml
+++ b/core/ipc/sink/kafka/server/pom.xml
@@ -24,7 +24,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
-            <Import-Package>*</Import-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/sink/off-heap/pom.xml
+++ b/core/ipc/sink/off-heap/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/ipc/twin/api/pom.xml
+++ b/core/ipc/twin/api/pom.xml
@@ -23,6 +23,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/twin/common/pom.xml
+++ b/core/ipc/twin/common/pom.xml
@@ -78,6 +78,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/twin/grpc/publisher/pom.xml
+++ b/core/ipc/twin/grpc/publisher/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/twin/grpc/subscriber/pom.xml
+++ b/core/ipc/twin/grpc/subscriber/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/twin/jms/publisher/pom.xml
+++ b/core/ipc/twin/jms/publisher/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/twin/kafka/publisher/pom.xml
+++ b/core/ipc/twin/kafka/publisher/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/twin/kafka/subscriber/pom.xml
+++ b/core/ipc/twin/kafka/subscriber/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/ipc/twin/memory/pom.xml
+++ b/core/ipc/twin/memory/pom.xml
@@ -22,6 +22,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/lib/pom.xml
+++ b/core/lib/pom.xml
@@ -24,6 +24,7 @@
             <Import-Package>
               <!-- Declare the Attach API as an optional dependency -->
               com.sun.tools.attach;resolution:=optional,
+              ${guavaImportPackage},
               *
             </Import-Package>
           </instructions>

--- a/core/mate/api/pom.xml
+++ b/core/mate/api/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/mate/model/pom.xml
+++ b/core/mate/model/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/mate/shell-commands/pom.xml
+++ b/core/mate/shell-commands/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/profiler/pom.xml
+++ b/core/profiler/pom.xml
@@ -21,6 +21,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/snmp/commands/pom.xml
+++ b/core/snmp/commands/pom.xml
@@ -27,6 +27,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/snmp/impl-snmp4j/pom.xml
+++ b/core/snmp/impl-snmp4j/pom.xml
@@ -27,6 +27,7 @@
               org.snmp4j.*
             </Export-Package>
             <Import-Package>
+              ${guavaImportPackage},
               org.apache.commons.lang;resolution:=optional,
               org.apache.log4j;resolution:=optional,
               *

--- a/core/snmp/profile-mapper/pom.xml
+++ b/core/snmp/profile-mapper/pom.xml
@@ -24,6 +24,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/test-api/alarms/pom.xml
+++ b/core/test-api/alarms/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/test-api/collection/pom.xml
+++ b/core/test-api/collection/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>org.opennms.core.test.*;version="${project.version}"</Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/core/test-api/db/pom.xml
+++ b/core/test-api/db/pom.xml
@@ -25,6 +25,7 @@
               org.opennms.core.test.db.annotations.*;version="${project.version}",
               org.opennms.core.test.db.*;version="${project.version}"
             </Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/dependencies/jest-complete-osgi/pom.xml
+++ b/dependencies/jest-complete-osgi/pom.xml
@@ -1,17 +1,16 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <groupId>org.opennms.features</groupId>
-    <artifactId>org.opennms.features.jest</artifactId>
+    <groupId>org.opennms</groupId>
+    <artifactId>dependencies</artifactId>
     <version>31.0.3-SNAPSHOT</version>
   </parent>
 
   <!-- Feature Definition -->
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.searchbox</groupId>
+  <groupId>org.opennms.dependencies</groupId>
   <artifactId>jest-complete-osgi</artifactId>
-  <version>${jestVersion}</version>
-  <name>jest-complete-osgi</name>
+  <name>OpenNMS :: Dependencies :: Jest (OSGi Bundle)</name>
   <description>shaded osgi bundle containing complete jest implementation</description>
   <packaging>bundle</packaging>
 
@@ -43,17 +42,6 @@
                 <excludes>
                 </excludes>
               </artifactSet>
-              <!-- <transformers> -->
-              <!-- <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"> -->
-              <!-- <manifestEntries> -->
-              <!-- <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName> -->
-              <!-- <Export-Package>io,io.searchbox,io.searchbox.action,io.searchbox.annotations,io.searchbox.client,io.searchbox.client.config,io.searchbox.client.config.exception,io.searchbox.client.config.idle,io.searchbox.client.http.apache,io.searchbox.cloning,io.searchbox.cluster,io.searchbox.core,io.searchbox.core.search,io.searchbox.core.search.aggregation,io.searchbox.core.search.sort,io.searchbox.indices,io.searchbox.indices.aliases,io.searchbox.indices.mapping,io.searchbox.indices.script,io.searchbox.indices.settings,io.searchbox.indices.template,io.searchbox.indices.type,io.searchbox.params,io.searchbox.snapshot -->
-              <!-- </Export-Package> -->
-              <!-- <Import-Package>*</Import-Package> -->
-              <!-- <Private-Package></Private-Package> -->
-              <!-- </manifestEntries> -->
-              <!-- </transformer> -->
-              <!-- </transformers> -->
               <createDependencyReducedPom>true</createDependencyReducedPom>
             </configuration>
           </execution>
@@ -64,24 +52,13 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <!-- <version>2.5.3</version> -->
         <extensions>true</extensions>
-        <executions>
-          <!-- <execution> -->
-          <!-- <id>bundle-manifest</id> -->
-          <!-- <phase>process-classes</phase> -->
-          <!-- <goals> -->
-          <!-- <goal>manifest</goal> -->
-          <!-- </goals> -->
-          <!-- </execution> -->
-        </executions>
         <configuration>
           <instructions>
             <unpackBundle>true</unpackBundle>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Version>${project.version}</Bundle-Version>
+            <Bundle-Version>${jestVersion}</Bundle-Version>
             <Export-Package>
-              io,
               io.searchbox,
               io.searchbox.action,
               io.searchbox.annotations,
@@ -107,14 +84,17 @@
               io.searchbox.params,
               io.searchbox.snapshot
             </Export-Package>
+            <!-- note: Jest 5.x was built against guava 21,
+                 but appears to only use APIs that are still available
+                 in at least 31, so this version="21" _should_ be OK -->
             <Import-Package>
-              com.google.common.base,
-              com.google.common.collect,
-              com.google.common.io,
-              com.google.common.reflect,
-              com.google.common.util.concurrent,
-              com.google.gson,
-              com.google.gson.annotations,
+              com.google.common.base;version="21",
+              com.google.common.collect;version="21",
+              com.google.common.io;version="21",
+              com.google.common.reflect;version="21",
+              com.google.common.util.concurrent;version="21",
+              com.google.gson;version="${jestGsonVersion}",
+              com.google.gson.annotations;version="${jestGsonVersion}",
               io.searchbox.action,
               io.searchbox.client.config.discovery,
               io.searchbox.client.config.exception,

--- a/dependencies/owasp/pom.xml
+++ b/dependencies/owasp/pom.xml
@@ -9,7 +9,7 @@
   <groupId>org.opennms.dependencies</groupId>
   <artifactId>owasp-dependencies</artifactId>
   <packaging>pom</packaging>
-  <name>OpenNMS Dependencies OWASP</name>
+  <name>OpenNMS :: Dependencies :: OWASP</name>
   <description>
     This module is used to provide a single artifact that the opennms project
     can depend on to use the OWASP Java Encoder and the OWASP HTML Sanitizer

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -30,6 +30,7 @@
     <module>javamail</module>
     <module>jaxb</module>
     <module>jcifs</module>
+    <module>jest-complete-osgi</module>
     <module>jfreechart</module>
     <module>jinterop</module>
     <module>jmx</module>

--- a/features/alarms/history/elastic/pom.xml
+++ b/features/alarms/history/elastic/pom.xml
@@ -34,6 +34,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/alarms/history/elastic/pom.xml
+++ b/features/alarms/history/elastic/pom.xml
@@ -71,9 +71,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.dependencies</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/features/amqp/event-forwarder/pom.xml
+++ b/features/amqp/event-forwarder/pom.xml
@@ -39,7 +39,11 @@
           <instructions>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <!-- Add classes that are included in Camel routes -->
-            <Import-Package>org.opennms.core.xml,*</Import-Package>
+            <Import-Package>
+              ${guavaImportPackage},
+              org.opennms.core.xml,
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/api-layer/common/pom.xml
+++ b/features/api-layer/common/pom.xml
@@ -35,6 +35,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/api-layer/core/pom.xml
+++ b/features/api-layer/core/pom.xml
@@ -35,6 +35,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/api-layer/dao-common/pom.xml
+++ b/features/api-layer/dao-common/pom.xml
@@ -35,6 +35,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/bsm/daemon/pom.xml
+++ b/features/bsm/daemon/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Private-Package>org.opennms.netmgt.bsm.service.internal.*</Private-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/bsm/persistence/api/pom.xml
+++ b/features/bsm/persistence/api/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/bsm/rest/api/pom.xml
+++ b/features/bsm/rest/api/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/bsm/rest/impl/pom.xml
+++ b/features/bsm/rest/impl/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/bsm/service/api/pom.xml
+++ b/features/bsm/service/api/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/bsm/service/impl/pom.xml
+++ b/features/bsm/service/impl/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Private-Package>org.opennms.netmgt.bsm.service.internal.*;org.opennms.netmgt.bsm.service.model.graph.internal.*</Private-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/bsm/vaadin-adminpage/pom.xml
+++ b/features/bsm/vaadin-adminpage/pom.xml
@@ -26,6 +26,7 @@
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         <Vaadin-Widgetsets>org.opennms.vaadin.DefaultWidgetset</Vaadin-Widgetsets>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/collection/api/pom.xml
+++ b/features/collection/api/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/collection/shell-commands/pom.xml
+++ b/features/collection/shell-commands/pom.xml
@@ -24,6 +24,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/collection/snmp-collector/pom.xml
+++ b/features/collection/snmp-collector/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/collection/thresholding/api/pom.xml
+++ b/features/collection/thresholding/api/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/collection/thresholding/impl/pom.xml
+++ b/features/collection/thresholding/impl/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/config/dao/impl/pom.xml
+++ b/features/config/dao/impl/pom.xml
@@ -19,6 +19,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/config/service/api/pom.xml
+++ b/features/config/service/api/pom.xml
@@ -18,6 +18,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/config/upgrade/pom.xml
+++ b/features/config/upgrade/pom.xml
@@ -17,6 +17,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -26,6 +26,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Karaf-Commands>*</Karaf-Commands>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/device-config/api/pom.xml
+++ b/features/device-config/api/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/device-config/monitor-adaptor/pom.xml
+++ b/features/device-config/monitor-adaptor/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/device-config/monitor/pom.xml
+++ b/features/device-config/monitor/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/device-config/persistence/impl/pom.xml
+++ b/features/device-config/persistence/impl/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/device-config/rest/pom.xml
+++ b/features/device-config/rest/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/device-config/retrieval/pom.xml
+++ b/features/device-config/retrieval/pom.xml
@@ -23,6 +23,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/device-config/service/pom.xml
+++ b/features/device-config/service/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/device-config/shell/pom.xml
+++ b/features/device-config/shell/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Karaf-Commands>*</Karaf-Commands>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/device-config/ssh-scripting/pom.xml
+++ b/features/device-config/ssh-scripting/pom.xml
@@ -23,6 +23,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/dhcpd/pom.xml
+++ b/features/dhcpd/pom.xml
@@ -24,6 +24,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Private-Package>org.opennms.features.dhcpd.impl.*</Private-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/discovery/pom.xml
+++ b/features/discovery/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/distributed/dao/test/pom.xml
+++ b/features/distributed/dao/test/pom.xml
@@ -19,6 +19,7 @@
                 <configuration>
                     <instructions>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/distributed/kv-store/api/pom.xml
+++ b/features/distributed/kv-store/api/pom.xml
@@ -22,6 +22,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/distributed/kv-store/blob/cassandra/pom.xml
+++ b/features/distributed/kv-store/blob/cassandra/pom.xml
@@ -22,6 +22,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/dnsresolver/netty/pom.xml
+++ b/features/dnsresolver/netty/pom.xml
@@ -22,6 +22,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/dnsresolver/shell/pom.xml
+++ b/features/dnsresolver/shell/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/eif-adapter/pom.xml
+++ b/features/eif-adapter/pom.xml
@@ -29,6 +29,7 @@
         <configuration>
           <instructions>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/endpoints/grafana/api/pom.xml
+++ b/features/endpoints/grafana/api/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/endpoints/grafana/client/pom.xml
+++ b/features/endpoints/grafana/client/pom.xml
@@ -24,6 +24,7 @@
             <Embed-Dependency>*;artifactId=okhttp|gson|okio</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package>
+              ${guavaImportPackage},
               dalvik.system;resolution:=optional,
               android.net;resolution:=optional,
               android.net.http;resolution:=optional,

--- a/features/endpoints/grafana/rest/pom.xml
+++ b/features/endpoints/grafana/rest/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/endpoints/grafana/service/pom.xml
+++ b/features/endpoints/grafana/service/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/adapters/common/pom.xml
+++ b/features/enlinkd/adapters/common/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/adapters/updaters/bridge/pom.xml
+++ b/features/enlinkd/adapters/updaters/bridge/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/adapters/updaters/cdp/pom.xml
+++ b/features/enlinkd/adapters/updaters/cdp/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/adapters/updaters/isis/pom.xml
+++ b/features/enlinkd/adapters/updaters/isis/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/adapters/updaters/lldp/pom.xml
+++ b/features/enlinkd/adapters/updaters/lldp/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/adapters/updaters/ospf/pom.xml
+++ b/features/enlinkd/adapters/updaters/ospf/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/generator/pom.xml
+++ b/features/enlinkd/generator/pom.xml
@@ -25,6 +25,7 @@
           <instructions>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/persistence/api/pom.xml
+++ b/features/enlinkd/persistence/api/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/enlinkd/service/impl/pom.xml
+++ b/features/enlinkd/service/impl/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/events/daemon/pom.xml
+++ b/features/events/daemon/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/events/shell-commands/pom.xml
+++ b/features/events/shell-commands/pom.xml
@@ -24,6 +24,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/events/sink/shell-commands/pom.xml
+++ b/features/events/sink/shell-commands/pom.xml
@@ -25,6 +25,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/events/syslog/pom.xml
+++ b/features/events/syslog/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               *

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Import-Package>
+              ${guavaImportPackage},
               org.snmp4j;resolution:=optional,
               org.slf4j.impl;resolution:=optional,
               org.eclipse.persistence.internal.jaxb;resolution:=optional,

--- a/features/flows/api/pom.xml
+++ b/features/flows/api/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/flows/api/pom.xml
+++ b/features/flows/api/pom.xml
@@ -42,9 +42,8 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.dependencies</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/features/flows/classification/engine/api/pom.xml
+++ b/features/flows/classification/engine/api/pom.xml
@@ -10,6 +10,20 @@
   <artifactId>org.opennms.features.flows.classification.engine.api</artifactId>
   <name>OpenNMS :: Features :: Flows :: Classification :: Engine :: API</name>
   <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.opennms.features.flows</groupId>

--- a/features/flows/classification/engine/impl/pom.xml
+++ b/features/flows/classification/engine/impl/pom.xml
@@ -10,6 +10,20 @@
   <artifactId>org.opennms.features.flows.classification.engine.impl</artifactId>
   <name>OpenNMS :: Features :: Flows :: Classification :: Engine :: Impl.</name>
   <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.opennms.core</groupId>

--- a/features/flows/classification/persistence/api/pom.xml
+++ b/features/flows/classification/persistence/api/pom.xml
@@ -10,6 +10,20 @@
   <artifactId>org.opennms.features.flows.classification.persistence.api</artifactId>
   <name>OpenNMS :: Features :: Flows :: Classification :: Persistence :: Api</name>
   <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
       <dependency>
         <groupId>org.opennms</groupId>

--- a/features/flows/classification/shell/pom.xml
+++ b/features/flows/classification/shell/pom.xml
@@ -23,6 +23,7 @@
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Private-Package></Private-Package>
                         <Karaf-Commands>org.opennms.netmgt.flows.clazzification.shell</Karaf-Commands>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/flows/elastic/pom.xml
+++ b/features/flows/elastic/pom.xml
@@ -111,9 +111,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.dependencies</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/features/flows/elastic/pom.xml
+++ b/features/flows/elastic/pom.xml
@@ -25,6 +25,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/flows/kafka-persistence/pom.xml
+++ b/features/flows/kafka-persistence/pom.xml
@@ -50,6 +50,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/flows/processing/pom.xml
+++ b/features/flows/processing/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/flows/rest/api/pom.xml
+++ b/features/flows/rest/api/pom.xml
@@ -10,6 +10,20 @@
   <artifactId>org.opennms.features.flows.rest.api</artifactId>
   <packaging>bundle</packaging>
   <name>OpenNMS :: Features :: Flows :: ReST :: API</name>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>javax.ws.rs</groupId>

--- a/features/flows/rest/impl/pom.xml
+++ b/features/flows/rest/impl/pom.xml
@@ -10,6 +10,20 @@
   <artifactId>org.opennms.features.flows.rest.impl</artifactId>
   <packaging>bundle</packaging>
   <name>OpenNMS :: Features :: Flows :: ReST :: Impl.</name>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.opennms.features.flows.rest</groupId>

--- a/features/geocoder/google/pom.xml
+++ b/features/geocoder/google/pom.xml
@@ -34,6 +34,7 @@
             <Embed-Dependency>*;artifactId=google-maps-services|gson|okhttp|okio</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package>
+              ${guavaImportPackage},
               dalvik.system;resolution:=optional,
               android.net.http;resolution:=optional,
               android.os;resolution:=optional,

--- a/features/geocoder/mapquest/pom.xml
+++ b/features/geocoder/mapquest/pom.xml
@@ -23,6 +23,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Private-Package>org.opennms.features.geocoder.mapquest.internal</Private-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/geocoder/nominatim/pom.xml
+++ b/features/geocoder/nominatim/pom.xml
@@ -31,6 +31,7 @@
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>!${bundle.namespace}.internal.*,${bundle.namespace}.*;version="${project.version}"</Export-Package>
             <Private-Package>${bundle.namespace}.internal.*</Private-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/geolocation/service/pom.xml
+++ b/features/geolocation/service/pom.xml
@@ -16,6 +16,20 @@
     <bundle.namespace>org.opennms.features.geolocation.services</bundle.namespace>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/features/graph/api/pom.xml
+++ b/features/graph/api/pom.xml
@@ -21,6 +21,7 @@
                     <instructions>
                         <Export-Package>{local-packages}</Export-Package>
                         <Private-Package></Private-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/graph/domain/pom.xml
+++ b/features/graph/domain/pom.xml
@@ -21,6 +21,7 @@
                 <configuration>
                     <instructions>
                         <Private-Package></Private-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/graph/provider/application/pom.xml
+++ b/features/graph/provider/application/pom.xml
@@ -19,7 +19,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Private-Package>{local-packages}</Private-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/graph/provider/bsm/pom.xml
+++ b/features/graph/provider/bsm/pom.xml
@@ -19,7 +19,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Private-Package>{local-packages}</Private-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/graph/provider/graphml/pom.xml
+++ b/features/graph/provider/graphml/pom.xml
@@ -19,8 +19,11 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>*,edu.uci.ics.jung.graph</Import-Package>
-                        <Private-Package>{local-packages}</Private-Package>
+                        <Import-Package>
+                            ${guavaImportPackage},
+                            edu.uci.ics.jung.graph,
+                            *
+                        </Import-Package>
                         <Export-Package></Export-Package>
                     </instructions>
                 </configuration>

--- a/features/graph/provider/legacy/pom.xml
+++ b/features/graph/provider/legacy/pom.xml
@@ -18,6 +18,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/features/graph/provider/topology/pom.xml
+++ b/features/graph/provider/topology/pom.xml
@@ -18,6 +18,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/features/graph/rest/impl/pom.xml
+++ b/features/graph/rest/impl/pom.xml
@@ -19,6 +19,7 @@
                 <configuration>
                     <instructions>
                         <Private-Package>org.opennms.netmgt.graph.rest.impl*</Private-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/graph/service/pom.xml
+++ b/features/graph/service/pom.xml
@@ -19,8 +19,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Private-Package>{local-packages}</Private-Package>
                         <Export-Package></Export-Package>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/graph/shell/pom.xml
+++ b/features/graph/shell/pom.xml
@@ -19,8 +19,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Private-Package>{local-packages}</Private-Package>
                         <Karaf-Commands>*</Karaf-Commands>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/graphml/api/pom.xml
+++ b/features/graphml/api/pom.xml
@@ -10,6 +10,20 @@
   <artifactId>org.opennms.features.graphml.api</artifactId>
   <name>OpenNMS :: Features :: GraphML :: API</name>
   <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.opennms.dependencies</groupId>

--- a/features/graphml/service/pom.xml
+++ b/features/graphml/service/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Private-Package>org.opennms.features.graphml.service.impl</Private-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/ifttt/pom.xml
+++ b/features/ifttt/pom.xml
@@ -22,6 +22,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/jest/client/pom.xml
+++ b/features/jest/client/pom.xml
@@ -35,9 +35,8 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.dependencies</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/features/jest/client/pom.xml
+++ b/features/jest/client/pom.xml
@@ -8,6 +8,20 @@
   <groupId>org.opennms.features.jest</groupId>
   <artifactId>org.opennms.features.jest.client</artifactId>
   <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/features/jest/dependencies/pom.xml
+++ b/features/jest/dependencies/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.16.0</version>
+            <version>${commonsCodecVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/features/jest/feature/pom.xml
+++ b/features/jest/feature/pom.xml
@@ -11,7 +11,6 @@
     <name>OpenNMS :: Features :: Jest :: Feature definition</name>
     <description>Feature definition for Jest (ElasticSearch Java ReST Client)</description>
     <packaging>pom</packaging>
-    <!-- Versions below should match versions defined in module "jest-complete-osgi" to avoid problems -->
     <dependencies>
         <dependency>
             <groupId>org.opennms.features.jest</groupId>
@@ -19,9 +18,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.searchbox</groupId>
+            <groupId>org.opennms.dependencies</groupId>
             <artifactId>jest-complete-osgi</artifactId>
-            <version>${jestVersion}</version>
         </dependency>
         <!--
             Same dependencies as in dependencies module.

--- a/features/jest/pom.xml
+++ b/features/jest/pom.xml
@@ -14,7 +14,6 @@
         <module>client</module>
         <module>dependencies</module>
         <module>feature</module>
-        <module>jest-complete-osgi</module>
     </modules>
     <build>
         <plugins>
@@ -32,13 +31,4 @@
             </plugin>
         </plugins>
     </build>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.searchbox</groupId>
-                <artifactId>jest</artifactId>
-                <version>${jestVersion}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/features/jmx-config-generator/pom.xml
+++ b/features/jmx-config-generator/pom.xml
@@ -29,6 +29,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/features/kafka/consumer/pom.xml
+++ b/features/kafka/consumer/pom.xml
@@ -32,6 +32,7 @@
         <configuration>
           <instructions>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -38,6 +38,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Karaf-Commands>*</Karaf-Commands>
             <Bundle-Activator>org.opennms.features.kafka.producer.collection.KafkaPersisterActivator</Bundle-Activator>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/measurements/api/pom.xml
+++ b/features/measurements/api/pom.xml
@@ -38,6 +38,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/measurements/shell/pom.xml
+++ b/features/measurements/shell/pom.xml
@@ -23,6 +23,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/minion/dominion/grpc-client/pom.xml
+++ b/features/minion/dominion/grpc-client/pom.xml
@@ -23,6 +23,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/minion/heartbeat/consumer/pom.xml
+++ b/features/minion/heartbeat/consumer/pom.xml
@@ -23,6 +23,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/newts/pom.xml
+++ b/features/newts/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Newts 1.x uses 18, and 25 is the last fully-compatible version before google started deprecating/freezing APIs -->
             <Import-Package>
               com.google.common.*;version="[18.0,26)",
               *

--- a/features/nrtg/web/pom.xml
+++ b/features/nrtg/web/pom.xml
@@ -22,6 +22,21 @@
     measurments.
   </description>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- OpenNMS NRTCollector -->
         <dependency>

--- a/features/openconfig/common/pom.xml
+++ b/features/openconfig/common/pom.xml
@@ -33,6 +33,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/openconfig/telemetry-client/pom.xml
+++ b/features/openconfig/telemetry-client/pom.xml
@@ -24,6 +24,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/opennms-es-rest/pom.xml
+++ b/features/opennms-es-rest/pom.xml
@@ -148,9 +148,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.dependencies</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/features/opennms-es-rest/pom.xml
+++ b/features/opennms-es-rest/pom.xml
@@ -39,6 +39,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/perspectivepoller/pom.xml
+++ b/features/perspectivepoller/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/poller/api/pom.xml
+++ b/features/poller/api/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/poller/monitors/core/pom.xml
+++ b/features/poller/monitors/core/pom.xml
@@ -23,6 +23,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <DynamicImport-Package>*</DynamicImport-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/poller/shell/pom.xml
+++ b/features/poller/shell/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/prometheus-collector/pom.xml
+++ b/features/prometheus-collector/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               org.opennms.netmgt.collection.adapters,

--- a/features/reporting/api/pom.xml
+++ b/features/reporting/api/pom.xml
@@ -26,6 +26,7 @@
               org.opennms.api.reporting.parameter.*;version="${project.version}",
               org.opennms.api.reporting.*;version="${project.version}"
             </Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/reporting/core/pom.xml
+++ b/features/reporting/core/pom.xml
@@ -39,6 +39,7 @@
               org.opennms.reporting.core.svclayer.*;version="${project.version}",
               org.opennms.reporting.core.*;version="${project.version}"
             </Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/reporting/jasper-reports/pom.xml
+++ b/features/reporting/jasper-reports/pom.xml
@@ -35,6 +35,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>org.opennms.reporting.jasperreports.svclayer.*;version="${project.version}"</Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/reporting/rest/pom.xml
+++ b/features/reporting/rest/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/scv/jceks-impl/pom.xml
+++ b/features/scv/jceks-impl/pom.xml
@@ -22,6 +22,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/scv/rest/pom.xml
+++ b/features/scv/rest/pom.xml
@@ -25,6 +25,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/search/api/pom.xml
+++ b/features/search/api/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/search/providers/pom.xml
+++ b/features/search/providers/pom.xml
@@ -20,6 +20,7 @@
           <instructions>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/search/service/pom.xml
+++ b/features/search/service/pom.xml
@@ -20,6 +20,7 @@
           <instructions>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/situation-feedback/api/pom.xml
+++ b/features/situation-feedback/api/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/situation-feedback/elastic/pom.xml
+++ b/features/situation-feedback/elastic/pom.xml
@@ -47,9 +47,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.dependencies</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/features/telemetry/config/jaxb/pom.xml
+++ b/features/telemetry/config/jaxb/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/daemon/pom.xml
+++ b/features/telemetry/daemon/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/distributed/common/pom.xml
+++ b/features/telemetry/distributed/common/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/listeners/pom.xml
+++ b/features/telemetry/listeners/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/adapters/pom.xml
+++ b/features/telemetry/protocols/adapters/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/bmp/adapter/pom.xml
+++ b/features/telemetry/protocols/bmp/adapter/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/bmp/parser/pom.xml
+++ b/features/telemetry/protocols/bmp/parser/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/bmp/persistence/impl/pom.xml
+++ b/features/telemetry/protocols/bmp/persistence/impl/pom.xml
@@ -24,6 +24,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/bmp/stats/pom.xml
+++ b/features/telemetry/protocols/bmp/stats/pom.xml
@@ -24,6 +24,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/flows/pom.xml
+++ b/features/telemetry/protocols/flows/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/jti/adapter/pom.xml
+++ b/features/telemetry/protocols/jti/adapter/pom.xml
@@ -28,6 +28,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/netflow/adapter/pom.xml
+++ b/features/telemetry/protocols/netflow/adapter/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/netflow/parser/pom.xml
+++ b/features/telemetry/protocols/netflow/parser/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/nxos/adapter/pom.xml
+++ b/features/telemetry/protocols/nxos/adapter/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/openconfig/adapter/pom.xml
+++ b/features/telemetry/protocols/openconfig/adapter/pom.xml
@@ -25,6 +25,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/sflow/adapter/pom.xml
+++ b/features/telemetry/protocols/sflow/adapter/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/protocols/sflow/parser/pom.xml
+++ b/features/telemetry/protocols/sflow/parser/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/telemetry/shell/pom.xml
+++ b/features/telemetry/shell/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/ticketing/jira-integration/pom.xml
+++ b/features/ticketing/jira-integration/pom.xml
@@ -19,6 +19,7 @@
             <instructions>
               <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
               <Karaf-Commands>*</Karaf-Commands>
+              <Import-Package>${guavaImportPackage},*</Import-Package>
             </instructions>
           </configuration>
         </plugin>

--- a/features/timeseries/pom.xml
+++ b/features/timeseries/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/topology-map/org.opennms.features.topology.api/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.api/pom.xml
@@ -21,6 +21,20 @@
 
   <packaging>bundle</packaging>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <!--
      | uncomment to add all imported (non-local) bundles to your compilation classpath

--- a/features/topology-map/org.opennms.features.topology.app/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.app/pom.xml
@@ -50,6 +50,7 @@
                         <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         <Vaadin-Widgetsets>org.opennms.features.topology.app.internal.gwt.TopologyAppWidgetSet</Vaadin-Widgetsets>
                         <Include-Resource>{maven-resources},target/gwt</Include-Resource>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/topology-map/org.opennms.features.topology.shell/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.shell/pom.xml
@@ -26,6 +26,7 @@
           <instructions>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/pom.xml
@@ -17,6 +17,20 @@
   <name>OpenNMS :: Features :: Topology :: Plugins :: Application</name>
   <packaging>bundle</packaging>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.opennms.features.topology</groupId>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/pom.xml
@@ -25,6 +25,7 @@
             <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.bsm/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.bsm/pom.xml
@@ -16,6 +16,20 @@
   <artifactId>org.opennms.features.topology.plugins.topo.bsm</artifactId>
   <name>OpenNMS :: Features :: Topology :: Plugins :: BSM</name>
   <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.opennms.features.topology</groupId>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/pom.xml
@@ -24,6 +24,7 @@
           <instructions>
             <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
@@ -21,6 +21,20 @@
 
   <packaging>bundle</packaging>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <!--
      | uncomment to add all imported (non-local) bundles to your compilation classpath

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.pathoutage/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.pathoutage/pom.xml
@@ -20,6 +20,20 @@
   <artifactId>org.opennms.features.topology.plugins.topo.pathoutage</artifactId>
   <name>OpenNMS :: Features :: Topology :: Plugins :: PathOutage</name>
   <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
 
     <!-- Embedded in jar (not provided) -->

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.vmware/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.vmware/pom.xml
@@ -15,6 +15,20 @@
   <artifactId>org.opennms.features.topology.plugins.topo.vmware</artifactId>
   <name>OpenNMS :: Features :: Topology :: Plugins :: VMware</name>
   <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <!--
      | uncomment to add all imported (non-local) bundles to your compilation classpath

--- a/features/vaadin-components/core/pom.xml
+++ b/features/vaadin-components/core/pom.xml
@@ -24,6 +24,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/vaadin-dashboard/pom.xml
+++ b/features/vaadin-dashboard/pom.xml
@@ -49,6 +49,7 @@
                         <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         <Vaadin-Widgetsets>org.opennms.features.vaadin.dashboard.DashboardWidgetSet</Vaadin-Widgetsets>
                         <Include-Resource>{maven-resources},target/gwt/</Include-Resource>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/vaadin-dashlets/dashlet-alarms/pom.xml
+++ b/features/vaadin-dashlets/dashlet-alarms/pom.xml
@@ -20,6 +20,20 @@
     <name>OpenNMS :: Features :: Dashlets :: Alarms</name>
 
     <packaging>bundle</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
 
         <dependency>

--- a/features/vaadin-dashlets/dashlet-bsm/pom.xml
+++ b/features/vaadin-dashlets/dashlet-bsm/pom.xml
@@ -20,6 +20,20 @@
     <name>OpenNMS :: Features :: Dashlets :: BSM</name>
 
     <packaging>bundle</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
 
         <dependency>

--- a/features/vaadin-dashlets/dashlet-grafana/pom.xml
+++ b/features/vaadin-dashlets/dashlet-grafana/pom.xml
@@ -21,6 +21,20 @@
     <name>OpenNMS :: Features :: Dashlets :: Grafana</name>
 
     <packaging>bundle</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>org.opennms.features</groupId>

--- a/features/vaadin-jmxconfiggenerator/pom.xml
+++ b/features/vaadin-jmxconfiggenerator/pom.xml
@@ -26,6 +26,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         <Vaadin-Widgetsets>org.opennms.vaadin.DefaultWidgetset</Vaadin-Widgetsets>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/vaadin-surveillance-views/pom.xml
+++ b/features/vaadin-surveillance-views/pom.xml
@@ -40,6 +40,7 @@
                         <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         <Vaadin-Widgetsets>org.opennms.vaadin.DefaultWidgetset</Vaadin-Widgetsets>
                         <Include-Resource>{maven-resources}</Include-Resource>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/wsman/pom.xml
+++ b/features/wsman/pom.xml
@@ -24,6 +24,7 @@
             <!-- Don't export any packages, expose services only. -->
             <Export-Package></Export-Package>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               org.opennms.core.network,

--- a/integrations/opennms-R/pom.xml
+++ b/integrations/opennms-R/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/integrations/opennms-geoip-provisioning-adapter/pom.xml
+++ b/integrations/opennms-geoip-provisioning-adapter/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/integrations/opennms-jasper-extensions/pom.xml
+++ b/integrations/opennms-jasper-extensions/pom.xml
@@ -29,6 +29,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/integrations/opennms-snmp-metadata-provisioning-adapter/pom.xml
+++ b/integrations/opennms-snmp-metadata-provisioning-adapter/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/integrations/opennms-vmware/pom.xml
+++ b/integrations/opennms-vmware/pom.xml
@@ -25,6 +25,7 @@
               <!-- Don't export any packages, expose services only. -->
               <Export-Package></Export-Package>
               <Import-Package>
+                ${guavaImportPackage},
                 org.eclipse.persistence.internal.jaxb;resolution:=optional,
                 org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
                 org.opennms.core.network,

--- a/integrations/opennms-wsman-asset-provisioning-adapter/pom.xml
+++ b/integrations/opennms-wsman-asset-provisioning-adapter/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-alarms/api/pom.xml
+++ b/opennms-alarms/api/pom.xml
@@ -24,6 +24,7 @@
               org.opennms.netmgt.alarmd.api.support.*;version="${project.version}",
               org.opennms.netmgt.alarmd.api.*;version="${project.version}"
             </Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-alarms/daemon/pom.xml
+++ b/opennms-alarms/daemon/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-alarms/email-northbounder/pom.xml
+++ b/opennms-alarms/email-northbounder/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>org.opennms.netmgt.alarmd.northbounder.email.*;version="${project.version}"</Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-config-dao/poll-outages/impl/pom.xml
+++ b/opennms-config-dao/poll-outages/impl/pom.xml
@@ -22,6 +22,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/opennms-config-dao/thresholding/impl/pom.xml
+++ b/opennms-config-dao/thresholding/impl/pom.xml
@@ -22,6 +22,7 @@
                         <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>${guavaImportPackage},*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/opennms-config-jaxb/pom.xml
+++ b/opennms-config-jaxb/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               org.opennms.netmgt.collection.adapters,

--- a/opennms-config-model/pom.xml
+++ b/opennms-config-model/pom.xml
@@ -98,6 +98,7 @@
               org.opennms.netmgt.xml.rtc.*;version="${project.version}"
             </Export-Package>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               io.swagger.v3.oas.annotations;resolution:=optional,

--- a/opennms-config/pom.xml
+++ b/opennms-config/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-correlation/drools-correlation-engine/pom.xml
+++ b/opennms-correlation/drools-correlation-engine/pom.xml
@@ -79,7 +79,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
-            <Import-Package>io.swagger.v3.oas.annotations;resolution:=optional,*</Import-Package>
+            <Import-Package>${guavaImportPackage},io.swagger.v3.oas.annotations;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-dao-api/pom.xml
+++ b/opennms-dao-api/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-dao/pom.xml
+++ b/opennms-dao/pom.xml
@@ -32,6 +32,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-enterprise-reporting/opennms-reportd/pom.xml
+++ b/opennms-enterprise-reporting/opennms-reportd/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-icmp/opennms-icmp-api/pom.xml
+++ b/opennms-icmp/opennms-icmp-api/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>org.opennms.netmgt.icmp.*;version="${project.version}"</Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-icmp/opennms-icmp-best/pom.xml
+++ b/opennms-icmp/opennms-icmp-best/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>org.opennms.netmgt.icmp.best.*;version="${project.version}"</Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/pom.xml
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               *

--- a/opennms-javamail/opennms-javamail-api/pom.xml
+++ b/opennms-javamail/opennms-javamail-api/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-model/pom.xml
+++ b/opennms-model/pom.xml
@@ -40,6 +40,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Import-Package>
+              ${guavaImportPackage},
               javassist.util.proxy,
               org.hibernate.proxy,
               *

--- a/opennms-provision/opennms-detector-jmx/pom.xml
+++ b/opennms-provision/opennms-detector-jmx/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>org.opennms.netmgt.provision.detector.jmx.*;version="${project.version}"</Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-provision/opennms-detector-registry/pom.xml
+++ b/opennms-provision/opennms-detector-registry/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-provision/opennms-detector-simple/pom.xml
+++ b/opennms-provision/opennms-detector-simple/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>org.opennms.netmgt.provision.detector.icmp.*;org.opennms.netmgt.provision.detector.loop.*;org.opennms.netmgt.provision.detector.smb.*;org.opennms.netmgt.provision.detector.snmp.*;version="${project.version}"</Export-Package>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-provision/opennms-detectorclient-rpc/pom.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               *

--- a/opennms-provision/opennms-provision-geolocation/pom.xml
+++ b/opennms-provision/opennms-provision-geolocation/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-provision/opennms-provision-persistence/pom.xml
+++ b/opennms-provision/opennms-provision-persistence/pom.xml
@@ -80,6 +80,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-provision/opennms-provision-shell/pom.xml
+++ b/opennms-provision/opennms-provision-shell/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Karaf-Commands>*</Karaf-Commands>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-provision/opennms-provisiond/pom.xml
+++ b/opennms-provision/opennms-provisiond/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-provision/opennms-requisition-dns/pom.xml
+++ b/opennms-provision/opennms-requisition-dns/pom.xml
@@ -23,6 +23,7 @@
             <!-- Don't export any packages, expose services only. -->
             <Export-Package></Export-Package>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               *

--- a/opennms-provision/opennms-requisition-service/pom.xml
+++ b/opennms-provision/opennms-requisition-service/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Import-Package>
+              ${guavaImportPackage},
               org.opennms.netmgt.model;resolution:=optional,
               *
             </Import-Package>

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-web-api/pom.xml
+++ b/opennms-web-api/pom.xml
@@ -20,6 +20,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>${guavaImportPackage},*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -147,6 +147,8 @@
             <Embed-Transitive>true</Embed-Transitive>
 
             <Import-Package>
+              ${guavaImportPackage},
+
               <!-- 
                 These are required classes that are not autodetected by bnd from:
                   - web.xml

--- a/pom.xml
+++ b/pom.xml
@@ -2947,6 +2947,11 @@
       </dependency>
       <dependency>
         <groupId>org.opennms.dependencies</groupId>
+        <artifactId>jest-complete-osgi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.opennms.dependencies</groupId>
         <artifactId>jfreechart-dependencies</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
@@ -4512,6 +4517,16 @@
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
         <version>${jakartaXmlBindVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.searchbox</groupId>
+        <artifactId>jest</artifactId>
+        <version>${jestVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.searchbox</groupId>
+        <artifactId>jest-common</artifactId>
+        <version>${jestVersion}</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1811,6 +1811,9 @@
     <vaadinLocalWorkers>${maxCpus}</vaadinLocalWorkers>
     <skipPdfGeneration>true</skipPdfGeneration>
 
+    <!-- use to easily template adding Guava to Import-Packages in bundles -->
+    <guavaImportPackage>com.google.common.*;version="${guavaVersion}"</guavaImportPackage>
+
     <!-- nodejs development -->
     <frontendPluginVersion>1.12.1</frontendPluginVersion>
     <nodeVersion>v16.18.1</nodeVersion>

--- a/protocols/xml/pom.xml
+++ b/protocols/xml/pom.xml
@@ -24,6 +24,7 @@
             <!-- Don't export any packages, expose services only. -->
             <Export-Package></Export-Package>
             <Import-Package>
+              ${guavaImportPackage},
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               org.opennms.core.network,


### PR DESCRIPTION
Friday cleanup work. :)

This PR does a couple of things:

1. move the weird jest thing we make into `dependencies/` and no longer mask a real project that isn't ours (and fix its guava dependencies)
2. add bundle `<Import-Package>` entries for Guava anywhere it's used, so you're allowed to use equal-to-or-higher versions.

A quick test shows everything still starts up normally, and these fixes will be even _better_ when they come forward to H32 since it will let us move forward on Guava versions without breaking existing things, and Newts will finally be in line with our newer Guava dependency.