### PR TITLE
Update README.md to link to install-scripts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Install OpenNMS
 
 For details on installing OpenNMS, see [Install OpenNMS][].
 
+TL;DR - If you just want to set up a simple non-production evaluation of OpenNMS Horizon on Linux, some basic install scripts are available at [opennms-forge/opennms-install](https://github.com/opennms-forge/opennms-install)
+
 Build OpenNMS
 ================
 


### PR DESCRIPTION
Added link on front page README to install scripts on opennms-forge

https://opennms.atlassian.net/browse/NMS-16129

TL;DR - If you just want to set up a simple non-production evaluation of OpenNMS Horizon on Linux, some basic install scripts are available at [opennms-forge/opennms-install](https://github.com/opennms-forge/opennms-install)

People just evaluating OpenNMS find these scripts very helpful to reduce the time to get a simple system working.
