### PR TITLE
NMS-16130: Save node preferences to local storage

### DIFF
--- a/ui/src/components/Nodes/ColumnSelectionPanel.vue
+++ b/ui/src/components/Nodes/ColumnSelectionPanel.vue
@@ -1,35 +1,31 @@
 <template>
   <div class="column-select-container">
-    <div>
-      <div>
-        <div class="feather-row node-actions-reset">
-          <div class="feather-col-9">
-          </div>
-          <div class="feather-col-3">
-            <FeatherButton primary @click="resetToDefault">Default</FeatherButton>
-          </div>
+    <div class="feather-row node-actions-reset">
+      <div class="feather-col-9">
+      </div>
+      <div class="feather-col-3 centered">
+        <FeatherButton secondary @click="resetToDefault">Default</FeatherButton>
+      </div>
+    </div>
+  </div>
+  <div
+    v-for="(col, index) in columns"
+    :key="col.id"
+    >
+      <div class="feather-row column-select-item-wrapper">
+        <div class="feather-col-9">
+          <FeatherCheckbox
+            class="checkbox"
+            @update:modelValue="selectColumn(col)"
+            :modelValue="col.selected"
+          >{{ col.label }}</FeatherCheckbox>
+        </div>
+        <div class="feather-col-3 centered">
+          <FeatherIcon :icon="upIcon" title="Move Up" @click="columnMove(true, index)" :class="getOrderIconCssClasses(true, index)" />
+          <FeatherIcon :icon="downIcon" title="Move Down" @click="columnMove(false, index)" :class="getOrderIconCssClasses(false, index)" />
         </div>
       </div>
-      <div
-        v-for="(col, index) in columns"
-        :key="col.id"
-        >
-          <div class="feather-row column-select-item-wrapper">
-            <div class="feather-col-9">
-              <FeatherCheckbox
-                class="checkbox"
-                @update:modelValue="selectColumn(col)"
-                :modelValue="col.selected"
-              >{{ col.label }}</FeatherCheckbox>
-            </div>
-            <div class="feather-col-3">
-              <FeatherIcon :icon="upIcon" title="Move Up" @click="columnMove(true, index)" :class="getOrderIconCssClasses(true, index)" />
-              <FeatherIcon :icon="downIcon" title="Move Down" @click="columnMove(false, index)" :class="getOrderIconCssClasses(false, index)" />
-            </div>
-          </div>
-      </div>
-    </div> 
-  </div> 
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -109,7 +105,6 @@ button.btn.btn-icon .node-actions-icon {
 }
 
 .column-select-container {
-  overflow-y: auto;
   padding: 4px;
 }
 
@@ -134,5 +129,9 @@ button.btn.btn-icon .node-actions-icon {
   &-down {
     margin-left: 4px;
   }
+}
+
+.feather-col-3.centered {
+  text-align: center;
 }
 </style>

--- a/ui/src/components/Nodes/NodePreferencesDialog.vue
+++ b/ui/src/components/Nodes/NodePreferencesDialog.vue
@@ -9,18 +9,27 @@
           <ColumnSelectionPanel></ColumnSelectionPanel>
         </FeatherTabPanel>
       </FeatherTabContainer>
+      <div class="button-panel">
+        <FeatherButton
+          primary
+          @click="savePreferences"
+        >Save and Close</FeatherButton>
+      </div>
     </div>
   </FeatherDialog>
 </template>
 
 <script setup lang="ts">
+import { FeatherButton } from '@featherds/button'
 import { FeatherDialog } from '@featherds/dialog'
 import {
   FeatherTab,
   FeatherTabContainer,
-  FeatherTabPanel,
+  FeatherTabPanel
 } from '@featherds/tabs'
 import ColumnSelectionPanel from './ColumnSelectionPanel.vue'
+import { saveNodePreferences } from '@/services/localStorageService'
+import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 
 defineProps({
   visible: {
@@ -29,13 +38,20 @@ defineProps({
   }
 })
 
-defineEmits(['close'])
+const emit = defineEmits(['close'])
+
+const nodeStructureStore = useNodeStructureStore()
 
 const labels = reactive({
   title: 'Node Preferences',
   close: 'Close'
 })
 
+const savePreferences = async () => {
+  const nodePrefs = await nodeStructureStore.getNodePreferences()
+  saveNodePreferences(nodePrefs)
+  emit('close', true)
+}
 </script>
 
 <style scoped lang="scss">
@@ -43,7 +59,12 @@ const labels = reactive({
   min-height: 300px;
   max-height: 600px;
   min-width: 550px;
+  overflow-x: hidden;
   overflow-y: auto;
   position: relative;
+}
+
+.button-panel {
+  margin-top: 0.5em;
 }
 </style>

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -14,7 +14,7 @@
               <FeatherIcon :icon="settingsIcon" class="node-actions-icon" />
             </FeatherButton>
           </div>
-          <div class="feather-col-11">
+          <div class="feather-col-11 search-filter-column">
             <FeatherInput
               @update:modelValue="searchFilterHandler"
               label="Search node label"
@@ -305,5 +305,9 @@ table {
 .title {
   @include headline1;
   display: block;
+}
+
+.feather-col-11.search-filter-column {
+  padding-left: 1rem;
 }
 </style>

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -24,10 +24,13 @@
 import NodesTable from '@/components/Nodes/NodesTable.vue'
 import NodeStructurePanel from '@/components/Nodes/NodeStructurePanel.vue'
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import { loadNodePreferences } from '@/services/localStorageService'
 import { useMenuStore } from '@/stores/menuStore'
+import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 import { BreadCrumb } from '@/types'
 
 const menuStore = useMenuStore()
+const nodeStructureStore = useNodeStructureStore()
 const homeUrl = computed<string>(() => menuStore.mainMenu?.homeUrl)
 
 const breadcrumbs = computed<BreadCrumb[]>(() => {
@@ -37,6 +40,14 @@ const breadcrumbs = computed<BreadCrumb[]>(() => {
   ]
 })
 
+onMounted(() => {
+  // load any saved preferences
+  const prefs = loadNodePreferences()
+
+  if (prefs) {
+    nodeStructureStore.setFromNodePreferences(prefs)
+  }
+})
 </script>
   
 <style lang="scss" scoped>

--- a/ui/src/services/localStorageService.ts
+++ b/ui/src/services/localStorageService.ts
@@ -1,0 +1,56 @@
+import { NodePreferences, OpenNmsPreferences } from '@/types'
+
+const OPENNMS_PREFERENCES_STORAGE_KEY = 'opennms-preferences'
+
+const defaultPreferences = () => {
+  return {
+    nodePreferences: {
+      nodeColumns: []
+    }
+  } as OpenNmsPreferences
+}
+
+export const savePreferences = (data: OpenNmsPreferences) => {
+  localStorage.setItem(OPENNMS_PREFERENCES_STORAGE_KEY, JSON.stringify(data, getCircularReplacer()))
+}
+
+export const loadPreferences = (): OpenNmsPreferences | null => {
+  const json = localStorage.getItem(OPENNMS_PREFERENCES_STORAGE_KEY)
+
+  if (json) {
+    const data = JSON.parse(json)
+    
+    if (data) {
+      return data as OpenNmsPreferences
+    }
+  }
+
+  return null
+}
+
+export const saveNodePreferences = (data: NodePreferences) => {
+  const prefs = loadPreferences() || defaultPreferences()
+  prefs.nodePreferences = data
+
+  savePreferences(prefs)
+}
+
+export const loadNodePreferences = (): NodePreferences | null => {
+  const prefs = loadPreferences() || defaultPreferences()
+
+  return prefs.nodePreferences
+}
+
+const getCircularReplacer = () => {
+  const seen = new WeakSet()
+
+  return (key: any, value: any) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return
+      }
+      seen.add(value)
+    }
+    return value
+  }
+}

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -1,6 +1,13 @@
 import { defineStore } from 'pinia'
 import API from '@/services'
-import { Category, MonitoringLocation, NodeColumnSelectionItem, SetOperator } from '@/types'
+import {
+  Category,
+  MonitoringLocation,
+  NodeColumnSelectionItem,
+  NodeFilterPreferences,
+  NodePreferences,
+  SetOperator
+} from '@/types'
 
 export const defaultColumns: NodeColumnSelectionItem[] = [
   { id: 'id', label: 'ID', selected: false, order: 0 },
@@ -79,6 +86,46 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     columns.value = [...newColumns]
   }
 
+  const getNodePreferences = async () => {
+    const nodeColumns = columns.value
+
+    const nodeFilter = {
+      categoryMode: categoryMode.value,
+      selectedCategories: selectedCategories.value,
+      selectedFlows: selectedFlows.value,
+      selectedMonitoringLocations: selectedMonitoringLocations.value
+    } as NodeFilterPreferences
+
+    const nodePrefs = {
+      nodeColumns,
+      nodeFilter
+    } as NodePreferences
+
+    return nodePrefs
+  }
+
+  const setFromNodePreferences = async (prefs: NodePreferences) => {
+    if (prefs.nodeColumns?.length) {
+      columns.value = [...prefs.nodeColumns]
+    }
+
+    if (prefs.nodeFilter) {
+      categoryMode.value = prefs.nodeFilter.categoryMode
+
+      if (prefs.nodeFilter.selectedCategories?.length) {
+        selectedCategories.value = [...prefs.nodeFilter.selectedCategories]
+      }
+
+      if (prefs.nodeFilter.selectedFlows?.length) {
+        selectedFlows.value = [...prefs.nodeFilter.selectedFlows]
+      }
+
+      if (prefs.nodeFilter.selectedMonitoringLocations?.length) {
+        selectedMonitoringLocations.value = [...prefs.nodeFilter.selectedMonitoringLocations]
+      }
+    }
+  }
+
   return {
     categories,
     categoryCount,
@@ -90,12 +137,14 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     selectedMonitoringLocations,
     getCategories,
     getMonitoringLocations,
+    getNodePreferences,
     resetColumnSelectionToDefault,
     setSelectedCategories,
     setCategoryMode,
     setSelectedFlows,
     setSelectedMonitoringLocations,
     setNodeColumnSelection,
+    setFromNodePreferences,
     updateNodeColumnSelection
   }
 })

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -505,3 +505,19 @@ export enum SetOperator {
   Union = 1,
   Intersection = 2
 }
+
+export interface NodeFilterPreferences {
+  categoryMode: SetOperator
+  selectedCategories: Category[]
+  selectedFlows: string[]
+  selectedMonitoringLocations: MonitoringLocation[]
+}
+
+export interface NodePreferences {
+  nodeColumns: NodeColumnSelectionItem[]
+  nodeFilter?: NodeFilterPreferences
+}
+
+export interface OpenNmsPreferences {
+  nodePreferences: NodePreferences
+}


### PR DESCRIPTION
On the Node Structure page, add a "Save and Close" button in the Preferences dialog to save all column and filter preferences to browser local storage. When the page loads, it will attempt to load any existing preferences.

This will save preferences if browser is closed and reopened, but of course the won't be saved if the user moves to a different browser or machine, and doesn't distinguish between different users in same machine user session. If needed, we can use Config Management / CM.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16130

