### PR TITLE
NMS-14078: Fix AdminPasswordGateIT smoke test

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -291,7 +291,7 @@ public abstract class AbstractOpenNMSSeleniumHelper {
      * skip the password gate page and then close the Usage Statistics Sharing dialog if present.
      */
     public void login() {
-        login(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, true, true, true);
+        login(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, true, true, true, false);
     }
 
     /**
@@ -308,13 +308,15 @@ public abstract class AbstractOpenNMSSeleniumHelper {
      *     to a different page before calling this method, e.g. to test that redirect after login works.
      */
     public void login(final String username, final String password, final boolean skip, final boolean closeUsageStatsSharing,
-                      final boolean navigateToLoginPage) {
-        LOG.debug("Login: username={}, skip={}, closeUsageStatsSharing={}, navigateToLoginPage={}",
-            username, skip, closeUsageStatsSharing, navigateToLoginPage);
+                      final boolean navigateToLoginPage, final boolean skipCookieDeletion) {
+        LOG.debug("Login: username={}, skip={}, closeUsageStatsSharing={}, navigateToLoginPage={}, skipCookieDeletion={}",
+            username, skip, closeUsageStatsSharing, navigateToLoginPage, skipCookieDeletion);
 
         if (navigateToLoginPage) {
-            // Start with a clean slate
-            getDriver().manage().deleteAllCookies();
+            if (!skipCookieDeletion) {
+                // Start with a clean slate
+                getDriver().manage().deleteAllCookies();
+            }
 
             getDriver().get(getBaseUrlInternal() + "opennms/login.jsp");
         }


### PR DESCRIPTION
[NMS-14078](https://opennms.atlassian.net/browse/NMS-14078) / [PR 6659](https://github.com/OpenNMS/opennms/pull/6659) introduced some changes that caused the `AdminPasswordGateIT` smoke test to fail. These partly have to do with the smoke test being somewhat contrived.

- removing cookies resulted in Rest API call to reset admin password to fail with a `401 Forbidden`
- issues when logged out, then navigating to a different page than the login page, logging in, then should be redirected back to original page

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-14078



[NMS-14078]: https://opennms.atlassian.net/browse/NMS-14078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ