### PR TITLE
NMS-16126: Node structure, add management IP or best IP address

### DIFF
--- a/ui/src/components/Nodes/ManagementIPTooltipCell.vue
+++ b/ui/src/components/Nodes/ManagementIPTooltipCell.vue
@@ -1,0 +1,45 @@
+<template>
+  <td :class="ipInfo.label ? 'pointer' : ''">
+    <FeatherTooltip
+      :title="tooltipTitle"
+      :alignment="PointerAlignment.left"
+      :placement="PopoverPlacement.top"
+      v-slot="{ attrs, on }">
+        <a v-bind="attrs" v-on="on" :href="computeNodeIpInterfaceLink(node.id, ipInfo.label)">
+          {{ ipInfo.label }}
+        </a>
+    </FeatherTooltip>
+  </td>
+</template>
+
+<script setup lang="ts">
+import { IpInterface, Node } from '@/types'
+import { FeatherTooltip, PointerAlignment, PopoverPlacement } from '@featherds/tooltip'
+import { PropType } from 'vue'
+import { IpInterfaceInfo, getBestIpInterfaceForNode } from './utils'
+
+const props = defineProps({
+  computeNodeIpInterfaceLink: {
+    required: true,
+    type: Function as PropType<(nodeId: number | string, ipAddress: string) => string>
+  },
+  node: {
+    required: true,
+    type: Object as PropType<Node>
+  },
+  nodeToIpInterfaceMap: {
+    required: true,
+    type: Object as PropType<Map<string, IpInterface[]>>
+  }
+})
+
+const ipInfo = computed<IpInterfaceInfo>(() => getBestIpInterfaceForNode(props.node.id, props.nodeToIpInterfaceMap))
+
+const tooltipTitle = computed<string>(() => {
+  const managed = ipInfo.value.managed ? 'Managed' : 'Unmanaged'
+  const primary = ipInfo.value.primaryLabel
+
+  return [managed, primary].join(', ')
+})
+
+</script>

--- a/ui/src/components/Nodes/NodeDetailsDialog.vue
+++ b/ui/src/components/Nodes/NodeDetailsDialog.vue
@@ -56,7 +56,7 @@ const nodeItems = computed(() => {
   return [
     { label: 'Node ID', text: props.node?.id, link: props.computeNodeLink(props.node?.id || 0) },
     { label: 'Node Label', text: props.node?.label, link: props.computeNodeLink(props.node?.id || 0) },
-    { label: 'IP Address', text: ipLabel.label, link: props.computeNodeIpInterfaceLink(props.node?.id || 0, ipLabel.ip) },
+    { label: 'IP Address', text: ipLabel.label, link: props.computeNodeIpInterfaceLink(props.node?.id || 0, ipLabel.label) },
     { label: 'Location', text: props.node?.location },
     { label: 'FS:FID', text: `${props.node?.foreignSource}:${props.node?.foreignId}` },
     { label: 'Sys Contact', text: props.node?.sysContact || EMPTY },

--- a/ui/src/components/Nodes/NodeDetailsDialog.vue
+++ b/ui/src/components/Nodes/NodeDetailsDialog.vue
@@ -17,13 +17,18 @@
 <script setup lang="ts">
 import { PropType } from 'vue'
 import { FeatherDialog } from '@featherds/dialog'
-import { hasEgressFlow, hasIngressFlow } from './utils'
+import { getBestIpInterfaceForNode, hasEgressFlow, hasIngressFlow } from './utils'
+import { useNodeStore } from '@/stores/nodeStore'
 import { Node } from '@/types'
 
 const props = defineProps({
   computeNodeLink: {
     required: true,
     type: Function as PropType<(id: number | string) => string>
+  },
+  computeNodeIpInterfaceLink: {
+    required: true,
+    type: Function as PropType<(nodeId: number | string, ipAddress: string) => string>
   },
   visible: {
     required: true,
@@ -43,11 +48,15 @@ const labels = reactive({
 })
 
 const EMPTY = '--'
+const nodeStore = useNodeStore()
 
 const nodeItems = computed(() => {
+  const ipLabel = getBestIpInterfaceForNode(props.node?.id || '', nodeStore.nodeToIpInterfaceMap)
+
   return [
     { label: 'Node ID', text: props.node?.id, link: props.computeNodeLink(props.node?.id || 0) },
     { label: 'Node Label', text: props.node?.label, link: props.computeNodeLink(props.node?.id || 0) },
+    { label: 'IP Address', text: ipLabel.label, link: props.computeNodeIpInterfaceLink(props.node?.id || 0, ipLabel.ip) },
     { label: 'Location', text: props.node?.location },
     { label: 'FS:FID', text: `${props.node?.foreignSource}:${props.node?.foreignId}` },
     { label: 'Sys Contact', text: props.node?.sysContact || EMPTY },

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -85,11 +85,12 @@
                       {{ node.label }}
                     </a>
                   </td>
-                  <td v-if="isSelectedColumn(column, 'ipaddress')">
-                    <a :href="computeNodeIpInterfaceLink(node.id, getIpAddressLabel(node.id).ip)">
-                      {{ getIpAddressLabel(node.id).label }}
-                    </a>
-                  </td>
+
+                  <ManagementIPTooltipCell v-if="isSelectedColumn(column, 'ipaddress')"
+                    :computeNodeIpInterfaceLink="computeNodeIpInterfaceLink"
+                    :node="node"
+                    :nodeToIpInterfaceMap="nodeStore.nodeToIpInterfaceMap"
+                  />
 
                   <td v-if="isSelectedColumn(column, 'location')">{{ node.location }}</td>
 
@@ -138,6 +139,7 @@ import Settings from '@featherds/icon/action/Settings'
 import { FeatherInput } from '@featherds/input'
 import { FeatherSortHeader, SORT } from '@featherds/table'
 import FlowTooltipCell from './FlowTooltipCell.vue'
+import ManagementIPTooltipCell from './ManagementIPTooltipCell.vue'
 import NodeActionsDropdown from './NodeActionsDropdown.vue'
 import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
 import NodeDetailsDialog from './NodeDetailsDialog.vue'
@@ -148,7 +150,6 @@ import {
   buildUpdatedNodeStructureQueryParams,
   generateBlob,
   generateDownload,
-  getBestIpInterfaceForNode,
   getExportData,
   getTableCssClasses,
   NodeStructureQueryParams
@@ -231,7 +232,7 @@ const getNodeTotalCount = () => {
 }
 
 const { queryParameters, updateQueryParameters, sort } = useQueryParameters({
-  limit: 10,
+  limit: 20,
   offset: 0,
   orderBy: 'label'
 }, nodeQuery)
@@ -301,10 +302,6 @@ const updateQuery = (searchVal?: string) => {
 
   nodeStore.getNodes(updatedParams, true)
   queryParameters.value = updatedParams
-}
-
-const getIpAddressLabel = (nodeId: string) => {
-  return getBestIpInterfaceForNode(nodeId, nodeStore.nodeToIpInterfaceMap)
 }
 
 const computeNodeLink = (nodeId: number | string) => {

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -33,7 +33,7 @@ import { getAliases, getCredentialsByAlias, addCredentials, updateCredentials } 
 import { getAlarms, modifyAlarm } from './alarmService'
 import { getEvents } from './eventService'
 import { getNodeIfServices } from './ifService'
-import { getIpInterfaces } from './ipInterfaceService'
+import { getIpInterfaces, getNodeIpInterfaceQuery } from './ipInterfaceService'
 import { search } from './searchService'
 import { getLogs, getLog } from './logsService'
 import { getWhoAmI } from './whoAmIService'
@@ -59,6 +59,7 @@ export default {
   getNodeOutages,
   getNodeIfServices,
   getIpInterfaces,
+  getNodeIpInterfaceQuery,
   getGraphNodesNodes,
   getNodeIpInterfaces,
   getNodeSnmpInterfaces,

--- a/ui/src/services/ipInterfaceService.ts
+++ b/ui/src/services/ipInterfaceService.ts
@@ -21,3 +21,16 @@ export const getIpInterfaces = async (queryParameters?: QueryParameters): Promis
     return false
   }
 }
+
+/**
+ * Construct the '_s' part of the getIpInterfaces query string with the given node ids and whether
+ * to return only managed interfaces or all.
+ * Use this in QueryParameters passed to getIpInterfaces.
+ */
+export const getNodeIpInterfaceQuery = (nodeIds: string[], managedOnly: boolean) => {
+  const ids = nodeIds.map(id => `node.id==${id}`).join(',')
+
+  const managedQuery = managedOnly ? ';isManaged==M' : ''
+
+  return `(${ids}${managedQuery})`
+}

--- a/ui/src/stores/nodeStore.ts
+++ b/ui/src/stores/nodeStore.ts
@@ -65,6 +65,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
   const getIpInterfacesForNodes = async (nodeIds: string[], managedOnly: boolean) => {
     const query = getNodeIpInterfaceQuery(nodeIds, managedOnly)
     const queryParameters = {
+      limit: nodeIds.length,
       _s: query
     } as QueryParameters
 

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -12,13 +12,14 @@ import {
 export const defaultColumns: NodeColumnSelectionItem[] = [
   { id: 'id', label: 'ID', selected: false, order: 0 },
   { id: 'label', label: 'Node Label', selected: true, order: 1 },
-  { id: 'location', label: 'Location', selected: true, order: 2 },
-  { id: 'foreignSource', label: 'Foreign Source', selected: true, order: 3 },
-  { id: 'foreignId', label: 'Foreign ID', selected: true, order: 4 },
-  { id: 'sysContact', label: 'Sys Contact', selected: true, order: 5 },
-  { id: 'sysLocation', label: 'Sys Location', selected: true, order: 6 },
-  { id: 'sysDescription', label: 'Sys Description', selected: true, order: 7 },
-  { id: 'flows', label: 'Flows', selected: true, order: 8 }
+  { id: 'ipaddress', label: 'IP Address', selected: true, order: 2 },
+  { id: 'location', label: 'Location', selected: true, order: 3 },
+  { id: 'foreignSource', label: 'Foreign Source', selected: true, order: 4 },
+  { id: 'foreignId', label: 'Foreign ID', selected: true, order: 5 },
+  { id: 'sysContact', label: 'Sys Contact', selected: true, order: 6 },
+  { id: 'sysLocation', label: 'Sys Location', selected: true, order: 7 },
+  { id: 'sysDescription', label: 'Sys Description', selected: true, order: 8 },
+  { id: 'flows', label: 'Flows', selected: true, order: 9 }
 ]
 
 export const useNodeStructureStore = defineStore('nodeStructureStore', () => {


### PR DESCRIPTION
Add the management IP address, or at least the "best" IP address, to the node table.

Any time the node query changes (sorting, filters, search), we also launch an IP Address query for the returned nodes and update a map.

For each node, we try to use the IP interface where snmpPrimary is 'P', or else at least isManaged, or else the first or onlly IP. Tooltip displays managed and SNMP Primary status, clicking on link brings you to the 'classic' IP Interface page.

Currently cannot sort by IP Address, but you can configure whether it displays and in which column order. Also displays in the Node Details dialog, and it has a link to the legacy IP Interface page.

Updated default pagination to 20 nodes per page.

Updated Search to have an implicit start and end wildcard, e.g. typing `host` will do a search on `*host*` and return nodes with labels like `localhost`, `host123`, 'my_host_name`, etc.

<img width="1058" alt="node-table-ipaddress" src="https://github.com/OpenNMS/opennms/assets/1933710/3e8c6ae7-55f5-4395-9731-5f40571b5a44">


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16126

