### PR TITLE
Minion docker doc install update

### DIFF
--- a/docs/modules/deployment/pages/minion/docker/minion.adoc
+++ b/docs/modules/deployment/pages/minion/docker/minion.adoc
@@ -101,7 +101,7 @@ Next, we need to create the keystore file and add the credentials for connecting
 ----
 mkdir keystore
 chown -R 10001:10001 keystore<1>
-docker-compose run -v $(pwd)/keystore:/keystore minion -s<2>
+docker-compose run --rm -v $(pwd)/keystore:/keystore minion -s<2>
 ----
 <1> Assign ownership so the container user account can write within the directory.
 <2> When prompted, enter the username and password for a `ROLE_MINION` user account on the {page-component-title} server.


### PR DESCRIPTION
Add flag to delete the temporary container used for creating the keystore.  Without this, extra containers are left behind on the system for the user to cleanup later.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): No Jira

