### PR TITLE
NMS-15062: update ActiveMQ to 5.15.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1585,7 +1585,7 @@
     <antVersion>1.10.13</antVersion>
     <args4jVersion>2.33</args4jVersion>
     <asmVersion>9.5</asmVersion>
-    <activemqVersion>5.15.5</activemqVersion>
+    <activemqVersion>5.15.15</activemqVersion>
     <atomikosVersion>3.9.2</atomikosVersion>
     <batikVersion>1.17</batikVersion>
     <bouncyCastleVersion>1.76</bouncyCastleVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1585,7 +1585,7 @@
     <antVersion>1.10.13</antVersion>
     <args4jVersion>2.33</args4jVersion>
     <asmVersion>9.5</asmVersion>
-    <activemqVersion>5.15.15</activemqVersion>
+    <activemqVersion>5.15.9</activemqVersion>
     <atomikosVersion>3.9.2</atomikosVersion>
     <batikVersion>1.17</batikVersion>
     <bouncyCastleVersion>1.76</bouncyCastleVersion>


### PR DESCRIPTION
5.15.9 is the last version compatible with our Camel version.  We needed to be on 5.15.8 or higher to deal with CVE-2018-11775 and CVE-2019-0222.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15062