### PR TITLE
NMS-16171: switch to the community fork of bsh 2.x

### DIFF
--- a/features/poller/monitors/core/pom.xml
+++ b/features/poller/monitors/core/pom.xml
@@ -57,6 +57,12 @@
     <dependency>
       <groupId>org.jolokia</groupId>
       <artifactId>jolokia-client-java</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>bsh</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opennms.features</groupId>

--- a/opennms-alarms/bsf-northbounder/pom.xml
+++ b/opennms-alarms/bsf-northbounder/pom.xml
@@ -61,7 +61,7 @@
       <artifactId>bsf</artifactId>
     </dependency>
     <dependency>
-      <groupId>bsh</groupId>
+      <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
     </dependency>
     <!-- test dependencies -->

--- a/opennms-correlation/drools-correlation-engine/pom.xml
+++ b/opennms-correlation/drools-correlation-engine/pom.xml
@@ -95,7 +95,7 @@
       <artifactId>opennms-correlator</artifactId>
     </dependency>
     <dependency>
-      <groupId>bsh</groupId>
+      <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
     </dependency>
     <dependency>

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -299,6 +299,12 @@
     <dependency>
       <groupId>org.jolokia</groupId>
       <artifactId>jolokia-client-java</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>bsh</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -328,9 +334,8 @@
       <artifactId>org.opennms.config-dao.poll-outages.impl</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- BeanShell scripting language -->
     <dependency>
-      <groupId>bsh</groupId>
+      <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1131,6 +1131,7 @@
                    <exclude>asm:*</exclude>                          <!-- use: org.ow2.asm.* -->
                    <exclude>org.ow2.asm:asm-all</exclude>            <!-- use: org.ow2.asm.* -->
                    <exclude>bouncycastle:*</exclude>                 <!-- use: org.bouncycastle:* instead, but not in a way that ends up in $OPENNMS_HOME/lib/ -->
+                   <exclude>bsh:*</exclude>                          <!-- use: org.apache-extras.beanshell:bsh -->
                    <exclude>c3p0:c3p0</exclude>                      <!-- use: com.mchange:c3p0 -->
                    <exclude>commons-logging:*</exclude>              <!-- use: jcl-over-slf4j -->
                    <exclude>com.github.detro:*</exclude>             <!-- use: com.codeborne.phantomjsdriver -->
@@ -3796,9 +3797,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>bsh</groupId>
+        <groupId>org.apache-extras.beanshell</groupId>
         <artifactId>bsh</artifactId>
-        <version>1.3.0</version>
+        <version>2.0b6</version>
       </dependency>
       <dependency>
         <groupId>org.mongodb</groupId>


### PR DESCRIPTION
This PR bumps beanshell to 2.0b6. There is a 2.1.1 version released now, but it hasn't been pushed to Maven Central yet.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16171

