### PR TITLE
NMS-16173: bump okio to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1734,7 +1734,7 @@
     <postgresqlVersion>42.5.4</postgresqlVersion>
     <powermockVersion>2.0.9</powermockVersion>
     <okhttpVersion>4.9.3</okhttpVersion>
-    <okioVersion>2.8.0</okioVersion>
+    <okioVersion>3.6.0</okioVersion>
     <opennmsApiVersion>1.5.0</opennmsApiVersion>
     <opennmsApiVersionOsgi>1.5.0</opennmsApiVersionOsgi>
     <osgiVersion>7.0.0</osgiVersion>


### PR DESCRIPTION
the 3.x series is backwards-compatible with 2.x, bump to latest 3.x

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16173