### PR TITLE
NMS-16116: Node structure add additional queries for snmp, flows, etc.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -58,6 +58,7 @@
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "ip-regex": "^5.0.0",
+    "is-ip": "^5.0.1",
     "is-valid-domain": "^0.1.6",
     "leaflet": "^1.8.0",
     "leaflet.markercluster": "^1.5.3",

--- a/ui/src/components/Nodes/ExtendedSearchPanel.vue
+++ b/ui/src/components/Nodes/ExtendedSearchPanel.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="extended-search-container">
+    <FeatherSelect
+      label="Search Type"
+      :options="searchOptions"
+      :textProp="'title'"
+      v-model="currentSelection"
+      @update:modelValue="onSelectionUpdated"
+    />
+
+    <FeatherInput
+      v-model="searchTerm"
+      @update:modelValue="onCurrentSearchUpdated"
+      label="Search Term"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { isIP } from 'is-ip'
+import { FeatherInput } from '@featherds/input'
+import { FeatherSelect, ISelectItemType } from '@featherds/select'
+import { useNodeQuery } from './hooks/useNodeQuery'
+import { useNodeStore } from '@/stores/nodeStore'
+import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { NodeQueryFilter, UpdateModelFunction } from '@/types'
+
+const searchOptions: ISelectItemType[] = [
+  { title: 'IP Address', value: 'ipAddress' },
+  { title: 'SNMP Alias', value: 'snmpIfAlias' },
+  { title: 'SNMP Description', value: 'snmpIfDesc' },
+  { title: 'SNMP Index', value: 'snmpIfIndex' },
+  { title: 'SNMP Name', value: 'snmpIfName' },
+  { title: 'SNMP Type', value: 'snmpIfType' }
+]
+const snmpKeys = ['snmpIfAlias', 'snmpIfDesc', 'snmpIfIndex', 'snmpIfName', 'snmpIfType']
+
+const { buildUpdatedNodeStructureQueryParameters } = useNodeQuery()
+const nodeStore = useNodeStore()
+const nodeStructureStore = useNodeStructureStore()
+const searchTerm = ref('')
+const currentSelection = ref<ISelectItemType | undefined>(undefined)
+
+const onCurrentSearchUpdated = (item: string) => {
+  if (currentSelection.value?.value === 'ipAddress') {
+    if (!isIP(item)) {
+      // prevent search with invalid IP addresses, they'll just cause 500 errors
+      return
+    }
+    nodeStructureStore.setFilterWithIpAddress(item)
+  } else if ((currentSelection.value?.value as string || '').startsWith('snmp')) {
+    nodeStructureStore.setFilterWithSnmpParams((currentSelection.value?.value as string), item)
+  }
+
+  updateQuery()
+}
+
+const onSelectionUpdated: UpdateModelFunction = (selected: any) => {
+  if (selected.value === 'ipAddress') {
+    nodeStructureStore.setFilterWithIpAddress(searchTerm.value)
+  } else if ((selected.value as string || '').startsWith('snmp')) {
+    nodeStructureStore.setFilterWithSnmpParams(selected.value, searchTerm.value)
+  }
+
+  updateQuery()
+}
+
+// helper used in getOptionFromFilter
+const getOptionFromObj = (obj: any, key: string) => {
+  if (obj[key]) {
+    return {
+      value: obj[key],
+      searchOption: searchOptions.find(x => x.value === key)
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Get an option object and search term based on the given filter.
+ * This prioritizes which search item is used.
+*/
+const getOptionFromFilter = (queryFilter: NodeQueryFilter) => {
+  if (queryFilter.ipAddress) {
+    return getOptionFromObj(queryFilter, 'ipAddress')
+  } else if (queryFilter.snmpParams) {
+    const p = queryFilter.snmpParams
+
+    for (let key of snmpKeys) {
+      const o = getOptionFromObj(p, key)
+
+      if (o) {
+        return o
+      }
+    }
+  }
+
+  return undefined
+}
+
+const updateQuery = () => {
+  // make sure anything setting nodeStore.nodeQueryParameters has been processed
+  nextTick()
+  const updatedParams = buildUpdatedNodeStructureQueryParameters(nodeStore.nodeQueryParameters, nodeStructureStore.queryFilter)
+
+  nodeStore.getNodes(updatedParams, true)
+}
+
+const updateFromStore = () => {
+  const option = getOptionFromFilter(nodeStructureStore.queryFilter)
+
+  if (option) {
+    searchTerm.value = option.value
+    currentSelection.value = option.searchOption
+  } else {
+    searchTerm.value = ''
+  }
+}
+
+watch([() => nodeStructureStore.queryFilter], () => {
+  updateFromStore()
+})
+
+onMounted(() => {
+  updateFromStore()
+})
+
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/ui/src/components/Nodes/NodeStructurePanel.vue
+++ b/ui/src/components/Nodes/NodeStructurePanel.vue
@@ -80,32 +80,20 @@
     </FeatherList>
   </FeatherExpansionPanel>
   <div class="search-autocomplete-panel">
-    <h1 class="title">Metadata Search</h1>
-    <FeatherAutocomplete
-      v-model="metaSearchString"
-      type="multi"
-      :results="metadataSearchResults"
-      label="Search"
-      class="map-search"
-      @search="resetMetaSearch"
-      :loading="loading"
-      :hideLabel="true"
-      text-prop="label"
-      @update:modelValue="selectMetaItem"
-      :labels="metaLabels"
-    ></FeatherAutocomplete>
+    <h1 class="title">Extended Search</h1>
+    <ExtendedSearchPanel />
   </div>
 </template>
 
 <script setup lang="ts">
 import ClearIcon from '@featherds/icon/action/Cancel'
-import { FeatherAutocomplete } from '@featherds/autocomplete'
 import { FeatherButton } from '@featherds/button'
 import { FeatherExpansionPanel } from '@featherds/expansion'
 import { FeatherIcon } from '@featherds/icon'
 import { FeatherList, FeatherListItem } from '@featherds/list'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 import { Category, MonitoringLocation, SetOperator } from '@/types'
+import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
 
 const nodeStructureStore = useNodeStructureStore()
 const clearIcon = ref(ClearIcon)
@@ -116,24 +104,7 @@ const locations = computed<MonitoringLocation[]>(() => nodeStructureStore.monito
 const selectedCategoryCount = computed<number>(() => nodeStructureStore.queryFilter.selectedCategories?.length || 0)
 const selectedFlowCount = computed<number>(() => nodeStructureStore.queryFilter.selectedFlows?.length || 0)
 const selectedLocationCount = computed<number>(() => nodeStructureStore.queryFilter.selectedMonitoringLocations?.length || 0)
-const isAnyFilterSelected = computed<boolean>(() => nodeStructureStore.queryFilter.searchTerm?.length > 0 || selectedCategoryCount.value > 0 || selectedFlowCount.value > 0 || selectedLocationCount.value > 0)
-
-const metaSearchString = ref()
-const loading = ref(false)
-const defaultMetaLabels = { noResults: 'Searching...' }
-const metaLabels = ref(defaultMetaLabels)
-
-const metadataSearchResults = computed(() => {
-  return ['cat', 'dog', 'parakeet'].map(x => ({ _text: x }))
-})
-
-const selectMetaItem = (obj: any) => {
-  console.log('selectMetaItem')
-}
-
-const resetMetaSearch = () => {
-  console.log('resetMetaSearch')
-}
+const isAnyFilterSelected = computed<boolean>(() => nodeStructureStore.isAnyFilterSelected())
 
 const categoryModeUpdated = (val: any) => {
   nodeStructureStore.setCategoryMode(val)

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -212,7 +212,7 @@ const dialogVisible = ref(false)
 const dialogNode = ref<Node>()
 const preferencesVisible = ref(false)
 const tableCssClasses = computed<string[]>(() => getTableCssClasses(nodeStructureStore.columns))
-const queryParameters = ref({ limit: 20, offset: 0, orderBy: 'label' } as QueryParameters)
+const queryParameters = ref<QueryParameters>(nodeStore.nodeQueryParameters)
 const pageNumber = ref(1)
 
 const isSelectedColumn = (column: NodeColumnSelectionItem, id: string) => {
@@ -223,11 +223,15 @@ const updatePageNumber = (page: number) => {
   pageNumber.value = page
   const pageSize = queryParameters.value.limit || 0
   queryParameters.value = { ...queryParameters.value, offset: (page - 1) * pageSize }
+  nodeStore.setNodeQueryParameters(queryParameters.value)
+
   updateQuery()
 }
 
 const updatePageSize = (size: number) => {
   queryParameters.value = { ...queryParameters.value, limit: size }
+  nodeStore.setNodeQueryParameters(queryParameters.value)
+
   updateQuery()
 }
 
@@ -302,7 +306,10 @@ const onNodeLinkClick = (nodeId: number | string) => {
 }
 
 const updateQuery = () => {
-  const updatedParams = buildUpdatedNodeStructureQueryParameters(queryParameters.value, nodeStructureStore.queryFilter)
+  // make sure anything setting nodeStore.nodeQueryParameters has been processed
+  nextTick()
+
+  const updatedParams = buildUpdatedNodeStructureQueryParameters(nodeStore.nodeQueryParameters, nodeStructureStore.queryFilter)
   queryParameters.value = updatedParams
 
   nodeStore.getNodes(updatedParams, true)

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -1,0 +1,118 @@
+import {
+  Category,
+  MonitoringLocation,
+  NodeQuerySnmpParams,
+  SetOperator
+} from '@/types'
+import { isIP } from 'is-ip'
+
+/** Parse node label from a vue-router route.query object */
+export const parseNodeLabel = (queryObject: any) => {
+  return queryObject.nodename as string || queryObject.nodeLabel as string || ''
+}
+
+/**
+ * Parse categories from a vue-router route.query object.
+ * The route.query 'categories' string can be a comma- or semicolon-separated list of either
+ * numeric Category ids or names.
+ * comma: Union; semicolon: Intersection
+ * 
+ * @returns The category mode and categories parsed from the queryObject. If 'selectedCategories' is empty,
+ * it means no categories were present.
+ */
+export const parseCategories = (queryObject: any, categories: Category[]) => {
+  let categoryMode: SetOperator = SetOperator.Union
+  const selectedCategories: Category[] = []
+
+  const queryCategories = queryObject.categories as string ?? ''
+
+  if (selectedCategories.length > 0) {
+    categoryMode = queryCategories.includes(';') ? SetOperator.Intersection : SetOperator.Union
+
+    const cats: string[] = queryCategories.replace(';', ',').split(',')
+
+    // add any valid categories
+    cats.forEach(c => {
+      if (/\d+/.test(c)) {
+        // category id number
+        const id = parseInt(c)
+
+        const item = categories.find(x => x.id === id)
+
+        if (item) {
+          selectedCategories.push(item)
+        }
+      } else {
+        // category name, case insensitive
+        const item = categories.find(x => x.name.toLowerCase() === c.toLowerCase())
+
+        if (item) {
+          selectedCategories.push(item)
+        }
+      }
+    })
+  }
+
+  return {
+    categoryMode,
+    selectedCategories
+  }
+}
+
+export const parseMonitoringLocation = (queryObject: any, monitoringLocations: MonitoringLocation[]) => {
+  const locationName = queryObject.monitoringLocation as string || ''
+
+  if (locationName) {
+    return monitoringLocations.find(x => x.name.toLowerCase() === locationName.toLowerCase()) ?? null
+  }
+
+  return null
+}
+
+export const parseFlows = (queryObject: any) => {
+  const flows = (queryObject.flows as string || '').toLowerCase()
+
+  if (flows === 'true') {
+    return ['Ingress', 'Egress']
+  } else if (flows === 'ingress') {
+    return ['Ingress']
+  } else if (flows === 'egress') {
+    return ['Egress']
+  }
+
+  // TODO: we don't yet have support for excluding flows, i.e. if queryObject.flows === 'false'
+
+  return []
+}
+
+/**
+ * Currently this accepts anything in any valid IPv4 or IPv6 format (see `is-ip`), but
+ * some formats may not actually be supported by our FIQL search.
+ */
+export const parseIplike = (queryObject: any) => {
+  const ip = queryObject.iplike as string || queryObject.ipAddress as string || ''
+
+  if (ip && isIP(ip)) {
+    return ip
+  }
+
+  return null
+}
+
+export const parseSnmpParams = (queryObject: any) => {
+  const snmpIfAlias = queryObject.snmpifalias as string || ''
+  const snmpIfDesc = queryObject.snmpifdesc as string || ''
+  const snmpIfIndex = queryObject.snmpifindex as string || ''
+  const snmpIfName = queryObject.snmpifname as string || ''
+
+  if (snmpIfAlias || snmpIfDesc || snmpIfIndex || snmpIfName) {
+    return {
+      snmpIfAlias,
+      snmpIfDesc,
+      snmpIfIndex,
+      snmpIfName
+    } as NodeQuerySnmpParams
+  }
+
+  return null
+}

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -51,7 +51,7 @@ onMounted(() => {
   const prefs = loadNodePreferences()
 
   if (queryStringHasTrackedValues(route.query)) {
-    const nodeFilter = buildNodeQueryFilterFromQueryString(route.query, nodeStructureStore.categories)
+    const nodeFilter = buildNodeQueryFilterFromQueryString(route.query, nodeStructureStore.categories, nodeStructureStore.monitoringLocations)
 
     const newPrefs = {
       nodeColumns: prefs?.nodeColumns || [],

--- a/ui/src/stores/nodeStore.ts
+++ b/ui/src/stores/nodeStore.ts
@@ -1,3 +1,4 @@
+import { NodeQueryFilter } from './../types/index';
 import { defineStore } from 'pinia'
 import API from '@/services'
 import { IpInterface, Node, NodeAvailability, Outage, QueryParameters, SnmpInterface } from '@/types'
@@ -14,6 +15,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
   const availability = ref({} as NodeAvailability)
   const outages = ref([] as Outage[])
   const outagesTotalCount = ref(0)
+  const nodeQueryParameters = ref({ limit: 20, offset: 0, orderBy: 'label' } as QueryParameters)
 
   // map of nodeId to IpInterfaces associated with that node
   const nodeToIpInterfaceMap = ref<Map<string, IpInterface[]>>(new Map<string, IpInterface[]>())
@@ -62,6 +64,10 @@ export const useNodeStore = defineStore('nodeStore', () => {
    * Get the IpInterfaces for the given nodes, then update the nodeToIpInterfaceMap.
    */
   const getIpInterfacesForNodes = async (nodeIds: string[], managedOnly: boolean) => {
+    if (nodeIds.length === 0) {
+      return
+    }
+
     const query = getNodeIpInterfaceQuery(nodeIds, managedOnly)
     const queryParameters = {
       limit: nodeIds.length,
@@ -96,6 +102,12 @@ export const useNodeStore = defineStore('nodeStore', () => {
     }
   }
 
+  const setNodeQueryParameters = async (params: QueryParameters) => {
+    nodeQueryParameters.value = {
+      ...params
+    }
+  }
+
   return {
     nodes,
     totalCount,
@@ -106,6 +118,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
     ipInterfacesTotalCount,
     availability,
     nodeToIpInterfaceMap,
+    nodeQueryParameters,
     outages,
     outagesTotalCount,
     getIpInterfacesForNodes,
@@ -114,6 +127,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
     getNodeSnmpInterfaces,
     getNodeIpInterfaces,
     getNodeAvailabilityPercentage,
-    getNodeOutages
+    getNodeOutages,
+    setNodeQueryParameters
   }
 })

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -501,13 +501,23 @@ export enum SetOperator {
   Intersection = 2
 }
 
+export interface NodeQuerySnmpParams {
+  snmpIfAlias: string
+  snmpIfDesc: string
+  snmpIfIndex: string
+  snmpIfName: string
+  snmpIfType: string
+}
+
 /** All components of a node structure query */
 export interface NodeQueryFilter {
   searchTerm: string
+  ipAddress?: string
   categoryMode: SetOperator
   selectedCategories: Category[]
   selectedFlows: string[]
   selectedMonitoringLocations: MonitoringLocation[]
+  snmpParams?: NodeQuerySnmpParams
 }
 
 export interface NodePreferences {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1862,6 +1862,13 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+clone-regexp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-3.0.0.tgz#c6dd5c6b85482306778f3dc4ac2bb967079069c2"
+  integrity sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==
+  dependencies:
+    is-regexp "^3.0.0"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -1903,6 +1910,11 @@ config-chain@^1.1.13:
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
+
+convert-hrtime@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/convert-hrtime/-/convert-hrtime-5.0.0.tgz#f2131236d4598b95de856926a67100a0a97e9fa3"
+  integrity sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==
 
 cookie@~0.5.0:
   version "0.5.0"
@@ -2640,6 +2652,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+function-timeout@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/function-timeout/-/function-timeout-0.1.1.tgz#6bf71d3d24c894d43b2bec312cabb8c5add2e9da"
+  integrity sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==
+
 get-func-name@^2.0.1, get-func-name@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
@@ -2857,6 +2874,14 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-ip@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-5.0.1.tgz#bec44442c823e591aa6f4d6fb9081d6a9be17e44"
+  integrity sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw==
+  dependencies:
+    ip-regex "^5.0.0"
+    super-regex "^0.2.0"
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -2871,6 +2896,11 @@ is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
+is-regexp@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-3.1.0.tgz#0235eab9cda5b83f96ac4a263d8c32c9d5ad7422"
+  integrity sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==
 
 is-valid-domain@^0.1.6:
   version "0.1.6"
@@ -3688,6 +3718,15 @@ strip-literal@^1.0.0, strip-literal@^1.0.1:
   dependencies:
     acorn "^8.10.0"
 
+super-regex@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/super-regex/-/super-regex-0.2.0.tgz#dc1e071e55cdcf56930eb6271f73653a655b2642"
+  integrity sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==
+  dependencies:
+    clone-regexp "^3.0.0"
+    function-timeout "^0.1.0"
+    time-span "^5.1.0"
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -3758,6 +3797,13 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+time-span@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/time-span/-/time-span-5.1.0.tgz#80c76cf5a0ca28e0842d3f10a4e99034ce94b90d"
+  integrity sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==
+  dependencies:
+    convert-hrtime "^5.0.0"
 
 tinybench@^2.5.0:
   version "2.5.1"


### PR DESCRIPTION
NMS-16116: Node structure add additional queries for flows, ipaddress, monitoringLocations, snmp parameters.

Parses these queries out from query string parameters, and also the user can use the UI to make these queries.

Added an `ExtendedSearchPanel` for making IP address and certain SNMP queries. For now can only search on one of these at a time, eventually can add more combinations.

As a note, when user enters a URL with a query string, or is redirected from another page, the app will "ingest" the query string filter parameters and add to the `pinia` store and update the UI, then clear the query string from the URL. Otherwise there could be issues trying to keep query string parameters and `pinia` store / UI elements all in sync. 

Also did some refactoring to break up large files, and fixed issue where IP interfaces searches were done with invalid IP addresses.

<img width="476" alt="Screenshot 2023-10-18 at 18 16 50" src="https://github.com/OpenNMS/opennms/assets/1933710/5faf42ce-048f-4d36-895c-c7f6f4aaebf9">


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16116

