### PR TITLE
update jetty, netty, and snappy-java to latest minor versions

### DIFF
--- a/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
+++ b/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
@@ -122,7 +122,7 @@
         <!-- Settings for X-Frame-Options to avoid clickjacking -->
         <!-- Comment out this block and the below reference to RewriteHandler to allow framing -->
         <Item>
-          <New id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <New id="sameOriginHeader" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
             <Set name="pattern">*</Set>
             <Set name="name">X-Frame-Options</Set>
             <Set name="value">SAMEORIGIN</Set>
@@ -131,14 +131,14 @@
         <!-- Jira NMS-14947 Cacheable HTTPS Responses - Cache Control Directive Missing or Misconfigured -->
         <!-- no caching for everything in "/opennms/*" excluding static assets "/opennms/assets/*"  -->
         <Item>
-          <New id="header" class="org.eclipse.jetty.rewrite.handler.HeaderRegexRule">
+          <New id="cacheControlHeader" class="org.eclipse.jetty.rewrite.handler.HeaderRegexRule">
             <Set name="regex">/opennms/(?!assets/).*</Set>
             <Set name="name">Cache-control</Set>
             <Set name="value">no-store</Set>
           </New>
         </Item>
         <Item>
-          <New id="header" class="org.eclipse.jetty.rewrite.handler.HeaderRegexRule">
+          <New id="assetsHeader" class="org.eclipse.jetty.rewrite.handler.HeaderRegexRule">
             <Set name="regex">/opennms/(?!assets/).*</Set>
             <Set name="name">Pragma</Set>
             <Set name="value">no-cache</Set>
@@ -164,7 +164,7 @@
        <Array type="org.eclipse.jetty.server.Handler">
            <!-- Comment out this item to allow framing -->
            <Item>
-             <Ref id="RewriteHandler"/>
+             <Ref refid="RewriteHandler"/>
            </Item>
            <Item>
                <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
@@ -193,13 +193,13 @@
 
   <Set name="handler">
     <New id="mdcHandler" class="org.opennms.netmgt.jetty.MDCHandler">
-      <Set name="handler"><Ref id="Handlers" /></Set>
+      <Set name="handler"><Ref refid="Handlers" /></Set>
     </New>
   </Set>
 
   <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
     <Set name="contexts">
-      <Ref id="Contexts" />
+      <Ref refid="Contexts" />
     </Set>
     <Call name="setContextAttribute">
       <Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>

--- a/pom.xml
+++ b/pom.xml
@@ -1682,8 +1682,8 @@
     <jcommonVersion>1.0.24</jcommonVersion>
     <jdom2Version>2.0.6.1</jdom2Version>
     <jettisonVersion>1.4.1</jettisonVersion>
-    <jettyVersion>9.4.51.v20230217</jettyVersion>
-    <jettyOsgiVersion>9.4.51</jettyOsgiVersion>
+    <jettyVersion>9.4.53.v20231009</jettyVersion>
+    <jettyOsgiVersion>9.4.53</jettyOsgiVersion>
     <jestVersion>5.3.4</jestVersion>
     <jestGsonVersion>${gsonVersion}</jestGsonVersion>
     <jfreechartVersion>1.5.4</jfreechartVersion>
@@ -1725,7 +1725,7 @@
     <minaVersion>2.2.2</minaVersion>
     <mockitoVersion>3.12.4</mockitoVersion>
     <netty3Version>3.10.6.Final</netty3Version>
-    <netty4Version>4.1.95.Final</netty4Version>
+    <netty4Version>4.1.100.Final</netty4Version>
     <newtsVersion>1.5.7</newtsVersion>
     <paxExamVersion>4.13.5</paxExamVersion>
     <paxLoggingVersion>2.0.14</paxLoggingVersion>
@@ -1763,7 +1763,7 @@
     <servletApiVersion>3.1.0</servletApiVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <smackVersion>4.0.6</smackVersion>
-    <snappyJavaVersion>1.1.10.3</snappyJavaVersion>
+    <snappyJavaVersion>1.1.10.5</snappyJavaVersion>
     <snmp4jVersion>2.5.5</snmp4jVersion>
     <snmp4jagentVersion>2.5.3</snmp4jagentVersion>
     <sonarVersion>3.9.1.2184</sonarVersion>


### PR DESCRIPTION
* `jetty`: 9.4.51.v20230217 -> 9.4.53.v20231009
* `netty`: 4.1.95.Final -> 4.1.100.Final
* `snappy-java`: 1.1.10.3 -> 1.1.10.5

Note that this also includes a backport to the fix to our included `jetty.xml` to resolve some validation issues. There is [a JIRA issue](https://opennms.atlassian.net/browse/NMS-16189) to remind us to make a note of this in the release notes for Meridian 2023.1.9.