### PR TITLE
NMS-15914: clean up snakeyaml usage

### DIFF
--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -182,13 +182,12 @@
 
     <feature name="jackson-dataformat-xml" version="${jackson2Version}" description="Jackson 2 :: XML Data Format">
         <feature version="[${jackson2Version},3)">jackson-core</feature>
-        <feature>snakeyaml</feature>
         <bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${jackson2Version}</bundle>
     </feature>
 
     <feature name="jackson-dataformat-yaml" version="${jackson2Version}" description="Jackson 2 :: YAML Data Format">
         <feature version="[${jackson2Version},3)">jackson-core</feature>
-        <feature>snakeyaml</feature>
+        <feature version="[${snakeyamlVersion},3)">snakeyaml</feature>
         <bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson2Version}</bundle>
     </feature>
 

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1912,6 +1912,7 @@
         <feature>org.json</feature>
         <feature>opennms-health-rest</feature>
         <feature version="${cxfVersion}">cxf-core</feature>
+        <feature version="${cxfVersion}">cxf-jackson</feature>
         <feature version="${cxfVersion}">cxf-jaxrs</feature>
         <!-- early start-level to override jettison version in 3rd-party feature files -->
         <bundle start-level="${earlyStartLevel}">mvn:org.codehaus.jettison/jettison/${jettisonVersion}</bundle>

--- a/container/features/src/test/karaf-resources/custom.properties
+++ b/container/features/src/test/karaf-resources/custom.properties
@@ -10,6 +10,7 @@ jre-11=${jre-10}, \
   sun.security.x509
 
 org.osgi.framework.system.packages.extra= \
+  java.net.http, \
   org.apache.karaf.branding, \
   sun.misc,\
   sun.net.dns,\

--- a/container/karaf/src/main/filtered-resources/etc/config.properties
+++ b/container/karaf/src/main/filtered-resources/etc/config.properties
@@ -88,6 +88,7 @@ org.osgi.framework.system.packages= \
 # Extra packages appended after standard packages
 #
 org.osgi.framework.system.packages.extra = \
+    java.net.http, \
     org.apache.karaf.branding, \
     sun.misc, \
     com.sun.jmx.remote.protocol, \

--- a/container/karaf/src/main/filtered-resources/etc/custom.properties
+++ b/container/karaf/src/main/filtered-resources/etc/custom.properties
@@ -41,6 +41,7 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         sun.reflect,\
         sun.security.ssl,\
         sun.security.x509,\
+        java.net.http,\
         javax.jms;version=1.1.0,\
         javax.mail;version=1.6.7,\
         javax.mail.internet;version=1.6.7,\
@@ -173,7 +174,7 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         io.netty.util.internal.logging;version="${netty4Version}",\
         io.netty.util.internal.svm;version="${netty4Version}",\
         io.netty.util.internal;uses:="io.netty.util,io.netty.util.concurrent,io.netty.util.internal.logging,javax.security.cert,reactor.blockhound,reactor.blockhound.integration";version="${netty4Version}",\
-        io.swagger.parser;version="${swaggerVersion}",\
+        io.swagger.parser;version="${swaggerParserVersion}",
         io.swagger.v3.core.converter;version="${swaggerVersion}",\
         io.swagger.v3.core.filter;version="${swaggerVersion}",\
         io.swagger.v3.core.jackson;version="${swaggerVersion}",\
@@ -205,16 +206,14 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         io.swagger.v3.oas.models.security;version="${swaggerVersion}",\
         io.swagger.v3.oas.models.servers;version="${swaggerVersion}",\
         io.swagger.v3.oas.models.tags;version="${swaggerVersion}",\
-        io.swagger.v3.parser;version="${swaggerVersion}",\
-        io.swagger.v3.parser.converter;version="${swaggerVersion}",\
-        io.swagger.v3.parser.core.extensions;version="${swaggerVersion}",\
-        io.swagger.v3.parser.core.models;version="${swaggerVersion}",\
-        io.swagger.v3.parser.exception;version="${swaggerVersion}",\
-        io.swagger.v3.parser.extensions;version="${swaggerVersion}",\
-        io.swagger.v3.parser.models;version="${swaggerVersion}",\
-        io.swagger.v3.parser.processors;version="${swaggerVersion}",\
-        io.swagger.v3.parser.reference;version="${swaggerVersion}",\
-        io.swagger.v3.parser.util;version="${swaggerVersion}",\
+        io.swagger.v3.parser.converter;version="${swaggerParserVersion}",\
+        io.swagger.v3.parser.core.extensions;version="${swaggerParserVersion}",\
+        io.swagger.v3.parser.core.models;version="${swaggerParserVersion}",\
+        io.swagger.v3.parser.exception;version="${swaggerParserVersion}",\
+        io.swagger.v3.parser.models;version="${swaggerParserVersion}",\
+        io.swagger.v3.parser.processors;version="${swaggerParserVersion}",\
+        io.swagger.v3.parser.util;version="${swaggerParserVersion}",\
+        io.swagger.v3.parser;version="${swaggerParserVersion}",\
         org.apache.commons.beanutils;version=${commonsBeanutilsVersion},\
         org.apache.commons.codec;version=${commonsCodecVersion},\
         org.apache.commons.codec.binary;version=${commonsCodecVersion},\

--- a/container/shared/src/main/filtered-resources/etc/custom.properties
+++ b/container/shared/src/main/filtered-resources/etc/custom.properties
@@ -27,9 +27,11 @@ karaf.systemBundlesStartLevel=50
 #
 # You can place any customized configuration here.
 #
-org.osgi.framework.system.packages.extra=sun.nio.ch, \
+org.osgi.framework.system.packages.extra=\
+              java.net.http, \
               sun.misc, \
               sun.net.dns, \
+              sun.nio.ch, \
               sun.reflect, \
               sun.security.ssl, \
               sun.security.x509

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -18206,9 +18206,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.69.5",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
-            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
+            "version": "1.69.7",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.7.tgz",
+            "integrity": "sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -35638,9 +35638,9 @@
             "dev": true
         },
         "sass": {
-            "version": "1.69.5",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
-            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
+            "version": "1.69.7",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.7.tgz",
+            "integrity": "sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -4054,15 +4054,15 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
-            "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.17.0.tgz",
+            "integrity": "sha512-C4bBaX2orvhK+LlwrY8oWGmSl4WolCfYm513gEccdWZj0CwGadbIADb0FtVEcI+WzUyjyoBj2JRP8g25E6IB8A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/types": "6.15.0",
-                "@typescript-eslint/typescript-estree": "6.15.0",
-                "@typescript-eslint/visitor-keys": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.17.0",
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/typescript-estree": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4079,6 +4079,81 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+            "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+            "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+            "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "9.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+            "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/debug": {
@@ -4098,10 +4173,70 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/@typescript-eslint/parser/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "node_modules/@typescript-eslint/scope-manager": {
@@ -24502,18 +24637,60 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
-            "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.17.0.tgz",
+            "integrity": "sha512-C4bBaX2orvhK+LlwrY8oWGmSl4WolCfYm513gEccdWZj0CwGadbIADb0FtVEcI+WzUyjyoBj2JRP8g25E6IB8A==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/types": "6.15.0",
-                "@typescript-eslint/typescript-estree": "6.15.0",
-                "@typescript-eslint/visitor-keys": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.17.0",
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/typescript-estree": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
                 "debug": "^4.3.4"
             },
             "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+                    "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "@typescript-eslint/visitor-keys": "6.17.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+                    "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+                    "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "@typescript-eslint/visitor-keys": "6.17.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "minimatch": "9.0.3",
+                        "semver": "^7.5.4",
+                        "ts-api-utils": "^1.0.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+                    "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24523,10 +24700,49 @@
                         "ms": "2.1.2"
                     }
                 },
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+                    "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
                     "dev": true
                 }
             }

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -15696,9 +15696,9 @@
             }
         },
         "node_modules/moment": {
-            "version": "2.29.4",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
             "engines": {
                 "node": "*"
             }
@@ -19516,6 +19516,14 @@
                 "jquery": "^3.0",
                 "moment": "^2.29.2",
                 "moment-timezone": "^0.5.0"
+            }
+        },
+        "node_modules/tempusdominus-core/node_modules/moment": {
+            "version": "2.29.4",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/terser": {
@@ -33575,9 +33583,9 @@
             }
         },
         "moment": {
-            "version": "2.29.4",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
         },
         "moment-timezone": {
             "version": "0.5.43",
@@ -36658,6 +36666,13 @@
                 "jquery": "^3.6.0",
                 "moment": "~2.29.2",
                 "moment-timezone": "^0.5.34"
+            },
+            "dependencies": {
+                "moment": {
+                    "version": "2.29.4",
+                    "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+                    "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+                }
             }
         },
         "terser": {

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -3963,16 +3963,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
-            "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.17.0.tgz",
+            "integrity": "sha512-Vih/4xLXmY7V490dGwBQJTpIZxH4ZFH6eCVmQ4RFkB+wmaCTDAx4dtgoWwMNGKLkqRY1L6rPqzEbjorRnDo4rQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/type-utils": "6.15.0",
-                "@typescript-eslint/utils": "6.15.0",
-                "@typescript-eslint/visitor-keys": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.17.0",
+                "@typescript-eslint/type-utils": "6.17.0",
+                "@typescript-eslint/utils": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -3997,6 +3997,53 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+            "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+            "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+            "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4012,6 +4059,18 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
@@ -4122,13 +4181,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
-            "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.17.0.tgz",
+            "integrity": "sha512-hDXcWmnbtn4P2B37ka3nil3yi3VCQO2QEB9gBiHJmQp5wmyQWqnjA85+ZcE8c4FqnaB6lBwMrPkgd4aBYz3iNg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.15.0",
-                "@typescript-eslint/utils": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.17.0",
+                "@typescript-eslint/utils": "6.17.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -4148,6 +4207,64 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+            "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+            "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "9.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+            "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4165,10 +4282,70 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "node_modules/@typescript-eslint/types": {
@@ -4268,17 +4445,17 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
-            "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.17.0.tgz",
+            "integrity": "sha512-LofsSPjN/ITNkzV47hxas2JCsNCEnGhVvocfyOcLzT9c/tSZE7SfhS/iWtzP1lKNOEfLhRTZz6xqI8N2RzweSQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/types": "6.15.0",
-                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.17.0",
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/typescript-estree": "6.17.0",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -4292,6 +4469,110 @@
                 "eslint": "^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+            "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+            "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+            "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "9.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+            "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.17.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4303,6 +4584,27 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/@typescript-eslint/utils/node_modules/semver": {
             "version": "7.5.4",
@@ -24442,16 +24744,16 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
-            "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.17.0.tgz",
+            "integrity": "sha512-Vih/4xLXmY7V490dGwBQJTpIZxH4ZFH6eCVmQ4RFkB+wmaCTDAx4dtgoWwMNGKLkqRY1L6rPqzEbjorRnDo4rQ==",
             "dev": true,
             "requires": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/type-utils": "6.15.0",
-                "@typescript-eslint/utils": "6.15.0",
-                "@typescript-eslint/visitor-keys": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.17.0",
+                "@typescript-eslint/type-utils": "6.17.0",
+                "@typescript-eslint/utils": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -24460,6 +24762,32 @@
                 "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+                    "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "@typescript-eslint/visitor-keys": "6.17.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+                    "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
+                    "dev": true
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+                    "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24468,6 +24796,12 @@
                     "requires": {
                         "ms": "2.1.2"
                     }
+                },
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                    "dev": true
                 },
                 "lru-cache": {
                     "version": "6.0.0",
@@ -24542,17 +24876,49 @@
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
-            "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.17.0.tgz",
+            "integrity": "sha512-hDXcWmnbtn4P2B37ka3nil3yi3VCQO2QEB9gBiHJmQp5wmyQWqnjA85+ZcE8c4FqnaB6lBwMrPkgd4aBYz3iNg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "6.15.0",
-                "@typescript-eslint/utils": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.17.0",
+                "@typescript-eslint/utils": "6.17.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
+                "@typescript-eslint/types": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+                    "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+                    "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "@typescript-eslint/visitor-keys": "6.17.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "minimatch": "9.0.3",
+                        "semver": "^7.5.4",
+                        "ts-api-utils": "^1.0.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+                    "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24562,10 +24928,49 @@
                         "ms": "2.1.2"
                     }
                 },
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+                    "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
                     "dev": true
                 }
             }
@@ -24633,20 +25038,77 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
-            "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.17.0.tgz",
+            "integrity": "sha512-LofsSPjN/ITNkzV47hxas2JCsNCEnGhVvocfyOcLzT9c/tSZE7SfhS/iWtzP1lKNOEfLhRTZz6xqI8N2RzweSQ==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.15.0",
-                "@typescript-eslint/types": "6.15.0",
-                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/scope-manager": "6.17.0",
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/typescript-estree": "6.17.0",
                 "semver": "^7.5.4"
             },
             "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+                    "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "@typescript-eslint/visitor-keys": "6.17.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+                    "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+                    "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "@typescript-eslint/visitor-keys": "6.17.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "minimatch": "9.0.3",
+                        "semver": "^7.5.4",
+                        "ts-api-utils": "^1.0.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "6.17.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+                    "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.17.0",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                    "dev": true
+                },
                 "lru-cache": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -24655,6 +25117,21 @@
                     "requires": {
                         "yallist": "^4.0.0"
                     }
+                },
+                "minimatch": {
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+                    "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 },
                 "semver": {
                     "version": "7.5.4",

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -17499,9 +17499,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-            "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -35083,9 +35083,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-            "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
             "dev": true
         },
         "pretty-format": {

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -3963,16 +3963,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.2.tgz",
-            "integrity": "sha512-3+9OGAWHhk4O1LlcwLBONbdXsAhLjyCFogJY/cWy2lxdVJ2JrcTF2pTGMaLl2AE7U1l31n8Py4a8bx5DLf/0dQ==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.14.0.tgz",
+            "integrity": "sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.13.2",
-                "@typescript-eslint/type-utils": "6.13.2",
-                "@typescript-eslint/utils": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2",
+                "@typescript-eslint/scope-manager": "6.14.0",
+                "@typescript-eslint/type-utils": "6.14.0",
+                "@typescript-eslint/utils": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -3997,6 +3997,53 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
+            "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4012,6 +4059,18 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
@@ -4122,13 +4181,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.2.tgz",
-            "integrity": "sha512-Qr6ssS1GFongzH2qfnWKkAQmMUyZSyOr0W54nZNU1MDfo+U4Mv3XveeLZzadc/yq8iYhQZHYT+eoXJqnACM1tw==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
+            "integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.13.2",
-                "@typescript-eslint/utils": "6.13.2",
+                "@typescript-eslint/typescript-estree": "6.14.0",
+                "@typescript-eslint/utils": "6.14.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -4148,6 +4207,63 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
+            "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4165,10 +4281,55 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "node_modules/@typescript-eslint/types": {
@@ -4268,17 +4429,17 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.2.tgz",
-            "integrity": "sha512-b9Ptq4eAZUym4idijCRzl61oPCwwREcfDI8xGk751Vhzig5fFZR9CyzDz4Sp/nxSLBYxUPyh4QdIDqWykFhNmQ==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
+            "integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.13.2",
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/typescript-estree": "6.13.2",
+                "@typescript-eslint/scope-manager": "6.14.0",
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/typescript-estree": "6.14.0",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -4292,6 +4453,109 @@
                 "eslint": "^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
+            "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
+            "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4303,6 +4567,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/@typescript-eslint/utils/node_modules/semver": {
             "version": "7.5.4",
@@ -24442,16 +24712,16 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.2.tgz",
-            "integrity": "sha512-3+9OGAWHhk4O1LlcwLBONbdXsAhLjyCFogJY/cWy2lxdVJ2JrcTF2pTGMaLl2AE7U1l31n8Py4a8bx5DLf/0dQ==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.14.0.tgz",
+            "integrity": "sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==",
             "dev": true,
             "requires": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.13.2",
-                "@typescript-eslint/type-utils": "6.13.2",
-                "@typescript-eslint/utils": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2",
+                "@typescript-eslint/scope-manager": "6.14.0",
+                "@typescript-eslint/type-utils": "6.14.0",
+                "@typescript-eslint/utils": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -24460,6 +24730,32 @@
                 "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
+                    "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "@typescript-eslint/visitor-keys": "6.14.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+                    "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+                    "dev": true
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+                    "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24468,6 +24764,12 @@
                     "requires": {
                         "ms": "2.1.2"
                     }
+                },
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                    "dev": true
                 },
                 "lru-cache": {
                     "version": "6.0.0",
@@ -24542,17 +24844,48 @@
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.2.tgz",
-            "integrity": "sha512-Qr6ssS1GFongzH2qfnWKkAQmMUyZSyOr0W54nZNU1MDfo+U4Mv3XveeLZzadc/yq8iYhQZHYT+eoXJqnACM1tw==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
+            "integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "6.13.2",
-                "@typescript-eslint/utils": "6.13.2",
+                "@typescript-eslint/typescript-estree": "6.14.0",
+                "@typescript-eslint/utils": "6.14.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
+                "@typescript-eslint/types": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+                    "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
+                    "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "@typescript-eslint/visitor-keys": "6.14.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.5.4",
+                        "ts-api-utils": "^1.0.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+                    "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24562,10 +24895,40 @@
                         "ms": "2.1.2"
                     }
                 },
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
                     "dev": true
                 }
             }
@@ -24633,20 +24996,76 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.2.tgz",
-            "integrity": "sha512-b9Ptq4eAZUym4idijCRzl61oPCwwREcfDI8xGk751Vhzig5fFZR9CyzDz4Sp/nxSLBYxUPyh4QdIDqWykFhNmQ==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
+            "integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.13.2",
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/typescript-estree": "6.13.2",
+                "@typescript-eslint/scope-manager": "6.14.0",
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/typescript-estree": "6.14.0",
                 "semver": "^7.5.4"
             },
             "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
+                    "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "@typescript-eslint/visitor-keys": "6.14.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+                    "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
+                    "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "@typescript-eslint/visitor-keys": "6.14.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.5.4",
+                        "ts-api-utils": "^1.0.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+                    "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                    "dev": true
+                },
                 "lru-cache": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -24655,6 +25074,12 @@
                     "requires": {
                         "yallist": "^4.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 },
                 "semver": {
                     "version": "7.5.4",

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -4282,23 +4282,6 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.2.tgz",
-            "integrity": "sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
         "node_modules/@typescript-eslint/type-utils": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
@@ -4446,102 +4429,6 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
-        "node_modules/@typescript-eslint/types": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.2.tgz",
-            "integrity": "sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==",
-            "dev": true,
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.2.tgz",
-            "integrity": "sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
@@ -4713,35 +4600,6 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
-        },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.2.tgz",
-            "integrity": "sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.13.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
         },
         "node_modules/@uirouter/core": {
             "version": "6.0.8",
@@ -18194,9 +18052,9 @@
             }
         },
         "node_modules/regenerator-runtime": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.2",
@@ -25023,16 +24881,6 @@
                 }
             }
         },
-        "@typescript-eslint/scope-manager": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.2.tgz",
-            "integrity": "sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2"
-            }
-        },
         "@typescript-eslint/type-utils": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
@@ -25090,68 +24938,6 @@
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
                     "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
                     "dev": true
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
-                }
-            }
-        },
-        "@typescript-eslint/types": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.2.tgz",
-            "integrity": "sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==",
-            "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.2.tgz",
-            "integrity": "sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
                 },
                 "lru-cache": {
                     "version": "6.0.0",
@@ -25284,24 +25070,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
                     "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
-                }
-            }
-        },
-        "@typescript-eslint/visitor-keys": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.2.tgz",
-            "integrity": "sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "6.13.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "3.4.3",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
                     "dev": true
                 }
             }
@@ -35934,9 +35702,9 @@
             }
         },
         "regenerator-runtime": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "regenerator-transform": {
             "version": "0.15.2",

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -3963,16 +3963,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.14.0.tgz",
-            "integrity": "sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
+            "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/type-utils": "6.14.0",
-                "@typescript-eslint/utils": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/type-utils": "6.15.0",
+                "@typescript-eslint/utils": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -3997,53 +3997,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-            "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
-            "dev": true,
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4059,18 +4012,6 @@
                 "supports-color": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
@@ -4282,14 +4223,31 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
-        "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
-            "integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
+            "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.14.0",
-                "@typescript-eslint/utils": "6.14.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
+            "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/utils": "6.15.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -4307,63 +4265,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
-            "dev": true,
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-            "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
@@ -4383,103 +4284,16 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
-        "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
-            "integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
-            "dev": true,
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@types/json-schema": "^7.0.12",
-                "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/typescript-estree": "6.14.0",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-            "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+        "node_modules/@typescript-eslint/types": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
+            "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -4489,14 +4303,14 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-            "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
+            "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -4516,24 +4330,7 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/debug": {
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
@@ -4550,16 +4347,68 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
+            "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@types/json-schema": "^7.0.12",
+                "@types/semver": "^7.5.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
-                "url": "https://opencollective.com/eslint"
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
@@ -4573,12 +4422,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
         },
         "node_modules/@typescript-eslint/utils/node_modules/semver": {
             "version": "7.5.4",
@@ -4600,6 +4443,35 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
+            "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.15.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
         },
         "node_modules/@uirouter/core": {
             "version": "6.0.8",
@@ -24689,16 +24561,16 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.14.0.tgz",
-            "integrity": "sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
+            "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
             "dev": true,
             "requires": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/type-utils": "6.14.0",
-                "@typescript-eslint/utils": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/type-utils": "6.15.0",
+                "@typescript-eslint/utils": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -24707,32 +24579,6 @@
                 "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
-                "@typescript-eslint/scope-manager": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-                    "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "@typescript-eslint/visitor-keys": "6.14.0"
-                    }
-                },
-                "@typescript-eslint/types": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-                    "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
-                    "dev": true
-                },
-                "@typescript-eslint/visitor-keys": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-                    "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "eslint-visitor-keys": "^3.4.1"
-                    }
-                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24741,12 +24587,6 @@
                     "requires": {
                         "ms": "2.1.2"
                     }
-                },
-                "eslint-visitor-keys": {
-                    "version": "3.4.3",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-                    "dev": true
                 },
                 "lru-cache": {
                     "version": "6.0.0",
@@ -24881,49 +24721,28 @@
                 }
             }
         },
-        "@typescript-eslint/type-utils": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
-            "integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
+        "@typescript-eslint/scope-manager": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
+            "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "6.14.0",
-                "@typescript-eslint/utils": "6.14.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0"
+            }
+        },
+        "@typescript-eslint/type-utils": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
+            "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/utils": "6.15.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
             "dependencies": {
-                "@typescript-eslint/types": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-                    "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
-                    "dev": true
-                },
-                "@typescript-eslint/typescript-estree": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-                    "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "@typescript-eslint/visitor-keys": "6.14.0",
-                        "debug": "^4.3.4",
-                        "globby": "^11.1.0",
-                        "is-glob": "^4.0.3",
-                        "semver": "^7.5.4",
-                        "ts-api-utils": "^1.0.1"
-                    }
-                },
-                "@typescript-eslint/visitor-keys": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-                    "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "eslint-visitor-keys": "^3.4.1"
-                    }
-                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24933,11 +24752,43 @@
                         "ms": "2.1.2"
                     }
                 },
-                "eslint-visitor-keys": {
-                    "version": "3.4.3",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
+            "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
+            "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
+            "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
                 },
                 "lru-cache": {
                     "version": "6.0.0",
@@ -24972,76 +24823,20 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
-            "integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
+            "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/typescript-estree": "6.14.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
                 "semver": "^7.5.4"
             },
             "dependencies": {
-                "@typescript-eslint/scope-manager": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-                    "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "@typescript-eslint/visitor-keys": "6.14.0"
-                    }
-                },
-                "@typescript-eslint/types": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-                    "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
-                    "dev": true
-                },
-                "@typescript-eslint/typescript-estree": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-                    "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "@typescript-eslint/visitor-keys": "6.14.0",
-                        "debug": "^4.3.4",
-                        "globby": "^11.1.0",
-                        "is-glob": "^4.0.3",
-                        "semver": "^7.5.4",
-                        "ts-api-utils": "^1.0.1"
-                    }
-                },
-                "@typescript-eslint/visitor-keys": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-                    "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "eslint-visitor-keys": "^3.4.1"
-                    }
-                },
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "eslint-visitor-keys": {
-                    "version": "3.4.3",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-                    "dev": true
-                },
                 "lru-cache": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -25050,12 +24845,6 @@
                     "requires": {
                         "yallist": "^4.0.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
                 },
                 "semver": {
                     "version": "7.5.4",
@@ -25070,6 +24859,24 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
                     "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
+            "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "6.15.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
                     "dev": true
                 }
             }

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -2362,9 +2362,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
-            "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+            "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4282,23 +4282,6 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.2.tgz",
-            "integrity": "sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
         "node_modules/@typescript-eslint/type-utils": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
@@ -4446,102 +4429,6 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
-        "node_modules/@typescript-eslint/types": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.2.tgz",
-            "integrity": "sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==",
-            "dev": true,
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.2.tgz",
-            "integrity": "sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
@@ -4713,35 +4600,6 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
-        },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.2.tgz",
-            "integrity": "sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.13.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
         },
         "node_modules/@uirouter/core": {
             "version": "6.0.8",
@@ -9238,15 +9096,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
-            "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+            "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.55.0",
+                "@eslint/js": "8.56.0",
                 "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -23585,9 +23443,9 @@
             }
         },
         "@eslint/js": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
-            "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+            "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
             "dev": true
         },
         "@gar/promisify": {
@@ -25023,16 +24881,6 @@
                 }
             }
         },
-        "@typescript-eslint/scope-manager": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.2.tgz",
-            "integrity": "sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2"
-            }
-        },
         "@typescript-eslint/type-utils": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
@@ -25090,68 +24938,6 @@
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
                     "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
                     "dev": true
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
-                }
-            }
-        },
-        "@typescript-eslint/types": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.2.tgz",
-            "integrity": "sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==",
-            "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.2.tgz",
-            "integrity": "sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
                 },
                 "lru-cache": {
                     "version": "6.0.0",
@@ -25284,24 +25070,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
                     "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
-                }
-            }
-        },
-        "@typescript-eslint/visitor-keys": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.2.tgz",
-            "integrity": "sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "6.13.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "3.4.3",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
                     "dev": true
                 }
             }
@@ -29003,15 +28771,15 @@
             }
         },
         "eslint": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
-            "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+            "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.55.0",
+                "@eslint/js": "8.56.0",
                 "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -4054,15 +4054,15 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.14.0.tgz",
-            "integrity": "sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
+            "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/typescript-estree": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4079,80 +4079,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-            "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
-            "dev": true,
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-            "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/debug": {
@@ -4172,55 +4098,10 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/parser/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "node_modules/@typescript-eslint/scope-manager": {
@@ -24621,59 +24502,18 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.14.0.tgz",
-            "integrity": "sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
+            "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/typescript-estree": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4"
             },
             "dependencies": {
-                "@typescript-eslint/scope-manager": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-                    "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "@typescript-eslint/visitor-keys": "6.14.0"
-                    }
-                },
-                "@typescript-eslint/types": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-                    "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
-                    "dev": true
-                },
-                "@typescript-eslint/typescript-estree": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-                    "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "@typescript-eslint/visitor-keys": "6.14.0",
-                        "debug": "^4.3.4",
-                        "globby": "^11.1.0",
-                        "is-glob": "^4.0.3",
-                        "semver": "^7.5.4",
-                        "ts-api-utils": "^1.0.1"
-                    }
-                },
-                "@typescript-eslint/visitor-keys": {
-                    "version": "6.14.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-                    "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "6.14.0",
-                        "eslint-visitor-keys": "^3.4.1"
-                    }
-                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24683,40 +24523,10 @@
                         "ms": "2.1.2"
                     }
                 },
-                "eslint-visitor-keys": {
-                    "version": "3.4.3",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-                    "dev": true
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
                     "dev": true
                 }
             }

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -1754,9 +1754,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.4.tgz",
-            "integrity": "sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.6.tgz",
+            "integrity": "sha512-kF1Zg62aPseQ11orDhFRw+aPG/eynNQtI+TyY+m33qJa2cJ5EEvza2P2BNTIA9E5MyqFABHEyY6CPHwgdy9aNg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.22.15",
@@ -22736,9 +22736,9 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.4.tgz",
-            "integrity": "sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.6.tgz",
+            "integrity": "sha512-kF1Zg62aPseQ11orDhFRw+aPG/eynNQtI+TyY+m33qJa2cJ5EEvza2P2BNTIA9E5MyqFABHEyY6CPHwgdy9aNg==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.22.15",

--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -4054,15 +4054,15 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.2.tgz",
-            "integrity": "sha512-MUkcC+7Wt/QOGeVlM8aGGJZy1XV5YKjTpq9jK6r6/iLsGXhBVaGP5N0UYvFsu9BFlSpwY9kMretzdBH01rkRXg==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.14.0.tgz",
+            "integrity": "sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.13.2",
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/typescript-estree": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2",
+                "@typescript-eslint/scope-manager": "6.14.0",
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/typescript-estree": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4079,6 +4079,80 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
+            "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
+            "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.14.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/debug": {
@@ -4098,10 +4172,55 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@typescript-eslint/parser/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "node_modules/@typescript-eslint/scope-manager": {
@@ -24502,18 +24621,59 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "6.13.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.2.tgz",
-            "integrity": "sha512-MUkcC+7Wt/QOGeVlM8aGGJZy1XV5YKjTpq9jK6r6/iLsGXhBVaGP5N0UYvFsu9BFlSpwY9kMretzdBH01rkRXg==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.14.0.tgz",
+            "integrity": "sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "6.13.2",
-                "@typescript-eslint/types": "6.13.2",
-                "@typescript-eslint/typescript-estree": "6.13.2",
-                "@typescript-eslint/visitor-keys": "6.13.2",
+                "@typescript-eslint/scope-manager": "6.14.0",
+                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/typescript-estree": "6.14.0",
+                "@typescript-eslint/visitor-keys": "6.14.0",
                 "debug": "^4.3.4"
             },
             "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
+                    "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "@typescript-eslint/visitor-keys": "6.14.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+                    "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
+                    "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "@typescript-eslint/visitor-keys": "6.14.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.5.4",
+                        "ts-api-utils": "^1.0.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "6.14.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+                    "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "6.14.0",
+                        "eslint-visitor-keys": "^3.4.1"
+                    }
+                },
                 "debug": {
                     "version": "4.3.4",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -24523,10 +24683,40 @@
                         "ms": "2.1.2"
                     }
                 },
+                "eslint-visitor-keys": {
+                    "version": "3.4.3",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+                    "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
                     "dev": true
                 }
             }

--- a/dependencies/cassandra-test/pom.xml
+++ b/dependencies/cassandra-test/pom.xml
@@ -87,7 +87,16 @@
           <groupId>com.boundary</groupId>
           <artifactId>high-scale-lib</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.33</version>
     </dependency>
     <!-- replaces com.boundary:high-scale-lib,
          removes overridden java.util.concurrent.* junk that breaks things -->

--- a/dependencies/liquibase/pom.xml
+++ b/dependencies/liquibase/pom.xml
@@ -31,6 +31,10 @@
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/docs/modules/deployment/pages/core/getting-started.adoc
+++ b/docs/modules/deployment/pages/core/getting-started.adoc
@@ -42,7 +42,7 @@ The following components and settings are required to set up a new {page-compone
 ifeval::["{page-component-title}" == "Meridian"]
 * Credentials to access the Meridian repositories.
 endif::[]
-* A Linux physical server, or a virtual machine running a <<core/system-requirements.adoc#operating-systems-core, supported Linux operating system>>.
+* A Linux physical server, or a virtual machine running a <<system-requirements.adoc#operating-systems-core, supported Linux operating system>>.
 * Internet access to download the installation packages.
 * A working DNS server, and a localhost and server name that resolve properly.
 * A system user with administrative permissions (`sudo`) to perform installation.

--- a/docs/modules/development/pages/rest/meta-data.adoc
+++ b/docs/modules/development/pages/rest/meta-data.adoc
@@ -2,9 +2,17 @@
 [[metadata-rest]]
 = Metadata
 
-You can query the actual metadata of nodes, interfaces, and services via REST endpoints.
+You can query, add, modify, or delete the actual metadata of nodes, interfaces, and services via REST endpoints.
 
-== GETs (reading metadata)
+Modification of metadata entries is limited to user defined contexts (starting with `X-`).
+Read about xref:operation:deep-dive/admin/metadata.adoc#metadata-contexts[how metadata contexts work] for further details.
+
+WARNING: It is highly recommended to not modify any metadata using this interface but use the provided requisition mechanisms instead.
+Nodes provisioned via requisition may have metadata overwritten during the resynchronization process.
+This can lead to loss of custom metadata defined outside the requisition.
+
+[[rest-api-meta-data-get]]
+== GETs (Reading Meta-Data)
 
 [caption=]
 .Metadata API GET functions
@@ -38,4 +46,65 @@ You can query the actual metadata of nodes, interfaces, and services via REST en
 
 | api/v2/nodes/\{id}/ipinterfaces/\{ipinterface}/services/\{service}/metadata/\{context}/\{key}
 | Get the entry for the given context and key associated with this service.
+|===
+
+[[rest-api-meta-data-post]]
+== POSTs (Adding Meta-Data)
+
+POST requires XML using `application/xml` as its Content-Type.
+
+[options="header", cols="5,10"]
+|===
+| Resource  | Description
+
+| api/v2/nodes/\{id\}/metadata
+| Adds a metadata entry to the given node.
+| api/v2/nodes/\{id\}/\{ipinterface\}/metadata
+| Adds a metadata entry to the given interface.
+
+| api/v2/nodes/\{id\}/\{ipinterface\}/services/\{service\}/metadata`
+| Adds a metadata entry to the given service.
+|===
+
+[[rest-api-meta-data-put]]
+== PUTs (Modifying Meta-Data)
+
+[options="header", cols="5,10"]
+|===
+| Resource | Description
+
+| api/v2/nodes/\{id\}/metadata/\{context\}/\{key}/\{value\}
+| Sets the given value for the node-level metadata entry specified by the given context and key.
+
+| api/v2/nodes/\{id\}/ipinterfaces/\{ipinterface\}/metadata/\{context\}/\{key}/\{value\}
+| Sets the given value for the interface-level metadata entry specified by the given context and key.
+
+| api/v2/nodes/\{id\}/ipinterfaces/\{ipinterface\}/services/\{service\}/metadata/\{context\}/\{key}/\{value\}
+| Sets the given value for the service-level metadata entry specified by the given context and key.
+|===
+
+[[rest-api-meta-data-delete]]
+== DELETEs (Removing Meta-Data)
+
+[options="header", cols="5,10"]
+|===
+| Resource | Description
+
+| api/v2/nodes/\{id\}/metadata/\{context\}
+| Deletes node-level metadata with the given context.
+
+| api/v2/nodes/\{id\}/metadata/\{context\}/\{key}
+| Deletes the node-level metadata entry for the given context and key.
+
+| api/v2/nodes/\{id\}/ipinterfaces/\{ipinterface\}/metadata/\{context\}
+| Deletes interface-level metadata with the given context.
+
+| api/v2/nodes/\{id\}/ipinterfaces/\{ipinterface\}/metadata/\{context\}/\{key}
+| Deletes the interface-level metadata entry for the given context and key.
+
+| api/v2/nodes/\{id\}/ipinterfaces/\{ipinterface\}/services/\{service\}/metadata/\{context\}
+| Deletes service-level metadata with the given context.
+
+| api/v2/nodes/\{id\}/ipinterfaces/\{ipinterface\}/services/\{service\}/metadata/\{context\}/\{key}
+| Deletes the service-level metadata entry for the given context and key.
 |===

--- a/docs/modules/development/pages/rest/meta-data.adoc
+++ b/docs/modules/development/pages/rest/meta-data.adoc
@@ -5,7 +5,7 @@
 You can query, add, modify, or delete the actual metadata of nodes, interfaces, and services via REST endpoints.
 
 Modification of metadata entries is limited to user defined contexts (starting with `X-`).
-Read about xref:operation:deep-dive/admin/metadata.adoc#metadata-contexts[how metadata contexts work] for further details.
+Read about xref:operation:deep-dive/meta-data.adoc#metadata-contexts[how metadata contexts work] for further details.
 
 WARNING: It is highly recommended to not modify any metadata using this interface but use the provided requisition mechanisms instead.
 Nodes provisioned via requisition may have metadata overwritten during the resynchronization process.

--- a/docs/modules/operation/nav.adoc
+++ b/docs/modules/operation/nav.adoc
@@ -69,6 +69,7 @@
 *** xref:deep-dive/performance-data-collection/resource-types.adoc[]
 **** xref:deep-dive/performance-data-collection/snmp-index.adoc[]
 *** xref:deep-dive/performance-data-collection/collectors.adoc[]
+*** xref:deep-dive/performance-data-collection/graphs.adoc[]
 *** xref:deep-dive/performance-data-collection/snmp-property-extenders/property-extenders.adoc[]
 **** xref:deep-dive/performance-data-collection/snmp-property-extenders/cisco-cbqos.adoc[]
 **** xref:deep-dive/performance-data-collection/snmp-property-extenders/enum-lookup.adoc[]

--- a/docs/modules/operation/pages/deep-dive/meta-data.adoc
+++ b/docs/modules/operation/pages/deep-dive/meta-data.adoc
@@ -21,6 +21,7 @@ You can view the metadata that is currently assigned to nodes, interfaces, and s
 .Node metadata
 image::metadata/metadata-view.png["{page-component-title} web UI showing a node's associated metadata"]
 
+[[metadata-contexts]]
 == Contexts
 
 Contexts distinguish different kinds of metadata use.

--- a/docs/modules/operation/pages/deep-dive/performance-data-collection/collectors.adoc
+++ b/docs/modules/operation/pages/deep-dive/performance-data-collection/collectors.adoc
@@ -10,4 +10,4 @@ Understanding xref:operation:deep-dive/performance-data-collection/resource-type
 
 == Supported collectors
 
-For information on supported collectors and how to configure them, see xref:operation:deep-dive/performance-data-collection/introduction.adoc[Performance Management].
+For information on supported collectors and how to configure them, see xref:reference:performance-data-collection/introduction.adoc[Collectors].

--- a/docs/modules/operation/pages/deep-dive/performance-data-collection/graphs.adoc
+++ b/docs/modules/operation/pages/deep-dive/performance-data-collection/graphs.adoc
@@ -1,0 +1,101 @@
+
+[[graphs]]
+= Graphing Metrics
+:description: Overview of creating custom RRDTool graphs for metrics collected by {page-component-title}.
+
+Collecting performance data is only good if you can view the metrics that have been persisted.
+{page-component-title} can display resource graphs that have been defined using link:https://oss.oetiker.ch/rrdtool/doc/rrdgraph.en.html[RRDTool] graphing syntax.
+
+NOTE: {page-component-title} defaults to showing graphs using our Backshift rendering engine.
+This is feature-compatible with rrdgraph commands, but runs in the browser as opposed to on the server back end.
+The graph rendering engine can be changed via `opennms.properties` settings.
+
+TIP: When using the xref:deep-dive/admin/mib.adoc[MIB Compiler] to generate collection definitions, the compiler will also create graph definitions for all the numeric values found in the MIB.
+
+As an alternative to creating graphs within {page-component-title}, you can also utilize our link:https://docs.opennms.com/grafana-plugin/latest/index.html[OpenNMS Plugin for Grafana] to create dashboards displaying various resource graphs.
+
+== Graph definitions
+
+Graphs are defined in in the `$\{OPENNMS_HOME}/etc/snmp-graph.properties.d` directory via `.properties` file.
+These files are re-read whenever the "Resource Graphs" page is loaded in the Web UI and do not require restarting any daemons to apply changes.
+When the Resource Graphs page is loaded for a node, {page-component-title} will look at the available metrics for the node, and will only display graphs where there are metrics for the `columns` defined in the graph.
+
+
+NOTE: While the graph directory name says `snmp-graph`, this system is used for displaying metrics regardless of which collector class was used.
+
+The definition file should start with a `reports` property that is a list of report names that are defined later on in the file.
+
+
+[cols="1,2"]
+|===
+| Property | Description
+
+| name
+| The name of the graph.
+This is dispalyed next to the graph in the Web UI.
+The `command` parameter can also include a `title` attribute that will render a title within the graph itself.
+
+| columns
+| Metric names to include in the graph.
+This is a comma-separated list of `alias` names from datacollection definitions.
+
+| type
+| The resource type that the `column` metrics belong to.
+This is often either `nodeSnmp` or `interfaceSnmp`, but may also be a custom resource type.
+
+| command
+| Parameters to feed into the graph rendering engine.
+This should be in link:https://oss.oetiker.ch/rrdtool/doc/rrdgraph.en.html[RRDTool syntax].
+
+| description
+| This is an optional property that can be used to describe the graph, however it is not rendered within the Web UI.
+
+| suppress
+| This is an optional property that can be used to suppress other graphs from rendering.
+This would be used if you have similar graphs based on different metrics and only want to display one or the other, based on the available data.
+|===
+
+=== Example report
+
+Below is an example of a graph from the default `mib2-graph.properties` file.
+
+[source, properties]
+----
+report.mib2.HCbits.name=Bits In/Out (High Speed) <1>
+report.mib2.HCbits.suppress=mib2.bits <2>
+report.mib2.HCbits.columns=ifHCInOctets,ifHCOutOctets <3>
+report.mib2.HCbits.type=interfaceSnmp <4>
+report.mib2.HCbits.command=--title="Bits In/Out (High Speed)" \ <5>
+ --vertical-label="Bits per second" \
+ DEF:octIn={rrd1}:ifHCInOctets:AVERAGE \
+ DEF:octOut={rrd2}:ifHCOutOctets:AVERAGE \
+ CDEF:rawbitsIn=octIn,8,* \
+ CDEF:rawbitsOut=octOut,8,* \
+ CDEF:rawbitsOutNeg=0,rawbitsOut,- \
+ CDEF:bytesIn=octIn,UN,0,octIn,IF \
+ CDEF:bytesOut=octOut,UN,0,octOut,IF \
+ CDEF:outSum=bytesOut,{diffTime},* \
+ CDEF:inSum=bytesIn,{diffTime},* \
+ CDEF:totSum=outSum,inSum,+ \
+ AREA:rawbitsIn#73d216 \
+ LINE1:rawbitsIn#4e9a06:"In " \
+ GPRINT:rawbitsIn:AVERAGE:"Avg  \\: %8.2lf %s" \
+ GPRINT:rawbitsIn:MIN:"Min  \\: %8.2lf %s" \
+ GPRINT:rawbitsIn:MAX:"Max  \\: %8.2lf %s\\n" \
+ AREA:rawbitsOutNeg#729fcf \
+ LINE1:rawbitsOutNeg#3465a4:"Out" \
+ GPRINT:rawbitsOut:AVERAGE:"Avg  \\: %8.2lf %s" \
+ GPRINT:rawbitsOut:MIN:"Min  \\: %8.2lf %s" \
+ GPRINT:rawbitsOut:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:inSum:AVERAGE:"  Tot In  \\: %8.2lf %sBytes" \
+ GPRINT:outSum:AVERAGE:" Tot Out  \\: %8.2lf %sBytes" \
+ GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %sBytes\\n"
+----
+<1> The name of the graph to display.
+<2> Suppresses the `mib2.bits` graph from displaying if this graph can be rendered.
+<3> List of metric alias names to include.
+These are referenced in the `DEF` commands based on the order they are listed.
+In this example, `ifHCInOctets` is `{rrd1}` and `ifHCOutOctets` is `{rrd2}`
+<4> The resource type of the graph.
+In this example, the `columns` defined should be collected as part of the SNMP Interface.
+<5> The RRDTool command to render the graph.

--- a/docs/modules/operation/pages/deep-dive/performance-data-collection/graphs.adoc
+++ b/docs/modules/operation/pages/deep-dive/performance-data-collection/graphs.adoc
@@ -6,11 +6,7 @@
 Collecting performance data is only good if you can view the metrics that have been persisted.
 {page-component-title} can display resource graphs that have been defined using link:https://oss.oetiker.ch/rrdtool/doc/rrdgraph.en.html[RRDTool] graphing syntax.
 
-NOTE: {page-component-title} defaults to showing graphs using our Backshift rendering engine.
-This is feature-compatible with rrdgraph commands, but runs in the browser as opposed to on the server back end.
-The graph rendering engine can be changed via `opennms.properties` settings.
-
-TIP: When using the xref:deep-dive/admin/mib.adoc[MIB Compiler] to generate collection definitions, the compiler will also create graph definitions for all the numeric values found in the MIB.
+NOTE: When using the xref:deep-dive/admin/mib.adoc[MIB Compiler] to generate collection definitions, the compiler will also create graph definitions for all the numeric values found in the MIB.
 
 As an alternative to creating graphs within {page-component-title}, you can also utilize our link:https://docs.opennms.com/grafana-plugin/latest/index.html[OpenNMS Plugin for Grafana] to create dashboards displaying various resource graphs.
 
@@ -19,20 +15,21 @@ As an alternative to creating graphs within {page-component-title}, you can also
 Graphs are defined in in the `$\{OPENNMS_HOME}/etc/snmp-graph.properties.d` directory via `.properties` file.
 These files are re-read whenever the "Resource Graphs" page is loaded in the Web UI and do not require restarting any daemons to apply changes.
 When the Resource Graphs page is loaded for a node, {page-component-title} will look at the available metrics for the node, and will only display graphs where there are metrics for the `columns` defined in the graph.
-
+Within the configuration files, each graph is referred to as a "report".
 
 NOTE: While the graph directory name says `snmp-graph`, this system is used for displaying metrics regardless of which collector class was used.
 
-The definition file should start with a `reports` property that is a list of report names that are defined later on in the file.
+The definition file should start with a `reports` property that is a comma-separated list of report names that are defined later on in the file.
+The list of report names should be followed by a group of definition properties.
 
-
+.Graph definition properties
 [cols="1,2"]
 |===
 | Property | Description
 
 | name
 | The name of the graph.
-This is dispalyed next to the graph in the Web UI.
+This is displayed next to the graph in the Web UI.
 The `command` parameter can also include a `title` attribute that will render a title within the graph itself.
 
 | columns
@@ -58,6 +55,7 @@ This would be used if you have similar graphs based on different metrics and onl
 === Example report
 
 Below is an example of a graph from the default `mib2-graph.properties` file.
+The `reports=` setting at the top of the file should include a reference to `mib2.HCbits`.
 
 [source, properties]
 ----
@@ -93,9 +91,10 @@ report.mib2.HCbits.command=--title="Bits In/Out (High Speed)" \ <5>
 ----
 <1> The name of the graph to display.
 <2> Suppresses the `mib2.bits` graph from displaying if this graph can be rendered.
+This assumes there is another section that defines a graph with the property `report.mib2.HCbits.name`.
 <3> List of metric alias names to include.
 These are referenced in the `DEF` commands based on the order they are listed.
-In this example, `ifHCInOctets` is `{rrd1}` and `ifHCOutOctets` is `{rrd2}`
+In this example, `ifHCInOctets` is `\{rrd1}` and `ifHCOutOctets` is `\{rrd2}`
 <4> The resource type of the graph.
 In this example, the `columns` defined should be collected as part of the SNMP Interface.
 <5> The RRDTool command to render the graph.

--- a/docs/modules/operation/pages/deep-dive/performance-data-collection/snmp-index.adoc
+++ b/docs/modules/operation/pages/deep-dive/performance-data-collection/snmp-index.adoc
@@ -96,10 +96,11 @@ This code snippet shows that the group for `mib2-host-resources-storage` was add
 == Create a report in snmp-graph.properties
 
 Finally, you can create a report in `snmp-graph.properties` like you normally would, with the exception that you must set the type to match the resource type's name.
+See xref:deep-dive/performance-data-collection/graphs.adoc[Graphing Metrics] for more information on creating resource graphs.
 
 This code snippet creates a report for `hrStorageIndex` disk utilization data:
 
-[source, xml]
+[source, properties]
 ----
 report.mib2.storage.usage.name=Storage Utilization (MIB-2 Host Resources)
 report.mib2.storage.usage.columns=hrStorageSize, hrStorageUsed, hrStorageAllocUnits

--- a/docs/modules/operation/pages/deep-dive/performance-data-collection/snmp-index.adoc
+++ b/docs/modules/operation/pages/deep-dive/performance-data-collection/snmp-index.adoc
@@ -126,7 +126,7 @@ You must make sure that you add your new report to the `reports` parameter in th
 In the example above, the report name is `mib2.storage.usage`.
 
 .Example of `reports` parameter, which configures available reports
-[source, xml]
+[source, properties]
 ----
 reports=mib2.bits, mib2.percentdiscards, mib2.percenterrors, \
 ...

--- a/docs/modules/reference/pages/telemetryd/protocols/openconfig.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/openconfig.adoc
@@ -72,6 +72,8 @@ The data contains metadata and is structured as a list of `key:value` pairs.
         <parameter key="port" value="${requisition:oc.port|9000}"/>
         <parameter key="retries" value="12"/>
         <parameter key="interval" value="300"/>
+        <parameter key="username" value="admin"/>
+        <parameter key="password" value="admin"/>
         <parameter key="tls.enabled" value="${requisition:oc.tls.enabled}"/>
         <parameter key="tls.trust.cert.path" value="${requisition:trust.cert.path}"/>
         <!-- Use groups to separate paths that need to be streamed at different frequencies -->
@@ -84,6 +86,11 @@ The data contains metadata and is structured as a list of `key:value` pairs.
     </package>
 </connector>
 ----
+
+
+=== Service
+For any interface that needs to enable OpenConfig streaming, we need to add a service on a given interface.
+This denotes `service-name` in above configuration which is defined as `OpenConfig`.
 
 === Packages
 At least one package must be present for the connector to function.
@@ -115,7 +122,7 @@ Parameters are passed to the connector and are interpolated for node/interface a
 | none
 
 | frequency
-| Frequency at which OpenConfig data can be streamed.
+| Frequency at which OpenConfig data can be streamed. This is parsed as milliseconds(ms) for jti and nanoseconds(ns) for gnmi
 | 300000
 
 3+| *Optional*
@@ -125,7 +132,7 @@ Parameters are passed to the connector and are interpolated for node/interface a
 | 0
 
 | interval
-| Interval at which client tries to make a connection when failed.
+| Interval at which client tries to make a connection when failed in seconds.
 | 300
 
 | tls.enabled
@@ -135,6 +142,23 @@ Parameters are passed to the connector and are interpolated for node/interface a
 | tls.trust.cert.path
 | Server trust certificate path.
 | none
+
+| origin
+| Origin that need to be subscribed to, only relevant for gnmi.
+| openconfig
+
+| username
+| Username that can be used to authenticate, sent as metadata to the server.
+| none
+
+| password
+| Password that can be used to authenticate, sent as metadata to the server.
+| none
+
+
+| mode
+| Specify mode for stream format. Options include gnmi or jti.
+| gnmi
 |===
 
 == OpenConfig adapter
@@ -168,7 +192,7 @@ Use the script extension to extract the desired metrics from the OpenConfig stre
 3+| *Optional*
 
 | mode
-| Specify mode for stream format.
+| Specify mode for stream format. Options include gnmi or jti.
 Options are `gnmi` or `jti`.
 | gnmi
 |===

--- a/features/bsm/rest/impl/pom.xml
+++ b/features/bsm/rest/impl/pom.xml
@@ -72,7 +72,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <scope>${onmsLibScope}</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/features/collection/snmp-collector/src/main/java/org/opennms/netmgt/collectd/SnmpPropertyExtenderProcessor.java
+++ b/features/collection/snmp-collector/src/main/java/org/opennms/netmgt/collectd/SnmpPropertyExtenderProcessor.java
@@ -121,6 +121,8 @@ public class SnmpPropertyExtenderProcessor {
             if (targetAttribute != null) {
                 LOG.debug("updateCollectionResource: adding property {} to resource {} with value {}", targetAttribute.getName(), targetResource, targetAttribute.getStringValue());
                 targetResource.setAttributeValue((SnmpAttributeType) targetAttribute.getAttributeType(), targetAttribute.getValue());
+            } else {
+                LOG.debug("updateCollectionResource: no match for resource {} (instance={}, class-name={})", targetResource, property.getInstance(), clazz.getSimpleName());
             }
         } catch (Exception e) {
             LOG.error("Cannot update collection resource {}", targetResource, e);

--- a/features/config/upgrade/pom.xml
+++ b/features/config/upgrade/pom.xml
@@ -24,20 +24,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-core</artifactId>
-            <version>${liquibaseVersion}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-          <version>${snakeyamlVersion}</version>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>liquibase-dependencies</artifactId>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.opennms.features.config.dao</groupId>

--- a/features/distributed/kv-store/blob/blob-itests/pom.xml
+++ b/features/distributed/kv-store/blob/blob-itests/pom.xml
@@ -72,5 +72,11 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.33</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/features/events/shell-commands/src/main/java/org/opennms/netmgt/events/commands/EventCommand.java
+++ b/features/events/shell-commands/src/main/java/org/opennms/netmgt/events/commands/EventCommand.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.events.commands;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.api.console.Terminal;
+import org.apache.karaf.shell.support.table.ShellTable;
+import org.opennms.core.criteria.Alias;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.api.EventDao;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsDistPoller;
+import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsEventParameter;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+@Command(scope = "opennms", name = "event", description = "Show event details for a given id")
+@Service
+public class EventCommand implements Action {
+
+    @Reference
+    public EventDao eventDao;
+
+    @Argument(name = "id", description = "Event Id to match (exact). If no argument is given, the most recent event will be displayed.", required = false, multiValued = false)
+    Integer id;
+
+    @Reference
+    Terminal terminal;
+
+    @Override
+    public Object execute() {
+        CriteriaBuilder criteriaBuilder = new CriteriaBuilder(OnmsEvent.class)
+                .orderBy("eventTime").desc()
+                .alias("node", "node", Alias.JoinType.LEFT_JOIN)
+                .alias("alarm", "alarm", Alias.JoinType.LEFT_JOIN)
+                .alias("eventParameters", "event_parameters", Alias.JoinType.LEFT_JOIN)
+                .alias("serviceType", "serviceType", Alias.JoinType.LEFT_JOIN)
+                .orderBy("id", false)
+                .limit(1);
+
+        if (id != null) {
+            criteriaBuilder = criteriaBuilder.eq("id", id);
+        }
+
+        final var onmsEvents = eventDao.findMatching(criteriaBuilder.toCriteria());
+
+        if (onmsEvents.size() == 0) {
+            return null;
+        }
+
+        final OnmsEvent onmsEvent = onmsEvents.get(0);
+
+        final ShellTable eventPropertyTable = new ShellTable();
+        eventPropertyTable.size(terminal.getWidth() - 1);
+        eventPropertyTable.column("Property");
+        eventPropertyTable.column("Value");
+
+        fillTable(eventPropertyTable, "eventUei", onmsEvent.getEventUei());
+        fillTable(eventPropertyTable, "eventTime", onmsEvent.getEventTime());
+        fillTable(eventPropertyTable, "eventHost", onmsEvent.getEventHost());
+        fillTable(eventPropertyTable, "eventSource", onmsEvent.getEventSource());
+        fillTable(eventPropertyTable, "ipAddr", onmsEvent.getIpAddr());
+        fillTable(eventPropertyTable, "distPoller", onmsEvent.getDistPoller());
+        fillTable(eventPropertyTable, "eventSnmpHost", onmsEvent.getEventSnmpHost());
+        fillTable(eventPropertyTable, "serviceType", onmsEvent.getServiceType());
+        fillTable(eventPropertyTable, "eventSnmp", onmsEvent.getEventSnmp());
+        fillTable(eventPropertyTable, "eventCreateTime", onmsEvent.getEventCreateTime());
+        fillTable(eventPropertyTable, "eventDescr", onmsEvent.getEventDescr());
+        fillTable(eventPropertyTable, "eventLog", onmsEvent.getEventLog());
+        fillTable(eventPropertyTable, "eventLogGroup", onmsEvent.getEventLogGroup());
+        fillTable(eventPropertyTable, "eventLogMsg", onmsEvent.getEventLogMsg());
+        fillTable(eventPropertyTable, "eventSeverity", onmsEvent.getEventSeverity());
+        fillTable(eventPropertyTable, "ifIndex", onmsEvent.getIfIndex());
+        fillTable(eventPropertyTable, "eventPathOutage", onmsEvent.getEventPathOutage());
+        fillTable(eventPropertyTable, "eventCorrelation", onmsEvent.getEventCorrelation());
+        fillTable(eventPropertyTable, "eventSurpressedCount", onmsEvent.getEventSuppressedCount());
+        fillTable(eventPropertyTable, "eventOperInstruct", onmsEvent.getEventOperInstruct());
+        fillTable(eventPropertyTable, "eventAutoAction", onmsEvent.getEventAutoAction());
+        fillTable(eventPropertyTable, "eventOperAction", onmsEvent.getEventOperAction());
+        fillTable(eventPropertyTable, "eventOperActionMenuText", onmsEvent.getEventOperActionMenuText());
+        fillTable(eventPropertyTable, "eventNotification", onmsEvent.getEventNotification());
+        fillTable(eventPropertyTable, "eventTTicket", onmsEvent.getEventTTicket());
+        fillTable(eventPropertyTable, "eventTTicketState", onmsEvent.getEventTTicketState());
+        fillTable(eventPropertyTable, "eventForward", onmsEvent.getEventForward());
+        fillTable(eventPropertyTable, "eventMouseOverText", onmsEvent.getEventMouseOverText());
+        fillTable(eventPropertyTable, "eventDisplay", onmsEvent.getEventDisplay());
+        fillTable(eventPropertyTable, "eventAckUser", onmsEvent.getEventAckUser());
+        fillTable(eventPropertyTable, "eventAckTime", onmsEvent.getEventAckTime());
+        fillTable(eventPropertyTable, "alarm", onmsEvent.getAlarm());
+        fillTable(eventPropertyTable, "node", onmsEvent.getNode());
+
+        System.out.println("\nEvent Properties for Event #" + onmsEvent.getId() + ":\n");
+        eventPropertyTable.print(System.out);
+
+        final ShellTable eventParameterTable = new ShellTable();
+        eventParameterTable.size(terminal.getWidth() - 1);
+        eventParameterTable.column("Name");
+        eventParameterTable.column("Type");
+        eventParameterTable.column("Value");
+
+        for (final OnmsEventParameter onmsEventParameter : onmsEvent.getEventParameters()) {
+            eventParameterTable.addRow().addContent(onmsEventParameter.getName(), onmsEventParameter.getType(), onmsEventParameter.getValue());
+        }
+
+        System.out.println("\nEvent Parameters for Event #" + onmsEvent.getId() + ":\n");
+        eventParameterTable.print(System.out);
+
+        return null;
+    }
+
+    private void fillTable(final ShellTable table, final String name, final Object object) {
+        String value;
+        if (object == null) {
+            value = "<not set>";
+        } else {
+            switch (name) {
+                case "eventSeverity":
+                    value = object + " (" + OnmsSeverity.get((Integer) object) + ")";
+                    break;
+                case "distPoller":
+                    value = String.valueOf(((OnmsDistPoller) object).getId());
+                    break;
+                case "serviceType":
+                    value = String.valueOf(((OnmsServiceType) object).getName());
+                    break;
+                case "alarm":
+                    value = String.valueOf(((OnmsAlarm) object).getId());
+                    break;
+                case "node":
+                    value = String.valueOf(((OnmsNode) object).getId());
+                    break;
+                default:
+                    value = object.toString();
+                    break;
+            }
+        }
+        table.addRow().addContent(name, value);
+    }
+}

--- a/features/measurements/rest/pom.xml
+++ b/features/measurements/rest/pom.xml
@@ -49,7 +49,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <scope>${onmsLibScope}</scope>
     </dependency>
 
     <!-- Testing -->

--- a/features/newts-repository-converter/pom.xml
+++ b/features/newts-repository-converter/pom.xml
@@ -99,6 +99,12 @@
       <version>1.5.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.33</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/features/newts/pom.xml
+++ b/features/newts/pom.xml
@@ -108,6 +108,17 @@
       <version>${project.version}</version>
       <type>pom</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.33</version>
     </dependency>
     <dependency>
       <groupId>org.opennms.dependencies</groupId>

--- a/features/nrtg/config.properties
+++ b/features/nrtg/config.properties
@@ -68,13 +68,15 @@ org.osgi.framework.system.packages=org.osgi.framework; version=1.5.0, \
  org.apache.karaf.version; version=2.2.8, \
  ${jre-${java.specification.version}}
 
-org.osgi.framework.system.packages.extra=sun.net.spi.nameservice, \
- javax.xml.bind; version=2.1.0 , \
+org.osgi.framework.system.packages.extra=\
+ java.net.http, \
+ javax.xml.bind; version=2.1.0, \
  javax.xml.bind.annotation; version=2.1.0, \
  javax.xml.bind.annotation.adapters; version=2.1.0, \
  javax.xml.bind.attachment; version=2.1.0, \
  javax.xml.bind.helpers; version=2.1.0, \
  javax.xml.bind.util; version=2.1.0, \
+ sun.net.spi.nameservice, \
 
 
 # javax.transaction is needed to avoid class loader constraint violation when using javax.sql  

--- a/features/openconfig/telemetry-client/src/main/java/org/opennms/features/openconfig/telemetry/OpenConfigClientImpl.java
+++ b/features/openconfig/telemetry-client/src/main/java/org/opennms/features/openconfig/telemetry/OpenConfigClientImpl.java
@@ -30,6 +30,7 @@ package org.opennms.features.openconfig.telemetry;
 
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
@@ -82,6 +83,7 @@ public class OpenConfigClientImpl implements OpenConfigClient {
     private static final int DEFAULT_INTERNAL_RETRIES = 5;
     private static final int DEFAULT_INTERNAL_TIMEOUT = 1000;
     private static final int DEFAULT_FREQUENCY = 300000; //5min
+    private static final long DEFAULT_FREQUENCY_FOR_GNMI = 300 * 10^9; // 5mins in nano seconds
     private static final int DEFAULT_INTERVAL_IN_SEC = 300; //5min
     private static final String PORT = "port";
     private static final String MODE = "mode";
@@ -90,6 +92,8 @@ public class OpenConfigClientImpl implements OpenConfigClient {
     private static final String INTERVAL = "interval";
     private static final String RETRIES = "retries";
     private static final String JTI_MODE = "jti";
+    private static final String ORIGIN = "origin";
+    private static final String DEFAULT_ORIGIN = "openconfig";
     private static final String USERNAME_FIELD = "username";
     private static final String PASSWORD_FIELD = "password";
     private ManagedChannel channel;
@@ -172,34 +176,36 @@ public class OpenConfigClientImpl implements OpenConfigClient {
                 paths.forEach(path -> requestBuilder.addPathList(Telemetry.Path.newBuilder().setPath(path).setSampleFrequency(frequency).build()));
             });
             asyncStub.telemetrySubscribe(requestBuilder.build(), new TelemetryDataHandler(host, port, handler));
-            LOG.info("Subscribed to OpenConfig telemetry stream at {}", InetAddressUtils.str(host));
+            LOG.info("Subscribed to OpenConfig telemetry stream at {}/{}", InetAddressUtils.str(host), port);
         } else {
 
             gNMIGrpc.gNMIStub gNMIStub = gNMIGrpc.newStub(channel);
             Gnmi.SubscribeRequest.Builder requestBuilder = Gnmi.SubscribeRequest.newBuilder();
             Gnmi.SubscriptionList.Builder subscriptionListBuilder = Gnmi.SubscriptionList.newBuilder();
             paramList.forEach(entry -> {
-                Integer frequency = StringUtils.parseInt(entry.get(FREQUENCY), DEFAULT_FREQUENCY);
+                Long frequency = StringUtils.parseLong(entry.get(FREQUENCY), DEFAULT_FREQUENCY_FOR_GNMI);
                 String pathString = entry.get(PATHS);
+                String origin = entry.get(ORIGIN);
                 List<String> paths = pathString != null ? Arrays.asList(pathString.split(",", -1)) : new ArrayList<>();
                 paths.forEach(path -> {
-                    Gnmi.Path gnmiPath = buildGnmiPath(path);
+                    Gnmi.Path gnmiPath = buildGnmiPath(path, origin);
                     Gnmi.Subscription subscription = Gnmi.Subscription.newBuilder()
                             .setPath(gnmiPath)
                             .setSampleInterval(frequency)
                             .setMode(Gnmi.SubscriptionMode.SAMPLE).build();
                     subscriptionListBuilder.addSubscription(subscription);
+                    subscriptionListBuilder.setMode(Gnmi.SubscriptionList.Mode.STREAM);
                 });
             });
             requestBuilder.setSubscribe(subscriptionListBuilder.build());
             StreamObserver<Gnmi.SubscribeRequest> requestStreamObserver = gNMIStub.subscribe(new GnmiDataHandler(handler, host, port));
             requestStreamObserver.onNext(requestBuilder.build());
-            LOG.info("Subscribed to OpenConfig telemetry stream at {}", InetAddressUtils.str(host));
+            LOG.info("Subscribed to OpenConfig telemetry stream at {}/{}", InetAddressUtils.str(host), port);
         }
     }
 
     // Builds gnmi path based on https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-path-conventions.md
-    static Gnmi.Path buildGnmiPath(String path) {
+    static Gnmi.Path buildGnmiPath(String path, String origin) {
         Gnmi.Path.Builder gnmiPathBuilder = Gnmi.Path.newBuilder();
         List<String> elemList =  Splitter.on(PATH_SEPARATOR).omitEmptyStrings().splitToList(path);
         elemList.forEach(elem -> {
@@ -214,6 +220,11 @@ public class OpenConfigClientImpl implements OpenConfigClient {
                 gnmiPathBuilder.addElem(Gnmi.PathElem.newBuilder().setName(elem).build());
             }
         });
+        if (Strings.isNullOrEmpty(origin)) {
+            gnmiPathBuilder.setOrigin(DEFAULT_ORIGIN);
+        } else {
+            gnmiPathBuilder.setOrigin(origin);
+        }
         return gnmiPathBuilder.build();
     }
 

--- a/features/openconfig/telemetry-client/src/test/java/org/opennms/features/openconfig/telemetry/GnmiPathTest.java
+++ b/features/openconfig/telemetry-client/src/test/java/org/opennms/features/openconfig/telemetry/GnmiPathTest.java
@@ -39,24 +39,24 @@ public class GnmiPathTest {
     public void testGnmiPath()
     {
         String path = "/interfaces/interface[name=Ethernet1][ifIndex=25]/state/counters";
-        Gnmi.Path gnmiPath = OpenConfigClientImpl.buildGnmiPath(path);
+        Gnmi.Path gnmiPath = OpenConfigClientImpl.buildGnmiPath(path, null);
         Assert.assertEquals(gnmiPath.getElemCount(), 4);
         Assert.assertEquals("interface", gnmiPath.getElemList().get(1).getName());
         Assert.assertEquals("Ethernet1", gnmiPath.getElemList().get(1).getKeyOrDefault("name", "nothing"));
         Assert.assertEquals("25", gnmiPath.getElemList().get(1).getKeyOrDefault("ifIndex", "nothing"));
         path = "/a/b[c=45]/e[d=25]/";
-        gnmiPath = OpenConfigClientImpl.buildGnmiPath(path);
+        gnmiPath = OpenConfigClientImpl.buildGnmiPath(path, null);
         Assert.assertEquals("b", gnmiPath.getElemList().get(1).getName());
         Assert.assertEquals("45", gnmiPath.getElemList().get(1).getKeyOrDefault("c", "nothing"));
         Assert.assertEquals("25", gnmiPath.getElemList().get(2).getKeyOrDefault("d", "nothing"));
         Assert.assertEquals(gnmiPath.getElemCount(), 3);
         path = "/";
-        gnmiPath = OpenConfigClientImpl.buildGnmiPath(path);
+        gnmiPath = OpenConfigClientImpl.buildGnmiPath(path, null);
         Assert.assertEquals(gnmiPath.getElemCount(), 0);
 
         // Path where there are inner /
         path = "/interfaces/interface[name=Ethernet1/2/3][ifIndex=25]/state/counters";
-        gnmiPath = OpenConfigClientImpl.buildGnmiPath(path);
+        gnmiPath = OpenConfigClientImpl.buildGnmiPath(path, null);
         Assert.assertEquals(gnmiPath.getElemCount(), 4);
         Assert.assertEquals("interface", gnmiPath.getElemList().get(1).getName());
         Assert.assertEquals("Ethernet1/2/3", gnmiPath.getElemList().get(1).getKeyOrDefault("name", "nothing"));

--- a/features/status/rest/pom.xml
+++ b/features/status/rest/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <scope>${onmsLibScope}</scope>
         </dependency>
         <dependency>
             <groupId>org.opennms.features.status</groupId>

--- a/opennms-provision/opennms-provision-shell/pom.xml
+++ b/opennms-provision/opennms-provision-shell/pom.xml
@@ -50,5 +50,9 @@
       <groupId>org.opennms</groupId>
       <artifactId>opennms-provision-persistence</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-snmp-metadata-provisioning-adapter</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/opennms-provision/opennms-provision-shell/src/main/java/org/opennms/netmgt/provision/requisition/command/SnmpMetadataProvisioningAdapterCommand.java
+++ b/opennms-provision/opennms-provision-shell/src/main/java/org/opennms/netmgt/provision/requisition/command/SnmpMetadataProvisioningAdapterCommand.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.requisition.command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.api.console.Terminal;
+import org.apache.karaf.shell.support.table.ShellTable;
+import org.opennms.core.criteria.Criteria;
+import org.opennms.core.criteria.restrictions.RegExpRestriction;
+import org.opennms.core.spring.BeanUtils;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMetaData;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.provision.SnmpMetadataException;
+import org.opennms.netmgt.provision.SnmpMetadataProvisioningAdapter;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionOperations;
+
+import com.google.common.primitives.Booleans;
+
+@Command(scope = "opennms", name = "snmp-metadata-provisioning-adapter", description = "Trigger SnmpMetadataProvisioningAdapter for a set of nodes")
+@Service
+public class SnmpMetadataProvisioningAdapterCommand implements Action {
+    @Reference
+    public TransactionOperations transactionOperations;
+
+    @Reference
+    private NodeDao nodeDao;
+
+    @Reference
+    Terminal terminal;
+
+    @Option(name = "-i", aliases = "--id", description = "Node Id to process", required = false, multiValued = false)
+    Integer id;
+
+    @Option(name = "-a", aliases = "--all", description = "Process all nodes", required = false, multiValued = false)
+    Boolean all;
+
+    @Option(name = "-r", aliases = "--regexp", description = "Process nodes by label (regular expression)", required = false, multiValued = false)
+    String regexp;
+
+    @Option(name = "-p", aliases = "--persist", description = "Persist data instead of displaying it", required = false, multiValued = false)
+    Boolean persist = false;
+
+
+    @Override
+    public Object execute() {
+        final int optionsSet = Booleans.countTrue(id != null, regexp != null, all != null);
+        if (optionsSet == 0) {
+            System.out.println("Please provide one of the options --id/-i, --all/-a or --regexp/-r");
+        } else {
+            if (optionsSet > 1) {
+                System.out.println("Please provide only one option (--id, --all, --regexp)");
+            } else {
+                transactionOperations.execute(new TransactionCallback<Void>() {
+                    @Override
+                    public Void doInTransaction(TransactionStatus transactionStatus) {
+                        final List<OnmsNode> onmsNodes = new ArrayList<>();
+
+                        if (all != null) {
+                            onmsNodes.addAll(nodeDao.findAll());
+                        }
+
+                        if (regexp != null) {
+                            final Criteria criteria = new Criteria(OnmsNode.class);
+                            criteria.addRestriction(new RegExpRestriction("label", regexp));
+                            onmsNodes.addAll(nodeDao.findMatching(criteria));
+                        }
+
+                        if (id != null) {
+                            onmsNodes.add(nodeDao.get(id));
+                        }
+
+                        processNodes(onmsNodes, persist);
+
+                        return null;
+                    }
+                });
+            }
+        }
+
+        return null;
+    }
+
+
+    private void processNodes(final List<OnmsNode> onmsNodes, final boolean persist) {
+        final SnmpMetadataProvisioningAdapter snmpMetadataProvisioningAdapter = BeanUtils.getBean("provisiondContext", "snmpMetadataProvisioningAdapter", SnmpMetadataProvisioningAdapter.class);
+
+        System.out.println("Processing " + onmsNodes.size() + " node(s)...");
+
+        for (final OnmsNode onmsNode : onmsNodes) {
+            System.out.printf("\nProcessing node '%s' (id=%d)...\n", onmsNode.getLabel(), onmsNode.getId());
+
+            if (onmsNode == null) {
+                System.out.println("Error: node is null.");
+                continue;
+            }
+
+            final OnmsIpInterface onmsIpInterface = onmsNode.getPrimaryInterface();
+
+            if (onmsIpInterface == null) {
+                System.out.println("Error: primary interface is null.");
+                continue;
+            }
+
+            final List<OnmsMetaData> results;
+
+            try {
+                if (persist) {
+                    System.out.printf("Calling SnmpMetadataProvisioingAdapter.doUpdateNode(%d)...\n", onmsNode.getId());
+                    snmpMetadataProvisioningAdapter.doUpdateNode(onmsNode.getId());
+                    continue;
+                } else {
+                    results = snmpMetadataProvisioningAdapter.createMetadata(onmsNode, onmsNode.getPrimaryInterface());
+                }
+            } catch (SnmpMetadataException e) {
+                System.out.println("Error: provisioning adapter threw exception");
+                e.printStackTrace(System.out);
+                continue;
+            }
+
+            if (results == null) {
+                System.out.println("Error: node don't support SNMP (provisioning adapter returned null).");
+                continue;
+            }
+
+            if (results.size() == 0) {
+                System.out.println("Provisioning adapter returned no data.");
+                continue;
+            } else {
+                System.out.printf("Provisioning adapter returned %d metadata entries.\n\n", results.size());
+            }
+
+            final ShellTable table = new ShellTable();
+            table.size(terminal.getWidth() - 1);
+            table.column("Context");
+            table.column("Key");
+            table.column("Value");
+
+
+            for (final OnmsMetaData onmsMetaData : results) {
+                table.addRow().addContent(onmsMetaData.getContext(), onmsMetaData.getKey(), onmsMetaData.getValue());
+            }
+
+            table.print(System.out);
+        }
+    }
+}

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -575,7 +575,7 @@
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
-      <version>${swaggerVersion}</version>
+      <version>${swaggerParserVersion}</version>
       <scope>${onmsLibScope}</scope>
     </dependency>
     <dependency>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
@@ -569,10 +569,16 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
         }
     }
 
-    protected WebApplicationException getException(final Status status, String msg, String... params) throws WebApplicationException {
+    protected static WebApplicationException getException(final Status status, String msg, String... params) throws WebApplicationException {
         if (params != null) msg = MessageFormatter.arrayFormat(msg, params).getMessage();
         LOG.error(msg);
         return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(msg).build());
+    }
+
+    protected static void checkUserDefinedMetadataContext(final String context) {
+        if (!context.startsWith("X-")) {
+            throw getException(Status.FORBIDDEN, "Only metadata in contexts starting with 'X-' can be modified");
+        }
     }
 
     /**

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
@@ -282,4 +282,88 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
                 .filter(e -> context.equals(e.getContext()) && key.equals(e.getKey()))
                 .collect(Collectors.toList()));
     }
+
+    @DELETE
+    @Path("{serviceName}/metadata/{context}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    public Response deleteMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") final String serviceName, @PathParam("context") final String context) {
+        checkUserDefinedMetadataContext(context);
+
+        writeLock();
+        try {
+            final OnmsMonitoredService service = getService(uriInfo, serviceName);
+
+            if (serviceName == null) {
+                throw getException(Status.BAD_REQUEST, "deleteMetaData: Can't find service " + serviceName);
+            }
+            service.removeMetaData(context);
+            getDao().update(service);
+            return Response.noContent().build();
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @DELETE
+    @Path("{serviceName}/metadata/{context}/{key}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    public Response deleteMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") final String serviceName, @PathParam("context") final String context, @PathParam("key") final String key) {
+        checkUserDefinedMetadataContext(context);
+
+        writeLock();
+        try {
+            final OnmsMonitoredService service = getService(uriInfo, serviceName);
+
+            if (serviceName == null) {
+                throw getException(Status.BAD_REQUEST, "deleteMetaData: Can't find service " + serviceName);
+            }
+            service.removeMetaData(context, key);
+            getDao().update(service);
+            return Response.noContent().build();
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @POST
+    @Path("{serviceName}/metadata")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    public Response postMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") final String serviceName, final OnmsMetaData entity) {
+        checkUserDefinedMetadataContext(entity.getContext());
+
+        writeLock();
+        try {
+            final OnmsMonitoredService service = getService(uriInfo, serviceName);
+
+            if (serviceName == null) {
+                throw getException(Status.BAD_REQUEST, "postMetaData: Can't find service " + serviceName);
+            }
+            service.addMetaData(entity.getContext(), entity.getKey(), entity.getValue());
+            getDao().update(service);
+            return Response.noContent().build();
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @PUT
+    @Path("{serviceName}/metadata/{context}/{key}/{value}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    public Response putMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") final String serviceName, @PathParam("context") final String context, @PathParam("key") final String key, @PathParam("value") final String value) {
+        checkUserDefinedMetadataContext(context);
+
+        writeLock();
+        try {
+            final OnmsMonitoredService service = getService(uriInfo, serviceName);
+
+            if (serviceName == null) {
+                throw getException(Status.BAD_REQUEST, "putMetaData: Can't find service " + serviceName);
+            }
+            service.addMetaData(context, key, value);
+            getDao().update(service);
+            return Response.noContent().build();
+        } finally {
+            writeUnlock();
+        }
+    }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -34,7 +34,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -57,6 +59,7 @@ import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.events.api.EventProxy;
+import org.opennms.netmgt.model.OnmsMetaData;
 import org.opennms.netmgt.model.OnmsMetaDataList;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsNodeList;
@@ -334,5 +337,85 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         return new OnmsMetaDataList(node.getMetaData().stream()
                 .filter(e -> context.equals(e.getContext()) && key.equals(e.getKey()))
                 .collect(Collectors.toList()));
+    }
+
+    @DELETE
+    @Path("{nodeCriteria}/metadata/{context}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    public Response deleteMetaData(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("context") final String context) {
+        checkUserDefinedMetadataContext(context);
+
+        writeLock();
+        try {
+            final OnmsNode node = getDao().get(nodeCriteria);
+            if (node == null) {
+                throw getException(Status.BAD_REQUEST, "deleteMetaData: Can't find node " + nodeCriteria);
+            }
+            node.removeMetaData(context);
+            getDao().update(node);
+            return Response.noContent().build();
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @DELETE
+    @Path("{nodeCriteria}/metadata/{context}/{key}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    public Response deleteMetaData(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("context") final String context, @PathParam("key") final String key) {
+        checkUserDefinedMetadataContext(context);
+
+        writeLock();
+        try {
+            final OnmsNode node = getDao().get(nodeCriteria);
+            if (node == null) {
+                throw getException(Status.BAD_REQUEST, "deleteMetaData: Can't find node " + nodeCriteria);
+            }
+            node.removeMetaData(context, key);
+            getDao().update(node);
+            return Response.noContent().build();
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @POST
+    @Path("{nodeCriteria}/metadata")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    public Response postMetaData(@PathParam("nodeCriteria") final String nodeCriteria, final OnmsMetaData entity) {
+        checkUserDefinedMetadataContext(entity.getContext());
+
+        writeLock();
+        try {
+            final OnmsNode node = getDao().get(nodeCriteria);
+            if (node == null) {
+                throw getException(Status.BAD_REQUEST, "postMetaData: Can't find node " + nodeCriteria);
+            }
+            node.addMetaData(entity.getContext(), entity.getKey(), entity.getValue());
+            getDao().update(node);
+            return Response.noContent().build();
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @PUT
+    @Path("{nodeCriteria}/metadata/{context}/{key}/{value}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    public Response putMetaData(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("context") final String context, @PathParam("key") final String key, @PathParam("value") final String value) {
+        checkUserDefinedMetadataContext(context);
+
+        writeLock();
+        try {
+            final OnmsNode node = getDao().get(nodeCriteria);
+            if (node == null) {
+                throw getException(Status.BAD_REQUEST, "putMetaData: Can't find node " + nodeCriteria);
+            }
+            node.addMetaData(context, key, value);
+            getDao().update(node);
+            return Response.noContent().build();
+        } finally {
+            writeUnlock();
+        }
     }
 }

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-common.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-common.xml
@@ -32,11 +32,6 @@
     <!-- Jackson JAXB JSON provider -->
     <bean id="jacksonJaxbJsonProvider" class="org.codehaus.jackson.jaxrs.JacksonJaxbJsonProvider"/>
 
-    <!-- Atom Serialization @Provider classes -->
-    <bean id="atomEntryProvider"       class="org.apache.cxf.jaxrs.provider.atom.AtomEntryProvider"/>
-    <bean id="atomFeedProvider"        class="org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider"/>
-    <!-- <bean id="atomPojoProvider"        class="org.apache.cxf.jaxrs.provider.atom.AtomPojoProvider"/> -->
-
     <!-- FIQL search @Provider class -->
     <bean id="searchContextProvider" class="org.apache.cxf.jaxrs.ext.search.SearchContextProvider"/>
 

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v1.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v1.xml
@@ -41,15 +41,11 @@
       <jaxrs:extensionMappings>
         <entry key="json" value="application/json" />
         <entry key="xml" value="application/xml" />
-        <entry key="atom" value="application/atom+xml" />
       </jaxrs:extensionMappings>
       <jaxrs:providers>
         <ref bean="lenientJaxbProvider"/>
         <ref bean="jaxbProvider"/>
         <ref bean="jacksonJaxbJsonProvider"/>
-        <ref bean="atomEntryProvider"/>
-        <ref bean="atomFeedProvider"/>
-        <!-- <ref bean="atomPojoProvider"/> -->
         <ref bean="errorResponseProvider" />
         <ref bean="noSuchElementProvider" />
         <ref bean="serviceUnavailableResponseProvider" />

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
@@ -79,15 +79,11 @@
       <jaxrs:extensionMappings>
         <entry key="json" value="application/json" />
         <entry key="xml" value="application/xml" />
-        <entry key="atom" value="application/atom+xml" />
       </jaxrs:extensionMappings>
       <jaxrs:providers>
         <ref bean="lenientJaxbProvider"/>
         <ref bean="jaxbProvider"/>
         <ref bean="jacksonJaxbJsonProvider"/>
-        <ref bean="atomEntryProvider"/>
-        <ref bean="atomFeedProvider"/>
-        <!-- <ref bean="atomPojoProvider"/> -->
         <ref bean="searchContextProvider"/>
         <ref bean="noSuchElementProvider" />
         <ref bean="errorResponseProvider" />

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/MetadataRestIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/MetadataRestIT.java
@@ -43,11 +43,7 @@ import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
-import org.opennms.netmgt.dao.DatabasePopulator;
-import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMetaDataList;
-import org.opennms.netmgt.model.OnmsMonitoredService;
-import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.slf4j.Logger;
@@ -56,7 +52,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @WebAppConfiguration
@@ -81,13 +76,6 @@ public class MetadataRestIT extends AbstractSpringJerseyRestTestCase {
     @Autowired
     private ServletContext m_context;
 
-    @Autowired
-    private DatabasePopulator databasePopulator;
-
-    private OnmsNode node;
-    private OnmsIpInterface ipInterface;
-    private OnmsMonitoredService service;
-
     public MetadataRestIT() {
         super(CXF_REST_V2_CONTEXT_PATH);
     }
@@ -98,33 +86,46 @@ public class MetadataRestIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Before
-    @Transactional
     public void before() throws Exception {
-        this.databasePopulator.populateDatabase();
+        final String node = "<node type=\"A\" label=\"CCC\" foreignSource=\"AAA\" foreignId=\"BBB\">" +
+                "<location>Default</location>" +
+                "<labelSource>H</labelSource>" +
+                "<sysContact>The Owner</sysContact>" +
+                "<sysDescription>" +
+                "Darwin TestMachine 9.4.0 Darwin Kernel Version 9.4.0: Mon Jun  9 19:30:53 PDT 2008; root:xnu-1228.5.20~1/RELEASE_I386 i386" +
+                "</sysDescription>" +
+                "<sysLocation>DevJam</sysLocation>" +
+                "<sysName>TestMachine1</sysName>" +
+                "<sysObjectId>.1.3.6.1.4.1.8072.3.2.255</sysObjectId>" +
+                "</node>";
+        sendPost("/nodes", node, 201);
 
-        this.node = this.databasePopulator.getNode1();
-        this.node.addMetaData("c1", "k1", "v1");
-        this.node.addMetaData("c2", "k2", "v2");
+        final String ipInterface = "<ipInterface snmpPrimary=\"P\">" +
+                "<ipAddress>10.10.10.10</ipAddress>" +
+                "<hostName>TestMachine</hostName>" +
+                "</ipInterface>";
+        sendPost("/nodes/AAA:BBB/ipinterfaces", ipInterface, 201);
 
-        this.ipInterface = node.getIpInterfaceByIpAddress("192.168.1.1");
-        this.ipInterface.addMetaData("c3", "k3", "v3");
-        this.ipInterface.addMetaData("c4", "k4", "v4");
+        final String service = "<service status=\"A\">" +
+                "<serviceType>" +
+                "<name>ICMP</name>" +
+                "</serviceType>" +
+                "</service>";
+        sendPost("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/services", service, 201);
 
-        this.service = ipInterface.getMonitoredServiceByServiceType("ICMP");
-        this.service.addMetaData("c5", "k5", "v5");
-        this.service.addMetaData("c6", "k6", "v6");
+        sendPut("/nodes/AAA:BBB/metadata/X-c1/k1/v1", service, 204);
+        sendPut("/nodes/AAA:BBB/metadata/X-c2/k2/v2", service, 204);
 
-        this.databasePopulator.getNodeDao().saveOrUpdate(this.node);
-        this.databasePopulator.getNodeDao().flush();
-        this.databasePopulator.getIpInterfaceDao().saveOrUpdate(this.ipInterface);
-        this.databasePopulator.getIpInterfaceDao().flush();
-        this.databasePopulator.getMonitoredServiceDao().saveOrUpdate(this.service);
-        this.databasePopulator.getMonitoredServiceDao().flush();
+        sendPut("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/metadata/X-c3/k3/v3", service, 204);
+        sendPut("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/metadata/X-c4/k4/v4", service, 204);
+
+        sendPut("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/services/ICMP/metadata/X-c5/k5/v5", service, 204);
+        sendPut("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/services/ICMP/metadata/X-c6/k6/v6", service, 204);
     }
 
     @After
     public void after() throws Exception {
-        this.databasePopulator.resetDatabase();
+        sendRequest(DELETE, "/nodes/AAA:BBB", 204);
     }
 
     private String requestJson(final String url, final int status) throws Exception {
@@ -143,51 +144,51 @@ public class MetadataRestIT extends AbstractSpringJerseyRestTestCase {
 
     @Test
     public void testNodeMetadataJson() throws Exception {
-        final String json = requestJson(String.format("/nodes/%s/metadata", this.node.getNodeId()), 200);
+        final String json = requestJson("/nodes/AAA:BBB/metadata", 200);
         JSONAssert.assertEquals(new JSONObject(
-                "{\"offset\" : 0, \"count\" : 2, \"totalCount\" : 2, \"metaData\" : [ { \"context\" : \"c1\", \"key\" : \"k1\", \"value\" : \"v1\" }, { \"context\" : \"c2\", \"key\" : \"k2\", \"value\" : \"v2\" }] }"
+                "{\"offset\" : 0, \"count\" : 2, \"totalCount\" : 2, \"metaData\" : [ { \"context\" : \"X-c1\", \"key\" : \"k1\", \"value\" : \"v1\" }, { \"context\" : \"X-c2\", \"key\" : \"k2\", \"value\" : \"v2\" }] }"
         ), new JSONObject(json), false);
     }
 
     @Test
     public void testNodeMetadataXml() throws Exception {
-        final String xml = requestXml(String.format("/nodes/%s/metadata", this.node.getNodeId()), 200);
+        final String xml = requestXml("/nodes/AAA:BBB/metadata", 200);
         Assert.assertEquals(JAXB.unmarshal(new StringSource(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><meta-data-list count=\"2\" offset=\"0\" totalCount=\"2\"><meta-data><context>c1</context><key>k1</key><value>v1</value></meta-data><meta-data><context>c2</context><key>k2</key><value>v2</value></meta-data></meta-data-list>"),
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><meta-data-list count=\"2\" offset=\"0\" totalCount=\"2\"><meta-data><context>X-c1</context><key>k1</key><value>v1</value></meta-data><meta-data><context>X-c2</context><key>k2</key><value>v2</value></meta-data></meta-data-list>"),
                 OnmsMetaDataList.class
         ), JAXB.unmarshal(new StringSource(xml), OnmsMetaDataList.class));
     }
 
     @Test
     public void testInterfaceMetadataJson() throws Exception {
-        final String json = requestJson(String.format("/nodes/%s/ipinterfaces/%s/metadata", this.node.getNodeId(), this.ipInterface.getIpAddressAsString()), 200);
+        final String json = requestJson("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/metadata", 200);
         JSONAssert.assertEquals(new JSONObject(
-                "{\"offset\" : 0, \"count\" : 2, \"totalCount\" : 2, \"metaData\" : [ { \"context\" : \"c3\", \"key\" : \"k3\", \"value\" : \"v3\" }, { \"context\" : \"c4\", \"key\" : \"k4\", \"value\" : \"v4\" }] }"
+                "{\"offset\" : 0, \"count\" : 2, \"totalCount\" : 2, \"metaData\" : [ { \"context\" : \"X-c3\", \"key\" : \"k3\", \"value\" : \"v3\" }, { \"context\" : \"X-c4\", \"key\" : \"k4\", \"value\" : \"v4\" }] }"
         ), new JSONObject(json), false);
     }
 
     @Test
     public void testInterfaceMetadataXml() throws Exception {
-        final String xml = requestXml(String.format("/nodes/%s/ipinterfaces/%s/metadata", this.node.getNodeId(), this.ipInterface.getIpAddressAsString()), 200);
+        final String xml = requestXml("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/metadata", 200);
         Assert.assertEquals(JAXB.unmarshal(new StringSource(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><meta-data-list count=\"2\" offset=\"0\" totalCount=\"2\"><meta-data><context>c3</context><key>k3</key><value>v3</value></meta-data><meta-data><context>c4</context><key>k4</key><value>v4</value></meta-data></meta-data-list>"),
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><meta-data-list count=\"2\" offset=\"0\" totalCount=\"2\"><meta-data><context>X-c3</context><key>k3</key><value>v3</value></meta-data><meta-data><context>X-c4</context><key>k4</key><value>v4</value></meta-data></meta-data-list>"),
                 OnmsMetaDataList.class
         ), JAXB.unmarshal(new StringSource(xml), OnmsMetaDataList.class));
     }
 
     @Test
     public void testServiceMetadataJson() throws Exception {
-        final String json = requestJson(String.format("/nodes/%s/ipinterfaces/%s/services/%s/metadata", this.node.getNodeId(), this.ipInterface.getIpAddressAsString(), this.service.getServiceName()), 200);
+        final String json = requestJson("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/services/ICMP/metadata", 200);
         JSONAssert.assertEquals(new JSONObject(
-                "{\"offset\" : 0, \"count\" : 2, \"totalCount\" : 2, \"metaData\" : [ { \"context\" : \"c5\", \"key\" : \"k5\", \"value\" : \"v5\" }, { \"context\" : \"c6\", \"key\" : \"k6\", \"value\" : \"v6\" }] }"
+                "{\"offset\" : 0, \"count\" : 2, \"totalCount\" : 2, \"metaData\" : [ { \"context\" : \"X-c5\", \"key\" : \"k5\", \"value\" : \"v5\" }, { \"context\" : \"X-c6\", \"key\" : \"k6\", \"value\" : \"v6\" }] }"
         ), new JSONObject(json), false);
     }
 
     @Test
     public void testServiceMetadataXml() throws Exception {
-        final String xml = requestXml(String.format("/nodes/%s/ipinterfaces/%s/services/%s/metadata", this.node.getNodeId(), this.ipInterface.getIpAddressAsString(), this.service.getServiceName()), 200);
+        final String xml = requestXml("/nodes/AAA:BBB/ipinterfaces/10.10.10.10/services/ICMP/metadata", 200);
         Assert.assertEquals(JAXB.unmarshal(new StringSource(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><meta-data-list count=\"2\" offset=\"0\" totalCount=\"2\"><meta-data><context>c5</context><key>k5</key><value>v5</value></meta-data><meta-data><context>c6</context><key>k6</key><value>v6</value></meta-data></meta-data-list>"),
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><meta-data-list count=\"2\" offset=\"0\" totalCount=\"2\"><meta-data><context>X-c5</context><key>k5</key><value>v5</value></meta-data><meta-data><context>X-c6</context><key>k6</key><value>v6</value></meta-data></meta-data-list>"),
                 OnmsMetaDataList.class
         ), JAXB.unmarshal(new StringSource(xml), OnmsMetaDataList.class));
     }

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmDetailController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmDetailController.java
@@ -31,6 +31,7 @@ package org.opennms.web.controller.alarm;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -55,6 +56,7 @@ import org.opennms.web.filter.Filter;
 import org.opennms.web.servlet.XssRequestWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
 import org.springframework.util.Assert;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.multiaction.MultiActionController;
@@ -150,9 +152,20 @@ public class AlarmDetailController extends MultiActionController {
         return mv;
     }
 
+    private void checkRole(HttpServletRequest httpServletRequest) throws ServletException {
+        final Authentication authentication = (Authentication) httpServletRequest.getUserPrincipal();
+        final boolean isAdmin = authentication.getAuthorities().stream().anyMatch(g -> Objects.equals(org.opennms.web.api.Authentication.ROLE_ADMIN, g.getAuthority()));
+        final boolean isReadOnly = authentication.getAuthorities().stream().anyMatch(g -> Objects.equals(org.opennms.web.api.Authentication.ROLE_READONLY, g.getAuthority()));
+        if (!isAdmin && isReadOnly) {
+            throw new ServletException("User '" + authentication.getName() + "', is a read-only user!");
+        }
+    }
+
     public ModelAndView removeStickyMemo(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception {
         int alarmId;
         String alarmIdString = "";
+
+        checkRole(httpServletRequest);
 
         // Try to parse alarm ID from string to integer
         try {
@@ -171,6 +184,8 @@ public class AlarmDetailController extends MultiActionController {
         int alarmId;
         String alarmIdString = "";
 
+        checkRole(httpServletRequest);
+
         // Try to parse alarm ID from string to integer
         try {
             alarmIdString = httpServletRequest.getParameter("alarmId");
@@ -188,6 +203,8 @@ public class AlarmDetailController extends MultiActionController {
         int alarmId;
         String alarmIdString = "";
 
+        checkRole(httpServletRequest);
+
         // Try to parse alarm ID from string to integer
         try {
             alarmIdString = httpServletRequest.getParameter("alarmId");
@@ -204,6 +221,8 @@ public class AlarmDetailController extends MultiActionController {
     public ModelAndView saveJournalMemo(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception {
         int alarmId;
         String alarmIdString = "";
+
+        checkRole(httpServletRequest);
 
         // Try to parse alarm ID from string to integer
         try {

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/detail.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/detail.jsp
@@ -467,10 +467,10 @@
   <div class="card-body severity-<%= alarm.getSeverity().getLabel().toLowerCase() %>">
 	         <form class="form" method="post" action="alarm/saveStickyMemo.htm">
                  <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
-				<textarea class="w-100 mb-1" name="stickyMemoBody" ><%=(alarm.getStickyMemo() != null && alarm.getStickyMemo().getBody() != null) ? alarm.getStickyMemo().getBody() : ""%></textarea>
+				<textarea <%=request.isUserInRole(Authentication.ROLE_READONLY)?"readonly":""%> class="w-100 mb-1" name="stickyMemoBody" ><%=(alarm.getStickyMemo() != null && alarm.getStickyMemo().getBody() != null) ? alarm.getStickyMemo().getBody() : ""%></textarea>
 				<input type="hidden" name="alarmId" value="<%=alarm.getId() %>"/>
-                <form:input class="btn btn-sm btn-secondary" type="submit" value="Save" />
-                <form:input class="btn btn-sm btn-secondary" type="button" value="Delete" onclick="document.getElementById('deleteStickyForm').submit();"/>
+                <input <%=request.isUserInRole(Authentication.ROLE_READONLY)?"disabled":""%> class="btn btn-sm btn-secondary" type="submit" value="Save" />
+                <input <%=request.isUserInRole(Authentication.ROLE_READONLY)?"disabled":""%> class="btn btn-sm btn-secondary" type="button" value="Delete" onclick="document.getElementById('deleteStickyForm').submit();"/>
 	         </form>
 	         <form id="deleteStickyForm" method="post" action="alarm/removeStickyMemo.htm">
                 <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
@@ -505,10 +505,10 @@
   <div class="card-body severity-<%= alarm.getSeverity().getLabel().toLowerCase() %>">
             <form class="form" method="post" action="alarm/saveJournalMemo.htm">
                 <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
-                <textarea class="w-100 mb-1" name="journalMemoBody" ><%=(alarm.getReductionKeyMemo() != null && alarm.getReductionKeyMemo().getBody() != null) ? alarm.getReductionKeyMemo().getBody() : ""%></textarea>
+                <textarea <%=request.isUserInRole(Authentication.ROLE_READONLY)?"readonly":""%> class="w-100 mb-1" name="journalMemoBody" ><%=(alarm.getReductionKeyMemo() != null && alarm.getReductionKeyMemo().getBody() != null) ? alarm.getReductionKeyMemo().getBody() : ""%></textarea>
                 <input type="hidden" name="alarmId" value="<%=alarm.getId()%>"/>
-                <form:input class="btn btn-sm btn-secondary" type="submit" value="Save" />
-                <form:input class="btn btn-sm btn-secondary" type="button" value="Delete" onclick="document.getElementById('deleteJournalForm').submit();"/>
+                <input <%=request.isUserInRole(Authentication.ROLE_READONLY)?"disabled":""%> class="btn btn-sm btn-secondary" type="submit" value="Save"/>
+                <input <%=request.isUserInRole(Authentication.ROLE_READONLY)?"disabled":""%> class="btn btn-sm btn-secondary" type="button" value="Delete" onclick="document.getElementById('deleteJournalForm').submit();"/>
             </form>
             <form id="deleteJournalForm" method="post" action="alarm/removeJournalMemo.htm">
                 <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1626,7 +1626,7 @@
     <c3p0Version>0.9.5.5</c3p0Version>
     <curatorVersion>5.5.0</curatorVersion>
     <curatorTestVersion>5.5.0</curatorTestVersion>
-    <cxfVersion>3.5.5</cxfVersion>
+    <cxfVersion>3.6.2</cxfVersion>
     <cxfXjcVersion>3.3.2</cxfXjcVersion>
     <dhcp4javaVersion>1.1.0</dhcp4javaVersion>
     <dnsjavaVersion>3.5.2_1</dnsjavaVersion>
@@ -1670,9 +1670,9 @@
     <httpasyncclientVersion>4.1.5</httpasyncclientVersion>
     <ipaddressVersion>5.4.0</ipaddressVersion>
     <jacksonVersion>1.9.14-atlassian-6</jacksonVersion>
-    <jackson2Version>2.14.2</jackson2Version>
+    <jackson2Version>2.15.3</jackson2Version>
     <jmsApiVersion>2.0.1</jmsApiVersion>
-    <snakeyamlVersion>1.33</snakeyamlVersion>
+    <snakeyamlVersion>2.1</snakeyamlVersion>
     <spiflyVersion>1.3.6</spiflyVersion>
     <jacocoVersion>0.8.9</jacocoVersion>
     <jasperreportsVersion>6.20.0</jasperreportsVersion>
@@ -5124,7 +5124,7 @@
       <dependency>
         <groupId>io.swagger.parser.v3</groupId>
         <artifactId>swagger-parser</artifactId>
-        <version>${swaggerVersion}</version>
+        <version>${swaggerParserVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>


### PR DESCRIPTION
FYI, didn't want to bother changing the branch name, but in the end I moved us to snakeyaml 2.1. :)

* bump jackson to latest 2.x
* also fix a `jackson-dataformat-xml` bug in the features file
* use snakeyaml 2.1 for jackson dependency
* exclude (optional) snakeyaml dep from liquibase
* bump swagger to newer version with better snakeyaml dep

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15914