### PR TITLE
NMS-15400: Allow multiple tile providers in Geographical Map

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuProvider.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuProvider.java
@@ -28,8 +28,6 @@
 
 package org.opennms.web.rest.support.menu;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -41,12 +39,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
+
 import org.opennms.core.resource.Vault;
 import org.opennms.web.api.Authentication;
 import org.opennms.web.rest.support.menu.xml.MenuXml;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+
 /**
  * Creates a MainMenu object that is used by the MenuRestService, which provides this data to the
  * new Vue UI Menubar.
@@ -110,6 +114,13 @@ public class MenuProvider {
 
             mainMenu.copyrightDates = String.format("2002-%d", LocalDate.now().getYear());
             mainMenu.version = Vault.getProperty("version.display");
+
+            var tileProviders = getTileProviders();
+
+            if (!tileProviders.isEmpty()) {
+                mainMenu.userTileProviders.clear();
+                mainMenu.userTileProviders.addAll(tileProviders);
+            }
 
             // Parse out menu data from "dispatcher-servlet.xml"
             MenuXml.BeansElement xBeans = null;
@@ -432,6 +443,29 @@ public class MenuProvider {
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * Get a list of user-defined Tile Providers. Currently we only actually support a single user-defined one.
+     * These are specified in the `opennms/etc/opennms.properties' file.
+     * The tile providers are used in the Vue Geographical Map, for example if the user wants to specify
+     * a map tile provider server in their own private network.
+     */
+    private List<TileProviderItem> getTileProviders() {
+        final var list = new ArrayList<TileProviderItem>();
+        final String url = System.getProperty("gwt.openlayers.url");
+        final String attribution = System.getProperty("gwt.openlayers.options.attribution");
+
+        if (!Strings.isNullOrEmpty(url)) {
+            var item = new TileProviderItem();
+            item.name = "User-Defined";
+            item.url = url;
+            item.attribution = !Strings.isNullOrEmpty(attribution) ? attribution : "";
+
+            list.add(item);
+        }
+
+        return list;
     }
 
     private void setFromBeanProperty(MenuXml.BeanPropertyElement propElem, String name, Consumer<String> consumer) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/TileProviderItem.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/TileProviderItem.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2022 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,30 +28,11 @@
 
 package org.opennms.web.rest.support.menu;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class MainMenu {
-    public String baseHref;
-    public String homeUrl;
-    public String formattedTime;
-    public String noticeStatus;
-    public String username;
-    public String baseNodeUrl;
-    public String copyrightDates;
-    public String version;
-    final public List<TileProviderItem> userTileProviders = new ArrayList<>();
-
-    final public List<TopMenuEntry> menus = new ArrayList<>();
-    public TopMenuEntry helpMenu;
-    public TopMenuEntry selfServiceMenu;
-    public TopMenuEntry userNotificationMenu;
-    public MenuEntry provisionMenu;
-    public MenuEntry flowsMenu;
-    public MenuEntry configurationMenu; // aka admin menu, the "cogs"
-    public Notices notices;
-
-    public void addTopMenu(TopMenuEntry entry) {
-        this.menus.add(entry);
-    }
+/**
+ * Geographical Map tile provider info for adding additional tile maps.
+ */
+public class TileProviderItem {
+    public String name;
+    public String url;
+    public String attribution;
 }

--- a/opennms-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/web.xml
@@ -108,7 +108,7 @@
     <init-param>
       <description>Sets the header value.</description>
       <param-name>value</param-name>
-      <param-value>default-src 'none' ; frame-src 'self' ; manifest-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://fonts.googleapis.com  https://fonts.gstatic.com; connect-src 'self' ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; base-uri 'self' ; form-action 'self' ; img-src 'self' https://tiles.opennms.org  https://*.tile.openstreetmap.org data:</param-value>
+      <param-value>default-src 'none' ; frame-src 'self' ; manifest-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://fonts.googleapis.com  https://fonts.gstatic.com; connect-src 'self' ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; base-uri 'self' ; form-action 'self' ; img-src 'self' https://tiles.opennms.org https://*.tile.openstreetmap.org https://*.tile.opentopomap.org data:</param-value>
     </init-param>
   </filter>
 

--- a/ui/src/components/Map/LeafletMap.vue
+++ b/ui/src/components/Map/LeafletMap.vue
@@ -340,20 +340,25 @@ const setBoundingBox = (nodeLabels: string[]) => {
 const invalidateSizeFn = () => leafletObject.value.invalidateSize()
 
 /***** Tile Layer *****/
+/**
+ * Tile provider for the Tile Layer menu. These are the default ones, but user can add an additional one
+ * in 'opennms/etc/opennms.properties' file, gwt.openlayers.url and gwt.openlayers.options.attribution
+ * properties.
+ */
 const tileProviders = [
   {
     name: 'OpenStreetMap',
     visible: true,
     attribution:
       '&copy; <a target="_blank" href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
   },
   {
     name: 'OpenTopoMap',
     visible: false,
     url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
     attribution:
-      'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+      'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
   }
 ]
 
@@ -362,6 +367,13 @@ onMounted(async () => {
   mapStore.fetchAlarms()
   nodeStore.getNodes()
   ipInterfaceStore.getAllIpInterfaces()
+
+  if (mainMenu.value.userTileProviders && mainMenu.value.userTileProviders?.length > 0) {
+    tileProviders.push({
+      ...mainMenu.value.userTileProviders[0],
+      visible: false
+    })
+  }
 })
 
 defineExpose({ invalidateSizeFn })

--- a/ui/src/types/mainMenu.d.ts
+++ b/ui/src/types/mainMenu.d.ts
@@ -23,6 +23,12 @@ export interface Notices {
   status: string | null
 }
 
+export interface TileProviderItem {
+  name: string
+  url: string
+  attribution: string
+}
+
 export interface MainMenu {
   baseHref: string
   homeUrl: string
@@ -32,6 +38,7 @@ export interface MainMenu {
   baseNodeUrl: string
   copyrightDates: string
   version: string
+  userTileProviders?: TileProviderItem[]
   
   menus: TopMenuItem[]
   helpMenu: TopMenuItem | null


### PR DESCRIPTION
Allow multiple "tile providers" to be configured in the Vue Geographical Map, so users can add their own, for example if they have a local/private map server.

There are 2 hard-coded ones in the Vue code. An additional one can be configured in `opennms/etc/opennms.properties` under the `gwt.openlayers.url` and `gwt.openlayers.options.attribution` properties.

The additional provider, if configured, is included in the Menu Rest API, `userTileProviders` array. It will display in the tile layer dropdown. Currently name is hard-coded to `User-Defined`.

<img width="508" alt="Screenshot 2023-10-25 at 13 51 50" src="https://github.com/OpenNMS/opennms/assets/1933710/1fc12bd0-01c8-4b95-b7f5-2e231e5ff5b8">

Will open a separate Documentation ticket as any added tile provider needs to be added to `web.xml` `Content-Security-Policy` `img-src` section, or else it will be blocked by the browser.

Also added the Open TopoMap `opentopomap.org` URL to CSP, it wasn't added by default and was not usable.

This needs to be backported to `foundation-2023`, will do in separate PR as code will be a bit different due to dependencies, `pinia` and other issues.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15400

