### PR TITLE
NMS-16181: use patched Hibernate 3.6

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -127,14 +127,14 @@
     <feature name="dom4j" version="${dom4jVersion}" description="DOM4J">
         <bundle dependency="true">wrap:mvn:org.dom4j/dom4j/${dom4jVersion}$Bundle-SymbolicName=org.dom4j&amp;Bundle-Version=${dom4jVersion}</bundle>
     </feature>
-    <feature name="hibernate36" version="3.6.10.Final" description="Hibernate :: Hibernate ORM">
+    <feature name="hibernate36" version="3.6.11.ONMS_RELEASE_1" description="Hibernate :: Hibernate ORM">
         <feature>commons-collections</feature>
         <feature>dom4j</feature>
         <bundle dependency="true">wrap:mvn:antlr/antlr/${antlr.version}$Bundle-SymbolicName=antlr&amp;Bundle-Version=${antlr.version}&amp;Import-Package=org.hibernate.hql.ast</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${geronimoVersion}</bundle>
         <bundle dependency="true">mvn:org.javassist/javassist/${javassistVersion}</bundle>
         <bundle>wrap:mvn:org.hibernate.javax.persistence/hibernate-jpa-2.0-api/1.0.1.Final$Bundle-SymbolicName=org.hibernate.jpa20.api&amp;Bundle-Version=1.0.1</bundle>
-        <bundle>wrap:mvn:org.hibernate/hibernate-core/3.6.10.Final$Bundle-SymbolicName=org.hibernate.core&amp;Bundle-Version=3.6.10&amp;Export-Package=org.hibernate*;version="3.6.10"</bundle>
+        <bundle>wrap:mvn:org.hibernate/hibernate-core/3.6.11.ONMS_RELEASE_1$Bundle-SymbolicName=org.hibernate.core&amp;Bundle-Version=3.6.11&amp;Export-Package=org.hibernate*;version="3.6.11"</bundle>
         <bundle>wrap:mvn:org.hibernate/hibernate-commons-annotations/3.2.0.Final$Bundle-SymbolicName=org.hibernate.commons.annotations&amp;Bundle-Version=3.2.0</bundle>
     </feature>
     <feature name="hibernate-validator4" version="${hibernateValidatorVersion}" description="Hibernate :: Hibernate Validator">

--- a/dependencies/hibernate/pom.xml
+++ b/dependencies/hibernate/pom.xml
@@ -15,7 +15,7 @@
     can depend on to use the hibernate library.
   </description>
   <properties>
-    <hibernateVersion>3.6.10.Final</hibernateVersion> 
+    <hibernateVersion>3.6.11.ONMS_RELEASE_1</hibernateVersion> 
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
This PR enables the use of a patched Hibernate that includes [a few extra changes on top of the last Hibernate 3.x release](https://github.com/hibernate/hibernate-orm/compare/3.6.10.Final...opennms-forge:hibernate-orm:3.6).

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16181
