### PR TITLE
NMS-16181: backport Hibernate fixes to 2020

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -183,15 +183,16 @@
     <feature name="dom4j" version="${dom4jVersion}" description="DOM4J">
         <bundle dependency="true">wrap:mvn:org.dom4j/dom4j/${dom4jVersion}</bundle>
     </feature>
-    <feature name="hibernate36" version="3.6.10.Final" description="Hibernate :: Hibernate ORM">
+    <feature name="hibernate36" version="3.6.11" description="Hibernate :: Hibernate ORM">
+        <feature>commons-collections</feature>
         <feature>dom4j</feature>
         <bundle dependency="true">wrap:mvn:antlr/antlr/${antlr.version}$Import-Package=org.hibernate.hql.ast</bundle>
         <bundle dependency="true">mvn:commons-collections/commons-collections/${commonsCollectionsVersion}</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${geronimoVersion}</bundle>
         <bundle dependency="true">mvn:org.javassist/javassist/3.18.2-GA</bundle>
-        <bundle>wrap:mvn:org.hibernate.javax.persistence/hibernate-jpa-2.0-api/1.0.1.Final</bundle>
-        <bundle>wrap:mvn:org.hibernate/hibernate-core/3.6.10.Final$Export-Package=org.hibernate*;version="3.6.10"</bundle>
-        <bundle>wrap:mvn:org.hibernate/hibernate-commons-annotations/3.2.0.Final</bundle>
+        <bundle>wrap:mvn:org.hibernate.javax.persistence/hibernate-jpa-2.0-api/1.0.1.Final$Bundle-SymbolicName=org.hibernate.jpa20.api&amp;Bundle-Version=1.0.1</bundle>
+        <bundle>wrap:mvn:org.hibernate/hibernate-core/3.6.11.ONMS_RELEASE_1$Bundle-SymbolicName=org.hibernate.core&amp;Bundle-Version=3.6.11&amp;Export-Package=org.hibernate*;version="3.6.11"</bundle>
+        <bundle>wrap:mvn:org.hibernate/hibernate-commons-annotations/3.2.0.Final$Bundle-SymbolicName=org.hibernate.commons.annotations&amp;Bundle-Version=3.2.0</bundle>
     </feature>
     <feature name="hibernate-validator41" version="4.1.0.Final" description="Hibernate :: Hibernate Validator">
         <feature>javax.validation</feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -183,7 +183,7 @@
     <feature name="dom4j" version="${dom4jVersion}" description="DOM4J">
         <bundle dependency="true">wrap:mvn:org.dom4j/dom4j/${dom4jVersion}</bundle>
     </feature>
-    <feature name="hibernate36" version="3.6.11" description="Hibernate :: Hibernate ORM">
+    <feature name="hibernate36" version="${hibernateVersion}" description="Hibernate :: Hibernate ORM">
         <feature>commons-collections</feature>
         <feature>dom4j</feature>
         <bundle dependency="true">wrap:mvn:antlr/antlr/${antlr.version}$Import-Package=org.hibernate.hql.ast</bundle>
@@ -191,8 +191,8 @@
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${geronimoVersion}</bundle>
         <bundle dependency="true">mvn:org.javassist/javassist/3.18.2-GA</bundle>
         <bundle>wrap:mvn:org.hibernate.javax.persistence/hibernate-jpa-2.0-api/1.0.1.Final$Bundle-SymbolicName=org.hibernate.jpa20.api&amp;Bundle-Version=1.0.1</bundle>
-        <bundle>wrap:mvn:org.hibernate/hibernate-core/3.6.11.ONMS_RELEASE_1$Bundle-SymbolicName=org.hibernate.core&amp;Bundle-Version=3.6.11&amp;Export-Package=org.hibernate*;version="3.6.11"</bundle>
-        <bundle>wrap:mvn:org.hibernate/hibernate-commons-annotations/3.2.0.Final$Bundle-SymbolicName=org.hibernate.commons.annotations&amp;Bundle-Version=3.2.0</bundle>
+        <bundle>wrap:mvn:org.hibernate/hibernate-core/${hibernateVersion}$Bundle-SymbolicName=org.hibernate.core&amp;Bundle-Version=${hibernateOsgiVersion}&amp;Export-Package=org.hibernate*;version="${hibernateOsgiVersion}"</bundle>
+        <bundle>wrap:mvn:org.hibernate/hibernate-commons-annotations/${hibernateAnnotationsVersion}$Bundle-SymbolicName=org.hibernate.commons.annotations&amp;Bundle-Version=${hibernateAnnotationsOsgiVersion}</bundle>
     </feature>
     <feature name="hibernate-validator41" version="4.1.0.Final" description="Hibernate :: Hibernate Validator">
         <feature>javax.validation</feature>

--- a/dependencies/hibernate/pom.xml
+++ b/dependencies/hibernate/pom.xml
@@ -15,7 +15,7 @@
     can depend on to use the hibernate library.
   </description>
   <properties>
-    <hibernateVersion>3.6.10.Final</hibernateVersion> 
+    <hibernateVersion>3.6.11.ONMS_RELEASE_1</hibernateVersion>
   </properties>
   <dependencies>
     <dependency>

--- a/dependencies/hibernate/pom.xml
+++ b/dependencies/hibernate/pom.xml
@@ -14,9 +14,6 @@
     This module is used to provide a single artifact that the opennms project
     can depend on to use the hibernate library.
   </description>
-  <properties>
-    <hibernateVersion>3.6.11.ONMS_RELEASE_1</hibernateVersion>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1676,6 +1676,10 @@
     <gwtPluginVersion>${gwtVersion}</gwtPluginVersion>
     <h2databaseVersion>1.4.197</h2databaseVersion>
     <hawtioVersion>1.4.68</hawtioVersion>
+    <hibernateVersion>3.6.11.ONMS_RELEASE_1</hibernateVersion>
+    <hibernateOsgiVersion>3.6.11</hibernateOsgiVersion>
+    <hibernateAnnotationsVersion>3.2.0.Final</hibernateAnnotationsVersion>
+    <hibernateAnnotationsOsgiVersion>3.2.0</hibernateAnnotationsOsgiVersion>
     <hibernateValidatorVersion>4.3.2.Final</hibernateValidatorVersion>
     <hikaricpVersion>2.5.1</hikaricpVersion>
     <httpcoreVersion>4.4.4</httpcoreVersion>


### PR DESCRIPTION
This PR backports my Hibernate patch to `foundation-2020`, it also includes an additional change to make it easier to manage Hibernate dependencies across Maven and OSGi.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16181