### PR TITLE
NMS-16212: Create missing prom-jmx-exporter folder in Minion container

### DIFF
--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -94,7 +94,7 @@ COPY ./minion-config-schema.yml /opt/minion/confd/
 RUN install -d -m 750 /opt/minion/server-certs
 
 # Create prom-jmx-exporter folder
-RUN install -d -m 750 -u 10001 -g 0 /opt/prom-jmx-exporter
+RUN install -d -m 750 /opt/prom-jmx-exporter && chown --chown=10001:0 /opt/prom-jmx-exporter
 
 # Arguments for labels should not invalidate caches
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -93,6 +93,9 @@ COPY ./minion-config-schema.yml /opt/minion/confd/
 # Create the directory for server certificates
 RUN install -d -m 750 /opt/minion/server-certs
 
+# Create prom-jmx-exporter folder
+RUN install -d -m 750 -u 10001 -g 0 /opt/prom-jmx-exporter
+
 # Arguments for labels should not invalidate caches
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
 ARG VERSION

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -94,7 +94,7 @@ COPY ./minion-config-schema.yml /opt/minion/confd/
 RUN install -d -m 750 /opt/minion/server-certs
 
 # Create prom-jmx-exporter folder
-RUN install -d -m 750 /opt/prom-jmx-exporter && chown --chown=10001:0 /opt/prom-jmx-exporter
+RUN install -d -m 750 /opt/prom-jmx-exporter && chown 10001:0 /opt/prom-jmx-exporter
 
 # Arguments for labels should not invalidate caches
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"


### PR DESCRIPTION
### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16212

