### PR TITLE
Docs: Include ES alarm history under alarms

### DIFF
--- a/docs/modules/operation/pages/deep-dive/alarms/history.adoc
+++ b/docs/modules/operation/pages/deep-dive/alarms/history.adoc
@@ -1,9 +1,1 @@
-
-[[ga-alarm-history]]
-= Alarm History
-:description: Get an overview of how {page-component-title} uses Elasticsearch to persist historical alarm data.
-
-Alarms are deleted from the {page-component-title} database as they clear or become stale.
-If you would like to keep an historical record of alarm data, you can enable the alarm history feature to provide long-term storage and maintain a history of alarm state changes in Elasticsearch.
-
-For more information, see xref:deep-dive/elasticsearch/features/alarm-history.adoc#ga-alarm-history[Alarm History].
+include::operation:deep-dive/elasticsearch/features/alarm-history.adoc[]


### PR DESCRIPTION
Include the Elastic Alarm History content within the Alarms section. This used to be a placeholder page that linked to the other section, and this change embeds the content so it shows up in both pages and is kept in sync with future changes.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?