### PR TITLE
NMS-16197: Node structure, more search types, fix switch

### DIFF
--- a/ui/src/components/Nodes/NodeDetailsDialog.vue
+++ b/ui/src/components/Nodes/NodeDetailsDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <FeatherDialog :modelValue="visible" relative :labels="labels" @update:modelValue="$emit('close')">
-    <div class="content">
+    <div class="node-details-content">
       <div class="feather-row" v-for="item in nodeItems" :key="item.label">
         <div class="feather-col-4">
           <span class="label">{{ item.label }}</span>
@@ -62,9 +62,15 @@ const nodeItems = computed(() => {
     { label: 'Location', text: props.node?.location },
     { label: 'FS:FID', text: `${props.node?.foreignSource}:${props.node?.foreignId}` },
     { label: 'Sys Contact', text: props.node?.sysContact || EMPTY },
-    { label: 'Sys Location', text: props.node?.sysLocation || EMPTY },
     { label: 'Sys Description', text: props.node?.sysDescription || EMPTY },
-    { label: 'Flows', text: flowsText(props.node) }
+    { label: 'Sys Location', text: props.node?.sysLocation || EMPTY },
+    { label: 'Sys Name', text: props.node?.sysName || EMPTY },
+    { label: 'Sys Object Id', text: props.node?.sysObjectId || EMPTY },
+    { label: 'Flows', text: flowsText(props.node) },
+    { label: 'Latitude/Longitude', text: `${props.node?.assetRecord.latitude ?? EMPTY} / ${props.node?.assetRecord.longitude ?? EMPTY}` },
+    { label: 'Asset Category', text: props.node?.assetRecord.category || EMPTY },
+    { label: 'Asset Description', text: props.node?.assetRecord.description || EMPTY },
+    { label: 'Maintenance Contract', text: props.node?.assetRecord.maintcontract || EMPTY }
   ]
 })
 
@@ -84,9 +90,11 @@ const flowsText = (node?: Node) => {
 </script>
 
 <style scoped lang="scss">
-.content {
+.node-details-content {
   min-height: 300px;
   min-width: 550px;
+  overflow-x: hidden;
+  overflow-y: auto;
   position: relative;
 }
 

--- a/ui/src/components/Nodes/NodeStructurePanel.vue
+++ b/ui/src/components/Nodes/NodeStructurePanel.vue
@@ -15,18 +15,14 @@
     </template>
     <template #default>
       <div class="category-button-group">
-        <FeatherButton
-          class="switcher-button"
-          :primary="categoryMode === SetOperator.Union"
-          :secondary="categoryMode !== SetOperator.Union"
-          @click="categoryModeUpdated(SetOperator.Union)"
-        >Any</FeatherButton>
-        <FeatherButton
-          class="switcher-button"
-          :primary="categoryMode === SetOperator.Intersection"
-          :secondary="categoryMode !== SetOperator.Intersection"
-          @click="categoryModeUpdated(SetOperator.Intersection)"
-        >All</FeatherButton>
+        <div class="category-switcher-container">
+          <span>Match All </span>
+          <SwitchRender
+            class="category-switcher-right"
+            :checked="categorySwitchChecked"
+            @click="onCategorySwitchClick"
+          />
+        </div>
       </div>
       <FeatherList class="category-list">
         <FeatherListItem
@@ -91,6 +87,7 @@ import { FeatherButton } from '@featherds/button'
 import { FeatherExpansionPanel } from '@featherds/expansion'
 import { FeatherIcon } from '@featherds/icon'
 import { FeatherList, FeatherListItem } from '@featherds/list'
+import { SwitchRender } from '@featherds/switch'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 import { Category, MonitoringLocation, SetOperator } from '@/types'
 import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
@@ -99,16 +96,13 @@ const nodeStructureStore = useNodeStructureStore()
 const clearIcon = ref(ClearIcon)
 const flowTypes = computed<string[]>(() => ['Ingress', 'Egress'])
 const categoryMode = computed(() => nodeStructureStore.queryFilter.categoryMode)
+const categorySwitchChecked = computed<boolean>(() => nodeStructureStore.queryFilter.categoryMode === SetOperator.Intersection)
 
 const locations = computed<MonitoringLocation[]>(() => nodeStructureStore.monitoringLocations)
 const selectedCategoryCount = computed<number>(() => nodeStructureStore.queryFilter.selectedCategories?.length || 0)
 const selectedFlowCount = computed<number>(() => nodeStructureStore.queryFilter.selectedFlows?.length || 0)
 const selectedLocationCount = computed<number>(() => nodeStructureStore.queryFilter.selectedMonitoringLocations?.length || 0)
 const isAnyFilterSelected = computed<boolean>(() => nodeStructureStore.isAnyFilterSelected())
-
-const categoryModeUpdated = (val: any) => {
-  nodeStructureStore.setCategoryMode(val)
-}
 
 const isCategorySelected = (cat: Category) => {
   return nodeStructureStore.queryFilter.selectedCategories.some(c => c.id === cat.id)
@@ -120,6 +114,11 @@ const isFlowSelected = (flow: string) => {
 
 const isLocationSelected = (loc: MonitoringLocation) => {
   return nodeStructureStore.queryFilter.selectedMonitoringLocations.some(x => x.name === loc.name)
+}
+
+const onCategorySwitchClick = () => {
+  const newMode = categoryMode.value === SetOperator.Union ? SetOperator.Intersection : SetOperator.Union
+  nodeStructureStore.setCategoryMode(newMode)
 }
 
 const onClearCategories = () => {
@@ -181,12 +180,14 @@ const onLocationClick = (loc: MonitoringLocation) => {
 }
 
 div.category-button-group {
-  margin-bottom: 1em;
+  margin-bottom: 0.5em;
 
-  > button.btn.switcher-button {
-    &.btn-primary, &.btn-secondary {
-      margin-left: 0;
-    }
+  .category-switcher-container {
+    line-height: 2.25rem;
+  }
+
+  .category-switcher-right {
+    float: right;
   }
 }
 

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -222,7 +222,7 @@ const isSelectedColumn = (column: NodeColumnSelectionItem, id: string) => {
 const updatePageNumber = (page: number) => {
   pageNumber.value = page
   const pageSize = queryParameters.value.limit || 0
-  queryParameters.value = { ...queryParameters.value, offset: (page - 1) * pageSize }
+  queryParameters.value = { ...queryParameters.value, offset: Math.max((page - 1) * pageSize, 0) }
   nodeStore.setNodeQueryParameters(queryParameters.value)
 
   updateQuery()

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -2,7 +2,9 @@ import {
   Category,
   MatchType,
   MonitoringLocation,
+  NodeQueryForeignSourceParams,
   NodeQuerySnmpParams,
+  NodeQuerySysParams,
   SetOperator
 } from '@/types'
 import { isIP } from 'is-ip'
@@ -100,6 +102,22 @@ export const parseIplike = (queryObject: any) => {
   return null
 }
 
+export const parseForeignSource = (queryObject: any) => {
+  const foreignSource = queryObject.foreignSource || ''
+  const foreignId = queryObject.foreignId || ''
+  const foreignSourceId = queryObject.fsfid || ''
+
+  if (foreignSource || foreignId || foreignSourceId) {
+    return {
+      foreignSource,
+      foreignId,
+      foreignSourceId
+    } as NodeQueryForeignSourceParams
+  }
+
+  return null
+}
+
 export const parseSnmpParams = (queryObject: any) => {
   const snmpIfAlias = queryObject.snmpifalias as string || ''
   const snmpIfDescription = queryObject.snmpifdescription as string || ''
@@ -115,6 +133,26 @@ export const parseSnmpParams = (queryObject: any) => {
       snmpIfName,
       snmpMatchType
     } as NodeQuerySnmpParams
+  }
+
+  return null
+}
+
+export const parseSysParams = (queryObject: any) => {
+  const sysContact = queryObject.sysContact as string || ''
+  const sysDescription = queryObject.sysDescription as string || ''
+  const sysLocation = queryObject.sysLocation as string || ''
+  const sysName = queryObject.sysName as string || ''
+  const sysObjectId = queryObject.sysObjectId as string || ''
+
+  if (sysContact || sysDescription || sysLocation || sysName || sysObjectId) {
+    return {
+      sysContact,
+      sysDescription,
+      sysLocation,
+      sysName,
+      sysObjectId
+    } as NodeQuerySysParams
   }
 
   return null

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -22,3 +22,16 @@ export const ellipsify = (text: string, count: number) => {
 
   return text
 }
+
+/**
+ * Returns whether the object has at least one valid (non-empty) string property.
+ */
+export const hasNonEmptyProperty = (obj?: any) => {
+  if (!obj) {
+    return false
+  }
+
+  const keys = Object.getOwnPropertyNames(obj)
+
+  return keys.some(k => !!((obj as any)[k]?.length))
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,3 +1,4 @@
+import { isString } from './../lib/utils';
 import { SORT } from '@featherds/table'
 
 export type UpdateModelFunction = (_value: any) => any
@@ -89,6 +90,7 @@ export interface Node {
   assetRecord: {
     longitude: string
     latitude: string
+    category: string
     description: string
     maintcontract: string
   }
@@ -506,6 +508,12 @@ export enum MatchType {
   Contains = 2
 }
 
+export interface NodeQueryForeignSourceParams {
+  foreignId: string
+  foreignSource: string
+  foreignSourceId: string
+}
+
 export interface NodeQuerySnmpParams {
   snmpIfAlias: string
   snmpIfDescription: string
@@ -515,15 +523,29 @@ export interface NodeQuerySnmpParams {
   snmpMatchType: MatchType
 }
 
+export interface NodeQuerySysParams {
+  sysContact: string
+  sysDescription: string
+  sysLocation: string
+  sysName: string
+  sysObjectId: string
+}
+
+export interface NodeQueryExtendedSearchParams {
+  ipAddress?: string
+  foreignSourceParams?: NodeQueryForeignSourceParams
+  snmpParams?: NodeQuerySnmpParams
+  sysParams?: NodeQuerySysParams
+}
+
 /** All components of a node structure query */
 export interface NodeQueryFilter {
   searchTerm: string
-  ipAddress?: string
   categoryMode: SetOperator
   selectedCategories: Category[]
   selectedFlows: string[]
   selectedMonitoringLocations: MonitoringLocation[]
-  snmpParams?: NodeQuerySnmpParams
+  extendedSearch: NodeQueryExtendedSearchParams
 }
 
 export interface NodePreferences {


### PR DESCRIPTION
Node structure panel, add search types for foreign source and id as well as "system" attributes (`sysContact`, `sysLocation`, etc.). Needed to refactor a bit to clean this up.

'system' attributes use a wildcard search. SNMP and foreign source/id attributes are exact search (due to current Rest API implementation).

Used the Feather `SwitchRender` control for Match Any / Match All for Category searches.

Added more fields to the Node Info dialog.

This is probably the last set of features for the Node Structure page for the upcoming Horizon 33 release.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16197

