### PR TITLE
NMS-16242: Install node-gyp for CircleCI build-ui

### DIFF
--- a/.circleci/main/jobs/build/build-ui.yml
+++ b/.circleci/main/jobs/build/build-ui.yml
@@ -4,6 +4,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Prebuild
+          command: |
+            yarn global add node-gyp
+      - run:
           name: Build
           command: |
             cd ui && yarn install && yarn build && yarn test


### PR DESCRIPTION
CircleCI `build-ui` keeps failing due to not having `node-gyp` installed, I believe it's needed for `yarn install`. This ensures that it is already installed in the build environment.

Error message in NMS ticket.

There could be a different or better way to do this, but this does work.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16242

