### PR TITLE
NMS-16229: Enable setting user-defined GeoMap tile provider as default

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -489,9 +489,12 @@ importer.adapter.dns.server=127.0.0.1
 
 # The tile server URL to use for OpenLayers.  This can be any mapnik-style tile server URL.
 # (Sorry, no support for multiple URLs yet.)
+# If 'gwt.openlayers.userDefinedAsDefault' is true, use this tile server as the default one on the Geographical Map page
 # OpenNMS default tile server
+gwt.openlayers.name=OpenNMS Default
 gwt.openlayers.url=https://tiles.opennms.org/${z}/${x}/${y}.png
 gwt.openlayers.options.attribution=Map data &copy; <a tabindex="-1" target="_blank" href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors under <a tabindex="-1" target="_blank" href="http://opendatacommons.org/licenses/odbl/">ODbL</a>, <a tabindex="-1" target="_blank" href="http://creativecommons.org/licenses/by-sa/2.0/">CC BY-SA 2.0</a>
+gwt.openlayers.userDefinedAsDefault=false
 
 # The radius, in pixels, that the maps will cluster nodes together at a particular zoom level.
 gwt.maxClusterRadius=350

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuProvider.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/MenuProvider.java
@@ -450,17 +450,22 @@ public class MenuProvider {
      * These are specified in the `opennms/etc/opennms.properties' file.
      * The tile providers are used in the Vue Geographical Map, for example if the user wants to specify
      * a map tile provider server in their own private network.
+     * If 'userDefinedAsDefault' is true, the user-defined tile provider will appear first on the Geographical Map
+     * and be loaded by default.
      */
     private List<TileProviderItem> getTileProviders() {
         final var list = new ArrayList<TileProviderItem>();
+        final String name = System.getProperty("gwt.openlayers.name");
         final String url = System.getProperty("gwt.openlayers.url");
         final String attribution = System.getProperty("gwt.openlayers.options.attribution");
+        final String userDefinedAsDefault = System.getProperty("gwt.openlayers.userDefinedAsDefault");
 
         if (!Strings.isNullOrEmpty(url)) {
             var item = new TileProviderItem();
-            item.name = "User-Defined";
+            item.name = !Strings.isNullOrEmpty(name) ? name : "User-Defined";
             item.url = url;
             item.attribution = !Strings.isNullOrEmpty(attribution) ? attribution : "";
+            item.userDefinedAsDefault = !Strings.isNullOrEmpty(userDefinedAsDefault) && userDefinedAsDefault.equals("true");
 
             list.add(item);
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/TileProviderItem.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/menu/TileProviderItem.java
@@ -35,4 +35,5 @@ public class TileProviderItem {
     public String name;
     public String url;
     public String attribution;
+    public Boolean userDefinedAsDefault;
 }

--- a/ui/src/types/mainMenu.d.ts
+++ b/ui/src/types/mainMenu.d.ts
@@ -27,6 +27,8 @@ export interface TileProviderItem {
   name: string
   url: string
   attribution: string
+  userDefinedAsDefault?: boolean
+  visible?: boolean
 }
 
 export interface MainMenu {


### PR DESCRIPTION
Previously, a user-defined geographical map tile provider was added to the end of the list of providers. So for example if a user did not want to use an Internet-based tile provider, the GeoMap page would still try to load the default `OpenStreetMap` provider tiles.

This allows setting the user-defined one as the default, which will appear first in the tile provider radio button selector, and will load by default. Also allows a name to be specified.

Configure in `etc/opennms.properties`:

```
gwt.openlayers.name=My Street Map
gwt.openlayers.url=http://192.168.0.99/{z}/{x}/{y}.png
gwt.openlayers.options.attribution=Map data &copy; <a tabindex="-1" target="_blank" href="http://192.168.0.99/copyright">My Street Map</a> contributors under <a tabindex="-1" target="_blank" href="192.168.0.99/licenses/odbl/">ODbL</a>, <a tabindex="-1" target="_blank" href="http://192.168.0.99/licenses/by-sa/2.0/">CC BY-SA 2.0</a>
gwt.openlayers.userDefinedAsDefault=true
```

There's a separate ticket for documentation for this feature.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16229
