### PR TITLE
NMS-16226: Clear Karaf's data directory on upgrade

### DIFF
--- a/core/upgrade/src/main/java/org/opennms/upgrade/api/OnmsUpgrade.java
+++ b/core/upgrade/src/main/java/org/opennms/upgrade/api/OnmsUpgrade.java
@@ -108,6 +108,15 @@ public interface OnmsUpgrade {
      * if OpenNMS must be stopped.
      */
     boolean requiresOnmsRunning();
+
+    /**
+     * Run only once and mark when successfully executed?
+     *
+     * @return true, whether this job should only be run once
+     */
+    default boolean runOnlyOnce() {
+        return true;
+    }
 }
 
 

--- a/core/upgrade/src/main/java/org/opennms/upgrade/support/Upgrade.java
+++ b/core/upgrade/src/main/java/org/opennms/upgrade/support/Upgrade.java
@@ -146,8 +146,12 @@ public class Upgrade {
         try {
             log("- Running execution phase\n");
             upg.execute();
-            log("- Saving the execution state\n");
-            markAsExecuted(upg);
+            if (upg.runOnlyOnce()) {
+                log("- Saving the execution state\n");
+                markAsExecuted(upg);
+            } else {
+                log("- Ignore the execution status, as this task is executed with every call\n");
+            }
         } catch (OnmsUpgradeException executeException) {
             log("  Warning: can't perform the upgrade operation because: %s\n", executeException.getMessage());
             try {

--- a/core/upgrade/src/test/java/org/opennms/upgrade/implementations/ClearKarafCacheMigratorOfflineIT.java
+++ b/core/upgrade/src/test/java/org/opennms/upgrade/implementations/ClearKarafCacheMigratorOfflineIT.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.upgrade.implementations;
+
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Path;
+
+import org.hamcrest.core.Is;
+import org.hamcrest.text.StringContainsInOrder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.upgrade.api.OnmsUpgradeException;
+
+import com.google.common.collect.Lists;
+
+public class ClearKarafCacheMigratorOfflineIT {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void before() throws Exception {
+        temporaryFolder.newFolder("data", "aaa");
+        temporaryFolder.newFolder("data", "bbb");
+        temporaryFolder.newFolder("etc");
+        temporaryFolder.newFile("data/history.txt");
+        temporaryFolder.newFile("data/foo.bar");
+        temporaryFolder.newFile("etc/opennms.properties");
+        temporaryFolder.newFile("etc/rrd-configuration.properties");
+        System.setProperty("opennms.home", temporaryFolder.getRoot().getAbsolutePath());
+    }
+
+    @Test
+    public void testDeletion() {
+        final Path temporaryPath = temporaryFolder.getRoot().toPath();
+        assertThat("temporary folder must exist", temporaryPath.toFile().exists(), Is.is(true));
+        assertThat("data directory must exist", temporaryPath.resolve("data").toFile().exists(), Is.is(true));
+        assertThat("data/history.txt file must exist", temporaryPath.resolve("data").resolve("history.txt").toFile().exists(), Is.is(true));
+        assertThat("data/foo.bar file must exist", temporaryPath.resolve("data").resolve("foo.bar").toFile().exists(), Is.is(true));
+        assertThat("data/aaa directory must exist", temporaryPath.resolve("data").resolve("aaa").toFile().exists(), Is.is(true));
+        assertThat("data/bbb directory must exist", temporaryPath.resolve("data").resolve("bbb").toFile().exists(), Is.is(true));
+        assertThat("etc/opennms.properties file must exist", temporaryPath.resolve("etc").resolve("opennms.properties").toFile().exists(), Is.is(true));
+        assertThat("etc/rrd-configuration.properties file must exist", temporaryPath.resolve("etc").resolve("rrd-configuration.properties").toFile().exists(), Is.is(true));
+
+        try {
+            new ClearKarafCacheMigratorOffline().execute();
+        } catch (OnmsUpgradeException e) {
+            assertThat("Exception message must match `Karaf's data directory ... pruned'", e.getMessage(), StringContainsInOrder.stringContainsInOrder(Lists.newArrayList("Karaf's data directory", "pruned")));
+        }
+
+        assertThat("temporary folder must exist", temporaryPath.toFile().exists(), Is.is(true));
+        assertThat("data directory must exist", temporaryPath.resolve("data").toFile().exists(), Is.is(true));
+        assertThat("data/history.txt file must exist", temporaryPath.resolve("data").resolve("history.txt").toFile().exists(), Is.is(true));
+        assertThat("data/foo.bar file must not exist", temporaryPath.resolve("data").resolve("foo.bar").toFile().exists(), Is.is(false));
+        assertThat("data/aaa directory must not exist", temporaryPath.resolve("data").resolve("aaa").toFile().exists(), Is.is(false));
+        assertThat("data/bbb directory must not exist", temporaryPath.resolve("data").resolve("bbb").toFile().exists(), Is.is(false));
+        assertThat("etc/opennms.properties file must exist", temporaryPath.resolve("etc").resolve("opennms.properties").toFile().exists(), Is.is(true));
+        assertThat("etc/rrd-configuration.properties file must exist", temporaryPath.resolve("etc").resolve("rrd-configuration.properties").toFile().exists(), Is.is(true));
+    }
+}

--- a/core/upgrade/src/test/java/org/opennms/upgrade/support/UpgradeTest.java
+++ b/core/upgrade/src/test/java/org/opennms/upgrade/support/UpgradeTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.opennms.upgrade.api.OnmsUpgradeException;
 import org.opennms.upgrade.tests.TestUpgradeA;
 import org.opennms.upgrade.tests.TestUpgradeB;
+import org.opennms.upgrade.tests.TestUpgradeEverytime;
 import org.opennms.upgrade.tests.TestUpgradeExecuted;
 import org.opennms.upgrade.tests.TestUpgradeNothing;
 import org.opennms.upgrade.tests.bad.TestUpgradeWIthException;
@@ -69,6 +70,8 @@ public class UpgradeTest {
         p.put(new TestUpgradeExecuted().getId(), new Date().toString());
         p.store(new FileWriter(statusFile), null);
         upgradeStatus = new UpgradeStatus(statusFile);
+        UpgradeHelper.executed.clear();
+        UpgradeHelper.rolledback.clear();
     }
 
     /**
@@ -91,12 +94,26 @@ public class UpgradeTest {
         Assert.assertFalse(upgradeStatus.wasExecuted(new TestUpgradeNothing()));
         performUpgrade("org.opennms.upgrade.tests");
         Assert.assertTrue(upgradeStatus.wasExecuted(new TestUpgradeNothing()));
-        Assert.assertEquals(3, UpgradeHelper.getExecutedList().size());
+        Assert.assertEquals(4, UpgradeHelper.getExecutedList().size());
         Assert.assertEquals(TestUpgradeNothing.class.getName(), UpgradeHelper.getExecutedList().get(0));
         Assert.assertEquals(TestUpgradeA.class.getName(), UpgradeHelper.getExecutedList().get(1));
         Assert.assertEquals(TestUpgradeB.class.getName(), UpgradeHelper.getExecutedList().get(2));
         Assert.assertEquals(1, UpgradeHelper.getRolledBackList().size());
         Assert.assertEquals(TestUpgradeWIthException.class.getName(), UpgradeHelper.getRolledBackList().get(0));
+    }
+
+    @Test
+    public void testUpgradeMoreThanOnce() throws Exception {
+        Assert.assertFalse(upgradeStatus.wasExecuted(new TestUpgradeNothing()));
+        Assert.assertEquals(0, UpgradeHelper.getExecutedList().stream().filter(c -> TestUpgradeA.class.getName().equals(c)).count());
+        Assert.assertEquals(0, UpgradeHelper.getExecutedList().stream().filter(c -> TestUpgradeEverytime.class.getName().equals(c)).count());
+        performUpgrade("org.opennms.upgrade.tests");
+        Assert.assertEquals(1, UpgradeHelper.getExecutedList().stream().filter(c -> TestUpgradeA.class.getName().equals(c)).count());
+        Assert.assertEquals(1, UpgradeHelper.getExecutedList().stream().filter(c -> TestUpgradeEverytime.class.getName().equals(c)).count());
+        performUpgrade("org.opennms.upgrade.tests");
+        performUpgrade("org.opennms.upgrade.tests");
+        Assert.assertEquals(1, UpgradeHelper.getExecutedList().stream().filter(c -> TestUpgradeA.class.getName().equals(c)).count());
+        Assert.assertEquals(3, UpgradeHelper.getExecutedList().stream().filter(c -> TestUpgradeEverytime.class.getName().equals(c)).count());
     }
 
     /**

--- a/core/upgrade/src/test/java/org/opennms/upgrade/tests/TestUpgradeEverytime.java
+++ b/core/upgrade/src/test/java/org/opennms/upgrade/tests/TestUpgradeEverytime.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,73 +32,47 @@ import org.opennms.upgrade.api.OnmsUpgrade;
 import org.opennms.upgrade.api.OnmsUpgradeException;
 import org.opennms.upgrade.support.UpgradeHelper;
 
-/**
- * The Class TestUpgradeB.
- * <p>This is an example implementation for the JUnit tests.</p>
- * 
- * @author Alejandro Galue <agalue@opennms.org>
- */
-public class TestUpgradeB implements OnmsUpgrade {
-
-    /* (non-Javadoc)
-     * @see org.opennms.upgrade.api.OnmsUpgrade#getOrder()
-     */
+public class TestUpgradeEverytime implements OnmsUpgrade {
     @Override
     public int getOrder() {
-        return 300;
+        return 301;
     }
 
-    /* (non-Javadoc)
-     * @see org.opennms.upgrade.api.OnmsUpgrade#getId()
-     */
     @Override
     public String getId() {
         return getClass().getName();
     }
 
-    /* (non-Javadoc)
-     * @see org.opennms.upgrade.api.OnmsUpgrade#getDescription()
-     */
     @Override
     public String getDescription() {
-        return "Testing class B";
+        return "Testing class that runs everytime";
     }
 
-    /* (non-Javadoc)
-     * @see org.opennms.upgrade.api.OnmsUpgrade#preExecute()
-     */
     @Override
     public void preExecute() throws OnmsUpgradeException {
     }
 
-    /* (non-Javadoc)
-     * @see org.opennms.upgrade.api.OnmsUpgrade#postExecute()
-     */
     @Override
     public void postExecute() throws OnmsUpgradeException {
     }
 
-    /* (non-Javadoc)
-     * @see org.opennms.upgrade.api.OnmsUpgrade#rollback()
-     */
     @Override
     public void rollback() throws OnmsUpgradeException {
         UpgradeHelper.addRolledBack(getId());
     }
 
-    /* (non-Javadoc)
-     * @see org.opennms.upgrade.api.OnmsUpgrade#execute()
-     */
     @Override
     public void execute() throws OnmsUpgradeException {
         UpgradeHelper.addExecuted(getId());
     }
 
-    /* (non-Javadoc)
-     * @see org.opennms.upgrade.api.OnmsUpgrade#requiresOnmsRunning()
-     */
     @Override
     public boolean requiresOnmsRunning() {
+        return false;
+    }
+
+    @Override
+    public boolean runOnlyOnce() {
         return false;
     }
 }


### PR DESCRIPTION
* JIRA: https://opennms.atlassian.net/browse/NMS-16226

The deletion of the files in the data directory is realized by an OnmsUpgrade task since in the script itself there is no chance to decide whether an upgrade is run or just help is displayed. 