### PR TITLE
NMS-16282: News Feed UI and Rest service

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -547,6 +547,16 @@ opennms.eventlist.showCount=false
 #
 #opennms.nodeStatusBar.show=false
 
+# This value allows you to enable/disable the News Feed Panel on the front
+# page in the OpenNMS web UI. Default: true
+#
+opennms.newsFeedPanel.show=true
+
+# This value allows you to set the News Feed URL for the News Feed Panel.
+# If commented-out or unset, the default value of 'https://www.opennms.com/feed/' is used.
+#
+#opennms.newsFeedPanel.url=https://www.opennms.com/feed/
+
 # This value disables the sending of successful login events.  The default is to send the
 # event.  Change this value to true to disable the publishing of this event.
 #org.opennms.security.disableLoginSuccessEvent=false

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/NewsFeed.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/NewsFeed.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.newsfeed;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NewsFeed {
+    private List<NewsFeedItem> items = new ArrayList<>();
+
+    public String channelTitle;
+
+    public List<NewsFeedItem> getItems() {
+        return this.items;
+    }
+
+    public void setItems(List<NewsFeedItem> items) {
+        this.items.clear();
+        this.items.addAll(items);
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/NewsFeedItem.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/NewsFeedItem.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.newsfeed;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NewsFeedItem {
+    private List<String> categories = new ArrayList<>();
+    private List<String> tags = new ArrayList<>();
+
+    public String title;
+    public String link;
+    public String description;
+    public String shortDescription;
+
+    public List<String> getCategories() {
+        return this.categories;
+    }
+
+    public void setCategories(List<String> categories) {
+        this.categories.clear();
+        this.categories.addAll(categories);
+    }
+
+    public List<String> getTags() {
+        return this.tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags.clear();
+        this.tags.addAll(tags);
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/NewsFeedProvider.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/NewsFeedProvider.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.newsfeed;
+
+import java.io.InputStream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import org.opennms.web.rest.support.newsfeed.xml.NewsFeedXml;
+
+public class NewsFeedProvider {
+    public NewsFeedProvider() {
+
+    }
+
+    public NewsFeedXml.RssElement parseXml(InputStream inputStream) throws javax.xml.bind.JAXBException {
+        NewsFeedXml.RssElement xRssElem = null;
+
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(NewsFeedXml.RssElement.class);
+            Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+            xRssElem = (NewsFeedXml.RssElement) jaxbUnmarshaller.unmarshal(inputStream);
+        } catch (JAXBException e) {
+            throw e;
+        }
+
+        return xRssElem;
+    }
+
+    public NewsFeed parseXmlToNewsFeed(NewsFeedXml.RssElement xRssElem) throws Exception {
+        final NewsFeed newsFeed = new NewsFeed();
+
+        var channelElem = xRssElem.getChannelElement();
+        newsFeed.channelTitle = channelElem.getTitle();
+
+        var items = new ArrayList<NewsFeedItem>();
+
+        for (var xItem : channelElem.getItems()) {
+            var item = new NewsFeedItem();
+
+            item.title = xItem.getTitle();
+            item.description = xItem.getDescription();
+            item.shortDescription = getShortDescription(xItem.getDescription());
+            item.link = xItem.getLink();
+
+            item.setCategories(parseCategories(xItem.getCategories()));
+            item.setTags(parseTags(xItem.getCategories()));
+
+            items.add(item);
+        }
+
+        newsFeed.setItems(items);
+
+        return newsFeed;
+    }
+
+    private String getShortDescription(String description) {
+        final int TRUNCATE_LENGTH = 200;
+
+        final int pStart = description.indexOf("<p>");
+        final int pEnd = description.indexOf("</p>");
+        final String innerText = pStart >= 0 && pEnd > (pStart + 3) ? description.substring(pStart + 3, pEnd) : "";
+        final String shortDescription = innerText.length() > TRUNCATE_LENGTH ? (innerText.substring(0, TRUNCATE_LENGTH) + "...") : innerText;
+
+        return shortDescription;
+    }
+
+    private List<String> parseCategories(List<String> categories) {
+        final List<String> cats =
+            categories.stream()
+                .filter(x -> x.length() > 0 && Character.isUpperCase(x.charAt(0)))
+                .sorted()
+                .collect(Collectors.toList());
+
+        return cats;
+    }
+
+    private List<String> parseTags(List<String> categories) {
+        final List<String> tags =
+            categories.stream()
+                .filter(x -> x.length() > 0 && Character.isLowerCase(x.charAt(0)))
+                .sorted()
+                .collect(Collectors.toList());
+
+        return tags;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/xml/NewsFeedXml.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/xml/NewsFeedXml.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support.newsfeed.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+public class NewsFeedXml {
+    public static class ItemElement {
+        private String title;
+        private String link;
+        private String description;
+
+        private List<String> categories = new ArrayList<>();
+
+        @XmlElement(name="title")
+        public String getTitle() {
+            return this.title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        @XmlElement(name="link")
+        public String getLink() {
+            return this.link;
+        }
+
+        public void setLink(String link) {
+            this.link = link;
+        }
+
+        @XmlElement(name="description")
+        public String getDescription() {
+            return this.description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        @XmlElement(name="category")
+        public List<String> getCategories() {
+            return this.categories;
+        }
+
+        public void setCategories(List<String> categories) {
+            this.categories = categories;
+        }
+    }
+
+    public static class ChannelElement {
+        private String title;
+
+        private List<ItemElement> items =  new ArrayList<>();
+
+        @XmlElement(name="title")
+        public String getTitle() {
+            return this.title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        @XmlElement(name="item", type=NewsFeedXml.ItemElement.class)
+        public List<ItemElement> getItems() {
+            return this.items;
+        }
+
+        public void setItem(List<ItemElement> items) {
+            this.items = items;
+        }
+    }
+
+    @XmlRootElement(name="rss", namespace="")
+    public static class RssElement {
+        private ChannelElement channelElement;
+
+        @XmlElement(name="channel", type= NewsFeedXml.ChannelElement.class)
+        public NewsFeedXml.ChannelElement getChannelElement() {
+            return this.channelElement;
+        }
+
+        public void setChannelElement(NewsFeedXml.ChannelElement c) {
+            this.channelElement = c;
+        }
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/xml/package-info.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/newsfeed/xml/package-info.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+@XmlSchema(
+    namespace="",
+    elementFormDefault = XmlNsForm.QUALIFIED
+)package org.opennms.web.rest.support.newsfeed.xml;
+
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NewsFeedRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NewsFeedRestService.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v2;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.opennms.web.rest.support.newsfeed.NewsFeed;
+import org.opennms.web.rest.support.newsfeed.NewsFeedProvider;
+import org.opennms.web.rest.support.newsfeed.xml.NewsFeedXml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import joptsimple.internal.Strings;
+
+/**
+ * Web Service for retrieving OpenNMS RSS feed.
+ */
+@Component
+@Path("newsfeed")
+@Tag(name = "Newsfeed", description = "Newsfeed API")
+public class NewsFeedRestService {
+    private static final String DEFAULT_NEWS_FEED_URL = "https://www.opennms.com/feed/";
+    private static final Logger LOG = LoggerFactory.getLogger(NewsFeedRestService.class);
+
+    private String feedUrl;
+
+    @Autowired
+    private NewsFeedProvider newsFeedProvider;
+
+    private final LoadingCache<String, String> cache;
+
+    public NewsFeedRestService() {
+        String newsFeedUrlProperty = System.getProperty("opennms.newsFeedPanel.url", "");
+        this.feedUrl = !Strings.isNullOrEmpty(newsFeedUrlProperty) ? newsFeedUrlProperty : DEFAULT_NEWS_FEED_URL;
+
+        this.cache = CacheBuilder.newBuilder()
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .maximumSize(100)
+            .build(new CacheLoader<String, String>() {
+                @Override
+                public String load(String cacheKey) throws Exception {
+                    String body = "";
+
+                    try {
+                        body = requestNewsFeed(feedUrl);
+                    } catch (Exception e) {
+                        LOG.error("News Feed: Got exception requesting feed from {}: {}", feedUrl, e.getMessage());
+                        throw e;
+                    }
+
+                    return body;
+                }
+            });
+    }
+
+    @GET
+    @Path("/")
+    @Produces({MediaType.APPLICATION_JSON})
+    @Operation(summary = "Get news feed", description = "Get news feed", operationId = "NewsFeedRestServiceGetNewsFeed")
+    public Response getNewsFeed(final @Context HttpServletRequest request) {
+        try {
+            String responseBody = this.cache.get("newsfeed");
+
+            InputStream inputStream = new ByteArrayInputStream(responseBody.getBytes());
+
+            NewsFeedXml.RssElement xRss = newsFeedProvider.parseXml(inputStream);
+            NewsFeed newsFeed = newsFeedProvider.parseXmlToNewsFeed(xRss);
+
+            return Response.ok(newsFeed).build();
+        } catch (Exception e) {
+            LOG.error("News Feed: Got exception: {}", e.getMessage());
+
+            throw new WebApplicationException(
+                Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .type(MediaType.TEXT_PLAIN)
+                    .entity("Error building news feed.").build());
+        }
+    }
+
+    private String requestNewsFeed(final String feedUrl) throws Exception, IOException, InterruptedException {
+        LOG.info("Requesting news feed from url {}.", feedUrl);
+
+        final HttpClient httpClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+        // 'User-Agent' header allows for statistics on News Feed access
+        final HttpRequest httpRequest = HttpRequest.newBuilder()
+            .GET()
+            .uri(URI.create(feedUrl))
+            .setHeader("User-Agent", "OpenNMS NewsFeedRestService")
+            .build();
+
+        final HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            LOG.error("Received error response from news feed: {}.", response.statusCode());
+
+            throw new Exception("Error response from news feed.");
+        }
+
+        final String responseBody = response.body();
+        LOG.info("Received news feed response.");
+
+        return responseBody;
+    }
+}

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
@@ -36,6 +36,8 @@
     <bean id="menuProvider" class="org.opennms.web.rest.support.menu.MenuProvider">
         <constructor-arg ref="dispatcherServletPath"/>
     </bean>
+    <bean id="newsfeedProvider" class="org.opennms.web.rest.support.newsfeed.NewsFeedProvider">
+    </bean>
 
     <!-- CXF OpenApiFeature -->
     <bean id="securityScheme" class="io.swagger.v3.oas.models.security.SecurityScheme">

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/newsfeed/NewsFeedController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/newsfeed/NewsFeedController.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.controller.newsfeed;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.AbstractController;
+
+/**
+ * A controller that handles the News Feed panel.
+ */
+public class NewsFeedController extends AbstractController implements InitializingBean {
+    private String m_successView;
+
+    /** {@inheritDoc} */
+    @Override
+    protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        final String viewName = getSuccessView() != null ? getSuccessView() : "newsfeed/newsFeedPanel";
+        final String shouldDisplayStr = System.getProperty("opennms.newsFeedPanel.show", "true");
+        final boolean shouldDisplay = Boolean.parseBoolean(shouldDisplayStr);
+
+        ModelAndView modelAndView = new ModelAndView(viewName);
+        modelAndView.addObject("shouldDisplay", shouldDisplay);
+
+        return modelAndView;
+    }
+
+    private String getSuccessView() {
+        return m_successView;
+    }
+
+    public void setSuccessView(String successView) {
+        m_successView = successView;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        Assert.notNull(m_successView, "property successView must be set");
+    }
+}

--- a/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -270,6 +270,10 @@
         <property name="eventConfDao" ref="eventConfDao"/>
     </bean>
 
+    <bean name="/newsfeed/newsFeedPanel.htm" class="org.opennms.web.controller.newsfeed.NewsFeedController">
+        <property name="successView" value="newsfeed/newsFeedPanel"/>
+    </bean>
+
     <bean name="mapMenuEntries" class="org.opennms.web.navigate.MenuDropdownNavBarEntry">
         <property name="name" value="Maps" />
         <property name="url" value="maps.htm" />

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/newsfeed/newsFeedPanel.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/newsfeed/newsFeedPanel.jsp
@@ -1,0 +1,172 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+--%>
+
+<%@page language="java"
+        contentType="text/html"
+        session="true"
+%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<!-- rss/rssNewsPanel.htm -->
+<div class="card opennms-newsfeed-wrapper">
+    <div class="card-header">
+        <a href="https://www.opennms.com/blog/" target="_blank">OpenNMS News Feed</a>
+    </div>
+    <div id="opennms-newsfeed-content">
+    </div>
+</div>
+
+<style>
+    .opennms-newsfeed-wrapper {
+        max-height: 500px;
+        overflow: auto;
+    }
+
+    #opennms-newsfeed-content {
+        padding: 6px 4px 4px 4px;
+    }
+
+    .opennms-newsfeed-item {
+
+    }
+
+    .opennms-newsfeed-error {
+        color: #f00;
+        font-weight: bold;
+    }
+</style>
+
+<script type="text/javascript">
+(function() {
+    function createTagLink(tag) {
+        const url = 'https://www.opennms.com/en/blog/tag/' + tag + '/';
+        return '<a href="' + url + '" target="_blank">#' + tag + '</a>';
+    }
+
+    function createCategoryLink(category) {
+        let cat = category.toLowerCase().replace(' ', '-');
+
+        if (cat === 'on-the-horizon') {
+            cat = 'opennms-on-the-horizon';
+        }
+
+        const url = 'https://www.opennms.com/en/blog/category/' + cat + '/';
+        return '<a href="' + url + '" target="_blank">' + category + '</a>';
+    }
+
+    function createTemplate(item, index) {
+        const arr = []
+
+        if (index > 0) {
+            arr.push('<hr />');
+        }
+
+        arr.push('<div class="opennms-newsfeed-item">');
+        arr.push('<h6><a href="' + item.link + '" target="_blank">' + item.title + '</a></h6>');
+        arr.push('<span>' + item.shortDescription + '</span>');
+        arr.push('<br ');
+
+        const categoryLinks = item.categories.map(c => createCategoryLink(c));
+        let cats = '<span><strong>&bull;</strong> ' + categoryLinks.join(' ');
+
+        const tagLinks = item.tags.map(t => createTagLink(t));
+        const tags = tagLinks.join(' ');
+
+        if (tagLinks.length > 0) {
+          cats = cats + ' ' + tags;
+        }
+
+        arr.push(cats);
+        arr.push('</span>');
+        arr.push('</div>');
+
+        return arr.join('\n');
+    }
+
+    function displayError(msg) {
+        const template =
+          '<div class="opennms-newsfeed-error">\n' +
+          '<span>' + msg + '</span>\n' +
+          '</div>\n';
+
+        $('#opennms-newsfeed-content').append(template);
+    }
+
+    function parseNewsFeed(data) {
+        $('#opennms-newsfeed-content').empty();
+
+        if (!data || (data && !data.items) || data.error) {
+            let message = 'Unknown error retrieving News Feed data.';
+
+            if (data && data.error) {
+                message = data.error;
+            } else if (data && !data.items) {
+                message = 'No News Feed items found.';
+            }
+
+            displayError(message);
+            return;
+        }
+
+        data.items.forEach(function(item, index) {
+            const template = createTemplate(item, index);
+            $('#opennms-newsfeed-content').append(template);
+        });
+    }
+
+    function getNewsFeed() {
+        <%
+          final String propertyUrl = System.getProperty("opennms.newsFeedPanel.url");
+
+          if (propertyUrl != null && propertyUrl.length() > 0) { %>
+          const newsFeedUrl = '<%=propertyUrl%>';
+        <% } else { %>
+          const newsFeedUrl = 'api/v2/newsfeed';
+        <% } %>
+
+        $.ajax({
+            url: newsFeedUrl,
+            method: 'GET',
+            dataType: 'json',
+            success: function(data) {
+                parseNewsFeed(data);
+            },
+            error: function(jqXhr, errorStatus) {
+                displayError('Error retrieving News Feed data');
+            }
+        });
+    }
+
+    $(document).ready(function() {
+        getNewsFeed();
+    });
+})();
+</script>

--- a/opennms-webapp/src/main/webapp/index.jsp
+++ b/opennms-webapp/src/main/webapp/index.jsp
@@ -3,8 +3,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -64,6 +64,12 @@
 			if (Boolean.parseBoolean(showApplicationsProblems)) { %>
 		<jsp:include page="/application/summary-box.htm" flush="false" />
 		<% } %>
+
+        <!-- News Feed Panel -->
+        <% String showNewsFeedPanel = System.getProperty("opennms.newsFeedPanel.show", "true");
+            if (Boolean.parseBoolean(showNewsFeedPanel)) { %>
+                <jsp:include page="/newsfeed/newsFeedPanel.htm" flush="false" />
+        <% } %>
 	</div>
 
 	<!-- Middle Column -->


### PR DESCRIPTION
Adding News Feed UI and Rest service.

This displays a News Feed panel on the OpenNMS front page with data taken from the OpenNMS RSS feed at https://www.opennms.com/feed/.

Due to CORS and other issues, we implemented this with an OpenNMS Rest service which queries the RSS feed and does some additional processing. The UI calls this Rest service instead of directly requesting from opennms.com.

Two configuration points are available in `etc/opennms.properties`:

- `opennms.newsFeedPanel.show`: controls whether the News Feed panel is displayed. If commented-out, lef unset, or set to `true`, the panel will display. Set it to `false` to suppress display, which also suppresses making the server-side call to the RSS feed

- `opennms.newsFeedPanel.url`: Should normally be commented-out, but allows override of the RSS feed URL that the Rest service calls to get the news feed data.

The RSS feed call has a 5 minute cache to prevent excessive external calls if there are lots of web clients logged into an OpenNMS instance. Since the RSS feed doesn't actually update that often (more like once or twice a week), could probably increase this, or make it configurable.

The lengthy description is truncated to 200 characters for display in the panel. Links to articles open in new tabs. The `category` items are parsed out and links are made to either categories or tags.

Currently we don't filter what items are displayed on category or tag, may be a future enhancement.

The `User-Agent` used to request the RSS feed is set to `OpenNMS NewsFeedRestService`, this could be used to capture some statistics re use of the news feed.

Lastly, this PR targets Horizon 32 (point release). It will also be applied separately to H33.

Screenshot:

<img width="381" alt="Screenshot 2024-01-02 at 14 35 43" src="https://github.com/OpenNMS/opennms/assets/1933710/630e47a6-c8cb-416e-b93d-4ff1c3b7000f">


Screenshot containing tag links:


<img width="368" alt="Screenshot 2024-01-02 at 14 45 15" src="https://github.com/OpenNMS/opennms/assets/1933710/3f2d67f2-2f00-4e54-9925-2145b5f8fd15">


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16282
