### PR TITLE
NMS-16288: LegacyDatetimeFormatterTest.testParse fails to parse date time when locale is set to `en_CA-UTF-8`

### DIFF
--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatter.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/LegacyDatetimeFormatter.java
@@ -93,7 +93,14 @@ public class LegacyDatetimeFormatter implements EventDatetimeFormatter {
         return formatter;
     });
 
-    private static final List<ThreadLocal<DateFormat>> preferredOrder = Arrays.asList(FORMATTER_LONG, FORMATTER_CUSTOM, FORMATTER_FULL, FORMATTER_DEFAULT);
+    public static final ThreadLocal<DateFormat> FORMATTER_CUSTOM_LOCALE = ThreadLocal.withInitial(() -> {
+        Locale.setDefault(Locale.US);
+        final DateFormat formatter = DateFormat.getDateTimeInstance();
+        formatter.setLenient(true);
+        return formatter;
+    });
+
+    private static final List<ThreadLocal<DateFormat>> preferredOrder = Arrays.asList(FORMATTER_LONG, FORMATTER_CUSTOM, FORMATTER_CUSTOM_LOCALE, FORMATTER_FULL, FORMATTER_DEFAULT);
 
     @Override
     public Date parse(final String dateString) throws ParseException {


### PR DESCRIPTION
### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16288

