### PR TITLE
normalize all Apache Commons usage

### DIFF
--- a/container/karaf/src/main/filtered-resources/etc/overrides.properties
+++ b/container/karaf/src/main/filtered-resources/etc/overrides.properties
@@ -19,6 +19,26 @@ mvn:org.codehaus.jettison/jettison/${jettisonVersion}
 mvn:org.jolokia/jolokia-osgi/${jolokiaVersion}
 mvn:org.jolokia/jolokia-client-java/${jolokiaVersion}
 
+# Apache Commons
+mvn:commons-beanutils/commons-beanutils/${commonsBeanutilsVersion}
+mvn:commons-cli/commons-cli/${commonsCliVersion}
+mvn:commons-codec/commons-codec/${commonsCodecVersion}
+mvn:commons-collections/commons-collections/${commonsCollectionsVersion}
+mvn:org.apache.commons/commons-compress/${commonsCompressVersion}
+mvn:commons-configuration/commons-configuration/${commonsConfigurationVersion}
+mvn:org.apache.commons/commons-csv/${commonsCsvVersion}
+mvn:commons-digester/commons-digester/${commonsDigesterVersion}
+mvn:commons-exec/commons-exec/${commonsExecVersion}
+mvn:commons-io/commons-io/${commonsIoVersion}
+mvn:org.apache.commons/commons-jexl/${commonsJexlVersion}
+mvn:org.apache.commons/commons-jexl3/${commonsJexl3Version}
+mvn:commons-jxpath/commons-jxpath/${commonsJxpathVersion}
+mvn:commons-lang/commons-lang/${commonsLangVersion}
+mvn:org.apache.commons/commons-lang3/${commonsLang3Version}
+mvn:commons-net/commons-net/${commonsNetVersion}
+mvn:commons-pool/commons-pool/${commonsPoolVersion}
+mvn:org.apache.commons/commons-pool2/${commonsPool2Version}
+
 # Just In Case (tm) make sure Jetty always gets only our vetted version
 mvn:org.eclipse.jetty/jetty-client/${jettyVersion};range=[9.4,10)
 mvn:org.eclipse.jetty/jetty-continuation/${jettyVersion};range=[9.4,10)

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -19,6 +19,26 @@ mvn:org.codehaus.jettison/jettison/${jettisonVersion}
 mvn:org.jolokia/jolokia-osgi/${jolokiaVersion}
 mvn:org.jolokia/jolokia-client-java/${jolokiaVersion}
 
+# Apache Commons
+mvn:commons-beanutils/commons-beanutils/${commonsBeanutilsVersion}
+mvn:commons-cli/commons-cli/${commonsCliVersion}
+mvn:commons-codec/commons-codec/${commonsCodecVersion}
+mvn:commons-collections/commons-collections/${commonsCollectionsVersion}
+mvn:org.apache.commons/commons-compress/${commonsCompressVersion}
+mvn:commons-configuration/commons-configuration/${commonsConfigurationVersion}
+mvn:org.apache.commons/commons-csv/${commonsCsvVersion}
+mvn:commons-digester/commons-digester/${commonsDigesterVersion}
+mvn:commons-exec/commons-exec/${commonsExecVersion}
+mvn:commons-io/commons-io/${commonsIoVersion}
+mvn:org.apache.commons/commons-jexl/${commonsJexlVersion}
+mvn:org.apache.commons/commons-jexl3/${commonsJexl3Version}
+mvn:commons-jxpath/commons-jxpath/${commonsJxpathVersion}
+mvn:commons-lang/commons-lang/${commonsLangVersion}
+mvn:org.apache.commons/commons-lang3/${commonsLang3Version}
+mvn:commons-net/commons-net/${commonsNetVersion}
+mvn:commons-pool/commons-pool/${commonsPoolVersion}
+mvn:org.apache.commons/commons-pool2/${commonsPool2Version}
+
 # Just In Case (tm) make sure Jetty always gets only our vetted version
 mvn:org.eclipse.jetty/jetty-client/${jettyVersion};range=[9.4,10)
 mvn:org.eclipse.jetty/jetty-continuation/${jettyVersion};range=[9.4,10)

--- a/features/jest/dependencies/pom.xml
+++ b/features/jest/dependencies/pom.xml
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/features/jest/feature/pom.xml
+++ b/features/jest/feature/pom.xml
@@ -42,7 +42,6 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -668,6 +668,10 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -622,8 +622,18 @@
       <scope>${onmsLibScope}</scope>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>${onmsLibScope}</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
+      <scope>${onmsLibScope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
       <scope>${onmsLibScope}</scope>
     </dependency>
     <dependency>
@@ -632,8 +642,23 @@
       <scope>${onmsLibScope}</scope>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>${onmsLibScope}</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
+      <scope>${onmsLibScope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+      <scope>${onmsLibScope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
       <scope>${onmsLibScope}</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1603,6 +1603,7 @@
     <cassandraVersion>3.11.5</cassandraVersion>
     <cloverVersion>3.2.0</cloverVersion>
     <commonsBeanutilsVersion>1.9.4</commonsBeanutilsVersion>
+    <commonsChainVersion>1.2</commonsChainVersion>
     <commonsCliVersion>1.2</commonsCliVersion>
     <commonsCodecVersion>1.16.0</commonsCodecVersion>
     <commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
@@ -1610,16 +1611,22 @@
     <commonsCompressVersion>1.23.0</commonsCompressVersion>
     <commonsConfigurationVersion>1.10</commonsConfigurationVersion>
     <commonsCsvVersion>1.5</commonsCsvVersion>
+    <commonsDaemonVersion>1.3.4</commonsDaemonVersion>
+    <commonsDbcpVersion>1.4</commonsDbcpVersion>
     <commonsDigesterVersion>2.1</commonsDigesterVersion>
     <commonsExecVersion>1.2</commonsExecVersion>
+    <commonsFileuploadVersion>1.5</commonsFileuploadVersion>
     <commonsJexlVersion>2.1.1</commonsJexlVersion>
+    <commonsJexl3Version>3.3</commonsJexl3Version>
     <commonsJxpathVersion>1.3</commonsJxpathVersion>
-    <commonsIoVersion>2.13.0</commonsIoVersion>
+    <commonsIoVersion>2.15.0</commonsIoVersion>
     <commonsLangVersion>2.6</commonsLangVersion>
     <commonsLang3Version>3.13.0</commonsLang3Version>
     <commonsMath3Version>3.6.1</commonsMath3Version>
     <commonsNetVersion>3.10.0</commonsNetVersion>
+    <commonsPoolVersion>1.6</commonsPoolVersion>
     <commonsPool2Version>2.4.3</commonsPool2Version>
+    <commonsTextVersion>1.11.0</commonsTextVersion>
     <commonsValidatorVersion>1.7</commonsValidatorVersion>
     <concurrentTreesVersion>2.6.1</concurrentTreesVersion>
     <cronParserCoreVersion>3.5</cronParserCoreVersion>
@@ -3875,12 +3882,12 @@
       <dependency>
         <groupId>commons-chain</groupId>
         <artifactId>commons-chain</artifactId>
-        <version>1.2</version>
+        <version>${commonsChainVersion}</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>1.2</version>
+        <version>${commonsCliVersion}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -3909,9 +3916,14 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>commons-daemon</groupId>
+        <artifactId>commons-daemon</artifactId>
+        <version>${commonsDaemonVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>commons-dbcp</groupId>
         <artifactId>commons-dbcp</artifactId>
-        <version>1.4</version>
+        <version>${commonsDbcpVersion}</version>
       </dependency>
       <dependency>
         <groupId>commons-digester</groupId>
@@ -3927,7 +3939,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-exec</artifactId>
-        <version>1.3</version>
+        <version>${commonsExecVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+        <version>${commonsFileuploadVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -4059,7 +4076,12 @@
       <dependency>
         <groupId>commons-pool</groupId>
         <artifactId>commons-pool</artifactId>
-        <version>1.6</version>
+        <version>${commonsPoolVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${commonsTextVersion}</version>
       </dependency>
       <dependency>
         <groupId>commons-validator</groupId>
@@ -5199,6 +5221,17 @@
         <artifactId>xmlunit</artifactId>
         <version>1.6</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-jexl3</artifactId>
+        <version>${commonsJexl3Version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This PR makes all apache commons packages use a top-level versioned entry in dependency management, and also updates the Karaf container(s) to use an override file that enforces using that version (or newer) in the OSGi side as well.