### PR TITLE
NMS-16284: User Data Collection CM, liquibase, Rest updates

### DIFF
--- a/features/config/upgrade/src/main/resources/changelog-cm/33.0.0/changelog-cm.xml
+++ b/features/config/upgrade/src/main/resources/changelog-cm/33.0.0/changelog-cm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:cm="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet author="stheleman" id="33.0.0-update-schema-datachoices-with-user-data-collection">
+        <cm:changeSchema schemaId="org.opennms.features.datachoices">
+            <cm:put name="userDataCollectionOptedIn" type="boolean" default="false"/>
+            <cm:put name="userDataCollectionNoticeAcknowledged" type="boolean" default="false"/>
+            <cm:put name="userDataCollectionNoticeAcknowledgedAt" type="string"/>
+            <cm:put name="userDataCollectionNoticeAcknowledgedBy" type="string"/>
+        </cm:changeSchema>
+    </changeSet>
+</databaseChangeLog>

--- a/features/config/upgrade/src/main/resources/changelog-cm/changelog-cm.xml
+++ b/features/config/upgrade/src/main/resources/changelog-cm/changelog-cm.xml
@@ -9,4 +9,5 @@
 
     <include file="changelog-cm/30.0.0/changelog-cm.xml"/>
     <include file="changelog-cm/32.0.0/changelog-cm.xml"/>
+    <include file="changelog-cm/33.0.0/changelog-cm.xml"/>
 </databaseChangeLog>

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/StateManager.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/StateManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,17 +28,19 @@
 
 package org.opennms.features.datachoices.internal;
 
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+
 import org.opennms.features.config.service.api.ConfigUpdateInfo;
 import org.opennms.features.config.service.api.ConfigurationManagerService;
 import org.opennms.features.config.service.util.CmProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
 
 /**
  * Maintains state in cfg file:
@@ -57,13 +59,33 @@ public class StateManager {
     private static final Logger LOG = LoggerFactory.getLogger(StateManager.class);
 
     private static final String PROPERTIES_CONFIG_NAME = "org.opennms.features.datachoices";
+
+    /**
+     * Whether data choices / Usage Statistics Sharing is enabled.
+     */
     private static final String ENABLED_KEY = "enabled";
     private static final String SYSTEM_ID_KEY = "systemid";
     private static final String ACKNOWLEDGED_BY_KEY = "acknowledged-by";
     private static final String ACKNOWLEDGED_AT_KEY = "acknowledged-at";
+
+    /**
+     * Whether the Usage Statistics Sharing notice was acknowledged.
+     */
     private static final String INITIAL_NOTICE_ACKNOWLEDGED_KEY = "initialNoticeAcknowledged";
     private static final String INITIAL_NOTICE_ACKNOWLEDGED_AT_KEY = "initialNoticeAcknowledgedAt";
     private static final String INITIAL_NOTICE_ACKNOWLEDGED_BY_KEY = "initialNoticeAcknowledgedBy";
+
+    /**
+     * Whether a user opted-in to User Data Collection.
+     */
+    private static final String USER_DATA_COLLECTION_OPTED_IN_KEY = "userDataCollectionOptedIn";
+
+    /**
+     * Whether the User Data Collection notice was acknowledged.
+     */
+    private static final String USER_DATA_COLLECTION_NOTICE_ACKNOWLEDGED_KEY = "userDataCollectionNoticeAcknowledged";
+    private static final String USER_DATA_COLLECTION_NOTICE_ACKNOWLEDGED_AT_KEY = "userDataCollectionNoticeAcknowledgedAt";
+    private static final String USER_DATA_COLLECTION_NOTICE_ACKNOWLEDGED_BY_KEY = "userDataCollectionNoticeAcknowledgedBy";
 
     private final List<StateChangeHandler> m_listeners = Lists.newArrayList();
     private final CmProperties propertiesCache;
@@ -101,8 +123,27 @@ public class StateManager {
         propertiesCache.setProperty(INITIAL_NOTICE_ACKNOWLEDGED_AT_KEY, new Date().toString());
     }
 
+    public Boolean isUserDataCollectionNoticeAcknowledged() throws IOException {
+        return (Boolean) propertiesCache.getProperty(USER_DATA_COLLECTION_NOTICE_ACKNOWLEDGED_KEY);
+    }
+
+    public void setUserDataCollectionNoticeAcknowledged(boolean status, String user) throws Exception {
+        propertiesCache.setProperty(USER_DATA_COLLECTION_NOTICE_ACKNOWLEDGED_KEY, status);
+        propertiesCache.setProperty(USER_DATA_COLLECTION_NOTICE_ACKNOWLEDGED_BY_KEY, user == null ? "" : user);
+        propertiesCache.setProperty(USER_DATA_COLLECTION_NOTICE_ACKNOWLEDGED_AT_KEY, new Date().toString());
+    }
+
+    public Boolean isUserDataCollectionOptedIn() throws IOException {
+        return (Boolean) propertiesCache.getProperty(USER_DATA_COLLECTION_OPTED_IN_KEY);
+    }
+
+    public void setUserDataCollectionOptedIn(boolean status) throws Exception {
+        propertiesCache.setProperty(USER_DATA_COLLECTION_OPTED_IN_KEY, status);
+    }
+
     public String getOrGenerateSystemId() throws IOException {
         String systemId = (String) propertiesCache.getProperty(SYSTEM_ID_KEY);
+
         if (systemId == null) {
             LOG.debug("No existing system id was found. Generating a new system id.");
             systemId = UUID.randomUUID().toString();

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UserDataCollectionStatusDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UserDataCollectionStatusDTO.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.internal;
+
+public class UserDataCollectionStatusDTO {
+    // note, these can be null (user never chose a status)
+    private Boolean optedIn;
+
+    private Boolean noticeAcknowledged;
+
+    public Boolean getOptedIn() {
+        return optedIn;
+    }
+
+    public void setOptedIn(Boolean status) {
+        optedIn = status;
+    }
+
+    public Boolean getNoticeAcknowledged() {
+        return noticeAcknowledged;
+    }
+
+    public void setNoticeAcknowledged(Boolean status) {
+        this.noticeAcknowledged = status;
+    }
+}

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -29,6 +29,7 @@
 package org.opennms.features.datachoices.web;
 
 import java.io.IOException;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -39,9 +40,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.opennms.features.datachoices.internal.UsageStatisticsMetadataDTO;
+
 import org.opennms.features.datachoices.internal.UsageStatisticsReportDTO;
 import org.opennms.features.datachoices.internal.UsageStatisticsStatusDTO;
+import org.opennms.features.datachoices.internal.UserDataCollectionStatusDTO;
 
 @Path("/datachoices")
 public interface DataChoiceRestService {
@@ -52,7 +54,7 @@ public interface DataChoiceRestService {
     @GET
     @Path("status")
     @Produces(value={MediaType.APPLICATION_JSON})
-    UsageStatisticsStatusDTO getStatus() throws ServletException, IOException;
+    Response getStatus() throws ServletException, IOException;
 
     @POST
     @Path("status")
@@ -62,5 +64,15 @@ public interface DataChoiceRestService {
     @GET
     @Path("meta")
     @Produces(value={MediaType.APPLICATION_JSON})
-    UsageStatisticsMetadataDTO getMetadata() throws ServletException, IOException;
+    Response getMetadata() throws ServletException, IOException;
+
+    @GET
+    @Path("userdatacollection")
+    @Produces(value={MediaType.APPLICATION_JSON})
+    Response getUserDataCollectionStatus() throws ServletException, IOException;
+
+    @POST
+    @Path("userdatacollection")
+    @Consumes({MediaType.APPLICATION_JSON})
+    Response setUserDataCollectionStatus(@Context HttpServletRequest request, UserDataCollectionStatusDTO dto) throws ServletException, IOException;
 }


### PR DESCRIPTION
User Data Collection updates to Configuration Management including the liquibase schema update. Added REST endpoint for getting and changing status of whether someone acknowledged the UI notice and opted in or out.

Note, we are only keeping track of whichever user acknowledged the notice first.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16284
