### PR TITLE
NMS-9677: add spring security openid dependencies

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -202,11 +202,13 @@
         <feature version="[4.2,4.3)">spring-web</feature>
         <feature>commons-codec</feature>
         <feature>javax.servlet</feature>
+        <bundle>wrap:mvn:org.openid4java/openid4java-nodeps/${openid4javaVersion}$Export-Package=org.openid4java*;version="${openid4javaVersion}"</bundle>
         <bundle>wrap:mvn:org.springframework.ldap/spring-ldap-core/${springLdapVersion}$Bundle-SymbolicName=org.springframework.ldap.core&amp;Bundle-Version=${springLdapVersion}&amp;Export-Package=org.springframework.ldap*;version="${springLdapVersion}"</bundle>
         <bundle>wrap:mvn:org.springframework.security/spring-security-aspects/${springSecurityVersion}$Bundle-SymbolicName=org.springframework.security.aspects&amp;Bundle-Version=${springSecurityVersion}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-core/${springSecurityVersion}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-config/${springSecurityVersion}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-ldap/${springSecurityVersion}</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-openid/${springSecurityVersion}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-remoting/${springSecurityVersion}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-web/${springSecurityVersion}</bundle>
     </feature>

--- a/container/karaf/src/main/filtered-resources/etc/custom.properties
+++ b/container/karaf/src/main/filtered-resources/etc/custom.properties
@@ -620,6 +620,23 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         org.joda.time;version=${jodaTimeVersion},\
         org.joda.time.format;version=${jodaTimeVersion},\
         org.nustaq.serialization;version=${fstVersion},\
+        org.openid4java;version=${openid4javaVersion},\
+        org.openid4java.association;version=${openid4javaVersion},\
+        org.openid4java.consumer;version=${openid4javaVersion},\
+        org.openid4java.discovery;version=${openid4javaVersion},\
+        org.openid4java.discovery.html;version=${openid4javaVersion},\
+        org.openid4java.discovery.xrds;version=${openid4javaVersion},\
+        org.openid4java.discovery.xri;version=${openid4javaVersion},\
+        org.openid4java.discovery.yadis;version=${openid4javaVersion},\
+        org.openid4java.infocard;version=${openid4javaVersion},\
+        org.openid4java.infocard.rp;version=${openid4javaVersion},\
+        org.openid4java.infocard.sts;version=${openid4javaVersion},\
+        org.openid4java.message;version=${openid4javaVersion},\
+        org.openid4java.message.ax;version=${openid4javaVersion},\
+        org.openid4java.message.pape;version=${openid4javaVersion},\
+        org.openid4java.message.sreg;version=${openid4javaVersion},\
+        org.openid4java.server;version=${openid4javaVersion},\
+        org.openid4java.util;version=${openid4javaVersion},\
         org.owasp.encoder;version=${owaspEncoderVersion},\
         org.quartz;version=${quartzVersion},\
         org.quartz.impl;version=${quartzVersion},\
@@ -998,6 +1015,7 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         org.springframework.security.ldap.search;version="${springSecurityVersion}";uses:="org.springframework.ldap.core,org.springframework.ldap.core.support,org.springframework.security.core.userdetails",\
         org.springframework.security.ldap.server;version="${springSecurityVersion}";uses:="org.apache.directory.server.core,org.springframework.beans,org.springframework.beans.factory,org.springframework.context",\
         org.springframework.security.ldap.userdetails;version="${springSecurityVersion}";uses:="javax.naming,org.springframework.ldap.core,org.springframework.security.core,org.springframework.security.core.userdetails,org.springframework.security.ldap,org.springframework.security.ldap.ppolicy,org.springframework.security.ldap.search,org.springframework.security.provisioning",\
+        org.springframework.security.openid;version="${springSecurityVersion}",\
         org.springframework.security.remoting;version="${springSecurityVersion}",\
         org.springframework.security.remoting.dns;version="${springSecurityVersion}",\
         org.springframework.security.remoting.httpinvoker;version="${springSecurityVersion}",\

--- a/dependencies/spring-security/pom.xml
+++ b/dependencies/spring-security/pom.xml
@@ -39,6 +39,34 @@
     </dependency>
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.spring-security-openid</artifactId>
+      <version>${springSecurityVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.openid4java</groupId>
+      <artifactId>openid4java-nodeps</artifactId>
+      <version>${openid4javaVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.nekohtml</groupId>
+      <artifactId>nekohtml</artifactId>
+      <version>1.9.22</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId>
       <version>${springSecurityVersion}</version>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -1771,6 +1771,7 @@
     <powermockVersion>2.0.9</powermockVersion>
     <okhttpVersion>4.9.3</okhttpVersion>
     <okioVersion>3.6.0</okioVersion>
+    <openid4javaVersion>0.9.6</openid4javaVersion>
     <opennmsApiVersion>1.5.0</opennmsApiVersion>
     <opennmsApiVersionOsgi>1.5.0</opennmsApiVersionOsgi>
     <osgiVersion>7.0.0</osgiVersion>


### PR DESCRIPTION
this doesn't directly address keycloak integration, but does at least provide the APIs to try playing with them against an actual openid instance