### PR TITLE
NMS-16305: update minion confd for java_opts appending

### DIFF
--- a/opennms-container/minion/container-fs/confd/templates/org.opennms.minion.process-env.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.opennms.minion.process-env.tmpl
@@ -5,7 +5,7 @@ are used by this template. */ -}}
 #
 # DON'T EDIT THIS FILE :: GENERATED WITH CONFD
 #
-JAVA_OPTS=
+CUSTOM_JAVA_OPTS=
     {{- range $index, $element := getvs "/process-env/java-opts/*" -}}
         {{- if $index}} {{end -}}
         {{- $element -}}

--- a/opennms-container/minion/container-fs/entrypoint.sh
+++ b/opennms-container/minion/container-fs/entrypoint.sh
@@ -209,6 +209,7 @@ configure() {
       [[ $assignment =~ ^#.* ]] && continue
       export "$assignment"
     done < "$MINION_PROCESS_ENV_CFG"
+    export JAVA_OPTS="$CUSTOM_JAVA_OPTS $JAVA_OPTS"
   fi
   if [[ -f "$MINION_SERVER_CERTS_CFG" ]]; then
     # cacerts is a symlink to a file, so *do not* put /. on the target


### PR DESCRIPTION
Change the variable for Minion confd java_opts so it doesn't overwrite the variable and can be used to append custom options to the string.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16305

