### PR TITLE
stop publishing our own weird jest version

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1533,7 +1533,7 @@
         <bundle>mvn:com.google.code.gson/gson/${jestGsonVersion}</bundle>
         <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/${httpcoreVersion}</bundle>
         <bundle>mvn:org.opennms.features.jest/org.opennms.features.jest.client/${project.version}</bundle>
-        <bundle>mvn:io.searchbox/jest-complete-osgi/${jestVersion}</bundle>
+        <bundle>mvn:org.opennms.features.jest/jest-complete-osgi/${project.version}</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcoreVersion}</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclientVersion}</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpasyncclient-osgi/${httpasyncclientVersion}</bundle>

--- a/features/alarms/history/elastic/pom.xml
+++ b/features/alarms/history/elastic/pom.xml
@@ -71,9 +71,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.features.jest</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/features/flows/api/pom.xml
+++ b/features/flows/api/pom.xml
@@ -42,9 +42,9 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.features.jest</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/features/flows/elastic/pom.xml
+++ b/features/flows/elastic/pom.xml
@@ -111,9 +111,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.features.jest</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/features/jest/client/pom.xml
+++ b/features/jest/client/pom.xml
@@ -35,9 +35,9 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.features.jest</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/features/jest/feature/pom.xml
+++ b/features/jest/feature/pom.xml
@@ -11,7 +11,6 @@
     <name>OpenNMS :: Features :: Jest :: Feature definition</name>
     <description>Feature definition for Jest (ElasticSearch Java ReST Client)</description>
     <packaging>pom</packaging>
-    <!-- Versions below should match versions defined in module "jest-complete-osgi" to avoid problems -->
     <dependencies>
         <dependency>
             <groupId>org.opennms.features.jest</groupId>
@@ -19,9 +18,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.searchbox</groupId>
+            <groupId>org.opennms.features.jest</groupId>
             <artifactId>jest-complete-osgi</artifactId>
-            <version>${jestVersion}</version>
+            <version>${project.version}</version>
         </dependency>
         <!--
             Same dependencies as in dependencies module.

--- a/features/jest/jest-complete-osgi/pom.xml
+++ b/features/jest/jest-complete-osgi/pom.xml
@@ -8,18 +8,11 @@
 
   <!-- Feature Definition -->
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.searchbox</groupId>
+  <groupId>org.opennms.features.jest</groupId>
   <artifactId>jest-complete-osgi</artifactId>
-  <version>${jestVersion}</version>
   <name>jest-complete-osgi</name>
   <description>shaded osgi bundle containing complete jest implementation</description>
   <packaging>bundle</packaging>
-
-  <properties>
-    <httpcoreVersion>4.3.3</httpcoreVersion>
-    <httpclientVersion>4.3.6</httpclientVersion>
-    <httpasyncclientVersion>4.0.2</httpasyncclientVersion>
-  </properties>
 
   <build>
 
@@ -64,60 +57,48 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <!-- <version>2.5.3</version> -->
         <extensions>true</extensions>
-        <executions>
-          <!-- <execution> -->
-          <!-- <id>bundle-manifest</id> -->
-          <!-- <phase>process-classes</phase> -->
-          <!-- <goals> -->
-          <!-- <goal>manifest</goal> -->
-          <!-- </goals> -->
-          <!-- </execution> -->
-        </executions>
         <configuration>
           <instructions>
             <unpackBundle>true</unpackBundle>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <Export-Package>
-              io,
-              io.searchbox,
-              io.searchbox.action,
-              io.searchbox.annotations,
-              io.searchbox.client,
-              io.searchbox.client.config,
-              io.searchbox.client.config.discovery,
-              io.searchbox.client.config.exception,
-              io.searchbox.client.config.idle,
-              io.searchbox.client.http.apache,
-              io.searchbox.cloning,
-              io.searchbox.cluster,
-              io.searchbox.core,
-              io.searchbox.core.search,
-              io.searchbox.core.search.aggregation,
-              io.searchbox.core.search.sort,
-              io.searchbox.indices,
-              io.searchbox.indices.aliases,
-              io.searchbox.indices.mapping,
-              io.searchbox.indices.script,
-              io.searchbox.indices.settings,
-              io.searchbox.indices.template,
-              io.searchbox.indices.type,
-              io.searchbox.params,
-              io.searchbox.snapshot
+              io.searchbox.action;version="${jestVersion}",
+              io.searchbox.annotations;version="${jestVersion}",
+              io.searchbox.client;version="${jestVersion}",
+              io.searchbox.client.config;version="${jestVersion}",
+              io.searchbox.client.config.discovery;version="${jestVersion}",
+              io.searchbox.client.config.exception;version="${jestVersion}",
+              io.searchbox.client.config.idle;version="${jestVersion}",
+              io.searchbox.client.http;version="${jestVersion}",
+              io.searchbox.client.http.apache;version="${jestVersion}",
+              io.searchbox.cloning;version="${jestVersion}",
+              io.searchbox.cluster;version="${jestVersion}",
+              io.searchbox.cluster.reroute;version="${jestVersion}",
+              io.searchbox.core;version="${jestVersion}",
+              io.searchbox.core.search.aggregation;version="${jestVersion}",
+              io.searchbox.core.search.sort;version="${jestVersion}",
+              io.searchbox.indices;version="${jestVersion}",
+              io.searchbox.indices.aliases;version="${jestVersion}",
+              io.searchbox.indices.mapping;version="${jestVersion}",
+              io.searchbox.indices.reindex;version="${jestVersion}",
+              io.searchbox.indices.script;version="${jestVersion}",
+              io.searchbox.indices.settings;version="${jestVersion}",
+              io.searchbox.indices.template;version="${jestVersion}",
+              io.searchbox.indices.type;version="${jestVersion}",
+              io.searchbox.params;version="${jestVersion}",
+              io.searchbox.snapshot;version="${jestVersion}",
+              io.searchbox.strings;version="${jestVersion}"
             </Export-Package>
             <Import-Package>
-              com.google.common.base,
-              com.google.common.collect,
-              com.google.common.io,
-              com.google.common.reflect,
-              com.google.common.util.concurrent,
+              com.google.common.base;version="${guavaOsgiVersion}",
+              com.google.common.collect;version="${guavaOsgiVersion}",
+              com.google.common.io;version="${guavaOsgiVersion}",
+              com.google.common.reflect;version="${guavaOsgiVersion}",
+              com.google.common.util.concurrent;version="${guavaOsgiVersion}",
               com.google.gson,
               com.google.gson.annotations,
-              io.searchbox.action,
-              io.searchbox.client.config.discovery,
-              io.searchbox.client.config.exception,
               org.apache.http,
               org.apache.http.auth,
               org.apache.http.client,
@@ -171,6 +152,7 @@
     <dependency>
       <groupId>io.searchbox</groupId>
       <artifactId>jest</artifactId>
+      <version>${jestVersion}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>

--- a/features/opennms-es-rest/pom.xml
+++ b/features/opennms-es-rest/pom.xml
@@ -148,9 +148,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.features.jest</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/features/situation-feedback/elastic/pom.xml
+++ b/features/situation-feedback/elastic/pom.xml
@@ -47,9 +47,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>io.searchbox</groupId>
+      <groupId>org.opennms.features.jest</groupId>
       <artifactId>jest-complete-osgi</artifactId>
-      <version>${jestVersion}</version>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
We're getting some build failures off and on related to maven not finding the right version of things, and I think it's related to our funky custom package that acts like it's owned by the jest project but isn't.

This cleans it up to make `jest-complete-osgi` a normal OpenNMS module which provides the correct OSGi metadata to load as if it were the other bundle.