### PR TITLE
NMS-16311: Minion confd kafka

### DIFF
--- a/opennms-container/minion/container-fs/confd/templates/disable-jms.boot.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/disable-jms.boot.tmpl
@@ -2,4 +2,5 @@
 are used by this template. */ -}}
 {{if (and (exists "/ipc/rpc/kafka/bootstrap.servers") (exists "/ipc/sink/kafka/bootstrap.servers")) -}}
 !minion-jms
+!opennms-core-ipc-jms
 {{end -}}


### PR DESCRIPTION
Address an issue where configuring Kafka RPC and SINK does not fully disable the JMS IPC for Active MQ, preventing the Minion from passing a health-check.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16311

