### PR TITLE
NMS-16283: User Data Collection UI and API

### DIFF
--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsMetadataDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsMetadataDTO.java
@@ -26,27 +26,39 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.features.datachoices.internal;
+package org.opennms.features.datachoices.internal.usagestatistics;
 
-public class UsageStatisticsStatusDTO {
-    // note, these can be null (user never chose a status)
-    private Boolean isEnabled;
+import java.util.ArrayList;
+import java.util.List;
 
-    private Boolean initialNoticeAcknowledged;
+public class UsageStatisticsMetadataDTO {
+    public static class UsageStatisticsMetadataItem {
+        public String key;
+        public String name;
+        public String description;
+        public String datatype; // "string", "number", "object"
 
-    public Boolean getEnabled() {
-        return isEnabled;
+        public UsageStatisticsMetadataItem() {
+        }
+
+        public UsageStatisticsMetadataItem(String key, String name, String description, String datatype) {
+            this.key = key;
+            this.name = name;
+            this.description = description;
+            this.datatype = datatype;
+        }
     }
 
-    public void setEnabled(Boolean enabled) {
-        isEnabled = enabled;
+    private List<UsageStatisticsMetadataItem> metadata = new ArrayList<>();
+
+    public UsageStatisticsMetadataDTO() {
     }
 
-    public Boolean getInitialNoticeAcknowledged() {
-        return initialNoticeAcknowledged;
+    public List<UsageStatisticsMetadataItem> getMetadata() {
+        return metadata;
     }
 
-    public void setInitialNoticeAcknowledged(Boolean status) {
-        this.initialNoticeAcknowledged = status;
+    public void setMetadata(List<UsageStatisticsMetadataItem> list) {
+        this.metadata = list;
     }
 }

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReportDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReportDTO.java
@@ -26,7 +26,7 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.features.datachoices.internal;
+package org.opennms.features.datachoices.internal.usagestatistics;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
@@ -26,7 +26,7 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.features.datachoices.internal;
+package org.opennms.features.datachoices.internal.usagestatistics;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,6 +65,7 @@ import org.opennms.core.rpc.common.RpcStrategy;
 import org.opennms.core.utils.SystemInfoUtils;
 import org.opennms.core.utils.TimeSeries;
 import org.opennms.core.web.HttpClientWrapper;
+import org.opennms.features.datachoices.internal.StateManager;
 import org.opennms.features.datachoices.internal.StateManager.StateChangeHandler;
 import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
 import org.opennms.features.usageanalytics.api.UsageAnalyticDao;

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsStatusDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsStatusDTO.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.internal.usagestatistics;
+
+public class UsageStatisticsStatusDTO {
+    // note, these can be null (user never chose a status)
+    private Boolean isEnabled;
+
+    private Boolean initialNoticeAcknowledged;
+
+    public Boolean getEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        isEnabled = enabled;
+    }
+
+    public Boolean getInitialNoticeAcknowledged() {
+        return initialNoticeAcknowledged;
+    }
+
+    public void setInitialNoticeAcknowledged(Boolean status) {
+        this.initialNoticeAcknowledged = status;
+    }
+}

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionFormData.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionFormData.java
@@ -26,27 +26,15 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.features.datachoices.internal;
+package org.opennms.features.datachoices.internal.userdatacollection;
 
-public class UserDataCollectionStatusDTO {
-    // note, these can be null (user never chose a status)
-    private Boolean optedIn;
-
-    private Boolean noticeAcknowledged;
-
-    public Boolean getOptedIn() {
-        return optedIn;
-    }
-
-    public void setOptedIn(Boolean status) {
-        optedIn = status;
-    }
-
-    public Boolean getNoticeAcknowledged() {
-        return noticeAcknowledged;
-    }
-
-    public void setNoticeAcknowledged(Boolean status) {
-        this.noticeAcknowledged = status;
-    }
+/**
+ * Data received from user UI input, sent to DataChoiceRestService.
+ */
+public class UserDataCollectionFormData {
+    public Boolean consent;
+    public String firstName;
+    public String lastName;
+    public String email;
+    public String company;
 }

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionService.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionService.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.internal.userdatacollection;
+
+import java.io.IOException;
+
+public interface UserDataCollectionService {
+    void submit(UserDataCollectionFormData data) throws Exception, IOException;
+}

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionServiceImpl.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionServiceImpl.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.internal.userdatacollection;
+
+import java.io.IOException;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserDataCollectionServiceImpl implements UserDataCollectionService {
+    private static final Logger LOG = LoggerFactory.getLogger(UserDataCollectionServiceImpl.class);
+
+    private UserDataCollectionSubmissionClient client;
+
+    /**
+     * The form with user data collection info has been received; validate and send to
+     * OpenNMS Stats endpoint for further processing.
+     * Does not update User Data Collection status in Config Management, client will make
+     * a separate call for that.
+     */
+    public void submit(UserDataCollectionFormData data) throws Exception, IOException {
+        var submissionData = createSubmissionData(data);
+        String json = jsonSerialize(submissionData);
+
+        try {
+            client.postForm(json);
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    private UserDataCollectionSubmissionData createSubmissionData(UserDataCollectionFormData data) {
+        var submissionData = new UserDataCollectionSubmissionData();
+        submissionData.consent = true;
+        submissionData.firstName = data.firstName;
+        submissionData.lastName = data.lastName;
+        submissionData.email = data.email;
+        submissionData.company = data.company;
+        submissionData.product = "Horizon";
+        submissionData.systemId = "";
+
+        return submissionData;
+    }
+
+    private String jsonSerialize(UserDataCollectionSubmissionData data) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationConfig.Feature.SORT_PROPERTIES_ALPHABETICALLY);
+        mapper.enable(SerializationConfig.Feature.INDENT_OUTPUT);
+
+        try {
+            return mapper.writeValueAsString(data);
+        } catch (IOException e) {
+            LOG.error("Error serializing submission Json data", e);
+            throw e;
+        }
+    }
+
+    public void setClient(UserDataCollectionSubmissionClient client) {
+        this.client = client;
+    }
+}

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionStatusDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionStatusDTO.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2023 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -26,39 +26,27 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.features.datachoices.internal;
+package org.opennms.features.datachoices.internal.userdatacollection;
 
-import java.util.ArrayList;
-import java.util.List;
+public class UserDataCollectionStatusDTO {
+    // note, these can be null (user never chose a status)
+    private Boolean optedIn;
 
-public class UsageStatisticsMetadataDTO {
-    public static class UsageStatisticsMetadataItem {
-        public String key;
-        public String name;
-        public String description;
-        public String datatype; // "string", "number", "object"
+    private Boolean noticeAcknowledged;
 
-        public UsageStatisticsMetadataItem() {
-        }
-
-        public UsageStatisticsMetadataItem(String key, String name, String description, String datatype) {
-            this.key = key;
-            this.name = name;
-            this.description = description;
-            this.datatype = datatype;
-        }
+    public Boolean getOptedIn() {
+        return optedIn;
     }
 
-    private List<UsageStatisticsMetadataItem> metadata = new ArrayList<>();
-
-    public UsageStatisticsMetadataDTO() {
+    public void setOptedIn(Boolean status) {
+        optedIn = status;
     }
 
-    public List<UsageStatisticsMetadataItem> getMetadata() {
-        return metadata;
+    public Boolean getNoticeAcknowledged() {
+        return noticeAcknowledged;
     }
 
-    public void setMetadata(List<UsageStatisticsMetadataItem> list) {
-        this.metadata = list;
+    public void setNoticeAcknowledged(Boolean status) {
+        this.noticeAcknowledged = status;
     }
 }

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionSubmissionClient.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionSubmissionClient.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.internal.userdatacollection;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserDataCollectionSubmissionClient {
+    private static final Logger LOG = LoggerFactory.getLogger(UserDataCollectionSubmissionClient.class);
+
+    private String endpointUrl;
+
+    public void postForm(String json) throws Exception, IOException, InterruptedException {
+        final HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        final HttpRequest httpRequest = HttpRequest.newBuilder()
+                .uri(URI.create(endpointUrl))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .setHeader("User-Agent", "OpenNMS UserDataCollection")
+                .build();
+
+        LOG.info("Sending User Data Collection submission form data to: {}", endpointUrl);
+        final HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() == 200) {
+           LOG.info("User Data Collection submission accepted.");
+        } else {
+            LOG.error("Received error response from submission endpoint. Status code: {}. Body: {}.", response.statusCode(), response.body());
+            throw new Exception("Received error response from submission endpoint.");
+        }
+    }
+
+    public void setEndpointUrl(String url) {
+        this.endpointUrl = url;
+    }
+}

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionSubmissionData.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/userdatacollection/UserDataCollectionSubmissionData.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.internal.userdatacollection;
+
+/**
+ * Data sent to User Data Collection submission endpoint.
+ */
+public class UserDataCollectionSubmissionData {
+    public boolean consent;
+    public String firstName;
+    public String lastName;
+    public String email;
+    public String company;
+    public String product;
+    public String systemId;
+}

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/shell/internal/DisplayUsageReportCommand.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/shell/internal/DisplayUsageReportCommand.java
@@ -35,7 +35,7 @@ import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.shell.console.OsgiCommandSupport;
-import org.opennms.features.datachoices.internal.UsageStatisticsReporter;
+import org.opennms.features.datachoices.internal.usagestatistics.UsageStatisticsReporter;
 
 /**
  * <p>This command implements the Apache Karaf 3 and Apache Karaf 4 shell APIs.

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/shell/internal/SendUsageReportCommand.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/shell/internal/SendUsageReportCommand.java
@@ -35,7 +35,7 @@ import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.shell.console.OsgiCommandSupport;
-import org.opennms.features.datachoices.internal.UsageStatisticsReporter;
+import org.opennms.features.datachoices.internal.usagestatistics.UsageStatisticsReporter;
 
 /**
  * <p>This command implements the Apache Karaf 3 and Apache Karaf 4 shell APIs.

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/DataChoiceRestService.java
@@ -41,9 +41,10 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.opennms.features.datachoices.internal.UsageStatisticsReportDTO;
-import org.opennms.features.datachoices.internal.UsageStatisticsStatusDTO;
-import org.opennms.features.datachoices.internal.UserDataCollectionStatusDTO;
+import org.opennms.features.datachoices.internal.usagestatistics.UsageStatisticsReportDTO;
+import org.opennms.features.datachoices.internal.usagestatistics.UsageStatisticsStatusDTO;
+import org.opennms.features.datachoices.internal.userdatacollection.UserDataCollectionFormData;
+import org.opennms.features.datachoices.internal.userdatacollection.UserDataCollectionStatusDTO;
 
 @Path("/datachoices")
 public interface DataChoiceRestService {
@@ -52,27 +53,32 @@ public interface DataChoiceRestService {
     UsageStatisticsReportDTO getUsageStatistics() throws ServletException, IOException;
 
     @GET
-    @Path("status")
+    @Path("/status")
     @Produces(value={MediaType.APPLICATION_JSON})
     Response getStatus() throws ServletException, IOException;
 
     @POST
-    @Path("status")
+    @Path("/status")
     @Consumes({MediaType.APPLICATION_JSON})
     Response setStatus(@Context HttpServletRequest request, UsageStatisticsStatusDTO dto) throws ServletException, IOException;
 
     @GET
-    @Path("meta")
+    @Path("/meta")
     @Produces(value={MediaType.APPLICATION_JSON})
     Response getMetadata() throws ServletException, IOException;
 
     @GET
-    @Path("userdatacollection")
+    @Path("/userdatacollection/status")
     @Produces(value={MediaType.APPLICATION_JSON})
     Response getUserDataCollectionStatus() throws ServletException, IOException;
 
     @POST
-    @Path("userdatacollection")
+    @Path("/userdatacollection/status")
     @Consumes({MediaType.APPLICATION_JSON})
     Response setUserDataCollectionStatus(@Context HttpServletRequest request, UserDataCollectionStatusDTO dto) throws ServletException, IOException;
+
+    @POST
+    @Path("/userdatacollection/submit")
+    @Consumes({MediaType.APPLICATION_JSON})
+    Response submitUserDataCollectionData(@Context HttpServletRequest request, UserDataCollectionFormData data) throws ServletException, IOException;
 }

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/ModalInjector.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/ModalInjector.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,48 +28,102 @@
 
 package org.opennms.features.datachoices.web.internal;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.opennms.features.datachoices.internal.StateManager;
+import org.opennms.web.api.HtmlInjector;
+
 import com.google.common.collect.Maps;
+
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import org.opennms.features.datachoices.internal.StateManager;
-import org.opennms.web.api.HtmlInjector;
 
+/**
+ * Create Data Choices markup to be injected into web pages.
+ * See opennms-webapp bootstrap-footer.jsp, HtmlInjectHandler.
+ *
+ * We optionally inject markup for a Usage Sharing Statistics notice and a User Data Collection input dialog.
+ */
 public class ModalInjector implements HtmlInjector {
+    public static final String CONSENT_TEXT = "I agree to receive email communications from OpenNMS";
+    public static final String LEGAL_CONSENT_COMMUNICATION_TEXT = "If you consent to us contacting you, please opt in below. We will maintain your data until you request us to delete it from our systems. You may opt out of receiving communications from us at any time.";
+
     private StateManager m_stateManager;
 
     @Override
     public String inject(HttpServletRequest request) throws TemplateException, IOException {
+        String usageStatisticsSharingHtml = getUsageStatisticsSharingModalHtml(request);
+        String userDataCollectionHtml = getUserDataCollectionModalHtml(request);
+
+        List<String> items = Stream.of(usageStatisticsSharingHtml, userDataCollectionHtml)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+
+        return items.isEmpty() ? null : String.join("\n", items);
+    }
+
+    protected String getUsageStatisticsSharingModalHtml(HttpServletRequest request) throws TemplateException, IOException {
         // don't display Usage Statistics Sharing notice if already acked or user previously opted-out
         boolean noticeAcked = m_stateManager.isInitialNoticeAcknowledged() != null &&
-            m_stateManager.isInitialNoticeAcknowledged().booleanValue();
+                m_stateManager.isInitialNoticeAcknowledged().booleanValue();
         boolean optedOut = m_stateManager.isEnabled() != null && !m_stateManager.isEnabled().booleanValue();
         boolean hideNotice = noticeAcked || optedOut;
 
         if (!hideNotice &&
-            isPage("/opennms/index.jsp", request) &&
-            isUserInAdminRole(request)) {
-            return generateModalHtml(true);
+                isPage("/opennms/index.jsp", request) &&
+                isUserInAdminRole(request)) {
+            Map<String, Object> data = Maps.newHashMap();
+            data.put("showOnLoad", true);
+
+            return generateModalHtml("modal.ftl.html", data);
         }
 
         return null;
     }
 
-    protected static String generateModalHtml(boolean showOnLoad) throws IOException, TemplateException {
+    protected String getUserDataCollectionModalHtml(HttpServletRequest request) throws TemplateException, IOException {
+        String show = System.getProperty("opennms.userDataCollection.show", "true");
+
+        // don't display User Data Collection form if disabled by configuration
+        if (show != null && show.toLowerCase().equals("false")) {
+            return null;
+        }
+
+        // don't display User Data Collection form if already seen
+        boolean noticeSeen = m_stateManager.isUserDataCollectionNoticeAcknowledged();
+
+        if (!noticeSeen &&
+                isPage("/opennms/index.jsp", request) &&
+                isUserInAdminOrRestRole(request)) {
+            Map<String, Object> data = Maps.newHashMap();
+            data.put("consentText", CONSENT_TEXT);
+            data.put("legalConsentCommunication", LEGAL_CONSENT_COMMUNICATION_TEXT);
+
+            return generateModalHtml("user-data-collection.ftl.html", data);
+        }
+
+        return null;
+    }
+
+    protected static String generateModalHtml(String templateName, Map<String, Object> data) throws IOException, TemplateException {
         Configuration cfg = new Configuration(Configuration.VERSION_2_3_21);
         ClassTemplateLoader ctl = new ClassTemplateLoader(ModalInjector.class, "/web");
         cfg.setTemplateLoader(ctl);
+
         // Load the template
-        Template template = cfg.getTemplate("modal.ftl.html");
-        // Build out model
-        Map<String, Object> data = Maps.newHashMap();
-        data.put("showOnLoad", showOnLoad);
+        Template template = cfg.getTemplate(templateName);
+
         // Render to string
         Writer out = new StringWriter();
         template.process(data, out);
@@ -87,6 +141,10 @@ public class ModalInjector implements HtmlInjector {
 
     protected static boolean isUserInAdminRole(HttpServletRequest request) {
         return request.isUserInRole("ROLE_ADMIN");
+    }
+
+    protected static boolean isUserInAdminOrRestRole(HttpServletRequest request) {
+        return request.isUserInRole("ROLE_ADMIN") || request.isUserInRole("ROLE_REST");
     }
 
     public void setStateManager(StateManager stateManager) {

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/ModalInjector.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/ModalInjector.java
@@ -2,7 +2,7 @@
  * This file is part of OpenNMS(R).
  *
  * Copyright (C) 2024 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 2016-2024 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/features/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -66,7 +66,7 @@
 
     <bean id="dataSourceFactoryBean" class="org.opennms.core.db.DataSourceFactoryBean" />
 
-	<bean id="usageStatisticsReporter" class="org.opennms.features.datachoices.internal.UsageStatisticsReporter"
+	<bean id="usageStatisticsReporter" class="org.opennms.features.datachoices.internal.usagestatistics.UsageStatisticsReporter"
         init-method="init" destroy-method="destroy">
         <property name="url" value="${url}"/>
         <property name="interval" value="${interval}"/>
@@ -95,11 +95,22 @@
         <property name="notificationDao" ref="notificationDao"/>
     </bean>
 
-    <bean id="dataChoiceRestService" class="org.opennms.features.datachoices.web.internal.DataChoiceRestServiceImpl">
-        <property name="stateManager" ref="stateManager"/>
-        <property name="usageStatisticsReporter" ref="usageStatisticsReporter"/>
+    <bean id="userDataCollectionSubmissionClient" class="org.opennms.features.datachoices.internal.userdatacollection.UserDataCollectionSubmissionClient">
+        <property name="endpointUrl" value="http://stats.opennms.org/datachoices/user-data-collection" />
     </bean>
-    <service interface="org.opennms.features.datachoices.web.DataChoiceRestService" ref="dataChoiceRestService" >
+
+    <bean id="userDataCollectionService" class="org.opennms.features.datachoices.internal.userdatacollection.UserDataCollectionServiceImpl">
+        <property name="client" ref="userDataCollectionSubmissionClient" />
+    </bean>
+    <service interface="org.opennms.features.datachoices.internal.userdatacollection.UserDataCollectionService" ref="userDataCollectionService">
+    </service>
+
+    <bean id="dataChoiceRestService" class="org.opennms.features.datachoices.web.internal.DataChoiceRestServiceImpl">
+        <property name="stateManager" ref="stateManager" />
+        <property name="usageStatisticsReporter" ref="usageStatisticsReporter" />
+        <property name="userDataCollectionService" ref="userDataCollectionService" />
+    </bean>
+    <service interface="org.opennms.features.datachoices.web.DataChoiceRestService" ref="dataChoiceRestService">
         <service-properties>
             <entry key="application-path" value="/rest" />
         </service-properties>
@@ -140,5 +151,4 @@
             </action>
         </command>
     </command-bundle>
-
 </blueprint>

--- a/features/datachoices/src/main/resources/web/user-data-collection.ftl.html
+++ b/features/datachoices/src/main/resources/web/user-data-collection.ftl.html
@@ -1,0 +1,386 @@
+<!-- User Data Collection form -->
+<style>
+    #user-data-collection-alert.alert {
+		/* ensure alert is above the geomap */
+		z-index: 1000;
+    }
+
+    #user-data-collection-alert h5.modal-title {
+        color: #265a87;
+    }
+
+    #user-data-collection-alert .modal-header {
+        background-color: #e9ecef;
+    }
+
+    #user-data-collection-alert .alert-dialog {
+       position: fixed;
+       top: 1rem;
+       right: auto;
+       left: max(calc(60% - 450px), 1px);
+       bottom: auto;
+       min-width: 600px;
+       max-width: 700px;
+       box-shadow: 1px 3px 3px #6c757d;
+    }
+
+    #user-data-collection-alert-body.modal-body {
+        padding: 0.25rem 1rem 1rem 1rem;
+    }
+
+    .alert-dialog .modal-content .modal-header {
+        border-bottom: none;
+    }
+
+    .user-data-collection-content, #user-data-collection-done {
+        color: #738198;
+        font-size: 0.875rem;
+    }
+
+    .udc-form-field {
+        margin-bottom: 1.2rem;
+    }
+
+    .udc-form-field label {
+        margin-bottom: 0.25rem;
+    }
+
+    .udc-form-required {
+        color: red;
+    }
+
+    .udc-fieldset-form-columns-1 .udc-form-field {
+        width: 100%;
+    }
+
+    .udc-fieldset-form-columns-2 .udc-form-field {
+        width: 50%;
+        float: left;
+    }
+
+    .udc-fieldset-form-columns-2 .udc-form-field.udc-form-field-left .udc-input-wrapper {
+        margin-right: 8px;
+    }
+
+    .udc-form-fieldset input.udc-input {
+        background-clip: padding-box;
+        background-color: #f5f8fa;
+        border: 1px solid #cbd6e2;
+        border-radius: 15px;
+        box-sizing: border-box;
+        color: #33475b;
+        height: 40px;
+        min-height: 27px;
+        max-width: 100%;
+        width: 100%;
+        font-size: 1.1rem;
+        font-weight: normal;
+        line-height: 1.2rem;
+        padding: 0 1.1rem;
+    }
+
+    .udc-form-fieldset input.udc-input:focus {
+        border-color: rgba(82, 168, 236, .8);
+        outline: none;
+    }
+
+    .udc-form-fieldset .udc-form-field span {
+        font-size: 1.1rem;
+        font-weight: 500;
+        line-height: 1.2rem;
+    }
+
+    .udc-required-msg {
+        color: red;
+        font-size: 1.1rem;
+        font-weight: normal;
+        line-height: 1.2rem;
+        margin-top: 0.25rem;
+    }
+
+    .udc-required-msg-hidden {
+        display: none;
+    }
+
+    .udc-legal-text {
+        color: #738198;
+        font-size: 0.75rem;
+    }
+
+    .udc-form-required.udc-legal-text,
+    .udc-legal-text.udc-required-msg {
+        color: red;
+    }
+
+    .udc-form-field input[type=checkbox] {
+        vertical-align: middle;
+    }
+
+    .user-data-collection-button {
+        border-radius: 0;
+		box-shadow: none;
+        font-size: 0.875rem;
+        font-weight: 700;
+        letter-spacing: 0.2em;
+        line-height: 1.25rem;
+        text-transform: uppercase;
+    }
+
+	.user-data-collection-submit-button, .user-data-collection-close-button {
+        background-color: #273180;
+        border: 2px solid transparent;
+        color: #fff;
+        margin-right: 1rem;
+    }
+
+    .user-data-collection-submit-button:hover, .user-data-collection-close-button:hover {
+        box-shadow: 3px 1px 2px #6c757d;
+        color: #fff;
+    }
+
+	.user-data-collection-dismiss-button {
+        border: 2px solid;
+        color: #273180;
+    }
+
+    .user-data-collection-dismiss-button:hover {
+        box-shadow: 3px 1px 2px #6c757d;
+    }
+
+    .user-data-collection-sending, .user-data-collection-error {
+        background-color: #e9ecef;
+        border: 1px solid #cbd6e2;
+        border-radius: 15px;
+        margin-top: 4px;
+        width: 100%;
+        font-size: 1.1rem;
+        line-height: 1.2rem;
+        padding: 4px;
+    }
+
+    .user-data-collection-sending .udc-sending-data {
+        color: #0c0;
+    }
+
+    .user-data-collection-error {
+        color: red;
+    }
+</style>
+
+<div class="alert alert-dismissable" id="user-data-collection-alert" tabindex="-1" role="alert">
+    <div class="alert-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">User Data Collection</h5>
+            </div>
+            <div id="user-data-collection-alert-body" class="modal-body">
+                <div class="user-data-collection-content">
+                    If you would like to receive more information about OpenNMS Horizon, Meridian
+                    and other products, please enter the information below and click Sign Up.
+                    You may also choose Opt Out to close this message.
+
+                    This notice will only display once, but you can visit <a href="#">here</a> to sign up.
+                </div>
+                <br />
+                <div id="user-data-collection-form-wrapper">
+                    <form id="user-data-collection-form">
+                        <fieldset class="udc-form-fieldset udc-fieldset-form-columns-2">
+                            <div class="udc-form-field udc-form-field-left">
+                                <label for="udcFirstName">
+                                    <span>First Name</span>
+                                    <span class="udc-form-required">*</span>
+                                </label>
+                                <div class="udc-input-wrapper">
+                                    <input type="text" name="firstName" id="udcFirstName" class="udc-input"></input>
+                                </div>
+                                <div class="udc-required-msg udc-required-msg-hidden">Please complete this required field.</div>
+                            </div>
+                            <div class="udc-form-field">
+                                <label for="udcLastName">
+                                    <span>Last Name</span>
+                                    <span class="udc-form-required">*</span>
+                                </label>
+                                <div class="udc-input-wrapper">
+                                    <input type="text" name="lastName" id="udcLastName" class="udc-input"></input>
+                                </div>
+                                <div class="udc-required-msg udc-required-msg-hidden">Please complete this required field.</div>
+                            </div>
+                        </fieldset>
+                        <fieldset class="udc-form-fieldset udc-fieldset-form-columns-1">
+                            <div class="udc-form-field">
+                                <label for="udcEmail">
+                                    <span>Email Address</span>
+                                    <span class="udc-form-required">*</span>
+                                </label>
+                                <div class="udc-input-wrapper">
+                                    <input type="text" name="email" id="udcEmail" class="udc-input"></input>
+                                </div>
+                                <div class="udc-required-msg udc-required-msg-hidden">Please complete this required field.</div>
+                            </div>
+                        </fieldset>
+                        <fieldset class="udc-form-fieldset udc-fieldset-form-columns-1">
+                            <div class="udc-form-field">
+                                <label for="udcCompany">
+                                    <span>Company Name</span>
+                                    <span class="udc-form-required">*</span>
+                                </label>
+                                <div class="udc-input-wrapper">
+                                    <input type="text" name="company" id="udcCompany" class="udc-input"></input>
+                                </div>
+                                <div class="udc-required-msg udc-required-msg-hidden">Please complete this required field.</div>
+                            </div>
+                        </fieldset>
+                        <fieldset>
+                            <p class="udc-legal-text">${legalConsentCommunication}</p>
+                        </fieldset>
+                        <fieldset>
+                            <div class="udc-form-field">
+                                <input type="checkbox" name="consent" id="udcConsent"></input>
+                                <span class="udc-legal-text">${consentText}</span>
+                                <span class="udc-form-required udc-legal-text">*</span>
+                                <div class="udc-required-msg udc-legal-text udc-required-msg-hidden">Please complete this required field.</div>
+                            </div>
+                        </fieldset>
+                        <fieldset>
+                            <div class="udc-legal-text">For more information, check out our <a href="https://www.opennms.com/privacy/">Privacy Policy</a>.</div>
+                        </fieldset>
+                        <fieldset>
+                            <div class="udc-legal-text">Required fields are marked with a <span class="udc-form-required udc-legal-text">*</span></div>
+                        </fieldset>
+                    </form>
+                </div>
+                <div id="user-data-collection-done" style="display: none;">
+                    <p>Thank you for submitting your information.</p>
+                    <p>Welcome to the Horizon Community! Feel free to browse our
+                    <a href="https://www.opennms.com/blog/">blog</a> or follow us on our socials.</p>
+                    <p>
+                        <a href="https://www.linkedin.com/company/the-opennms-group/">LinkedIn</a> |
+                        <a href="http://www.twitter.com/opennms">Twitter</a> |
+                        <a href="https://www.facebook.com/OpenNMS/">Facebook</a> |
+                        <a href="http://www.youtube.com/user/opennms">YouTube</a> |
+                        <a href="http://www.reddit.com/r/opennms">Reddit</a> |
+                        <a href="https://chat.opennms.com/">Mattermost Chat</a> |
+                        <a href="https://opennms.discourse.group/">Discourse</a>
+                    </p>
+                </div>
+                <div class="user-data-collection-sending" style="display: none;">
+                    <span class="udc-sending-data">Sending data...</span>
+                </div>
+                <div class="user-data-collection-error" style="display: none;">
+                    <span>There was an error processing your request. You may click Opt Out to close this window.</span>
+                </div>
+                <br />
+                <div class="user-data-collection-buttons">
+                    <input type="hidden" id="user-data-collection-opted-in" value="false"></input>
+                    <input type="hidden" id="user-data-collection-acked" value="false"></input>
+                    <button id="user-data-collection-notice-submit" type="button" class="btn user-data-collection-button user-data-collection-submit-button">Sign Up</button>
+                    <button id="user-data-collection-notice-dismiss" type="button" class="btn user-data-collection-button user-data-collection-dismiss-button" data-dismiss="alert">Opt Out</button>
+                    <button id="user-data-collection-notice-close" type="button" class="btn user-data-collection-button user-data-collection-close-button" style="display: none;" data-dismiss="alert">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+(function() {
+    function userDataCollectionAckInitialNotice() {
+        var acked = $('#user-data-collection-acked').val();
+
+        if (acked === 'true') {
+            // already acked
+            return;
+        }
+
+        var optedIn = $('#user-data-collection-opted-in').val();
+        var data = { optedIn: optedIn === 'true', noticeAcknowledged: true };
+
+        $.ajax({
+            url: 'rest/datachoices/userdatacollection/status',
+            method: 'POST',
+            dataType: null,
+            contentType: 'application/json',
+            processData: false,
+            data: JSON.stringify(data)
+        })
+        .done(function() {
+            console.log('User Data Collection notice acknowledged, opt-in: ' + optedIn);
+        })
+        .fail(function() {
+            console.error('User Data Collection notice acknowledgement failed, opt-in: ' + optedIn);
+        });
+    }
+
+    function userDataCollectionSubmitForm() {
+        $('.user-data-collection-error').hide();
+
+        var firstName = $('#udcFirstName').val();
+        var lastName = $('#udcLastName').val();
+        var email = $('#udcEmail').val();
+        var company = $('#udcCompany').val();
+        var consent = $('#udcConsent').is(':checked');
+
+        if ([firstName, lastName, email, company, consent].some(function(x) { return !x; })) {
+            $('.udc-required-msg').removeClass('udc-required-msg-hidden');
+            return false;
+        }
+
+        $('.udc-required-msg').addClass('udc-required-msg-hidden');
+
+        var data = {
+            firstName: firstName,
+            lastName: lastName,
+            email: email,
+            company: company,
+            consent: true
+        };
+
+        $('.user-data-collection-sending').show();
+
+        $.ajax({
+            url: 'rest/datachoices/userdatacollection/submit',
+            method: 'POST',
+            dataType: null,
+            contentType: 'application/json',
+            processData: false,
+            data: JSON.stringify(data)
+        })
+        .done(function() {
+            $('#user-data-collection-opted-in').val('true');
+            $('.user-data-collection-content').hide();
+            $('#user-data-collection-form-wrapper').hide();
+            $('#user-data-collection-notice-submit').hide();
+            $('#user-data-collection-notice-dismiss').hide();
+
+            $('#user-data-collection-done').show();
+            $('#user-data-collection-notice-close').show();
+
+            userDataCollectionAckInitialNotice();
+            $('#user-data-collection-acked').val('true');
+        })
+        .fail(function() {
+            $('#user-data-collection-opted-in').val('false');
+            $('.user-data-collection-error').show();
+            alert('There was an error processing your request.');
+        })
+        .always(function() {
+            $('.user-data-collection-sending').hide();
+        });
+
+        return false;
+    }
+
+    $(document).ready(function() {
+        $('#user-data-collection-notice-dismiss').click(function() {
+            userDataCollectionAckInitialNotice();
+        });
+
+        $('#user-data-collection-notice-submit').click(function(e) {
+            e.preventDefault();
+            userDataCollectionSubmitForm();
+        });
+
+        $('#user-data-collection-alert').alert();
+    });
+})();
+</script>

--- a/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTOTest.java
+++ b/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/UsageStatisticsReportDTOTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.junit.Test;
+import org.opennms.features.datachoices.internal.usagestatistics.UsageStatisticsReportDTO;
 
 import com.google.common.collect.Maps;
 

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -560,6 +560,12 @@ opennms.newsFeedPanel.show=true
 #
 #opennms.newsFeedPanel.url=https://www.opennms.com/feed/
 
+# This value enables or disables display of the User Data Collection popup.
+# Set to false to disable showing the popup and to prevent any data being sent.
+# If commented-out or unset, the default value is true.
+# NOTE: For now, this is disabled since implementation is not yet complete.
+opennms.userDataCollection.show=false
+
 # This value disables the sending of successful login events.  The default is to send the
 # event.  Change this value to true to disable the publishing of this event.
 #org.opennms.security.disableLoginSuccessEvent=false


### PR DESCRIPTION
User Data Collection: UI, REST API and CRM integration.

Displays a dialog the first time any user logs in to request some user data and send it to a CRM endpoint. User can opt-out. Notice is only displayed once.

Workflow:

- Configuration Management check done to see if notice had been previously acknowledged, only display if not
- User can opt-in or opt-out
- Either opt-in or opt-out is recorded in the CM database via a REST POST to `rest/datachoices/userdatacollection/status`
- Opt-in results in a submission to `stats.opennms.org/datachoices/user-data-collection`. Then, the `usage-stats-handler` app makes a server-side call to the CRM

This can be disabled by setting `opennms.userDataCollection.show=false` in `etc/opennms.properties`.

> **NOTE:** For this PR, this feature is disabled by default by the `opennms.userDataCollection.show=false` setting. Once the `usage-stats-handler` has been deployed and is running, this feature will be enabled by default.

Dialog window:

<img width="711" alt="udc-dialog" src="https://github.com/OpenNMS/opennms/assets/1933710/067dd193-904f-4603-a357-0be1744ada01">

After sent:

<img width="639" alt="udc-after-sent" src="https://github.com/OpenNMS/opennms/assets/1933710/ef5bdd20-2bf9-4568-ade6-387251dce06d">

It's expected there will be some iteration on the UI, wording, links, etc.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16283
* `usage-stats-handler` PR: https://github.com/OpenNMS/usage-stats-handler/pull/12
