### PR TITLE
NMS-16316: Auto update eventconf from overlay events

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
@@ -7,6 +7,7 @@
          <rra>RRA:MAX:0.5:288:366</rra>
          <rra>RRA:MIN:0.5:288:366</rra>
       </rrd>
+      <!-- Custom collection groups for the default collection go here -->
       <include-collection dataCollectionGroup="MIB2"/>
       <include-collection dataCollectionGroup="3Com"/>
       <include-collection dataCollectionGroup="Acme Packet"/>
@@ -85,6 +86,8 @@
       <include-collection dataCollectionGroup="Zertico"/>
       <include-collection dataCollectionGroup="Zeus"/>
    </snmp-collection>
+
+   <!-- Custom collection packages go here -->
 
    <!--
       We need a dedicated collection with a different RRD setup for EJN equipment because

--- a/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
@@ -8,6 +8,7 @@
          <doNotOverride>script</doNotOverride>
       </security>
    </global>
+   <!-- Custom event configs go here -->
    <event-file>events/opennms.snmp.trap.translator.events.xml</event-file>
    <event-file>events/opennms.ackd.events.xml</event-file>
    <event-file>events/opennms.alarm.events.xml</event-file>

--- a/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
@@ -26,10 +26,10 @@
         * org.opennms.netmgt.syslogd.CustomSyslogParser: A backwards-compatible parser that has the same behavior
           as OpenNMS 1.8 (and previous).  It has relaxed standards and can usually pull data out of most BSD-
           or Syslog-NG-style traps.
-        * org.opennms.netmgt.syslogd.RadixTreeSyslogParser: This parser uses a set of patterns to match all 
+        * org.opennms.netmgt.syslogd.RadixTreeSyslogParser: This parser uses a set of patterns to match all
           RFC 3164, RFC 5424, and syslog-ng message formats. Because it is the most flexible parser, it is the
-          preferred implementation in most cases. Like the legacy Rfc5424SyslogParser, it currently discards 
-          RFC 5424 structured data. It ignores the forwarding-regexp, matching-group-host, and matching-group-message 
+          preferred implementation in most cases. Like the legacy Rfc5424SyslogParser, it currently discards
+          RFC 5424 structured data. It ignores the forwarding-regexp, matching-group-host, and matching-group-message
           parameters in favor of using an internal set of patterns.
         * DEPRECATED: org.opennms.netmgt.syslogd.SyslogNGParser: A stricter variant of the CustomSyslogParser which parses
           Syslog-NG's default format.  It ignores forwarding-regexp, matching-group-host, and matching-group-message
@@ -45,7 +45,7 @@
         anchor your regular expression matches with ^ and $, like in the examples below.  Failure to do so can
         cause extreme slowdowns, especially with large amounts of <ueiMatch> tags.
     -->
-
+    <!-- Custom syslog configs go here -->
     <import-file>syslog/ApacheHTTPD.syslog.xml</import-file>
     <import-file>syslog/LinuxKernel.syslog.xml</import-file>
     <import-file>syslog/NetgearProsafeSmartSwitch.syslog.xml</import-file>


### PR DESCRIPTION
This is planned for after #7028 merges.  That PR provides some placeholders in select config files as both a operator note and scripting placeholder.

This PR updates the core container entrypoint.sh script to update `eventconf.xml`  and syslog config based on any files in the overlay events/syslog directories. If the user provides a customized eventconf/syslog config that doesn't include the placeholder comments, this script will skip over and make no changes.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16316

