### PR TITLE
NMS-16302: bump zookeeper to latest 3.7.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1836,7 +1836,7 @@
     <xstreamVersion>1.4.20</xstreamVersion>
     <wsdl4jVersion>1.6.3</wsdl4jVersion>
     <wsmanVersion>1.2.3</wsmanVersion>
-    <zookeeperVersion>3.5.10</zookeeperVersion>
+    <zookeeperVersion>3.7.2</zookeeperVersion>
     <zstdJniVersion>1.5.2-1</zstdJniVersion>
     <minaSshdVersion>2.11.0</minaSshdVersion>
     <karafSshdVersion>${karafVersion}.ONMS_1</karafSshdVersion>


### PR DESCRIPTION
This PR bumps Zookeeper to the newest 3.7.x. 3.8 causes a deadlock in the tests, but 3.7.2 has no known CVEs open against it so it should be good enough for now.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16302

