### PR TITLE
NMS-16326: User Data Collection page to re-enable the signup dialog

### DIFF
--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/UserDataCollectionAdminPageNavEntry.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/web/internal/UserDataCollectionAdminPageNavEntry.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.datachoices.web.internal;
+
+import org.opennms.web.navigate.PageNavEntry;
+
+public class UserDataCollectionAdminPageNavEntry implements PageNavEntry {
+    @Override
+    public String getName() {
+        return "User Data Collection";
+    }
+
+    @Override
+    public String getUrl() {
+        return "admin/user-data-collection/index.jsp";
+    }
+}

--- a/features/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -134,6 +134,15 @@
         </service-properties>
     </service>
 
+    <bean id="userDataCollectionAdminPageNavEntry" class="org.opennms.features.datachoices.web.internal.UserDataCollectionAdminPageNavEntry"/>
+    <service interface="org.opennms.web.navigate.PageNavEntry" ref="userDataCollectionAdminPageNavEntry">
+        <service-properties>
+            <entry key="Page" value="admin" />
+            <entry key="Category" value="operations" />
+            <entry key="registration.export" value="true" />
+        </service-properties>
+    </service>
+
     <command-bundle xmlns="http://karaf.apache.org/xmlns/shell/v1.1.0">
         <command>
             <action class="org.opennms.features.datachoices.shell.internal.SendUsageReportCommand">

--- a/features/datachoices/src/main/resources/web/user-data-collection.ftl.html
+++ b/features/datachoices/src/main/resources/web/user-data-collection.ftl.html
@@ -179,7 +179,7 @@
                     and other products, please enter the information below and click Sign Up.
                     You may also choose Opt Out to close this message.
 
-                    This notice will only display once, but you can visit <a href="#">here</a> to sign up.
+                    This notice will only display once, but you can visit <a href="admin/user-data-collection/index.jsp">here</a> to re-enable sign up.
                 </div>
                 <br />
                 <div id="user-data-collection-form-wrapper">

--- a/opennms-webapp/src/main/webapp/admin/user-data-collection/index.jsp
+++ b/opennms-webapp/src/main/webapp/admin/user-data-collection/index.jsp
@@ -1,0 +1,111 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2024 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+--%>
+
+<%@ page import="org.opennms.web.utils.Bootstrap" %>
+<% Bootstrap.with(pageContext)
+          .headTitle("User Data Collection")
+          .breadcrumb("Admin", "admin/index.jsp")
+          .breadcrumb("User Data Collection")
+          .build(request);
+%>
+<jsp:directive.include file="/includes/bootstrap.jsp" />
+
+<style>
+    .admin-user-data-collection-form-wrapper {
+        margin-bottom: 50px;
+        margin-top: 8px;
+    }
+
+    .user-data-collection-button {
+        border-radius: 0;
+		box-shadow: none;
+        font-size: 0.875rem;
+        font-weight: 700;
+        letter-spacing: 0.2em;
+        line-height: 1.25rem;
+        text-transform: uppercase;
+    }
+
+	.user-data-collection-enable-button {
+        background-color: #273180;
+        border: 2px solid transparent;
+        color: #fff;
+        margin-right: 1rem;
+    }
+
+    .user-data-collection-enable-button:hover {
+        box-shadow: 3px 1px 2px #6c757d;
+        color: #fff;
+    }
+</style>
+
+<div>
+If you would like to receive more information about OpenNMS Horizon, Meridian and other products, please click
+Enable below and you will be redirected to the main page where you can enter your information.
+</div>
+<div class="admin-user-data-collection-form-wrapper">
+    <form id="admin-user-data-collection-form">
+        <button id="user-data-collection-notice-enable" type="button" class="btn user-data-collection-button user-data-collection-enable-button">Enable</button>
+    </form>
+</div>
+
+<script type="text/javascript">
+(function() {
+    function userDataCollectionEnableInitialNotice() {
+        var data = {
+            noticeAcknowledged: false
+        };
+
+        $.ajax({
+            url: 'rest/datachoices/userdatacollection/status',
+            method: 'POST',
+            dataType: null,
+            contentType: 'application/json',
+            processData: false,
+            data: JSON.stringify(data)
+        })
+        .done(function() {
+            window.location.href = '/index.jsp';
+        })
+        .fail(function() {
+            alert('There was an error processing your request.');
+        });
+    }
+
+    $(document).ready(function() {
+        $('#user-data-collection-notice-enable').click(function(e) {
+            e.preventDefault();
+            userDataCollectionEnableInitialNotice();
+        });
+    });
+})();
+</script>
+
+<jsp:include page="/includes/bootstrap-footer.jsp" flush="false"/>

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminPageIT.java
@@ -95,7 +95,8 @@ public class AdminPageIT extends OpenNMSSeleniumIT {
         new String[] { "Ops Board Configuration", "//div[@id='content']//iframe" },
         new String[] { "Surveillance Views Configuration", "//div[@id='content']//iframe" },
         new String[] { "JMX Configuration Generator", "//div[@id='content']//iframe" },
-        new String[] { "Usage Statistics Sharing", "//div[contains(@class, 'card')]//span[text()='Usage Statistics Sharing']" }
+        new String[] { "Usage Statistics Sharing", "//div[contains(@class, 'card')]//span[text()='Usage Statistics Sharing']" },
+        new String[] { "User Data Collection", "//div[contains(@class, 'admin-user-data-collection-form-wrapper')]" }
     };
 
     @Before


### PR DESCRIPTION
Add a link on the Admin page to a User Data Collection page which allows user to re-enable the signup dialog, even if they initially opted-out. Would also allow other users besides the initial one to sign up.

Sign up dialog also contains a link to go to this page.

UDC Admin Page:

<img width="1613" alt="udc-admin-page" src="https://github.com/OpenNMS/opennms/assets/1933710/884731b2-1c45-4d02-bb28-4d141c240f5a">


Link on Admin page:

<img width="794" alt="admin-page-link" src="https://github.com/OpenNMS/opennms/assets/1933710/3a04017f-c1db-4dba-ab02-aee41786982e">


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16326
