### PR TITLE
NMS-16346 Update docs for Newts configs

### DIFF
--- a/docs/modules/deployment/pages/time-series-storage/newts/configuration.adoc
+++ b/docs/modules/deployment/pages/time-series-storage/newts/configuration.adoc
@@ -35,6 +35,10 @@ If including multiple node references, separate each with a single comma.
 | Password to use when connecting to Cassandra via CQL.
 | cassandra
 
+| org.opennms.newts.config.datacenter
+| Set this to the value of your local datacenter for the best performance.
+| datacenter1
+
 | org.opennms.newts.config.ssl
 | Enable or disable SSL when connecting to Cassandra.
 | false

--- a/docs/modules/reference/pages/configuration/core-docker.adoc
+++ b/docs/modules/reference/pages/configuration/core-docker.adoc
@@ -79,11 +79,12 @@
 |===
 | Environment variable          | Description                                                                       | Required | Default value
 | `REPLICATION_FACTOR`          | Set Cassandra replication factor for the newts keyspace if Newts is used.      | optional | `1`
-| `OPENNMS_CASSANDRA_HOSTNAMES` | A comma-separated list with Cassandra hosts for Newts                         | optional | `localhost`
+| `OPENNMS_CASSANDRA_HOSTNAME`  | A comma-separated list with Cassandra hosts for Newts                         | optional | `localhost`
 | `OPENNMS_CASSANDRA_KEYSPACE`  | Name of the keyspace used by Newts                                              | optional | `newts`
 | `OPENNMS_CASSANDRA_PORT`      | Cassandra server port                                                           | optional | `9042`
 | `OPENNMS_CASSANDRA_USERNAME`  | Username with access to Cassandra                                              | optional | `cassandra`
 | `OPENNMS_CASSANDRA_PASSWORD`  | Password for user with access to Cassandra                                      | optional | `cassandra`
+| `OPENNMS_CASSANDRA_DATACENTER` | Set this to the value of your local datacenter for the best performance                                     | optional | `datacenter1`
 |===
 
 == Directory conventions


### PR DESCRIPTION
v32 added the `datacenter` property to Newts, but the docs weren't updated to reference this properly.  And NMS-16346 pointed out there was a misspelling on the Newts hostname setting for confd.

### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16346

