### PR TITLE
fix code coverage to run under JDK17

### DIFF
--- a/.circleci/main/executors.yml
+++ b/.circleci/main/executors.yml
@@ -4,7 +4,10 @@ executors:
       - image: cimg/base:stable-20.04
   build-executor:
     docker:
-      - image: opennms/build-env:circleci-ubuntu-jdk11-b9919
+      - image: opennms/build-env:circleci-ubuntu-jdk11
+  coverage-executor:
+    docker:
+      - image: opennms/build-env:circleci-ubuntu-jdk17
   docs-executor:
     docker:
       - image: opennms/antora:3.1.4-b10433

--- a/.circleci/main/jobs/code-coverage.yml
+++ b/.circleci/main/jobs/code-coverage.yml
@@ -1,16 +1,16 @@
  jobs:
   code-coverage:
-    executor: build-executor
+    executor: coverage-executor
     resource_class: xlarge
     steps:
       - cached-checkout
       - attach_workspace:
           at: ~/
       - cached-download:
-          url: https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.8/org.jacoco.cli-0.8.8-nodeps.jar
+          url: https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.11/org.jacoco.cli-0.8.11-nodeps.jar
           file: /tmp/jacoco-cli.jar
       - cached-download:
-          url: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747.zip
+          url: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006.zip
           file: /tmp/sonar-scanner-cli.zip
       - extract-pom-version
       - restore-maven-cache
@@ -24,6 +24,6 @@
           name: Run SonarQube Code Analysis
           when: always
           command: |
-            export MAVEN_OPTS="-Xmx12g -XX:ReservedCodeCacheSize=1g -XX:+TieredCompilation"
+            export MAVEN_OPTS="-Xmx12g -XX:ReservedCodeCacheSize=2g -XX:+TieredCompilation -XX:+UseShenandoahGC"
             .circleci/scripts/sonar.sh
       - save-sonar-cache

--- a/.circleci/scripts/sonar.sh
+++ b/.circleci/scripts/sonar.sh
@@ -119,7 +119,7 @@ fi
 
 mkdir -p /tmp/sonar-cache
 export SONAR_USER_HOME=/tmp/sonar-cache
-export SONAR_SCANNER_OPTS="${MAVEN_OPTS:--Xmx7g}"
+export SONAR_SCANNER_OPTS="${MAVEN_OPTS:=-Xmx7g} -verbose:gc"
 
 echo "#### Executing Sonar"
 # shellcheck disable=SC2086


### PR DESCRIPTION
JDK11 support was sunsetted Feb 2024 by Sonar upstream.

This PR bumps to the latest Sonar CLI, makes a few memory changes, and turns on verbose GC so that we get enough log output during scanning that it doesn't fail out.