### PR TITLE
NMS-16356: Add procps which is required by the Karaf status scripts

### DIFF
--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -59,7 +59,7 @@ RUN chmod +x /tmp/plugins.sh  && cd /tmp && ./plugins.sh && rm ./plugins.sh
 ##
 FROM ${BASE_IMAGE}
 
-ARG REQUIRED_RPMS="hostname uuid"
+ARG REQUIRED_RPMS="hostname uuid procps"
 
 # Collect generic steps in a layer for caching
 

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -44,7 +44,7 @@ RUN chmod -R g-w /opt/usr-share/sentinel && \
 
 FROM ${BASE_IMAGE} as sentinel-base
 
-ARG REQUIRED_RPMS="hostname uuid"
+ARG REQUIRED_RPMS="hostname uuid procps"
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Add procps to the required RPMS in the production container image in our Minion and Sentinel.

## Review hint

I've looked into the Core container image and we don't provide the Karaf status script in the same way as in Minion and Sentinel, which is the reason, I haven't added it to the core image.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16356

