### PR TITLE
NMS-16320: Fixed requisition handling

### DIFF
--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImporter.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImporter.java
@@ -21,7 +21,6 @@
  */
 package org.opennms.netmgt.provision.service.vmware;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
 import java.net.InetAddress;
@@ -180,23 +179,12 @@ public class VmwareImporter {
      * @return the requisition object
      */
     private Requisition buildVMwareRequisition() {
-        VmwareViJavaAccess vmwareViJavaAccess = null;
-
         // for now, set the foreign source to the specified vcenter host
         m_requisition = new Requisition(request.getForeignSource());
 
         logger.debug("Creating new VIJava access object for host {} ...", request.getHostname());
-        if ((request.getHostname() == null || "".equals(request.getHostname())) || (request.getPassword() == null || "".equals(request.getPassword()))) {
-            logger.info("No credentials found for connecting to host {}, trying anonymously...", request.getHostname());
-            try {
-                vmwareViJavaAccess = new VmwareViJavaAccess(request.getHostname());
-            } catch (IOException e) {
-                logger.warn("Error initialising VMware connection to '{}': '{}'", request.getHostname(), e.getMessage());
-                return null;
-            }
-        } else {
-            vmwareViJavaAccess = new VmwareViJavaAccess(request.getHostname(), request.getUsername(), request.getPassword());
-        }
+        final VmwareViJavaAccess vmwareViJavaAccess = new VmwareViJavaAccess(request.getHostname(), request.getUsername(), request.getPassword());
+
         logger.debug("Successfully created new VIJava access object for host {}", request.getHostname());
 
         logger.debug("Connecting VIJava access for host {} ...", request.getHostname());

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionTool.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionTool.java
@@ -43,7 +43,6 @@ import org.opennms.core.xml.JaxbUtils;
 import org.opennms.features.scv.api.SecureCredentialsVault;
 import org.opennms.netmgt.config.vmware.VmwareConfig;
 import org.opennms.netmgt.config.vmware.VmwareServer;
-import org.opennms.netmgt.provision.persist.requisition.Requisition;
 
 /**
  * The Class VmwareRequisitionTool
@@ -94,17 +93,7 @@ public abstract class VmwareRequisitionTool {
             }
         }
 
-        VmwareRequisitionUrlConnection c = new VmwareRequisitionUrlConnection(url) {
-            @Override
-            protected Requisition getExistingRequisition(String foreignSource) {
-                // This is not elegant but it is necessary to avoid booting Spring
-                File req = new File(ConfigFileConstants.getFilePathString(), "imports" + File.separator + foreignSource + ".xml");
-                if (req.exists()) {
-                    return JaxbUtils.unmarshal(Requisition.class, req);
-                }
-                return null;
-            }
-        };
+        final VmwareRequisitionUrlConnection c = new VmwareRequisitionUrlConnection(url);
         c.connect();
         InputStream is = c.getInputStream();
         if (is == null) {

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlConnection.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlConnection.java
@@ -106,12 +106,9 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
             }
         }
 
-        if (Strings.isNullOrEmpty(parameters.get("username"))) {
-            logger.error("Error getting username for VMware management server '{}'.", parameters.get("host"));
-        }
-
-        if (Strings.isNullOrEmpty(parameters.get("password"))) {
-            logger.error("Error getting password for VMware management server '{}'.", parameters.get("host"));
+        if (Strings.isNullOrEmpty(parameters.get("username")) || Strings.isNullOrEmpty(parameters.get("password"))) {
+            logger.error("Error getting username/password for VMware management server '{}'.", parameters.get("host"));
+            throw new IllegalArgumentException("Username and password must not be empty or null");
         }
     }
 

--- a/integrations/opennms-vmware/src/main/java/org/opennms/protocols/vmware/VmwareViJavaAccess.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/protocols/vmware/VmwareViJavaAccess.java
@@ -38,7 +38,6 @@
 
 package org.opennms.protocols.vmware;
 
-import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
@@ -58,12 +57,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 
-import org.opennms.core.mate.api.Interpolator;
-import org.opennms.core.mate.api.Scope;
-import org.opennms.core.mate.api.SecureCredentialsVaultScope;
-import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.utils.AnyServerX509TrustManager;
-import org.opennms.features.scv.api.SecureCredentialsVault;
 import org.opennms.netmgt.collectd.vmware.vijava.VmwarePerformanceValues;
 import org.opennms.netmgt.config.vmware.VmwareServer;
 import org.opennms.netmgt.dao.vmware.VmwareConfigDao;
@@ -151,52 +145,6 @@ public class VmwareViJavaAccess implements AutoCloseable {
         this.m_hostname = hostname;
         this.m_username = username;
         this.m_password = password;
-    }
-
-    /**
-     * Constructor for creating a instance for a given server. Checks whether credentials
-     * are available in the Vmware config file.
-     *
-     * @param hostname the vCenter's hostname
-     * @throws IOException
-     */
-    public VmwareViJavaAccess(String hostname) throws IOException {
-        if (m_vmwareConfigDao == null) {
-            m_vmwareConfigDao = BeanUtils.getBean("daoContext", "vmwareConfigDao", VmwareConfigDao.class);
-        }
-
-        final SecureCredentialsVault secureCredentialsVault = BeanUtils.getBean("jceksScvContext", "jceksSecureCredentialsVault", SecureCredentialsVault.class);
-
-        this.m_hostname = hostname;
-
-        if (m_vmwareConfigDao == null) {
-            logger.error("vmwareConfigDao should be a non-null value.");
-        } else {
-            Map<String, VmwareServer> serverMap = m_vmwareConfigDao.getServerMap();
-            if (serverMap == null) {
-                logger.error("Error getting vmware-config.xml's server map.");
-            } else {
-                VmwareServer vmwareServer = serverMap.get(m_hostname);
-
-                if (vmwareServer == null) {
-                    logger.error("Error getting credentials for VMware management server '{}'.", m_hostname);
-                } else {
-                    final Scope scvScope = new SecureCredentialsVaultScope(secureCredentialsVault);
-                    this.m_username = Interpolator.interpolate(vmwareServer.getUsername(), scvScope).output;
-                    this.m_password = Interpolator.interpolate(vmwareServer.getPassword(), scvScope).output;
-                }
-            }
-        }
-
-        if (this.m_username == null) {
-            logger.error("Error getting username for VMware management server '{}'.", m_hostname);
-            this.m_username = "";
-        }
-
-        if (this.m_password == null) {
-            logger.error("Error getting password for VMware management server '{}'.", m_hostname);
-            this.m_password = "";
-        }
     }
 
     public VmwareViJavaAccess(VmwareServer vmwareServer) {

--- a/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/NMS16320Test.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/NMS16320Test.java
@@ -1,0 +1,109 @@
+package org.opennms.netmgt.provision.service.vmware;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.core.utils.url.GenericURLFactory;
+import org.opennms.features.scv.api.Credentials;
+import org.opennms.features.scv.api.SecureCredentialsVault;
+import org.opennms.features.scv.jceks.JCEKSSecureCredentialsVault;
+import org.opennms.netmgt.config.vmware.VmwareServer;
+import org.opennms.netmgt.dao.vmware.VmwareConfigDao;
+import org.opennms.netmgt.provision.persist.RequisitionProviderRegistry;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.opennms.netmgt.provision.persist.rpc.LocationAwareRequisitionClientImpl;
+import org.opennms.netmgt.provision.persist.rpc.RequisitionRequestBuilderImpl;
+
+public class NMS16320Test {
+    public Map<String, String> parameters;
+    public LocationAwareRequisitionClientImpl client;
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void setUpClass() {
+        GenericURLFactory.initialize();
+    }
+
+    @Before
+    public void before() throws Exception {
+        tempFolder.create();
+        final File keystoreFile = new File(tempFolder.getRoot(), "scv.jce");
+        final SecureCredentialsVault secureCredentialsVault = new JCEKSSecureCredentialsVault(keystoreFile.getAbsolutePath(), "notRealPassword");
+        secureCredentialsVault.setCredentials("vmware", new Credentials("opennms-pittsboro", "p1tt5boro"));
+
+
+        final VmwareServer vmwareServer1 = new VmwareServer();
+        vmwareServer1.setHostname("my.first.vcenter.server.org");
+        vmwareServer1.setUsername("${scv:vmware:username}");
+        vmwareServer1.setPassword("${scv:vmware:password}");
+
+        final VmwareServer vmwareServer2 = new VmwareServer();
+        vmwareServer2.setHostname("my.second.vcenter.server.org");
+        vmwareServer2.setUsername("opennms-fulda");
+        vmwareServer2.setPassword("fu7da");
+
+        final Map<String, VmwareServer> serverMap = new TreeMap<>();
+        serverMap.put("my.first.vcenter.server.org", vmwareServer1);
+        serverMap.put("my.second.vcenter.server.org", vmwareServer2);
+
+        final VmwareConfigDao vmwareConfigDao = mock(VmwareConfigDao.class);
+        when(vmwareConfigDao.getServerMap()).thenReturn(serverMap);
+
+        client = mock(LocationAwareRequisitionClientImpl.class);
+
+        final RequisitionProviderRegistry requisitionProviderRegistry = mock(RequisitionProviderRegistry.class);
+        when(client.getRegistry()).thenReturn(requisitionProviderRegistry);
+        when(requisitionProviderRegistry.getProviderByType("vmware")).thenReturn(new VmwareRequisitionProvider());
+        when(client.requisition()).thenReturn(new RequisitionRequestBuilderImpl(client) {
+            @Override
+            public CompletableFuture<Requisition> execute() {
+                NMS16320Test.this.parameters = parameters;
+                return CompletableFuture.completedFuture(new Requisition());
+            }
+        });
+
+        VmwareRequisitionUrlConnection.setVmwareConfigDao(vmwareConfigDao);
+        VmwareRequisitionUrlConnection.setSecureCredentialsVault(secureCredentialsVault);
+        VmwareRequisitionUrlConnection.setRequisitionProviderClient(client);
+    }
+
+    @Test
+    public void testClient() throws Exception {
+        new VmwareRequisitionUrlConnection(new URL("vmware://my.first.vcenter.server.org?location=Pittsboro")).getInputStream();
+        Assert.assertEquals("my.first.vcenter.server.org", parameters.get("host"));
+        Assert.assertEquals("Pittsboro", parameters.get("location"));
+        Assert.assertEquals("opennms-pittsboro", parameters.get("username"));
+        Assert.assertEquals("p1tt5boro", parameters.get("password"));
+        parameters.clear();
+        new VmwareRequisitionUrlConnection(new URL("vmware://my.second.vcenter.server.org?location=Fulda")).getInputStream();
+        Assert.assertEquals("my.second.vcenter.server.org", parameters.get("host"));
+        Assert.assertEquals("Fulda", parameters.get("location"));
+        Assert.assertEquals("opennms-fulda", parameters.get("username"));
+        Assert.assertEquals("fu7da", parameters.get("password"));
+        parameters.clear();
+        new VmwareRequisitionUrlConnection(new URL("vmware://my.third.vcenter.server.org?location=Apex&username=opennms-apex&password=ap3x")).getInputStream();
+        Assert.assertEquals("my.third.vcenter.server.org", parameters.get("host"));
+        Assert.assertEquals("Apex", parameters.get("location"));
+        Assert.assertEquals("opennms-apex", parameters.get("username"));
+        Assert.assertEquals("ap3x", parameters.get("password"));
+        parameters.clear();
+        new VmwareRequisitionUrlConnection(new URL("vmware://my.fourth.vcenter.server.org?username=opennms-default&password=d3fault")).getInputStream();
+        Assert.assertEquals("my.fourth.vcenter.server.org", parameters.get("host"));
+        Assert.assertNull(parameters.get("location"));
+        Assert.assertEquals("opennms-default", parameters.get("username"));
+        Assert.assertEquals("d3fault", parameters.get("password"));
+    }
+}

--- a/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlTest.java
@@ -62,28 +62,28 @@ public class VmwareRequisitionUrlTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {     
              {
-               "vmware://vcenter.mydomain.org?importHostPoweredOff=true",
-               "requisition://vmware?host=vcenter.mydomain.org&importHostPoweredOff=true"
+               "vmware://vcenter.mydomain.org?importHostPoweredOff=true&username=username&password=password",
+               "requisition://vmware?host=vcenter.mydomain.org&importHostPoweredOff=true&username=username&password=password"
              },
              {
-               "vmware://172.16.123.100/vCenterImport?key=shouldImport;value=1",
-               "requisition://vmware/vCenterImport?host=172.16.123.100&key=shouldImport;value=1"
+               "vmware://172.16.123.100/vCenterImport?key=shouldImport;value=1&username=username&password=password",
+               "requisition://vmware/vCenterImport?host=172.16.123.100&key=shouldImport;value=1&username=username&password=password"
              },
              {
-               "vmware://172.16.123.100/vCenterImport?_shouldImport=1",
-               "requisition://vmware/vCenterImport?host=172.16.123.100&_shouldImport=1"
+               "vmware://172.16.123.100/vCenterImport?_shouldImport=1&username=username&password=password",
+               "requisition://vmware/vCenterImport?host=172.16.123.100&_shouldImport=1&username=username&password=password"
              },
              {
                "vmware://172.16.123.100/vCenterImport?_shouldImport=1;username=opennms;password=secret",
                "requisition://vmware/vCenterImport?host=172.16.123.100&_shouldImport=1&username=opennms&password=secret"
              },
              {
-               "vmware://[2001:db8:0:8d3:0:8a2e:70:7344]?virtualMachineServices=VM-SERVICE1,VM-SERVICE2",
-               "requisition://vmware?host=[2001:db8:0:8d3:0:8a2e:70:7344]&virtualMachineServices=VM-SERVICE1,VM-SERVICE2"
+               "vmware://[2001:db8:0:8d3:0:8a2e:70:7344]?virtualMachineServices=VM-SERVICE1,VM-SERVICE2&username=username&password=password",
+               "requisition://vmware?host=[2001:db8:0:8d3:0:8a2e:70:7344]&virtualMachineServices=VM-SERVICE1,VM-SERVICE2&username=username&password=password"
              },
              {
-                "vmware://vcenter.mydomain.org?importHostPoweredOff=true&timeout=3050&cimTimeout=3100",
-                "requisition://vmware?host=vcenter.mydomain.org&importHostPoweredOff=true&timeout=3050&cimTimeout=3100"
+                "vmware://vcenter.mydomain.org?importHostPoweredOff=true&timeout=3050&cimTimeout=3100&username=username&password=password",
+                "requisition://vmware?host=vcenter.mydomain.org&importHostPoweredOff=true&timeout=3050&cimTimeout=3100&username=username&password=password"
              }
        });
     }

--- a/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlTest.java
@@ -22,26 +22,41 @@
 package org.opennms.netmgt.provision.service.vmware;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.rmi.RemoteException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.opennms.core.utils.url.GenericURLFactory;
+import org.opennms.features.scv.api.SecureCredentialsVault;
+import org.opennms.features.scv.jceks.JCEKSSecureCredentialsVault;
+import org.opennms.netmgt.config.vmware.VmwareServer;
+import org.opennms.netmgt.dao.vmware.VmwareConfigDao;
 import org.opennms.netmgt.provision.service.requisition.RequisitionUrlConnection;
 
 @RunWith(Parameterized.class)
 public class VmwareRequisitionUrlTest {
     private final String vmwareUrl;
     private final String requisitionUrl;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    private final SecureCredentialsVault secureCredentialsVault;
 
     @Parameters
     public static Collection<Object[]> data() {
@@ -78,13 +93,23 @@ public class VmwareRequisitionUrlTest {
         GenericURLFactory.initialize();
     }
 
-    public VmwareRequisitionUrlTest(String vmwareUrl, String requisitionUrl) {
+    public VmwareRequisitionUrlTest(String vmwareUrl, String requisitionUrl) throws IOException {
+        tempFolder.create();
+
         this.vmwareUrl = vmwareUrl;
         this.requisitionUrl = requisitionUrl;
+
+        final File keystoreFile = new File(tempFolder.getRoot(), "scv.jce");
+        secureCredentialsVault = new JCEKSSecureCredentialsVault(keystoreFile.getAbsolutePath(), "notRealPassword");
     }
 
     @Test
     public void compareGeneratedRequests() throws MalformedURLException, RemoteException {
+        final VmwareConfigDao vmwareConfigDao = mock(VmwareConfigDao.class);
+        when(vmwareConfigDao.getServerMap()).thenReturn(new HashMap<String, VmwareServer>());
+
+        VmwareRequisitionUrlConnection.setSecureCredentialsVault(secureCredentialsVault);
+        VmwareRequisitionUrlConnection.setVmwareConfigDao(vmwareConfigDao);
         VmwareRequisitionUrlConnection vmwareUrlConnection = new VmwareRequisitionUrlConnection(new URL(vmwareUrl));
         VmwareImportRequest vmwareUrlImportRequest = vmwareUrlConnection.getImportRequest();
 

--- a/opennms-base-assembly/src/main/filtered/bin/vmwarecimquery
+++ b/opennms-base-assembly/src/main/filtered/bin/vmwarecimquery
@@ -21,5 +21,6 @@ exec "$OPENNMS_BINDIR"/runjava -r -- \
 	-Dopennms.home="$OPENNMS_HOME" \
 	-Dlog4j.configurationFile="$OPENNMS_HOME"/etc/log4j2-tools.xml \
 	-cp "$JAKARTA_JAR:$JDK9_JAXB:$CORE_JAR:$YAVIJAVA_JAR:$VMWARE_JAR:$JCIFS_JAR:$DOM4J_JAR:$CIM_JAR:$SLP_JAR:$SLF4J_API_JAR:$SLF4J_L4J_JAR:$LOG4J_JAR:$COMMONS_CLI_JAR" \
+	$("${OPENNMS_HOME}/bin/_module_opts.sh") \
 	org.opennms.protocols.vmware.VmwareCimQuery \
 	"$@"

--- a/opennms-base-assembly/src/main/filtered/bin/vmwarereqtool
+++ b/opennms-base-assembly/src/main/filtered/bin/vmwarereqtool
@@ -15,5 +15,6 @@ exec "$OPENNMS_BINDIR"/runjava -r -- $JAVA_OPTIONS \
 	-Drrd.base.dir="$OPENNMS_SHAREDIR"/rrd \
 	-Drrd.binary="${install.rrdtool.bin}" \
 	-Dopennms.manager.class="$APP_CLASS" \
+	$("${OPENNMS_HOME}/bin/_module_opts.sh") \
 	-jar "$OPENNMS_HOME"/lib/opennms_bootstrap.jar \
 	"$@"

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ImportJob.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ImportJob.java
@@ -21,6 +21,8 @@
  */
 package org.opennms.netmgt.provision.service;
 
+import org.opennms.core.mate.api.EntityScopeProvider;
+import org.opennms.core.mate.api.Interpolator;
 import org.opennms.netmgt.provision.service.operations.ProvisionMonitor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
@@ -48,11 +50,13 @@ public class ImportJob implements Job {
 
     private ProvisionMonitor provisionMonitor;
 
+    private EntityScopeProvider entityScopeProvider;
+
     /** {@inheritDoc} */
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try {
-            String url = context.getJobDetail().getJobDataMap().getString(URL);
+            String url = Interpolator.interpolate(context.getJobDetail().getJobDataMap().getString(URL), entityScopeProvider.getScopeForScv()).output;
             Assert.notNull(url);
             Assert.notNull(provisionMonitor);
             String rescanExisting = context.getJobDetail().getJobDataMap().getString(RESCAN_EXISTING);
@@ -77,5 +81,13 @@ public class ImportJob implements Job {
 
     public void setMonitor(ProvisionMonitor provisionMonitor) {
         this.provisionMonitor = provisionMonitor;
+    }
+
+    public EntityScopeProvider getEntityScopeProvider() {
+        return entityScopeProvider;
+    }
+
+    public void setEntityScopeProvider(EntityScopeProvider entityScopeProvider) {
+        this.entityScopeProvider = entityScopeProvider;
     }
 }

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ImportJobFactory.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ImportJobFactory.java
@@ -21,6 +21,7 @@
  */
 package org.opennms.netmgt.provision.service;
 
+import org.opennms.core.mate.api.EntityScopeProvider;
 import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
@@ -42,6 +43,9 @@ public class ImportJobFactory implements JobFactory {
     @Autowired
     private MonitorHolder monitorHolder;
 
+    @Autowired
+    private EntityScopeProvider entityScopeProvider;
+
     /** {@inheritDoc} */
     @Override
     public Job newJob(final TriggerFiredBundle bundle, final Scheduler scheduler) throws SchedulerException {
@@ -55,6 +59,7 @@ public class ImportJobFactory implements JobFactory {
             job = jobClass.getDeclaredConstructor().newInstance();
             job.setProvisioner(getProvisioner());
             job.setMonitor(monitorHolder.createMonitor(jobDetail.getKey().getName(), job));
+            job.setEntityScopeProvider(entityScopeProvider);
 
             return job;
         } catch (Exception e) {

--- a/opennms-provision/opennms-requisition-service/src/main/java/org/opennms/netmgt/provision/persist/rpc/RequisitionRequestBuilderImpl.java
+++ b/opennms-provision/opennms-requisition-service/src/main/java/org/opennms/netmgt/provision/persist/rpc/RequisitionRequestBuilderImpl.java
@@ -44,7 +44,7 @@ public class RequisitionRequestBuilderImpl implements RequisitionRequestBuilder 
 
     private final LocationAwareRequisitionClientImpl client;
 
-    private final Map<String, String> parameters = new HashMap<>();
+    protected final Map<String, String> parameters = new HashMap<>();
 
     private RequisitionProvider provider;
 


### PR DESCRIPTION
* JIRA: https://opennms.atlassian.net/browse/NMS-16320

* VMware requisition is now location-aware when triggered by UI and not only when triggered by Karaf shell
* Meta-data interpolation is done at the correct time
* Fixed VMware tools in bin