### PR TITLE
NMS-16366: Provide an option to disable splitting of metric messages

### DIFF
--- a/docs/modules/operation/pages/deep-dive/kafka-producer/configure-kafka.adoc
+++ b/docs/modules/operation/pages/deep-dive/kafka-producer/configure-kafka.adoc
@@ -124,11 +124,6 @@ Consult the source code of the `org.opennms.netmgt.model.OnmsAlarm` class in you
 
 To enable metric forwarding, set the value of the `forward.metrics` property to `true`.
 
-Kafka Producer sends a full CollectionSet as one message to Kafka.
-Large network equipment might have hundreds of thousands of metrics that could generate messages over the Kafka limit (1MB in size by default).
-If the message size is over 1MB , they will broken up into smaller messages that are less than 1MB.
-When sending one CollectionSet over multiple messages, their timestamps will remain same.
-
 [source, console]
 ----
 $ ssh -p 8101 admin@localhost
@@ -138,6 +133,25 @@ admin@opennms()> config:property-set forward.metrics true
 admin@opennms()> config:update
 ----
 
+Kafka Producer sends a full CollectionSet as one message to Kafka.
+Large network equipment might have hundreds of thousands of metrics that could generate messages over the Kafka limit (1MB in size by default).
+If the message size is over 1MB , they will broken up into smaller messages that are less than 1MB.
+When sending one CollectionSet over multiple messages, their timestamps will remain same.
+=== Disable metrics splitting into multiple kafka messages
+To disable metrics splitting into multiple kafka messages, set the value of `disable.metrics.splitting` property to `true`.
+
+[source, console]
+----
+$ ssh -p 8101 admin@localhost
+...
+admin@opennms()> config:edit org.opennms.features.kafka.producer
+admin@opennms()> config:property-set disable.metrics.splitting true
+admin@opennms()> config:update
+----
+Or add following line at `$OPENNMS_HOME/etc/org.opennms.features.kafka.producer.cfg`
+```
+disable.metrics.splitting = true
+```
 === Enable exclusive metric forwarding
 
 Once metric forwarding is enabled, you can use this as the exclusive persistence strategy by setting the following system property:

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersister.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersister.java
@@ -85,7 +85,7 @@ public class KafkaPersister implements Persister {
 
     void bisectAndSendMessageToKafka(CollectionSetProtos.CollectionSet collectionSetProto) {
 
-        if (!disableMetricsSplitting && checkForMaxSize(collectionSetProto.toByteArray().length)) {
+        if (!getDisableMetricsSplitting() && checkForMaxSize(collectionSetProto.toByteArray().length)) {
 
             if(collectionSetProto.getResourceCount() == 1) {
                 /// Handle the case where resource is only one with too many attributes that can cross max buffer size.
@@ -272,5 +272,9 @@ public class KafkaPersister implements Persister {
 
     public void setDisableMetricsSplitting(Boolean disableMetricsSplitting) {
         this.disableMetricsSplitting = disableMetricsSplitting;
+    }
+
+    public Boolean getDisableMetricsSplitting() {
+        return disableMetricsSplitting;
     }
 }

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersister.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersister.java
@@ -28,10 +28,8 @@
 
 package org.opennms.features.kafka.producer.collection;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.opennms.features.kafka.producer.model.CollectionSetProtos;
@@ -45,14 +43,15 @@ import org.opennms.netmgt.collection.api.ServiceParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Iterables;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 public class KafkaPersister implements Persister {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaPersister.class);
 
-    private final int MAX_BUFFER_SIZE_CONFIGURED = 921600;
+    private static final int MAX_BUFFER_SIZE_CONFIGURED = 921600;
 
     private CollectionSetMapper collectionSetMapper;
 
@@ -61,6 +60,8 @@ public class KafkaPersister implements Persister {
     private KafkaProducer<String, byte[]> producer;
     
     private String topicName = "metrics";
+
+    private Boolean disableMetricsSplitting = false;
 
     public KafkaPersister(ServiceParameters params) {
         m_params = params;
@@ -84,7 +85,7 @@ public class KafkaPersister implements Persister {
 
     void bisectAndSendMessageToKafka(CollectionSetProtos.CollectionSet collectionSetProto) {
 
-        if (checkForMaxSize(collectionSetProto.toByteArray().length)) {
+        if (!disableMetricsSplitting && checkForMaxSize(collectionSetProto.toByteArray().length)) {
 
             if(collectionSetProto.getResourceCount() == 1) {
                 /// Handle the case where resource is only one with too many attributes that can cross max buffer size.
@@ -269,4 +270,7 @@ public class KafkaPersister implements Persister {
         // not handled here
     }
 
+    public void setDisableMetricsSplitting(Boolean disableMetricsSplitting) {
+        this.disableMetricsSplitting = disableMetricsSplitting;
+    }
 }

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersisterActivator.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersisterActivator.java
@@ -28,9 +28,6 @@
 
 package org.opennms.features.kafka.producer.collection;
 
-import java.util.Dictionary;
-import java.util.Hashtable;
-
 import org.opennms.netmgt.collection.api.PersisterFactory;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.ResourceDao;
@@ -41,6 +38,9 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Dictionary;
+import java.util.Hashtable;
+
 public class KafkaPersisterActivator implements BundleActivator {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaPersisterActivator.class);
@@ -48,11 +48,14 @@ public class KafkaPersisterActivator implements BundleActivator {
     public static final String PRODUCER_CONFIG = "org.opennms.features.kafka.producer";
     private static final String METRIC_TOPIC = "metricTopic";
 
+    private static final String DISABLE_METRIC_SPLITTING = "disable.metrics.splitting";
+
     @Override
     public void start(BundleContext context) throws Exception {
         ConfigurationAdmin configAdmin = null;
         Boolean forwardMetrics = false;
         String metricTopic = null;
+        boolean disableMetricsSplitting = false;
         try {
             configAdmin = context.getService(context.getServiceReference(ConfigurationAdmin.class));
             if (configAdmin != null) {
@@ -63,6 +66,9 @@ public class KafkaPersisterActivator implements BundleActivator {
                     }
                     if (properties.get(METRIC_TOPIC) instanceof String) {
                         metricTopic = (String) properties.get(METRIC_TOPIC);
+                    }
+                    if (properties.get(DISABLE_METRIC_SPLITTING) instanceof String) {
+                        disableMetricsSplitting = Boolean.parseBoolean((String) properties.get(DISABLE_METRIC_SPLITTING));
                     }
                 }
             }
@@ -83,6 +89,7 @@ public class KafkaPersisterActivator implements BundleActivator {
                 kafkaPersisterFactory.setConfigAdmin(configAdmin);
                 kafkaPersisterFactory.init();
                 kafkaPersisterFactory.setTopicName(metricTopic);
+                kafkaPersisterFactory.setDisableMetricsSplitting(disableMetricsSplitting);
                 Dictionary<String, String> props = new Hashtable<String, String>();
                 // needed to register to onms registry.
                 props.put("strategy", "kafka");

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersisterFactory.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersisterFactory.java
@@ -28,11 +28,6 @@
 
 package org.opennms.features.kafka.producer.collection;
 
-import java.io.IOException;
-import java.util.Dictionary;
-import java.util.Enumeration;
-import java.util.Properties;
-
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -47,6 +42,11 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Properties;
+
 public class KafkaPersisterFactory implements PersisterFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaPersisterFactory.class);
@@ -55,6 +55,7 @@ public class KafkaPersisterFactory implements PersisterFactory {
     private KafkaProducer<String, byte[]> producer;
     private ConfigurationAdmin configAdmin;
     private String topicName;
+    private boolean disableMetricsSplitting = false;
 
     @Override
     public Persister createPersister(ServiceParameters params, RrdRepository repository, boolean dontPersistCounters,
@@ -68,6 +69,7 @@ public class KafkaPersisterFactory implements PersisterFactory {
         persister.setCollectionSetMapper(collectionSetMapper);
         persister.setProducer(producer);
         persister.setTopicName(topicName);
+        persister.setDisableMetricsSplitting(disableMetricsSplitting);
         return persister;
     }
 
@@ -111,4 +113,8 @@ public class KafkaPersisterFactory implements PersisterFactory {
         this.topicName = topicName;
     }
 
+
+    public void setDisableMetricsSplitting(boolean disableMetricsSplitting) {
+        this.disableMetricsSplitting = disableMetricsSplitting;
+    }
 }

--- a/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
+++ b/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
@@ -22,6 +22,7 @@
       <cm:property name="alarmFeedbackTopic" value="alarmFeedback"/>
       <cm:property name="metricTopic" value="metrics"/>
       <cm:property name="forward.metrics" value="true"/>
+      <cm:property name="disable.metrics.splitting" value="false"/>
       <cm:property name="nodeRefreshTimeoutMs" value="300000"/> <!-- 5 minutes -->
       <cm:property name="alarmSync" value="true"/>
       <cm:property name="eventFilter" value=""/>

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
@@ -28,46 +28,7 @@
 
 package org.opennms.features.kafka.producer;
 
-import static org.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Hashtable;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-
+import com.google.common.base.Strings;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -115,7 +76,45 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
-import com.google.common.base.Strings;
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Verifies events/alarms/nodes forwarded to Kafka.
@@ -548,6 +547,8 @@ public class KafkaForwarderIT implements TemporaryDatabaseAware<MockDatabase> {
         private Map<String, OpennmsModelProtos.Alarm> alarmsByReductionKey = new LinkedHashMap<>();
         private AtomicInteger numRecordsConsumed = new AtomicInteger(0);
 
+        private AtomicInteger numOfMetricRecords = new AtomicInteger(0);
+
         public KafkaMessageConsumerRunner(String kafkaConnectString) {
             this.kafkaConnectString = Objects.requireNonNull(kafkaConnectString);
         }
@@ -587,6 +588,7 @@ public class KafkaForwarderIT implements TemporaryDatabaseAware<MockDatabase> {
                                 break;
                             case METRIC_TOPIC_NAME :
                                 collectionSetValues.add(CollectionSetProtos.CollectionSet.parseFrom(record.value()));
+                                numOfMetricRecords.incrementAndGet();
                                 break;
                             case ALARM_FEEDBACK_TOPIC_NAME:
                                 final OpennmsModelProtos.AlarmFeedback alarmFeedbackRecord = record.value() != null ?
@@ -640,6 +642,14 @@ public class KafkaForwarderIT implements TemporaryDatabaseAware<MockDatabase> {
         }
         public void clearCollectionSetValues() {
             collectionSetValues.clear();
+        }
+
+        public AtomicInteger getNumOfMetricRecords (){
+            return numOfMetricRecords;
+        }
+
+        public void clearNumofMetricRecords() {
+            numOfMetricRecords.set(0);
         }
 
     }


### PR DESCRIPTION
Provide an option to disable splitting of metric messages while forwarding to kafka

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16366

