### PR TITLE
NMS-16396: update to latest docker deploy base

### DIFF
--- a/opennms-container/common.mk
+++ b/opennms-container/common.mk
@@ -12,7 +12,7 @@ endif
 VERSION                 := $(shell ../../.circleci/scripts/pom2version.sh ../../pom.xml)
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:ubuntu-3.3.0.b259-jre-11
+BASE_IMAGE              := opennms/deploy-base:ubuntu-3.3.1.b264-jre-11
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKER_REGISTRY         := docker.io
 DOCKER_ORG              := opennms

--- a/opennms-container/core/Dockerfile
+++ b/opennms-container/core/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Use Java base image and setup required RPMS as cacheable image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubuntu-3.3.0.b259-jre-11"
+ARG BASE_IMAGE="opennms/deploy-base:ubuntu-3.3.1.b264-jre-11"
 
 FROM ${BASE_IMAGE} as core-tarball
 

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -4,7 +4,7 @@
 # To avoid issues, we rearrange the directories in pre-stage to avoid injecting these
 # as additional layers into the final image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubuntu-3.3.0.b259-jre-11"
+ARG BASE_IMAGE="opennms/deploy-base:ubuntu-3.3.1.b264-jre-11"
 
 FROM ${BASE_IMAGE} as minion-base
 

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Use Java base image and setup required DEBS as cacheable image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubuntu-3.3.0.b259-jre-11"
+ARG BASE_IMAGE="opennms/deploy-base:ubuntu-3.3.1.b264-jre-11"
 
 FROM ${BASE_IMAGE} as sentinel-tarball
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
@@ -51,7 +51,7 @@ public class MockCloudContainer extends GenericContainer<MockCloudContainer> {
     private static final Path CLOUD_MOCK_PATH_CONTAINER = Path.of("/").resolve(CLOUD_MOCK_PATH_HOST.getFileName());
     private static final String CLOUD_MOCK_MAIN = "org.opennms.plugins.cloud.ittest.MockCloudMain";
     public MockCloudContainer() {
-        super(DockerImageName.parse("opennms/deploy-base:ubuntu-3.3.0.b259-jre-11"));
+        super(DockerImageName.parse("opennms/deploy-base:ubuntu-3.3.1.b264-jre-11"));
         withCopyFileToContainer(MountableFile.forHostPath(CLOUD_MOCK_PATH_HOST), CLOUD_MOCK_PATH_CONTAINER.toString())
                 .withCommand("/usr/bin/java", "-cp", CLOUD_MOCK_PATH_CONTAINER.toString(), CLOUD_MOCK_MAIN)
                 .withExposedPorts(PORT)


### PR DESCRIPTION
We are not actually vulnerable to the liblzma issue but I'm taking this opportunity to make sure our images are up-to-date before release next week.