### PR TITLE
NMS-16406: Allow update-package-permissions to set ownership for customized users.

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
@@ -27,12 +27,6 @@ if ! id -u "${RUNAS}" >/dev/null 2>&1; then
   exit 1
 fi
 
-if [ "${RUNAS}" != "opennms" ]; then
-  echo "\$RUNAS has been changed from the default 'opennms' user. Assuming you know what you're doing and _not_ changing ownership of any files."
-  echo ""
-  exit 0
-fi
-
 RUNAS_UID="$(id -u "${RUNAS}" 2>/dev/null || :)"
 RUNAS_GID="$(id -g "${RUNAS}" 2>/dev/null || :)"
 


### PR DESCRIPTION
Because the step that changes file ownership keys off of the RUNAS variable, it does not make sense to bail out when RUNAS does not equal {{opennms}} and it can leave the installation in an inconsistent state.

Remove the check and exit, and allow the package upgrade to continue setting file ownership.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16406

