### PR TITLE
NMS-16406: Allow update-package-permissions to set ownership for customized users.

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
@@ -28,7 +28,7 @@ if ! id -u "${RUNAS}" >/dev/null 2>&1; then
 fi
 
 if [ "${RUNAS}" != "opennms" ]; then
-  printf '%s\n\n' "\$RUNAS has been changed from the default 'opennms' user. Assuming you know what you're doing and changing ownership of files to ${RUNAS}."
+  printf '$RUNAS has been changed from the default "opennms" user. Assuming you know what you're doing and changing ownership of files to "%s".\n\n' "${RUNAS}"
 fi
 
 RUNAS_UID="$(id -u "${RUNAS}" 2>/dev/null || :)"

--- a/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
@@ -28,9 +28,7 @@ if ! id -u "${RUNAS}" >/dev/null 2>&1; then
 fi
 
 if [ "${RUNAS}" != "opennms" ]; then
-  echo "\$RUNAS has been changed from the default 'opennms' user. Assuming you know what you're doing and _not_ changing ownership of any files."
-  echo ""
-  exit 0
+  printf '%s\n\n' "\$RUNAS has been changed from the default 'opennms' user. Assuming you know what you're doing and changing ownership of files to ${RUNAS}."
 fi
 
 RUNAS_UID="$(id -u "${RUNAS}" 2>/dev/null || :)"


### PR DESCRIPTION
Because the step that changes file ownership keys off of the RUNAS variable, it does not make sense to bail out when RUNAS does not equal `opennms` and it can leave the installation in an inconsistent state.

Modify the message printed to indicate that file ownership will be changed to the RUNAS user, and do not exit immediately.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16406

