### PR TITLE
chg: re-use eol services

### DIFF
--- a/core/upgrade/src/main/java/org/opennms/upgrade/implementations/EOLServiceConfigMigratorOffline.java
+++ b/core/upgrade/src/main/java/org/opennms/upgrade/implementations/EOLServiceConfigMigratorOffline.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -45,6 +46,18 @@ import org.opennms.upgrade.api.OnmsUpgradeException;
  * @author <a href="mailto:ranger@opennms.org">Benjamin Reed</a>
  */
 public class EOLServiceConfigMigratorOffline extends AbstractOnmsUpgrade {
+
+    static final List<String> EOL_SERVICES = List.of(
+            "OpenNMS:Name=Linkd",
+            "OpenNMS:Name=Xmlrpcd",
+            "OpenNMS:Name=XmlrpcProvisioner",
+            "OpenNMS:Name=AccessPointMonitor",
+            "OpenNMS:Name=PollerBackEnd",
+            "OpenNMS:Name=Reportd",
+            "OpenNMS:Name=Statsd",
+            "OpenNMS:Name=Tl1d"
+    );
+
     /** 
      * The services configuration file.
      */
@@ -129,22 +142,11 @@ public class EOLServiceConfigMigratorOffline extends AbstractOnmsUpgrade {
      */
     @Override
     public void execute() throws OnmsUpgradeException {
-        final String[] eol = {
-                "OpenNMS:Name=Linkd",
-                "OpenNMS:Name=Xmlrpcd",
-                "OpenNMS:Name=XmlrpcProvisioner",
-                "OpenNMS:Name=AccessPointMonitor",
-                "OpenNMS:Name=PollerBackEnd",
-                "OpenNMS:Name=Reportd",
-                "OpenNMS:Name=Statsd",
-                "OpenNMS:Name=Tl1d"
-        };
-
         try {
             final ServiceConfiguration currentCfg = JaxbUtils.unmarshal(ServiceConfiguration.class, configFile);
 
             // Remove any end-of-life'd daemons from service configuration
-            for (final String serviceName : eol) {
+            for (final String serviceName : EOL_SERVICES) {
                 final Service eolService = getService(currentCfg, serviceName);
                 if (eolService == null) {
                     continue;

--- a/core/upgrade/src/test/java/org/opennms/upgrade/implementations/EOLServiceConfigMigratorOfflineTest.java
+++ b/core/upgrade/src/test/java/org/opennms/upgrade/implementations/EOLServiceConfigMigratorOfflineTest.java
@@ -55,16 +55,7 @@ public class EOLServiceConfigMigratorOfflineTest {
     private final int m_totalAfter;
     private final int m_enabledAfter;
 
-    private final List<String> m_disabled = Arrays.asList(
-            "OpenNMS:Name=Linkd",
-            "OpenNMS:Name=Xmlrpcd",
-            "OpenNMS:Name=XmlrpcProvisioner",
-            "OpenNMS:Name=AccessPointMonitor",
-            "OpenNMS:Name=PollerBackEnd",
-            "OpenNMS:Name=Reportd",
-            "OpenNMS:Name=Statsd",
-            "OpenNMS:Name=Tl1d"
-    );
+    private static final List<String> DISABLED_SERVICES = EOLServiceConfigMigratorOffline.EOL_SERVICES;
 
     public EOLServiceConfigMigratorOfflineTest(final String testFile, final int totalBefore, final int totalAfter, final int enabledAfter) {
         m_testFile = testFile;
@@ -134,13 +125,13 @@ public class EOLServiceConfigMigratorOfflineTest {
 
         for (final Service svc : cfg.getServices()) {
             final String serviceName = svc.getName();
-            if (m_disabled.contains(serviceName)) {
+            if (DISABLED_SERVICES.contains(serviceName)) {
                 assertFalse("Service " + serviceName + " should be disabled.", svc.isEnabled());
             }
         }
         for (final Service svc : factory.getServices()) {
             final String serviceName = svc.getName();
-            assertFalse("Service " + serviceName + " should not be in the active service list.", m_disabled.contains(svc.getName()));
+            assertFalse("Service " + serviceName + " should not be in the active service list.", DISABLED_SERVICES.contains(svc.getName()));
         }
     }
 


### PR DESCRIPTION
Here we refactor the offline migrator to reuse the list of end of life services instead of re-defining them.