### PR TITLE
NMS-16462: Upgrade UI to Node 18

### DIFF
--- a/.circleci/main/executors.yml
+++ b/.circleci/main/executors.yml
@@ -19,4 +19,4 @@ executors:
       image: ubuntu-2204:2023.04.2
   ui-executor:
     docker:
-      - image: cimg/node:16.18.1
+      - image: cimg/node:18.18.1

--- a/pom.xml
+++ b/pom.xml
@@ -1871,9 +1871,9 @@
 
     <!-- nodejs development -->
     <frontendPluginVersion>1.14.2</frontendPluginVersion>
-    <nodeVersion>v18.18.1</nodeVersion>
-    <npmVersion>8.19.4</npmVersion>
-    <yarnVersion>v1.22.19</yarnVersion>
+    <nodeVersion>v18.18.2</nodeVersion>
+    <npmVersion>9.8.1</npmVersion>
+    <yarnVersion>1.22.19</yarnVersion>
 
     <!-- configuration manager -->
     <xmlschemaVersion>2.3.1</xmlschemaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1871,7 +1871,7 @@
 
     <!-- nodejs development -->
     <frontendPluginVersion>1.14.2</frontendPluginVersion>
-    <nodeVersion>v16.20.2</nodeVersion>
+    <nodeVersion>v18.18.1</nodeVersion>
     <npmVersion>8.19.4</npmVersion>
     <yarnVersion>v1.22.19</yarnVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1873,7 +1873,7 @@
     <frontendPluginVersion>1.14.2</frontendPluginVersion>
     <nodeVersion>v18.18.2</nodeVersion>
     <npmVersion>9.8.1</npmVersion>
-    <yarnVersion>1.22.19</yarnVersion>
+    <yarnVersion>v1.22.19</yarnVersion>
 
     <!-- configuration manager -->
     <xmlschemaVersion>2.3.1</xmlschemaVersion>

--- a/ui/README.md
+++ b/ui/README.md
@@ -4,7 +4,8 @@ This template should help get you started developing with Vue 3 and Typescript i
 
 ## Build instructions
 
-This project was started with Node v14+
+This project requires Node 18+.
+
 You will also need [yarn](https://yarnpkg.com/getting-started/install)
 
 To install packages and run dev server

--- a/ui/package.json
+++ b/ui/package.json
@@ -100,7 +100,7 @@
     "vue-tsc": "^0.40.1"
   },
   "engines": {
-    "node": ">=16.18.1",
+    "node": ">=18",
     "yarn": ">=1.22.18"
   },
   "resolutions": {


### PR DESCRIPTION
Update UI to use Node 18 as it's needed by some dependencies, and we're overdue to upgrade it.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16462

