### PR TITLE
NMS-16388: Allow set to be invoked via LocationAwareSnmpClient

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpStrategy.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpStrategy.java
@@ -38,7 +38,7 @@ public interface SnmpStrategy {
     SnmpValue get(SnmpAgentConfig agentConfig, SnmpObjId oid);
     SnmpValue[] get(SnmpAgentConfig agentConfig, SnmpObjId[] oids);
     CompletableFuture<SnmpValue[]> getAsync(SnmpAgentConfig agentConfig, SnmpObjId[] oids);
-
+    CompletableFuture<SnmpValue[]> setAsync(SnmpAgentConfig agentConfig, SnmpObjId[] oids, SnmpValue[] values);
     SnmpValue getNext(SnmpAgentConfig agentConfig, SnmpObjId oid);
     SnmpValue[] getNext(SnmpAgentConfig agentConfig, SnmpObjId[] oids);
     

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpUtils.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpUtils.java
@@ -89,6 +89,10 @@ public abstract class SnmpUtils {
         return getStrategy().getAsync(agentConfig, oids);
     }
 
+    public static CompletableFuture<SnmpValue[]> setAsync(SnmpAgentConfig agentConfig, SnmpObjId[] oids, SnmpValue[] values) {
+        return getStrategy().setAsync(agentConfig, oids, values);
+    }
+
     public static SnmpValue getNext(SnmpAgentConfig agentConfig, SnmpObjId oid) {
         return getStrategy().getNext(agentConfig, oid);
     }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/proxy/LocationAwareSnmpClient.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/proxy/LocationAwareSnmpClient.java
@@ -21,13 +21,17 @@
  */
 package org.opennms.netmgt.snmp.proxy;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.opennms.netmgt.snmp.CollectionTracker;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpValue;
+
+import com.google.common.collect.Lists;
 
 /**
  * Asynchronous SNMP client API that either executes the request locally, delegating
@@ -55,4 +59,14 @@ public interface LocationAwareSnmpClient {
     SNMPRequestBuilder<List<SnmpValue>> get(SnmpAgentConfig agent, SnmpObjId... oids);
 
     SNMPRequestBuilder<List<SnmpValue>> get(SnmpAgentConfig agent, List<SnmpObjId> oids);
+
+    SNMPRequestBuilder<SnmpValue> set(SnmpAgentConfig agent, List<SnmpObjId> oids, List<SnmpValue> values);
+
+    default SNMPRequestBuilder<SnmpValue> set(SnmpAgentConfig agent, SnmpObjId oid, SnmpValue value) {
+        return set(agent, Collections.singletonList(oid), Collections.singletonList(value));
+    }
+
+    default SNMPRequestBuilder<SnmpValue> set(SnmpAgentConfig agent, SnmpObjId[] oids, SnmpValue[] values) {
+        return set(agent, Lists.newArrayList(oids), Lists.newArrayList(values));
+    }
 }

--- a/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/JoeSnmpStrategy.java
+++ b/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/JoeSnmpStrategy.java
@@ -157,7 +157,7 @@ public class JoeSnmpStrategy implements SnmpStrategy {
 
     @Override
     public CompletableFuture<SnmpValue[]> setAsync(SnmpAgentConfig agentConfig, SnmpObjId[] oids, SnmpValue[] values) {
-        LOG.warn("The JoeSnmpStrategy does not support asynchronous SNMP GET requests.");
+        LOG.warn("The JoeSnmpStrategy does not support asynchronous SNMP SET requests.");
         return CompletableFuture.completedFuture(set(agentConfig, oids, values));
     }
 

--- a/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/JoeSnmpStrategy.java
+++ b/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/JoeSnmpStrategy.java
@@ -155,7 +155,13 @@ public class JoeSnmpStrategy implements SnmpStrategy {
         return CompletableFuture.completedFuture(get(agentConfig, oids));
     }
 
-        @Override
+    @Override
+    public CompletableFuture<SnmpValue[]> setAsync(SnmpAgentConfig agentConfig, SnmpObjId[] oids, SnmpValue[] values) {
+        LOG.warn("The JoeSnmpStrategy does not support asynchronous SNMP GET requests.");
+        return CompletableFuture.completedFuture(set(agentConfig, oids, values));
+    }
+
+    @Override
     public SnmpValue getNext(SnmpAgentConfig snmpAgentConfig, SnmpObjId oid) {
         SnmpObjId[] oids = { oid };
         return getNext(snmpAgentConfig, oids)[0];

--- a/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategy.java
+++ b/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategy.java
@@ -127,6 +127,11 @@ public class MockSnmpStrategy implements SnmpStrategy {
     }
 
     @Override
+    public CompletableFuture<SnmpValue[]> setAsync(SnmpAgentConfig agentConfig, SnmpObjId[] oids, SnmpValue[] values) {
+        return CompletableFuture.completedFuture(set(agentConfig, oids, values));
+    }
+
+    @Override
     public SnmpValue getNext(final SnmpAgentConfig agentConfig, final SnmpObjId oid) {
         final PropertyOidContainer oidContainer = getOidContainer(agentConfig);
         if (oidContainer == null) return null;

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JAgentConfig.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JAgentConfig.java
@@ -132,8 +132,8 @@ public class Snmp4JAgentConfig {
         }
     }
 
-    public String getWriteCommunity() {
-        return m_config.getWriteCommunity();
+    public OctetString getWriteCommunity() {
+        return convertCommunity(m_config.getWriteCommunity());
     }
 
     @Override
@@ -260,27 +260,31 @@ public class Snmp4JAgentConfig {
 
     @VisibleForTesting
     public Target getTarget() {
-        Target target = createTarget();
+        return getTarget(false);
+    }
+
+    public Target getTarget(final boolean useWriteCommunity) {
+        Target target = createTarget(useWriteCommunity);
         target.setVersion(getVersion());
         target.setRetries(getRetries());
         target.setTimeout(getTimeout());
         target.setAddress(getAddress());
         target.setMaxSizeRequestPDU(getMaxRequestSize());
-            
+
         return target;
     }
 
-    private Target createTarget() {
-        return (isSnmpV3() ? createUserTarget() : createCommunityTarget());
+    private Target createTarget(final boolean useWriteCommunity) {
+        return (isSnmpV3() ? createUserTarget() : createCommunityTarget(useWriteCommunity));
     }
 
     boolean isSnmpV3() {
         return m_config.getVersion() == SnmpConstants.version3;
     }
 
-    private Target createCommunityTarget() {
+    private Target createCommunityTarget(final boolean useWriteCommunity) {
         CommunityTarget target = new CommunityTarget();
-        target.setCommunity(getReadCommunity());
+        target.setCommunity(useWriteCommunity ? getWriteCommunity() : getReadCommunity());
         return target;
     }
 

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/AbstractSNMPRequestBuilder.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/AbstractSNMPRequestBuilder.java
@@ -37,17 +37,19 @@ public abstract class AbstractSNMPRequestBuilder<T> implements SNMPRequestBuilde
     private final SnmpAgentConfig agent;
     private List<SnmpGetRequestDTO> gets;
     private List<SnmpWalkRequestDTO> walks;
+    private List<SnmpSetRequestDTO> sets;
     private String location;
     private String systemId;
     private String description;
     private Long timeToLiveInMilliseconds = null;
 
     public AbstractSNMPRequestBuilder(LocationAwareSnmpClientRpcImpl client,
-            SnmpAgentConfig agent, List<SnmpGetRequestDTO> gets, List<SnmpWalkRequestDTO> walks) {
+            SnmpAgentConfig agent, List<SnmpGetRequestDTO> gets, List<SnmpWalkRequestDTO> walks, List<SnmpSetRequestDTO> sets) {
         this.client = Objects.requireNonNull(client);
         this.agent = Objects.requireNonNull(agent);
         this.gets = Objects.requireNonNull(gets);
         this.walks = Objects.requireNonNull(walks);
+        this.sets = Objects.requireNonNull(sets);
     }
 
     @Override
@@ -89,6 +91,7 @@ public abstract class AbstractSNMPRequestBuilder<T> implements SNMPRequestBuilde
         snmpRequestDTO.setDescription(description);
         snmpRequestDTO.setGetRequests(gets);
         snmpRequestDTO.setWalkRequests(walks);
+        snmpRequestDTO.setSetRequests(sets);
         // TTL specified in agent configuration overwrites any previous ttls specified.
         if (agent.getTTL() != null) {
             timeToLiveInMilliseconds = agent.getTTL();

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientRpcImpl.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientRpcImpl.java
@@ -23,6 +23,7 @@ package org.opennms.netmgt.snmp.proxy.common;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -113,6 +114,11 @@ public class LocationAwareSnmpClientRpcImpl implements LocationAwareSnmpClient, 
     @Override
     public SNMPRequestBuilder<List<SnmpValue>> get(SnmpAgentConfig agent, List<SnmpObjId> oids) {
         return new SNMPMultiGetBuilder(this, agent, oids);
+    }
+
+    @Override
+    public SNMPRequestBuilder<SnmpValue> set(SnmpAgentConfig agent, List<SnmpObjId> oids, List<SnmpValue> values) {
+        return new SNMPSetBuilder(this, agent, oids, values);
     }
 
     public CompletableFuture<SnmpMultiResponseDTO> execute(SnmpRequestDTO request) {

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPMultiGetBuilder.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPMultiGetBuilder.java
@@ -33,7 +33,7 @@ import org.opennms.netmgt.snmp.SnmpValue;
 public class SNMPMultiGetBuilder extends AbstractSNMPRequestBuilder<List<SnmpValue>> {
 
     public SNMPMultiGetBuilder(LocationAwareSnmpClientRpcImpl client, SnmpAgentConfig agent, List<SnmpObjId> oids) {
-        super(client, agent, buildGetRequests(oids), Collections.emptyList());
+        super(client, agent, buildGetRequests(oids), Collections.emptyList(), Collections.emptyList());
     }
 
     private static List<SnmpGetRequestDTO> buildGetRequests(List<SnmpObjId> oids) {

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPSetBuilder.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPSetBuilder.java
@@ -1,0 +1,33 @@
+package org.opennms.netmgt.snmp.proxy.common;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpObjId;
+import org.opennms.netmgt.snmp.SnmpResult;
+import org.opennms.netmgt.snmp.SnmpValue;
+
+public class SNMPSetBuilder extends AbstractSNMPRequestBuilder<SnmpValue> {
+
+    public SNMPSetBuilder(LocationAwareSnmpClientRpcImpl client, SnmpAgentConfig agent, List<SnmpObjId> oids, List<SnmpValue> values) {
+        super(client, agent, Collections.emptyList(), Collections.emptyList(), buildGetRequests(oids, values));
+    }
+
+    private static List<SnmpSetRequestDTO> buildGetRequests(List<SnmpObjId> oids, List<SnmpValue> values) {
+        final SnmpSetRequestDTO setRequest = new SnmpSetRequestDTO();
+        setRequest.setOids(oids);
+        setRequest.setValues(values);
+        return Collections.singletonList(setRequest);
+    }
+
+    @Override
+    protected SnmpValue processResponse(SnmpMultiResponseDTO response) {
+        return response.getResponses().stream()
+                .flatMap(res -> res.getResults().stream())
+                .findFirst()
+                .map(SnmpResult::getValue)
+                .orElse(null);
+    }
+}

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPSingleGetBuilder.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPSingleGetBuilder.java
@@ -32,7 +32,7 @@ import org.opennms.netmgt.snmp.SnmpValue;
 public class SNMPSingleGetBuilder extends AbstractSNMPRequestBuilder<SnmpValue> {
 
     public SNMPSingleGetBuilder(LocationAwareSnmpClientRpcImpl client, SnmpAgentConfig agent, SnmpObjId oid) {
-        super(client, agent, buildGetRequests(oid), Collections.emptyList());
+        super(client, agent, buildGetRequests(oid), Collections.emptyList(), Collections.emptyList());
     }
 
     private static List<SnmpGetRequestDTO> buildGetRequests(SnmpObjId oid) {

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPWalkBuilder.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPWalkBuilder.java
@@ -31,7 +31,7 @@ import org.opennms.netmgt.snmp.SnmpResult;
 public class SNMPWalkBuilder extends AbstractSNMPRequestBuilder<List<SnmpResult>> {
 
     public SNMPWalkBuilder(LocationAwareSnmpClientRpcImpl client, SnmpAgentConfig agent, List<SnmpObjId> oids) {
-        super(client, agent, Collections.emptyList(), buildWalkRequests(oids));
+        super(client, agent, Collections.emptyList(), buildWalkRequests(oids), Collections.emptyList());
     }
 
     private static List<SnmpWalkRequestDTO> buildWalkRequests(List<SnmpObjId> oids) {

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPWalkWithTrackerBuilder.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SNMPWalkWithTrackerBuilder.java
@@ -34,7 +34,7 @@ public class SNMPWalkWithTrackerBuilder extends AbstractSNMPRequestBuilder<Colle
     private final CollectionTracker m_tracker;
 
     public SNMPWalkWithTrackerBuilder(LocationAwareSnmpClientRpcImpl client, SnmpAgentConfig agent, CollectionTracker tracker) {
-        super(client, agent, Collections.emptyList(), buildWalkRequests(tracker));
+        super(client, agent, Collections.emptyList(), buildWalkRequests(tracker), Collections.emptyList());
         m_tracker = tracker;
     }
 

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpRequestDTO.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpRequestDTO.java
@@ -61,6 +61,9 @@ public class SnmpRequestDTO implements RpcRequest {
     @XmlElement(name="walk")
     private List<SnmpWalkRequestDTO> walks = new ArrayList<>(0);
 
+    @XmlElement(name="set")
+    private List<SnmpSetRequestDTO> sets = new ArrayList<>(0);
+
     @XmlTransient
     private Long timeToLive;
 
@@ -108,6 +111,15 @@ public class SnmpRequestDTO implements RpcRequest {
         return walks;
     }
 
+    public void setSetRequests(List<SnmpSetRequestDTO> sets) {
+        this.sets = sets;
+    }
+
+    public List<SnmpSetRequestDTO> getSetRequest() {
+        return sets;
+    }
+
+
     public String getDescription() {
         return description;
     }
@@ -145,7 +157,7 @@ public class SnmpRequestDTO implements RpcRequest {
 
     @Override
     public int hashCode() {
-        return Objects.hash(location, systemId, agent, gets, walks, description, timeToLive);
+        return Objects.hash(location, systemId, agent, gets, walks, sets, description, timeToLive);
     }
 
     @Override
@@ -162,6 +174,7 @@ public class SnmpRequestDTO implements RpcRequest {
                 && Objects.equals(this.agent, other.agent)
                 && Objects.equals(this.gets, other.gets)
                 && Objects.equals(this.walks, other.walks)
+                && Objects.equals(this.sets, other.sets)
                 && Objects.equals(this.description, other.description)
                 && Objects.equals(this.timeToLive, other.timeToLive);
     }

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpSetRequestDTO.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpSetRequestDTO.java
@@ -1,0 +1,76 @@
+package org.opennms.netmgt.snmp.proxy.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.opennms.netmgt.snmp.SnmpObjId;
+import org.opennms.netmgt.snmp.SnmpObjIdXmlAdapter;
+import org.opennms.netmgt.snmp.SnmpValue;
+
+@XmlRootElement(name="snmp-set-request")
+@XmlAccessorType(XmlAccessType.NONE)
+public class SnmpSetRequestDTO {
+
+    @XmlAttribute(name="correlation-id")
+    private String correlationId;
+
+    @XmlElement(name="oid")
+    @XmlJavaTypeAdapter(SnmpObjIdXmlAdapter.class)
+    private List<SnmpObjId> oids = new ArrayList<>(0);
+
+    @XmlElement(name="value")
+    @XmlJavaTypeAdapter(SnmpObjIdXmlAdapter.class)
+    private List<SnmpValue> values = new ArrayList<>(0);
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public List<SnmpObjId> getOids() {
+        return oids;
+    }
+
+    public void setOids(List<SnmpObjId> oids) {
+        this.oids = oids;
+    }
+
+    public List<SnmpValue> getValues() {
+        return values;
+    }
+
+    public void setValues(List<SnmpValue> values) {
+        this.values = values;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(correlationId, oids, values);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        final SnmpSetRequestDTO other = (SnmpSetRequestDTO) obj;
+        return Objects.equals(this.correlationId, other.correlationId)
+                && Objects.equals(this.oids, other.oids)
+                && Objects.equals(this.values, other.values);
+    }
+}

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/MockSnmpStrategy.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/MockSnmpStrategy.java
@@ -42,7 +42,8 @@ import org.opennms.netmgt.snmp.TrapNotificationListener;
 
 public class MockSnmpStrategy implements SnmpStrategy {
 
-    private static boolean firstCall = true;
+    private static boolean firstGetCall = true;
+    private static boolean firstSetCall = true;
 
     @Override
     public SnmpWalker createWalker(SnmpAgentConfig agentConfig, String name, CollectionTracker tracker) {
@@ -71,8 +72,17 @@ public class MockSnmpStrategy implements SnmpStrategy {
 
     @Override
     public CompletableFuture<SnmpValue[]> getAsync(SnmpAgentConfig agentConfig, SnmpObjId[] oids) {
-        if (firstCall) {
-            firstCall = false;
+        if (firstGetCall) {
+            firstGetCall = false;
+            return SnmpProxyRpcModuleTest.completedFuture;
+        }
+        return SnmpProxyRpcModuleTest.failedFuture;
+    }
+
+    @Override
+    public CompletableFuture<SnmpValue[]> setAsync(SnmpAgentConfig agentConfig, SnmpObjId[] oids, SnmpValue[] values) {
+        if (firstSetCall) {
+            firstSetCall = false;
             return SnmpProxyRpcModuleTest.completedFuture;
         }
         return SnmpProxyRpcModuleTest.failedFuture;
@@ -151,6 +161,6 @@ public class MockSnmpStrategy implements SnmpStrategy {
     }
 
     public static void setFirstCall(boolean firstCall) {
-        MockSnmpStrategy.firstCall = firstCall;
+        MockSnmpStrategy.firstGetCall = firstCall;
     }
 }

--- a/features/juniper-tca-collector/src/test/java/org/opennms/netmgt/collectd/tca/TcaCollectorIT.java
+++ b/features/juniper-tca-collector/src/test/java/org/opennms/netmgt/collectd/tca/TcaCollectorIT.java
@@ -75,6 +75,7 @@ import org.opennms.netmgt.model.NetworkBuilder;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.rrd.RrdStrategy;
+import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpUtils;
 import org.opennms.netmgt.snmp.SnmpValue;
@@ -294,9 +295,12 @@ public class TcaCollectorIT implements InitializingBean {
 		SnmpValue v1a = SnmpUtils.get(m_collectionAgent.getAgentConfig(), peer1);
 		SnmpValue v2a = SnmpUtils.get(m_collectionAgent.getAgentConfig(), peer2);
 
+		final SnmpAgentConfig agentConfig = m_collectionAgent.getAgentConfig();
+		agentConfig.setWriteCommunity("public");
+
 		// Set New Values
-		SnmpUtils.set(m_collectionAgent.getAgentConfig(), peer1, valFac.getOctetString(sb.toString().getBytes()));
-		SnmpUtils.set(m_collectionAgent.getAgentConfig(), peer2, valFac.getOctetString(sb.toString().getBytes()));
+		SnmpUtils.set(agentConfig, peer1, valFac.getOctetString(sb.toString().getBytes()));
+		SnmpUtils.set(agentConfig, peer2, valFac.getOctetString(sb.toString().getBytes()));
 
 		// Validate New Values
 		SnmpValue v1b = SnmpUtils.get(m_collectionAgent.getAgentConfig(), peer1);

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/AbstractSnmpCollectorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/AbstractSnmpCollectorIT.java
@@ -179,6 +179,7 @@ public abstract class AbstractSnmpCollectorIT implements InitializingBean, TestC
                 m_pollOutagesDao, collector.getClass().getCanonicalName());
         m_collectionAgent = DefaultSnmpCollectionAgent.create(iface.getId(), m_ipInterfaceDao, m_transactionManager);
         m_agentConfig = SnmpPeerFactory.getInstance().getAgentConfig(InetAddressUtils.getLocalHostAddress());
+        m_agentConfig.setWriteCommunity("public");
     }
 
     protected abstract AbstractSnmpCollector createSnmpCollector();

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorMinMaxValIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorMinMaxValIT.java
@@ -137,6 +137,7 @@ public class SnmpCollectorMinMaxValIT implements TestContextAware, InitializingB
 
         SnmpPeerFactory.setInstance(m_snmpPeerFactory);
         m_agentConfig = m_snmpPeerFactory.getAgentConfig(InetAddressUtils.addr(TEST_HOST_ADDRESS));
+        m_agentConfig.setWriteCommunity("public");
 
         m_rrdStrategy = new JRobinRrdStrategy();
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpSetIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpSetIT.java
@@ -1,0 +1,211 @@
+package org.opennms.netmgt.collectd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.core.rpc.mock.MockRpcClientFactory;
+import org.opennms.netmgt.mock.OpenNMSITCase;
+import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpObjId;
+import org.opennms.netmgt.snmp.SnmpUtils;
+import org.opennms.netmgt.snmp.SnmpValue;
+import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;
+import org.opennms.netmgt.snmp.proxy.common.LocationAwareSnmpClientRpcImpl;
+import org.opennms.netmgt.snmp.snmp4j.Snmp4JValueFactory;
+import org.snmp4j.TransportMapping;
+import org.snmp4j.agent.BaseAgent;
+import org.snmp4j.agent.CommandProcessor;
+import org.snmp4j.agent.DuplicateRegistrationException;
+import org.snmp4j.agent.mo.MOAccessImpl;
+import org.snmp4j.agent.mo.MOScalar;
+import org.snmp4j.agent.mo.MOTableRow;
+import org.snmp4j.agent.mo.snmp.RowStatus;
+import org.snmp4j.agent.mo.snmp.SnmpCommunityMIB;
+import org.snmp4j.agent.mo.snmp.SnmpNotificationMIB;
+import org.snmp4j.agent.mo.snmp.SnmpTargetMIB;
+import org.snmp4j.agent.mo.snmp.StorageType;
+import org.snmp4j.agent.mo.snmp.VacmMIB;
+import org.snmp4j.agent.security.MutableVACM;
+import org.snmp4j.mp.MPv3;
+import org.snmp4j.security.SecurityLevel;
+import org.snmp4j.security.SecurityModel;
+import org.snmp4j.security.SecurityProtocols;
+import org.snmp4j.security.USM;
+import org.snmp4j.smi.Address;
+import org.snmp4j.smi.GenericAddress;
+import org.snmp4j.smi.Integer32;
+import org.snmp4j.smi.OID;
+import org.snmp4j.smi.OctetString;
+import org.snmp4j.smi.Variable;
+import org.snmp4j.transport.TransportMappings;
+
+import com.google.common.collect.Lists;
+
+public class SnmpSetIT extends OpenNMSITCase {
+    private static class TestSnmpAgent extends BaseAgent {
+        private static final String ADDRESS = "127.0.0.1/9161";
+
+        private TestSnmpAgent(TemporaryFolder tempFolder) throws IOException {
+            super(tempFolder.newFile("conf.agent"), tempFolder.newFile("bootCounter.agent"), new CommandProcessor(new OctetString(MPv3.createLocalEngineID())));
+            final MOScalar myScalar1 = new MOScalar(new OID(".1.3.0"), MOAccessImpl.ACCESS_READ_WRITE, new OctetString("initial1"));
+            final MOScalar myScalar2 = new MOScalar(new OID(".1.4.0"), MOAccessImpl.ACCESS_READ_WRITE, new OctetString("initial2"));
+            try {
+                server.register(myScalar1, null);
+                server.register(myScalar2, null);
+            } catch (DuplicateRegistrationException e) {
+                //ignore
+            }
+        }
+
+        @Override
+        protected void initTransportMappings() throws IOException {
+            transportMappings = new TransportMapping[1];
+            final Address addr = GenericAddress.parse(ADDRESS);
+            final TransportMapping<? extends Address> tm = TransportMappings.getInstance().createTransportMapping(addr);
+            transportMappings[0] = tm;
+        }
+
+        @Override
+        protected void registerManagedObjects() {
+        }
+
+        @Override
+        protected void unregisterManagedObjects() {
+        }
+
+        @Override
+        protected void addUsmUser(USM usm) {
+        }
+
+        @Override
+        protected void addNotificationTargets(final SnmpTargetMIB snmpTargetMIB, final SnmpNotificationMIB snmpNotificationMIB) {
+        }
+
+        public void start() throws IOException {
+            init();
+            addShutdownHook();
+            getServer().addContext(new OctetString("public"));
+            finishInit();
+            SecurityProtocols.getInstance().addDefaultProtocols();
+            run();
+            sendColdStartNotification();
+        }
+
+        @Override
+        protected void addViews(final VacmMIB vacmMIB) {
+            // define read community access
+            vacmMIB.addGroup(SecurityModel.SECURITY_MODEL_SNMPv2c, new OctetString("cpublic"), new OctetString("v1v2group1"), StorageType.nonVolatile);
+            vacmMIB.addAccess(new OctetString("v1v2group1"), new OctetString("public"), SecurityModel.SECURITY_MODEL_SNMPv2c, SecurityLevel.NOAUTH_NOPRIV, MutableVACM.VACM_MATCH_EXACT, new OctetString("fullReadView1"), new OctetString("fullWriteView1"), new OctetString("fullNotifyView1"), StorageType.nonVolatile);
+            vacmMIB.addViewTreeFamily(new OctetString("fullReadView1"), new OID("1.3"), new OctetString(), VacmMIB.vacmViewIncluded, StorageType.nonVolatile);
+            vacmMIB.addViewTreeFamily(new OctetString("fullReadView1"), new OID("1.4"), new OctetString(), VacmMIB.vacmViewIncluded, StorageType.nonVolatile);
+            // define write community access
+            vacmMIB.addGroup(SecurityModel.SECURITY_MODEL_SNMPv2c, new OctetString("cprivate"), new OctetString("v1v2group2"), StorageType.nonVolatile);
+            vacmMIB.addAccess(new OctetString("v1v2group2"), new OctetString("public"), SecurityModel.SECURITY_MODEL_SNMPv2c, SecurityLevel.NOAUTH_NOPRIV, MutableVACM.VACM_MATCH_EXACT, new OctetString("fullReadView2"), new OctetString("fullWriteView2"), new OctetString("fullNotifyView2"), StorageType.nonVolatile);
+            vacmMIB.addViewTreeFamily(new OctetString("fullReadView2"), new OID("1.3"), new OctetString(), VacmMIB.vacmViewIncluded, StorageType.nonVolatile);
+            vacmMIB.addViewTreeFamily(new OctetString("fullWriteView2"), new OID("1.3"), new OctetString(), VacmMIB.vacmViewIncluded, StorageType.nonVolatile);
+            vacmMIB.addViewTreeFamily(new OctetString("fullReadView2"), new OID("1.4"), new OctetString(), VacmMIB.vacmViewIncluded, StorageType.nonVolatile);
+            vacmMIB.addViewTreeFamily(new OctetString("fullWriteView2"), new OID("1.4"), new OctetString(), VacmMIB.vacmViewIncluded, StorageType.nonVolatile);
+        }
+
+        @Override
+        protected void addCommunities(final SnmpCommunityMIB communityMIB) {
+            // read community
+            final Variable[] com2sec = new Variable[]{new OctetString("public"), new OctetString("cpublic"), getAgent().getContextEngineID(), new OctetString("public"), new OctetString(), new Integer32(StorageType.nonVolatile), new Integer32(RowStatus.active)};
+            final MOTableRow row = communityMIB.getSnmpCommunityEntry().createRow(new OctetString("public2public").toSubIndex(true), com2sec);
+            communityMIB.getSnmpCommunityEntry().addRow((SnmpCommunityMIB.SnmpCommunityEntryRow) row);
+            // write community
+            final Variable[] com2sec2 = new Variable[]{new OctetString("private"), new OctetString("cprivate"), getAgent().getContextEngineID(), new OctetString("public"), new OctetString(), new Integer32(StorageType.nonVolatile), new Integer32(RowStatus.active)};
+            final MOTableRow row2 = communityMIB.getSnmpCommunityEntry().createRow(new OctetString("public2public").toSubIndex(true), com2sec2);
+            communityMIB.getSnmpCommunityEntry().addRow((SnmpCommunityMIB.SnmpCommunityEntryRow) row2);
+        }
+    }
+
+    private final LocationAwareSnmpClient m_locationAwareSnmpClient = new LocationAwareSnmpClientRpcImpl(new MockRpcClientFactory());
+
+    private TestSnmpAgent testSnmpAgent;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        setStartEventd(false);
+        super.setUp();
+
+        SnmpUtils.unsetStrategyResolver();
+        System.getProperties().remove("org.opennms.snmp.strategyClass");
+
+        final TemporaryFolder temporaryFolder = new TemporaryFolder();
+        temporaryFolder.create();
+
+        testSnmpAgent = new TestSnmpAgent(temporaryFolder);
+        testSnmpAgent.start();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        testSnmpAgent.stop();
+        testSnmpAgent = null;
+    }
+
+    @Test
+    public void testSnmpSet() throws InterruptedException, ExecutionException {
+        final SnmpAgentConfig snmpAgentConfig = new SnmpAgentConfig();
+        snmpAgentConfig.setAddress(myLocalHost());
+        snmpAgentConfig.setPort(9161);
+        snmpAgentConfig.setReadCommunity("public");
+        snmpAgentConfig.setWriteCommunity("private");
+        snmpAgentConfig.setVersion(SnmpAgentConfig.VERSION2C);
+        snmpAgentConfig.setRetries(2);
+
+        // first get, text should be "initial1"
+        final SnmpValue result1 = m_locationAwareSnmpClient.get(snmpAgentConfig, SnmpObjId.get(".1.3.0")).execute().get();
+        assertEquals("initial1", result1.toString());
+
+        // invoke set, return value should be "foobar"
+        final SnmpValue modifiedText = new Snmp4JValueFactory().getOctetString("foobar".getBytes());
+        final SnmpValue result2 = m_locationAwareSnmpClient.set(snmpAgentConfig, SnmpObjId.get(".1.3.0"), modifiedText).execute().get();
+        assertEquals("foobar", result2.toString());
+
+        // now get again, value should be "foobar" now
+        final SnmpValue result3 = m_locationAwareSnmpClient.get(snmpAgentConfig, SnmpObjId.get(".1.3.0")).execute().get();
+        assertEquals("foobar", result3.toString());
+    }
+
+    @Test
+    public void testTwoSnmpSet() throws InterruptedException, ExecutionException {
+        final SnmpAgentConfig snmpAgentConfig = new SnmpAgentConfig();
+        snmpAgentConfig.setAddress(myLocalHost());
+        snmpAgentConfig.setPort(9161);
+        snmpAgentConfig.setReadCommunity("public");
+        snmpAgentConfig.setWriteCommunity("private");
+        snmpAgentConfig.setVersion(SnmpAgentConfig.VERSION2C);
+        snmpAgentConfig.setRetries(2);
+
+        // first get, text should be "initial1"
+        final SnmpValue result1 = m_locationAwareSnmpClient.get(snmpAgentConfig, SnmpObjId.get(".1.3.0")).execute().get();
+        assertEquals("initial1", result1.toString());
+        final SnmpValue result2 = m_locationAwareSnmpClient.get(snmpAgentConfig, SnmpObjId.get(".1.4.0")).execute().get();
+        assertEquals("initial2", result2.toString());
+
+        // invoke set, passing both variable changes at once, return value should be "foobar1" or "foobar2"
+        final SnmpValue modifiedText1 = new Snmp4JValueFactory().getOctetString("foobar1".getBytes());
+        final SnmpValue modifiedText2 = new Snmp4JValueFactory().getOctetString("foobar2".getBytes());
+        final SnmpValue result3 = m_locationAwareSnmpClient.set(snmpAgentConfig, Lists.newArrayList(SnmpObjId.get(".1.3.0"), SnmpObjId.get(".1.4.0")), Lists.newArrayList(modifiedText1, modifiedText2)).execute().get();
+        assertTrue("foobar1".equals(result3.toString()) || "foobar2".equals(result3.toString()));
+
+        // now get again, values should be "foobar1" and "foobar2" now
+        final SnmpValue result4 = m_locationAwareSnmpClient.get(snmpAgentConfig, SnmpObjId.get(".1.3.0")).execute().get();
+        assertEquals("foobar1", result4.toString());
+        final SnmpValue result5 = m_locationAwareSnmpClient.get(snmpAgentConfig, SnmpObjId.get(".1.4.0")).execute().get();
+        assertEquals("foobar2", result5.toString());
+    }
+}


### PR DESCRIPTION
This is part of

* JIRA: https://opennms.atlassian.net/browse/NMS-16388

Allows to invoke SNMP SET via LocationAwareSnmpClient. Since LocationAwareSnmpClient only works with Snmp4j, so I did not changed anything regarding JoeSnmp. I also altered the way the SNMP community is used in case of v1/v2c. If a SET PDU is sent the write community will be used, otherwise the read community.