### PR TITLE
NMS-16513: Added missing exclusion rule for jettison

### DIFF
--- a/opennms-full-assembly/src/assembly/components/osgi.xml
+++ b/opennms-full-assembly/src/assembly/components/osgi.xml
@@ -13,6 +13,8 @@
         <exclude>**/*jasypt*/1.9.2_1/*</exclude>
         <exclude>**/jettison/1.3.*</exclude>
         <exclude>**/jettison/1.3.*/*</exclude>
+        <exclude>**/jettison/1.4.*</exclude>
+        <exclude>**/jettison/1.4.*/*</exclude>
         <exclude>**/proton-j/0.14.0/*</exclude>
         <exclude>**/proton-j/0.14.0</exclude>
         <exclude>**/proton-j/0.14.0/*</exclude>


### PR DESCRIPTION
* JIRA: https://opennms.atlassian.net/browse/NMS-16513