### PR TITLE
NMS-15169: Added jackson-dataformat-yaml to opennms-health-rest-service feature

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1999,6 +1999,7 @@
         <feature>opennms-health-rest</feature>
         <feature version="${cxfVersion}">cxf-core</feature>
         <feature version="${cxfVersion}">cxf-jaxrs</feature>
+        <feature>jackson-dataformat-yaml</feature>
         <!-- early start-level to override jettison version in 3rd-party feature files -->
         <bundle start-level="${earlyStartLevel}">mvn:org.codehaus.jettison/jettison/${jettisonVersion}</bundle>
         <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson2Version}</bundle>


### PR DESCRIPTION
Should fix CircleCI Sentinel smoke test errors for develop.