### PR TITLE
chore: Update auto-assign-reviewer to use Node 16 instead of Node 12

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: shufo/auto-assign-reviewer-by-files@v1.1.4
+      - uses: shufo/auto-assign-reviewer-by-files@v1.1.5
         with:
           config: ".github/assign-by-files.yml"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Node 12 in 1.1.4 is deprecated and the auto-assign-reviewer action uses Node 16 with version 1.1.5.

See: https://github.com/shufo/auto-assign-reviewer-by-files/releases/tag/v1.1.5
