### PR TITLE
NMS-16587: Update linux UBI version to 9.4

### DIFF
--- a/opennms-container/common.mk
+++ b/opennms-container/common.mk
@@ -12,7 +12,7 @@ endif
 VERSION                 := $(shell ../../.circleci/scripts/pom2version.sh ../../pom.xml)
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:ubi9-3.4.0.b269-jre-17
+BASE_IMAGE              := opennms/deploy-base:ubi9-3.5.0.b276-jre-17
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKER_REGISTRY         := docker.io
 DOCKER_ORG              := opennms

--- a/opennms-container/core/Dockerfile
+++ b/opennms-container/core/Dockerfile
@@ -23,7 +23,7 @@
 ##
 # Use Java base image and setup required RPMs as cacheable image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.4.0.b269-jre-17"
+ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.5.0.b276-jre-17"
 
 FROM ${BASE_IMAGE} as core-tarball
 

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -26,7 +26,7 @@
 # To avoid issues, we rearrange the directories in pre-stage to avoid injecting these
 # as additional layers into the final image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.4.0.b269-jre-17"
+ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.5.0.b276-jre-17"
 
 FROM ${BASE_IMAGE} as minion-base
 

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -23,7 +23,7 @@
 ##
 # Use Java base image and setup required RPMs as cacheable image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.4.0.b269-jre-17"
+ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.5.0.b276-jre-17"
 
 FROM ${BASE_IMAGE} as sentinel-tarball
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
@@ -44,7 +44,7 @@ public class MockCloudContainer extends GenericContainer<MockCloudContainer> {
     private static final Path CLOUD_MOCK_PATH_CONTAINER = Path.of("/").resolve(CLOUD_MOCK_PATH_HOST.getFileName());
     private static final String CLOUD_MOCK_MAIN = "org.opennms.plugins.cloud.ittest.MockCloudMain";
     public MockCloudContainer() {
-        super(DockerImageName.parse("opennms/deploy-base:ubi9-3.4.0.b269-jre-17"));
+        super(DockerImageName.parse("opennms/deploy-base:ubi9-3.5.0.b276-jre-17"));
         withCopyFileToContainer(MountableFile.forHostPath(CLOUD_MOCK_PATH_HOST), CLOUD_MOCK_PATH_CONTAINER.toString())
                 .withCommand("/usr/bin/java", "-cp", CLOUD_MOCK_PATH_CONTAINER.toString(), CLOUD_MOCK_MAIN)
                 .withExposedPorts(PORT)


### PR DESCRIPTION
Updating the container's base image to UBI 9.4

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16587

