### PR TITLE
NMS-16951: Set logging to matching class TcpListener

### DIFF
--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/listener/TcpListener.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/listener/TcpListener.java
@@ -48,7 +48,7 @@ import io.netty.handler.logging.LoggingHandler;
 
 public class TcpListener {
 
-    private static final Logger LOG = LoggerFactory.getLogger(UdpListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TcpListener.class);
 
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;


### PR DESCRIPTION
### All Contributors

Fix the logging class to TcpListener instead of UdpListener.

## Reviewer Hints

I've backported the patch to fix Meridian 2022 onwards.

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

JIRA: https://opennms.atlassian.net/browse/NMS-16951