### PR TITLE
NMS-17083: Investigate Develop branch failure when using OIA 2.0

### DIFF
--- a/features/container/minion/pom.xml
+++ b/features/container/minion/pom.xml
@@ -84,13 +84,13 @@
     </build>
 
     <dependencies>
-        <dependency>
+        <!--dependency>
           <groupId>org.opennms.integration.api.sample</groupId>
           <artifactId>sample-project</artifactId>
           <version>${opennmsApiVersion}</version>
           <type>xml</type>
           <classifier>blueprint-minion</classifier>
-        </dependency>
+        </dependency-->
         <dependency>
             <groupId>org.opennms.container</groupId>
             <artifactId>org.opennms.container.shared</artifactId>

--- a/features/container/minion/pom.xml
+++ b/features/container/minion/pom.xml
@@ -84,13 +84,25 @@
     </build>
 
     <dependencies>
-        <!--dependency>
+        <dependency>
+          <groupId>org.opennms.dependencies</groupId>
+          <artifactId>jaxb-dependencies</artifactId>
+          <version>${project.version}</version>
+          <type>pom</type>
+        </dependency>
+        <dependency>
           <groupId>org.opennms.integration.api.sample</groupId>
           <artifactId>sample-project</artifactId>
           <version>${opennmsApiVersion}</version>
           <type>xml</type>
           <classifier>blueprint-minion</classifier>
-        </dependency-->
+          <exclusions>
+           <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+           </exclusion>
+          </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.opennms.container</groupId>
             <artifactId>org.opennms.container.shared</artifactId>

--- a/features/container/minion/pom.xml
+++ b/features/container/minion/pom.xml
@@ -85,6 +85,13 @@
 
     <dependencies>
         <dependency>
+          <groupId>org.opennms.integration.api.sample</groupId>
+          <artifactId>sample-project</artifactId>
+          <version>${opennmsApiVersion}</version>
+          <type>xml</type>
+          <classifier>blueprint-minion</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.container</groupId>
             <artifactId>org.opennms.container.shared</artifactId>
             <version>${project.version}</version>

--- a/features/container/sentinel/pom.xml
+++ b/features/container/sentinel/pom.xml
@@ -276,7 +276,7 @@
                 <configuration>
                     <finalName>${project.artifactId}</finalName>
                     <archiveZip>false</archiveZip>
-                    <javase>11</javase>
+                    <javase>17</javase>
                     <featuresProcessing>${project.build.directory}/internal/features-processing.xml</featuresProcessing>
                     <propertyFileEdits>${project.build.directory}/internal/assembly-property-edits.xml</propertyFileEdits>
                     <generateConsistencyReport>${project.build.directory}/consistency-report</generateConsistencyReport>
@@ -466,6 +466,14 @@
         </dependency>
 
         <!-- OpenNMS dependencies for unpacking/assembling -->
+        <dependency>
+          <groupId>org.opennms.integration.api.sample</groupId>
+          <artifactId>sample-project</artifactId>
+          <version>${opennmsApiVersion}</version>
+          <type>xml</type>
+          <classifier>blueprint-sentinel</classifier>
+        </dependency>
+
         <dependency>
             <groupId>org.opennms.core</groupId>
             <artifactId>org.opennms.core.cli</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1933,8 +1933,8 @@
     <okhttp3Version>3.10.0</okhttp3Version>
     <okioGrafanaVersion>1.14.0</okioGrafanaVersion>
     <openid4javaVersion>0.9.6</openid4javaVersion>
-    <opennmsApiVersion>1.6.1</opennmsApiVersion>
-    <opennmsApiVersionOsgi>1.6.1</opennmsApiVersionOsgi>
+    <opennmsApiVersion>2.0.0-SNAPSHOT</opennmsApiVersion>
+    <opennmsApiVersionOsgi>2.0.0.SNAPSHOT</opennmsApiVersionOsgi>
     <osgiVersion>7.0.0</osgiVersion>
     <osgiAnnotationVersion>7.0.0</osgiAnnotationVersion>
     <osgiCompendiumVersion>7.0.0</osgiCompendiumVersion>


### PR DESCRIPTION
Enable OIA 2.0
Update Sentinel and Minion so they can build (fix dependency) with newer version of OIA

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17083

