### PR TITLE
NMS-17007: Handle if CA cert with alias already exists for Minion

### DIFF
--- a/opennms-container/minion/container-fs/entrypoint.sh
+++ b/opennms-container/minion/container-fs/entrypoint.sh
@@ -223,6 +223,10 @@ configure() {
     export JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=$CACERTS -Djavax.net.ssl.trustStorePassword=changeit"
     while read certid; do
       [[ $certid =~ ^#.* ]] && continue
+      # check if CA cert already exists and remove so re-adding doesn't error
+      if keytool -list -alias "$certid" -keystore "$CACERTS" -storepass changeit; then
+        keytool -delete -alias "$certid" -keystore "$CACERTS" -storepass changeit
+      fi
       keytool -importcert -file "/opt/minion/server-certs/$certid" -alias "$certid" -keystore "$CACERTS" -storepass changeit -noprompt
     done < "$MINION_SERVER_CERTS_CFG"
   fi


### PR DESCRIPTION
### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17007

This is the same PR as #7588 but based off the `foundation-2024` branch

@indigo423 apologies for the mess about, if you could sign this one off again please? 

