### PR TITLE
NMS-17726: Allow user to set min and max Java heap size

### DIFF
--- a/opennms-container/minion/container-fs/entrypoint.sh
+++ b/opennms-container/minion/container-fs/entrypoint.sh
@@ -19,6 +19,7 @@ CONFD_CONFIG_DIR="/opt/minion/confd"
 CONFD_BIN="/usr/local/bin/confd"
 CONFD_CONFIG_FILE="${CONFD_CONFIG_DIR}/confd.toml"
 CACERTS="/opt/minion/cacerts"
+export JAVA_OPTS="${JAVA_OPTS} -Xms${JAVA_MIN_MEM:-2g} -Xmx${JAVA_MAX_MEM:-2g}"
 
 export KARAF_OPTS="-Djava.locale.providers=CLDR,COMPAT -Djdk.util.zip.disableZip64ExtraFieldValidation=true"
 


### PR DESCRIPTION
### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

Allow user to set the Java initial and maximum heap size with the [documented JAVA_MIN_MEM and JAVA_MAX_MEM](https://docs.opennms.com/horizon/32/deployment/minion/install.html#install-the-minion-package) environment variables in the docker-compose example.

### Reviewer Hint

There was no default set. I have set the initial and maximum heap space to 2 GB by default. It might be too high/low.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17726

