### PR TITLE
NMS-17737  Update OSHI library to 6.7.1

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1566,8 +1566,7 @@
         <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.usageanalytics/org.opennms.features.usageanalytics.api/${project.version}</bundle>
-        <bundle>mvn:net.java.dev.jna/jna/${jnaVersion}</bundle>
-        <bundle>mvn:net.java.dev.jna/jna-platform/${jnaVersion}</bundle>
+        <feature>java-native-access</feature>
         <bundle>mvn:com.github.oshi/oshi-core/${oshi.core.version}</bundle>
     </feature>
     <feature name="opennms-es-rest" version="${project.version}" description="OpenNMS :: Features :: ElasticSearch Rest">

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1566,7 +1566,9 @@
         <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.usageanalytics/org.opennms.features.usageanalytics.api/${project.version}</bundle>
-        <bundle dependency="true">mvn:com.github.oshi/oshi-core/${oshi.core.version}</bundle>
+        <bundle>mvn:net.java.dev.jna/jna/${jnaVersion}</bundle>
+        <bundle>mvn:net.java.dev.jna/jna-platform/${jnaVersion}</bundle>
+        <bundle>mvn:com.github.oshi/oshi-core/${oshi.core.version}</bundle>
     </feature>
     <feature name="opennms-es-rest" version="${project.version}" description="OpenNMS :: Features :: ElasticSearch Rest">
         <details>OpenNMS :: Features :: ElasticSearch Rest</details>

--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -38,6 +38,16 @@
             <artifactId>oshi-core</artifactId>
             <version>${oshi.core.version}</version>
         </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jnaVersion}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>${jnaVersion}</version>
+            </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>

--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -38,16 +38,11 @@
             <artifactId>oshi-core</artifactId>
             <version>${oshi.core.version}</version>
         </dependency>
-            <dependency>
-                <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna</artifactId>
-                <version>${jnaVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna-platform</artifactId>
-                <version>${jnaVersion}</version>
-            </dependency>
+        <dependency>
+            <groupId>org.opennms.dependencies</groupId>
+            <artifactId>jna-dependencies</artifactId>
+            <type>pom</type>
+        </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
@@ -336,7 +336,6 @@ public class UsageStatisticsReporter implements StateChangeHandler {
             try {
                 final long currentTime = System.currentTimeMillis();
                 final long twentyFourHoursAgo = currentTime - Duration.ofHours(24).toMillis();
-
                 final List<Filter> filters = Collections.singletonList(new TimeRangeFilter(twentyFourHoursAgo, currentTime));
                 flowCount = flowQueryService.getFlowCount(filters).get();
 

--- a/features/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -66,7 +66,9 @@
 
     <bean id="dataSourceFactoryBean" class="org.opennms.core.db.DataSourceFactoryBean" />
 
-    <reference id="flowQueryService" interface="org.opennms.netmgt.flows.api.FlowQueryService" />
+    <reference id="flowQueryService"
+               interface="org.opennms.netmgt.flows.api.FlowQueryService"
+               availability="optional"/>
 
 	<bean id="usageStatisticsReporter" class="org.opennms.features.datachoices.internal.usagestatistics.UsageStatisticsReporter"
         init-method="init" destroy-method="destroy">

--- a/features/system-report/pom.xml
+++ b/features/system-report/pom.xml
@@ -103,7 +103,11 @@
       <artifactId>oshi-core</artifactId>
       <version>${oshi.core.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>jna-dependencies</artifactId>
+      <type>pom</type>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1864,7 +1864,7 @@
     <jldapVersion>4.3</jldapVersion>
     <jmhVersion>1.37</jmhVersion>
     <jmxremote.optional.version>1.0_01-ea</jmxremote.optional.version>
-    <jnaVersion>5.12.1</jnaVersion>
+    <jnaVersion>5.16.0</jnaVersion>
     <jnrVersion>3.1.17</jnrVersion>
     <jodaTimeVersion>2.12.5</jodaTimeVersion>
     <jolokiaVersion>1.7.2</jolokiaVersion>
@@ -2029,7 +2029,7 @@
     <!-- CI Settings -->
     <!-- Limit ITs to 30 minutes by default -->
     <test.fork.timeout>1800</test.fork.timeout>
-    <oshi.core.version>6.2.2</oshi.core.version>
+    <oshi.core.version>6.7.1</oshi.core.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
The OSHI library (com.github.oshi) which we are using in datachoicesis currently on version 6.7.0, we are on 6.2.2. They added some things for Mac Sequoia among other things, we should probably update.



* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17737

