### PR TITLE
NMS-17766: Do not display menu item if property check fails

### DIFF
--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/menu/MenuProviderTest.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/menu/MenuProviderTest.java
@@ -30,13 +30,14 @@ import java.util.Optional;
 import com.google.common.base.Strings;
 import org.junit.Assert;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.startsWith;
 
 import org.opennms.web.rest.support.menu.xml.MenuXml;
 
@@ -189,7 +190,7 @@ public class MenuProviderTest {
             this.isZenithConnectEnabled = isZenithConnectEnabled;
         }
 
-        private boolean isZenithConnectEnabled;
+        final private boolean isZenithConnectEnabled;
 
         public String getRemoteUser() {
             return "admin1";

--- a/opennms-webapp/src/main/java/org/opennms/web/navigate/LocationBasedNavBarEntry.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/navigate/LocationBasedNavBarEntry.java
@@ -88,7 +88,7 @@ public class LocationBasedNavBarEntry implements NavBarEntry {
     @Override
     public DisplayStatus evaluate(MenuContext context) {
         if (!evaluateSystemProperty()) {
-            return DisplayStatus.DISPLAY_NO_LINK;
+            return DisplayStatus.NO_DISPLAY;
         }
 
         return isLinkMatches(context) ? DisplayStatus.DISPLAY_NO_LINK : DisplayStatus.DISPLAY_LINK;


### PR DESCRIPTION
Update the `LocationBasedNavBarEntry` mechanism to not display the menu item at all if a system property check fails.

This means that the "Zenith Connect" menu entry should not appear in the legacy menu unless the feature has been enabled in the properties file.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17766

