### PR TITLE
NMS-17753  Coretex timeseries metatags broken in 33.1.4

### DIFF
--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
@@ -195,6 +195,7 @@ public class Controller {
             if (entry.getKey() == null || entry.getValue() == null || !(entry.getValue() instanceof String)) {
                 continue;
             }
+            // Since we are only interpolating scv related properties, we restrict this to interpolating only scv related properties.
             if (((String) entry.getValue()).contains("${scv:")) {
                 System.setProperty(entry.getKey().toString(), Interpolator.interpolate(entry.getValue().toString(), scope).output);
             }

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
@@ -75,8 +75,6 @@ public class Controller {
      */
     public static final String CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
 
-
-   // public  static final  String LOAD_INTERPOLATE_PROPERTIES ="org.opennnms.load.interpolate.properties";
     /**
      * The log4j category used to log debug messages and statements.
      */
@@ -150,12 +148,7 @@ public class Controller {
             System.exit(1);
         }
 
-     //   final String shouldLoadInterpolatePropertiesStr = System.getProperty(LOAD_INTERPOLATE_PROPERTIES, "false");
-     //   final boolean shouldLoadInterpolateProperties = Boolean.parseBoolean(shouldLoadInterpolatePropertiesStr);
-
-      //  if(shouldLoadInterpolateProperties) {
-            interpolateSystemProperties();
-       // }
+        interpolateSystemProperties();
 
         String command = argv[argv.length - 1];
 

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
@@ -75,6 +75,8 @@ public class Controller {
      */
     public static final String CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
 
+
+    public  static final  String LOAD_INTERPOLATE_PROPERTIES ="org.opennnms.load.interpolate.properties";
     /**
      * The log4j category used to log debug messages and statements.
      */
@@ -148,7 +150,12 @@ public class Controller {
             System.exit(1);
         }
 
-        interpolateSystemProperties();
+        final String shouldLoadInterpolatePropertiesStr = System.getProperty(LOAD_INTERPOLATE_PROPERTIES, "false");
+        final boolean shouldLoadInterpolateProperties = Boolean.parseBoolean(shouldLoadInterpolatePropertiesStr);
+
+        if(shouldLoadInterpolateProperties) {
+            interpolateSystemProperties();
+        }
 
         String command = argv[argv.length - 1];
 

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
@@ -76,7 +76,7 @@ public class Controller {
     public static final String CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
 
 
-    public  static final  String LOAD_INTERPOLATE_PROPERTIES ="org.opennnms.load.interpolate.properties";
+   // public  static final  String LOAD_INTERPOLATE_PROPERTIES ="org.opennnms.load.interpolate.properties";
     /**
      * The log4j category used to log debug messages and statements.
      */
@@ -150,12 +150,12 @@ public class Controller {
             System.exit(1);
         }
 
-        final String shouldLoadInterpolatePropertiesStr = System.getProperty(LOAD_INTERPOLATE_PROPERTIES, "false");
-        final boolean shouldLoadInterpolateProperties = Boolean.parseBoolean(shouldLoadInterpolatePropertiesStr);
+     //   final String shouldLoadInterpolatePropertiesStr = System.getProperty(LOAD_INTERPOLATE_PROPERTIES, "false");
+     //   final boolean shouldLoadInterpolateProperties = Boolean.parseBoolean(shouldLoadInterpolatePropertiesStr);
 
-        if(shouldLoadInterpolateProperties) {
+      //  if(shouldLoadInterpolateProperties) {
             interpolateSystemProperties();
-        }
+       // }
 
         String command = argv[argv.length - 1];
 
@@ -199,7 +199,12 @@ public class Controller {
         final Scope scope = new SecureCredentialsVaultScope(secureCredentialsVault);
 
         for(final Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
-            System.setProperty(entry.getKey().toString(), Interpolator.interpolate(entry.getValue().toString(), scope).output);
+            if (entry.getKey() == null || entry.getValue() == null || !(entry.getValue() instanceof String)) {
+                continue;
+            }
+            if (((String) entry.getValue()).contains("${scv:")) {
+                System.setProperty(entry.getKey().toString(), Interpolator.interpolate(entry.getValue().toString(), scope).output);
+            }
         }
     }
 

--- a/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
+++ b/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
@@ -94,7 +94,6 @@ public class ControllerTest {
 
     @Test
     public void testNoInterpolationForNonMatchingProperties() throws Exception {
-        // Define properties with placeholders not related to the secure credentials vault.
         final String nodePropertyKey = "org.opennms.timeseries.tin.metatags.tag.node";
         final String nodeOriginalValue = "${node:label}";
         final String locationPropertyKey = "org.opennms.timeseries.tin.metatags.tag.location";

--- a/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
+++ b/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
@@ -94,6 +94,7 @@ public class ControllerTest {
 
     @Test
     public void testNoInterpolationForNonMatchingProperties() throws Exception {
+
         final String nodePropertyKey = "org.opennms.timeseries.tin.metatags.tag.node";
         final String nodeOriginalValue = "${node:label}";
         final String locationPropertyKey = "org.opennms.timeseries.tin.metatags.tag.location";

--- a/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
+++ b/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
@@ -94,7 +94,6 @@ public class ControllerTest {
 
     @Test
     public void testNoInterpolationForNonMatchingProperties() throws Exception {
-
         final String nodePropertyKey = "org.opennms.timeseries.tin.metatags.tag.node";
         final String nodeOriginalValue = "${node:label}";
         final String locationPropertyKey = "org.opennms.timeseries.tin.metatags.tag.location";

--- a/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
+++ b/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
@@ -93,6 +93,21 @@ public class ControllerTest {
     }
 
     @Test
+    public void testNoInterpolationForNonMatchingProperty() throws Exception {
+        final String propertyKey = "non.placeholder.${scv:secret:password}";
+        final String originalValue = "this is a plain value";
+        System.setProperty(propertyKey, originalValue);
+
+        Controller.setSecureCredentialsVault(secureCredentialsVault);
+        Controller.interpolateSystemProperties();
+
+        Assert.assertEquals("Property value should not be modified",
+                originalValue, System.getProperty(propertyKey));
+    }
+
+
+
+    @Test
     public void testAttach() throws Exception {
     
         for (VirtualMachineDescriptor vm : VirtualMachine.list()) {

--- a/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
+++ b/core/daemon/src/test/java/org/opennms/netmgt/vmmgr/ControllerTest.java
@@ -93,16 +93,21 @@ public class ControllerTest {
     }
 
     @Test
-    public void testNoInterpolationForNonMatchingProperty() throws Exception {
-        final String propertyKey = "non.placeholder.${scv:secret:password}";
-        final String originalValue = "this is a plain value";
-        System.setProperty(propertyKey, originalValue);
+    public void testNoInterpolationForNonMatchingProperties() throws Exception {
+        // Define properties with placeholders not related to the secure credentials vault.
+        final String nodePropertyKey = "org.opennms.timeseries.tin.metatags.tag.node";
+        final String nodeOriginalValue = "${node:label}";
+        final String locationPropertyKey = "org.opennms.timeseries.tin.metatags.tag.location";
+        final String locationOriginalValue = "${node:location}";
+
+        System.setProperty(nodePropertyKey, nodeOriginalValue);
+        System.setProperty(locationPropertyKey, locationOriginalValue);
 
         Controller.setSecureCredentialsVault(secureCredentialsVault);
         Controller.interpolateSystemProperties();
 
-        Assert.assertEquals("Property value should not be modified",
-                originalValue, System.getProperty(propertyKey));
+        Assert.assertEquals("Property value should not be modified", nodeOriginalValue, System.getProperty(nodePropertyKey));
+        Assert.assertEquals("Property value should not be modified", locationOriginalValue, System.getProperty(locationPropertyKey));
     }
 
 

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -665,6 +665,8 @@ net.sf.jasperreports.chart.pie.ignore.duplicated.key=true
 #Disables the processing of counter wraps, replacing these with NaNs instead.
 org.opennms.newts.nan_on_counter_wrap=true
 
+org.opennnms.load.interpolate.properties=false
+
 ###### Evaluate #####
 # Use these properties to configure persistence using Evaluate
 # Note that Evaluate must be enabled using the 'org.opennms.timeseries.strategy' property

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -665,8 +665,6 @@ net.sf.jasperreports.chart.pie.ignore.duplicated.key=true
 #Disables the processing of counter wraps, replacing these with NaNs instead.
 org.opennms.newts.nan_on_counter_wrap=true
 
-org.opennnms.load.interpolate.properties=false
-
 ###### Evaluate #####
 # Use these properties to configure persistence using Evaluate
 # Note that Evaluate must be enabled using the 'org.opennms.timeseries.strategy' property


### PR DESCRIPTION
 upgraded OpenNMS i from 33.1.3 to 33.1.4 and data collected in victoria metrics (via the Cortex Time Series plugin) stopped including the additional metatags that  had configured. Reverting to 33.1.3 immediately adds them back to collected data.

the config  in  ${OPENNMS_HOME}/etc/opennms.properties.d/timeseries.properties file that looks like this:

`org.opennms.timeseries.strategy=integration
org.opennms.timeseries.tin.metatags.tag.node=${node:label}
org.opennms.timeseries.tin.metatags.tag.location=${node:location}
org.opennms.timeseries.tin.metatags.tag.ifDescr=${interface:if-description}
org.opennms.timeseries.tin.metatags.tag.ifAlias=${interface:if-alias}
org.opennms.timeseries.tin.metatags.tag.ifName=${interface:if-name}
org.opennms.timeseries.tin.metatags.tag.ipAddress=${interface:address}`

With 33.1.4 It  only contain  mtype nad resourceId labels in result , with 33.1.3 there is  those plus lables plus ifDescr, ifName, ipAddress, location, and node.


* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17753

