### PR TITLE
NMS-17751 Monitoring Systems Rest API

### DIFF
--- a/docs/modules/development/nav.adoc
+++ b/docs/modules/development/nav.adoc
@@ -46,6 +46,7 @@
 *** xref:rest/maps.adoc[]
 *** xref:rest/measurements.adoc[]
 *** xref:rest/meta-data.adoc[]
+*** xref:rest/monitoring_systems.adoc[]
 *** xref:rest/newsfeed.adoc[]
 *** xref:rest/nodes.adoc[]
 *** xref:rest/node_links.adoc[]

--- a/docs/modules/development/pages/rest/monitoring_systems.adoc
+++ b/docs/modules/development/pages/rest/monitoring_systems.adoc
@@ -1,0 +1,46 @@
+
+= Monitoring Systems REST API
+
+Use the Monitoring Systems REST API to fetch information about the main monitoring system.
+
+An OpenNMS monitoring system is a system that can poll status of nodes
+and report events that occur on the network.
+Examples of monitoring systems include:
+
+- OpenNMS (main)
+- OpenNMS Remote Poller
+- OpenNMS Minion
+
+NOTE: If not otherwise specified, the `Content-Type` of the request and response is `application/json`.
+
+[caption=]
+.Monitoring Systems API functions
+[cols="1,1,3"]
+|===
+| Resource  | Method    | Description
+
+| /monitoringSystems/main
+| GET
+| Retrieves information about the main monitoring system in OpenNMS, including the `id`, `label`, `location` and `type`.
+This API should return the core OpenNMS system. Other systems include sentinels and minions. The `id` is a `uuid` which uniquely identifies this monitoring system.
+|===
+
+== Examples:
+
+.Get main monitoring system
+[source,bash]
+----
+curl -u admin:admin http://localhost:8980/opennms/rest/monitoringSystems/main -v
+----
+
+.Response:
+
+[source,json]
+----
+{
+  "id": "9e0a8a1d-46e0-4833-b3f1-f0deba566785",
+  "label": "localhost",
+  "location": "Default",
+  "type": "OpenNMS"
+}
+----

--- a/features/bsm/rest/impl/src/test/java/org/opennms/web/rest/v2/bsm/AbstractBusinessServiceRestServiceIT.java
+++ b/features/bsm/rest/impl/src/test/java/org/opennms/web/rest/v2/bsm/AbstractBusinessServiceRestServiceIT.java
@@ -140,7 +140,7 @@ public abstract class AbstractBusinessServiceRestServiceIT extends AbstractSprin
     @After
     public void tearDown() throws Exception {
         super.tearDown();
-        databasePopulator.resetDatabase(true);
+        databasePopulator.resetDatabase(false, true);
     }
 
     public AbstractBusinessServiceRestServiceIT() {

--- a/features/bsm/service/impl/src/test/java/org/opennms/netmgt/bsm/service/internal/BusinessServiceManagerImplIT.java
+++ b/features/bsm/service/impl/src/test/java/org/opennms/netmgt/bsm/service/internal/BusinessServiceManagerImplIT.java
@@ -118,7 +118,7 @@ public class BusinessServiceManagerImplIT {
 
     @After
     public void after() {
-        populator.resetDatabase(true);
+        populator.resetDatabase(false, true);
     }
 
     @Test

--- a/features/bsm/service/impl/src/test/java/org/opennms/netmgt/bsm/service/internal/DefaultBusinessServiceStateMachineIT.java
+++ b/features/bsm/service/impl/src/test/java/org/opennms/netmgt/bsm/service/internal/DefaultBusinessServiceStateMachineIT.java
@@ -121,7 +121,7 @@ public class DefaultBusinessServiceStateMachineIT {
 
     @After
     public void after() {
-        populator.resetDatabase(true);
+        populator.resetDatabase(false, true);
     }
 
     /**

--- a/features/bsm/test-util/src/main/java/org/opennms/netmgt/bsm/test/BsmDatabasePopulator.java
+++ b/features/bsm/test-util/src/main/java/org/opennms/netmgt/bsm/test/BsmDatabasePopulator.java
@@ -36,8 +36,9 @@ public class BsmDatabasePopulator extends DatabasePopulator {
         super.populateDatabase();
     }
 
-    public void resetDatabase(boolean cleanUpNotInitializedBusinessServicesAsWell) {
-        resetDatabase();
+    public void resetDatabase(boolean includingMonitoringSystems, boolean cleanUpNotInitializedBusinessServicesAsWell) {
+        super.resetDatabase(includingMonitoringSystems);
+
         if (cleanUpNotInitializedBusinessServicesAsWell) {
             businessServiceDao.findAll().forEach(eachBs -> businessServiceDao.delete(eachBs));
         }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoringSystemDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoringSystemDao.java
@@ -27,4 +27,5 @@ public interface MonitoringSystemDao extends OnmsDao<OnmsMonitoringSystem, Strin
 
     long getNumMonitoringSystems(String type);
 
+    OnmsMonitoringSystem getMainMonitoringSystem();
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockMonitoringSystemDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockMonitoringSystemDao.java
@@ -41,4 +41,7 @@ public class MockMonitoringSystemDao extends AbstractMockDao<OnmsMonitoringSyste
     public long getNumMonitoringSystems(String type) {
         return 0;
     }
+
+    @Override
+    public OnmsMonitoringSystem getMainMonitoringSystem() { return null; }
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/DatabasePopulator.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/DatabasePopulator.java
@@ -24,8 +24,8 @@ package org.opennms.netmgt.dao;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.opennms.core.utils.InetAddressUtils;
@@ -40,6 +40,7 @@ import org.opennms.netmgt.dao.api.EventDao;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.api.MonitoringSystemDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.NotificationDao;
 import org.opennms.netmgt.dao.api.OnmsDao;
@@ -59,6 +60,7 @@ import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsEventParameter;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsMonitoringSystem;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsNode.NodeType;
 import org.opennms.netmgt.model.OnmsNotification;
@@ -149,7 +151,6 @@ public class DatabasePopulator {
     private ApplicationDao applicationDao;
     private AcknowledgmentDao m_acknowledgmentDao;
     private TransactionOperations m_transOperation;
-
     private OnmsNode m_node1;
     private OnmsNode m_node2;
     private OnmsNode m_node3;
@@ -217,21 +218,49 @@ public class DatabasePopulator {
         }
     }
 
+    /**
+     * Populate a "main" DistPoller (an OnmsMonitoringSystem) entry in the database, if it doesn't already exist.
+     * This is for tests that need a MonitoringSystem with a different id or other fields than the
+     * default DistPoller.
+     * Those tests should call resetDatabase(true) before and after the tests.
+     */
+    public void populateMainDistPoller(String id, String label, String location) {
+        if (m_populateInSeparateTransaction) {
+            m_transOperation.execute(new TransactionCallbackWithoutResult() {
+                @Override
+                public void doInTransactionWithoutResult(final TransactionStatus status) {
+                    doPopulateMainDistPoller(id, label, location);
+                }
+            });
+        } else {
+            doPopulateMainDistPoller(id, label, location);
+        }
+    }
+
     public void resetDatabase() {
+        resetDatabase(false);
+    }
+
+    /**
+     * Reset the database, clear all rows.
+     * @param includingMonitoringSystems If true, also removes any MonitoringSystem entries.
+     */
+    public void resetDatabase(boolean includingMonitoringSystems) {
         if (m_resetInSeperateTransaction) {
             m_transOperation.execute(new TransactionCallbackWithoutResult() {
                 @Override
                 public void doInTransactionWithoutResult(final TransactionStatus status) {
-                    doResetDatabase();
+                    doResetDatabase(includingMonitoringSystems);
                 }
             });
         } else {
-            doResetDatabase();
+            doResetDatabase(includingMonitoringSystems);
         }
     }
 
-    private void doResetDatabase() {
+    private void doResetDatabase(boolean includingMonitoringSystems) {
         LOG.debug("==== DatabasePopulator Reset ====");
+
         for (final OnmsOutage outage : m_outageDao.findAll()) {
             m_outageDao.delete(outage);
         }
@@ -278,10 +307,17 @@ public class DatabasePopulator {
                 m_monitoringLocationDao.delete(location);
             }
         }
+
+        if (includingMonitoringSystems) {
+            for (final OnmsDistPoller system : m_distPollerDao.findAll()) {
+                m_distPollerDao.delete(system.getId());
+            }
+        }
+
         for (final OnmsCategory category : m_categoryDao.findAll()) {
             m_categoryDao.delete(category);
         }
-        
+
         LOG.debug("= DatabasePopulatorExtension Reset Starting =");
     	for (Extension eachExtension : extensions) {
     			DaoSupport daoSupport = eachExtension.getDaoSupport();
@@ -305,7 +341,8 @@ public class DatabasePopulator {
         m_nodeDao.flush();
         m_serviceTypeDao.flush();
         m_monitoringLocationDao.flush();
-        
+        m_distPollerDao.flush();
+
         LOG.debug("==== DatabasePopulator Reset Finished ====");
     }
 
@@ -430,6 +467,23 @@ public class DatabasePopulator {
         
         LOG.debug("==== DatabasePopulator Finished ====");
     }
+
+    private void doPopulateMainDistPoller(String id, String label, String location) {
+        // If main entry already exists, ignore
+        final OnmsDistPoller system = m_distPollerDao.whoami();
+
+        if (system == null) {
+            // Did not exist, add it
+            OnmsDistPoller newSystem = new OnmsDistPoller();
+            newSystem.setId(id);
+            newSystem.setLabel(label);
+            newSystem.setLocation(location);
+            newSystem.setType(OnmsMonitoringSystem.TYPE_OPENNMS);
+
+            m_distPollerDao.save(newSystem);
+            m_distPollerDao.flush();
+        }
+   }
 
     private OnmsCategory getCategory(final String categoryName) {
         OnmsCategory cat = m_categoryDao.findByName(categoryName, true);

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/MonitoringSystemDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/MonitoringSystemDaoHibernate.java
@@ -25,16 +25,35 @@ import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.MonitoringSystemDao;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
 
-public class MonitoringSystemDaoHibernate extends AbstractDaoHibernate<OnmsMonitoringSystem, String> implements MonitoringSystemDao {
+import java.util.Optional;
 
+public class MonitoringSystemDaoHibernate extends AbstractDaoHibernate<OnmsMonitoringSystem, String>
+        implements MonitoringSystemDao {
     public MonitoringSystemDaoHibernate() {
         super(OnmsMonitoringSystem.class);
     }
 
+    /**
+     * Get the number of monitoring systems of the given type.
+     * @param type an OnmsMonitoringSystem.TYPE_ string.
+     */
     @Override
     public long getNumMonitoringSystems(String type) {
         CriteriaBuilder criteriaBuilder = new CriteriaBuilder(OnmsMonitoringSystem.class);
         criteriaBuilder.eq("type", type);
         return countMatching(criteriaBuilder.toCriteria());
+    }
+
+    /**
+     * Get the "main" monitoring system. This has type OnmsMonitoringSystem.TYPE_OPENNMS.
+     */
+    @Override
+    public OnmsMonitoringSystem getMainMonitoringSystem() {
+        CriteriaBuilder criteriaBuilder = new CriteriaBuilder(OnmsMonitoringSystem.class);
+        criteriaBuilder.eq("type", OnmsMonitoringSystem.TYPE_OPENNMS);
+
+        Optional<OnmsMonitoringSystem> system = this.findMatching(criteriaBuilder.toCriteria()).stream().findFirst();
+
+        return system.orElse(null);
     }
 }

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-databasePopulator.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-databasePopulator.xml
@@ -26,5 +26,4 @@
 		<property name="acknowledgmentDao" ref="acknowledgmentDao" />
 		<property name="serviceTypeDao" ref="serviceTypeDao" />
 	</bean>
-
 </beans>

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/MonitoringSystemDaoHibernateIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/MonitoringSystemDaoHibernateIT.java
@@ -1,0 +1,89 @@
+package org.opennms.netmgt.dao.hibernate;
+
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.netmgt.dao.api.MonitoringSystemDao;
+import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class MonitoringSystemDaoHibernateIT implements InitializingBean {
+    public static final String DEFAULT_SYSTEM_LABEL = "localhost";
+    public static final String DEFAULT_SYSTEM_LOCATION = "Default";
+    private String testSystemId;
+
+    @Autowired
+    private MonitoringSystemDao m_monitoringSystemDao;
+
+    @Autowired
+    private DatabasePopulator m_databasePopulator;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        BeanUtils.assertAutowiring(this);
+    }
+
+    @Before
+    public void setUp() {
+        testSystemId = UUID.randomUUID().toString().toLowerCase();
+
+        // force test database to have our main monitoring system (DistPoller is actually a Monitoring System)
+        m_databasePopulator.resetDatabase(true);
+        m_databasePopulator.populateMainDistPoller(testSystemId, DEFAULT_SYSTEM_LABEL, DEFAULT_SYSTEM_LOCATION);
+        m_databasePopulator.populateDatabase();
+    }
+
+    @After
+    public void tearDown() {
+        m_databasePopulator.resetDatabase(true);
+    }
+
+    @Test
+    @Transactional
+    public void testGetNumMonitoringSystems() {
+        long result = m_monitoringSystemDao.getNumMonitoringSystems(OnmsMonitoringSystem.TYPE_OPENNMS);
+        assertEquals(1, result);
+
+        result = m_monitoringSystemDao.getNumMonitoringSystems(OnmsMonitoringSystem.TYPE_MINION);
+        assertEquals(0, result);
+
+        result = m_monitoringSystemDao.getNumMonitoringSystems(OnmsMonitoringSystem.TYPE_SENTINEL);
+        assertEquals(0, result);
+    }
+
+    @Test
+    @Transactional
+    public void testGetMainSystem() {
+        OnmsMonitoringSystem system = m_monitoringSystemDao.getMainMonitoringSystem();
+
+        assertNotNull(system);
+        assertEquals(testSystemId, system.getId());
+        assertEquals(DEFAULT_SYSTEM_LABEL, system.getLabel());
+        assertEquals(DEFAULT_SYSTEM_LOCATION, system.getLocation());
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringSystemsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringSystemsRestService.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.opennms.netmgt.dao.api.MonitoringSystemDao;
+import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Basic Web Service using REST for {@link OnmsMonitoringSystem} entity.
+ */
+@Component
+@Path("monitoringSystems")
+@Transactional
+@Tag(name = "MonitoringSystems", description = "Monitoring Systems API")
+public class MonitoringSystemsRestService {
+    private static final Logger LOG = LoggerFactory.getLogger(MonitoringSystemsRestService.class);
+
+    @Autowired
+    private MonitoringSystemDao dao;
+
+    public static class MonitoringSystemResponseDTO {
+        public String id;
+        public String label;
+        public String location;
+        public String type;
+    }
+
+    @GET
+    @Path("/main")
+    @Produces({MediaType.APPLICATION_JSON})
+    @Operation(summary = "Get main monitoring system", description = "Get main monitoring system",
+            operationId = "MonitoringSystemsRestServiceGetMainMonitoringSystem")
+    public Response getMainMonitoringSystem(final @Context HttpServletRequest request) {
+        try {
+            OnmsMonitoringSystem system = dao.getMainMonitoringSystem();
+
+            if (system != null) {
+                MonitoringSystemResponseDTO dto = new MonitoringSystemResponseDTO();
+                dto.id = system.getId();
+                dto.label = system.getLabel();
+                dto.location = system.getLocation();
+                dto.type = system.getType();
+
+                return Response.ok(dto).build();
+            }
+
+            return Response.noContent().build();
+        } catch (Exception e) {
+            throw new WebApplicationException(
+                    Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                            .type(MediaType.TEXT_PLAIN)
+                            .entity("Error getting monitoring system.").build());
+        }
+    }
+}

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/MonitoringSystemsRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/MonitoringSystemsRestServiceIT.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Collections;
+import java.util.UUID;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties="org.apache.cxf.Logger=org.apache.cxf.common.logging.Slf4jLogger")
+@JUnitTemporaryDatabase
+@Transactional
+public class MonitoringSystemsRestServiceIT extends AbstractSpringJerseyRestTestCase {
+    public static final String DEFAULT_SYSTEM_LABEL = "localhost";
+    public static final String DEFAULT_SYSTEM_LOCATION = "Default";
+    private String testSystemId;
+    private static final Logger LOG = LoggerFactory.getLogger(MonitoringSystemsRestServiceIT.class);
+
+    @Autowired
+    private DatabasePopulator m_databasePopulator;
+
+    public MonitoringSystemsRestServiceIT () {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
+
+    @Override
+    protected void afterServletStart() throws Exception {
+        MockLogAppender.setupLogging(true, "DEBUG");
+
+        testSystemId = UUID.randomUUID().toString().toLowerCase();
+
+        // force test database to have our main monitoring system (DistPoller is actually a Monitoring System)
+        m_databasePopulator.resetDatabase(true);
+        m_databasePopulator.populateMainDistPoller(testSystemId, DEFAULT_SYSTEM_LABEL, DEFAULT_SYSTEM_LOCATION);
+        m_databasePopulator.populateDatabase();
+    }
+
+    @Override
+    protected void beforeServletDestroy() throws Exception {
+        m_databasePopulator.resetDatabase(true);
+    }
+
+    @Test
+    public void testGetMainMonitoringSystem() throws Exception {
+        final String jsonResponse = sendRequest(GET, "/monitoringSystems/main", Collections.emptyMap(), 200);
+
+        assertNotNull(jsonResponse);
+
+        final JSONObject object = new JSONObject(jsonResponse);
+
+        assertEquals(testSystemId, object.getString("id"));
+        assertEquals("localhost", object.getString("label"));
+        assertEquals("Default", object.getString("location"));
+        assertEquals("OpenNMS", object.getString("type"));
+    }
+}


### PR DESCRIPTION
We want to get the Meridian system ID to use in Zenith Connect to uniquely identify the system that is registering with Zenith to send data. The system ID is the MonitoringSystem id field for the `OpenNMS` `type`, a uuid.

We are providing a Rest API to get the "main" OpenNMS system.

The front end will be implemented separately.

Had to do some additional work to optionally have the `DatabasePopulator` create the original `DistPoller` (which is the `OnmsMonitoringSystem`) with a specified ID for these integration tests only. By default, the id is a uuid with all 0's, which doesn't matter for all the other integration tests.

PR includes documentation and integration tests.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17751
