### PR TITLE
NMS-15676: Detect whether OpenNMS is running inside container

### DIFF
--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.util.ArrayList;
@@ -310,9 +311,14 @@ public class UsageStatisticsReporter implements StateChangeHandler {
     }
 
     private boolean isContainerized() {
+        // this will detect podman even in custom container builds
         final boolean inPodman = new File("/run/.containerenv").exists();
+        // this will detect docker even in custom container builds
         final boolean inDocker = new File("/.dockerenv").exists();
-        return inPodman || inDocker;
+        // this will detect in any case if our unmodified container is run, since this file was created in our Dockerfile
+        final boolean containerRunning = new File("/CONTAINER_RUNNING").exists();
+
+        return inPodman || inDocker || containerRunning;
     }
 
     private void setJmxAttributes(UsageStatisticsReportDTO usageStatisticsReport) {

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
@@ -316,7 +316,7 @@ public class UsageStatisticsReporter implements StateChangeHandler {
         // this will detect docker even in custom container builds
         final boolean inDocker = new File("/.dockerenv").exists();
         // this will detect in any case if our unmodified container is run, since this file was created in our Dockerfile
-        final boolean containerRunning = new File("/CONTAINER_RUNNING").exists();
+        final boolean containerRunning = "container".equals(System.getenv("OPENNMS_EXECUTION_ENVIRONMENT"));
 
         return inPodman || inDocker || containerRunning;
     }

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -85,6 +85,8 @@ ADDITIONAL_MANAGER_OPTIONS=""
 APP_PARMS_CONTROLLER=""
 APP_PARMS_AFTER=""
 
+export OPENNMS_EXECUTION_ENVIRONMENT="${OPENNMS_EXECUTION_ENVIRONMENT:-bareMetalOrVm}"
+
 #### ------------> DO NOT CHANGE VARIABLES IN THIS FILE <------------- ####
 #### Create $OPENNMS_HOME/etc/opennms.conf and put overrides in there. ####
 #### ------------> DO NOT CHANGE VARIABLES IN THIS FILE <------------- ####

--- a/opennms-container/core/Dockerfile
+++ b/opennms-container/core/Dockerfile
@@ -126,6 +126,8 @@ COPY --chown=10001:0 ./container-fs/health.sh /
 # Allow users in the root group to access them with the same authorization as the directory and file owner
 RUN chmod -R g=u /usr/share/opennms/etc
 RUN find /usr/share/opennms/data /usr/share/opennms/system /opennms-data -type d -print0 | xargs -0 chmod g=u
+# Allow OpenNMS to detect whether it is run in a container
+RUN touch /CONTAINER_RUNNING
 
 # Arguments for labels should not invalidate caches
 ARG VERSION

--- a/opennms-container/core/Dockerfile
+++ b/opennms-container/core/Dockerfile
@@ -164,6 +164,7 @@ CMD [ "-h" ]
 
 ### Runtime information and not relevant at build time
 ENV JAVA_OPTS="-Xmx1024m -XX:MaxMetaspaceSize=512m"
+ENV OPENNMS_EXECUTION_ENVIRONMENT=container
 
 # Volumes for storing data outside of the container
 VOLUME [ "/opt/opennms/etc", "/opt/opennms-etc-overlay", "/opennms-data" ]

--- a/opennms-container/core/Dockerfile
+++ b/opennms-container/core/Dockerfile
@@ -126,8 +126,6 @@ COPY --chown=10001:0 ./container-fs/health.sh /
 # Allow users in the root group to access them with the same authorization as the directory and file owner
 RUN chmod -R g=u /usr/share/opennms/etc
 RUN find /usr/share/opennms/data /usr/share/opennms/system /opennms-data -type d -print0 | xargs -0 chmod g=u
-# Allow OpenNMS to detect whether it is run in a container
-RUN touch /CONTAINER_RUNNING
 
 # Arguments for labels should not invalidate caches
 ARG VERSION
@@ -164,6 +162,7 @@ CMD [ "-h" ]
 
 ### Runtime information and not relevant at build time
 ENV JAVA_OPTS="-Xmx1024m -XX:MaxMetaspaceSize=512m"
+# Allow OpenNMS to detect whether it is run in a container
 ENV OPENNMS_EXECUTION_ENVIRONMENT=container
 
 # Volumes for storing data outside of the container


### PR DESCRIPTION
* JIRA: https://opennms.atlassian.net/browse/NMS-15676

I read a lot about different cloud container engine and there are not really good ways to detect whether we are running inside a container. So, I choosed a simple but bulletproof method that at least will work in every case for the containers that are built by us. The tests regarding docker and podman are still in place, so user-built containers are also detected for these two platforms.