### PR TITLE
NMS-17767: Use systemId in Zenith Connect UI

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -32,11 +32,13 @@ import { useAuthStore } from '@/stores/authStore'
 import { useInfoStore } from '@/stores/infoStore'
 import { usePluginStore } from '@/stores/pluginStore'
 import { useMenuStore } from '@/stores/menuStore'
+import { useMonitoringSystemStore } from '@/stores/monitoringSystemStore'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 
 const authStore = useAuthStore()
 const infoStore = useInfoStore()
 const menuStore = useMenuStore()
+const monitoringSystemStore = useMonitoringSystemStore()
 const nodeStructureStore = useNodeStructureStore()
 const pluginStore = usePluginStore()
 
@@ -45,6 +47,7 @@ onMounted(() => {
   infoStore.getInfo()
   menuStore.getMainMenu()
   menuStore.getNotificationSummary()
+  monitoringSystemStore.getMainMonitoringSystem()
   nodeStructureStore.getCategories()
   nodeStructureStore.getMonitoringLocations()
   pluginStore.getPlugins()

--- a/ui/src/components/ZenithConnect/ZenithConnectRegister.vue
+++ b/ui/src/components/ZenithConnect/ZenithConnectRegister.vue
@@ -83,18 +83,20 @@ import { FeatherButton } from '@featherds/button'
 import { FeatherInput } from '@featherds/input'
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
 import { useMenuStore } from '@/stores/menuStore'
+import { useMonitoringSystemStore } from '@/stores/monitoringSystemStore'
 import { BreadCrumb } from '@/types'
 
 const menuStore = useMenuStore()
-
-const systemId = ref('TBD')
-const displayName = ref('')
+const monitoringSystemStore = useMonitoringSystemStore()
 
 const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
 const baseHref = computed<string>(() => menuStore.mainMenu.baseHref)
 const zenithConnectBaseUrl = computed<string>(() => menuStore.mainMenu.zenithConnectBaseUrl)
 const zenithConnectRelativeUrl = computed<string>(() => menuStore.mainMenu.zenithConnectRelativeUrl)
 const zenithUrl = computed<string>(() => `${zenithConnectBaseUrl.value}${zenithConnectRelativeUrl.value}`)
+const systemId = computed(() => monitoringSystemStore.mainMonitoringSystem?.id ?? '')
+const systemLabel = computed(() => monitoringSystemStore.mainMonitoringSystem?.label ?? '')
+const displayName = ref(systemLabel.value)
 
 const breadcrumbs = computed<BreadCrumb[]>(() => {
   return [
@@ -105,8 +107,6 @@ const breadcrumbs = computed<BreadCrumb[]>(() => {
 })
 
 const onRegisterWithZenith = () => {
-  // TODO: Get this from DB
-  systemId.value = '12345'
   // Example callbackUrl: http://localhost:8980/opennms/ui/index.html#/zenith-connect/register
   const callbackUrl = `${baseHref.value}ui/index.html#/zenith-connect/register-result`
 
@@ -120,6 +120,10 @@ const onRegisterWithZenith = () => {
 onMounted(async () => {
   if (!homeUrl.value || !baseHref.value) {
     menuStore.getMainMenu()
+  }
+
+  if (!monitoringSystemStore.mainMonitoringSystem) {
+    monitoringSystemStore.getMainMonitoringSystem()
   }
 })
 </script>

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -49,6 +49,7 @@ import {
 } from './deviceService'
 
 import { getMainMenu, getNotificationSummary } from './menuService'
+import { getMainMonitoringSystem } from './monitoringSystemService'
 import { getFileNames, getFile, getSnippets, postFile, deleteFile, getFileExtensions } from './configService'
 import { getAliases, getCredentialsByAlias, addCredentials, updateCredentials } from './scvService'
 
@@ -97,6 +98,7 @@ export default {
   getSnippets,
   getMainMenu,
   getNotificationSummary,
+  getMainMonitoringSystem,
   getFileNames,
   getFileExtensions,
   getOpenApiV1,

--- a/ui/src/services/monitoringSystemService.ts
+++ b/ui/src/services/monitoringSystemService.ts
@@ -1,0 +1,39 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { v2 } from './axiosInstances'
+import { MonitoringSystemMainResponse } from '@/types'
+
+const endpoint = '/monitoringSystems'
+
+export const getMainMonitoringSystem = async (): Promise<MonitoringSystemMainResponse | false> => {
+  try {
+    const url = `${endpoint}/main`
+    const resp = await v2.get(url)
+
+    const data = resp.data as MonitoringSystemMainResponse
+
+    return data
+  } catch (err) {
+    return false
+  }
+}

--- a/ui/src/stores/monitoringSystemStore.ts
+++ b/ui/src/stores/monitoringSystemStore.ts
@@ -1,0 +1,47 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { defineStore } from 'pinia'
+import API from '@/services'
+import { MonitoringSystemMainResponse } from '@/types'
+
+export const useMonitoringSystemStore = defineStore('monitoringSystemStore', () => {
+  const mainMonitoringSystem = ref<MonitoringSystemMainResponse>()
+
+  const setMainMonitoringSystem = (system: MonitoringSystemMainResponse) => {
+    mainMonitoringSystem.value = system
+  }
+
+  const getMainMonitoringSystem = async () => {
+    const resp = await API.getMainMonitoringSystem()
+
+    if (resp) {
+      mainMonitoringSystem.value = resp
+    }
+  }
+
+  return {
+    getMainMonitoringSystem,
+    mainMonitoringSystem,
+    setMainMonitoringSystem
+  }
+})

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -103,6 +103,13 @@ export interface MonitoringLocationApiResponse extends ApiResponse {
   location: MonitoringLocation[]
 }
 
+export interface MonitoringSystemMainResponse {
+  id: string
+  label: string
+  location: string
+  type: string
+}
+
 export interface Node {
   location: string
   type: string


### PR DESCRIPTION
We added a Rest API to get the main monitoring system info. This calls that API to get the Meridian `systemId` and also the `label` to populate fields used to register the Meridian instance with Zenith.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17767

