### PR TITLE
NMS-17756: Modified entrypoint.sh and disabled ActiveMQ in Kafka Smoke Tests

### DIFF
--- a/opennms-container/minion/container-fs/entrypoint.sh
+++ b/opennms-container/minion/container-fs/entrypoint.sh
@@ -96,11 +96,6 @@ function parseEnvironment() {
     # Configure additional features
     IFS=$'\n'
 
-    IPC_CONFIGURED="false"
-    TWIN_CONFIGURED="false"
-    RPC_CONFIGURED="false"
-    SINK_CONFIGURED="false"
-
     for VAR in $(env)
     do
         env_var=$(echo "$VAR" | cut -d= -f1)
@@ -117,46 +112,12 @@ function parseEnvironment() {
             ipc_name=$(echo "$env_var" | cut -d_ -f3- | tr '[:upper:]' '[:lower:]' | tr _ .)
             updateConfig "$ipc_name" "${!env_var}" "${MINION_HOME}/etc/org.opennms.core.ipc.kafka.cfg"
             if [[ "$ipc_name" == "bootstrap.servers" ]]; then
-                IPC_CONFIGURED="true"
                 echo "opennms-core-ipc-kafka"   > ${MINION_HOME}/etc/featuresBoot.d/kafka.boot
-            fi
-        fi
-
-        if [[ $env_var =~ ^KAFKA_TWIN_ ]]; then
-            twin_name=$(echo "$env_var" | cut -d_ -f3- | tr '[:upper:]' '[:lower:]' | tr _ .)
-            updateConfig "$twin_name" "${!env_var}" "${MINION_HOME}/etc/org.opennms.core.ipc.twin.kafka.cfg"
-            if [[ "$twin_name" == "bootstrap.servers" ]]; then
-                TWIN_CONFIGURED="true"
-                echo "!opennms-core-ipc-twin-jms"   > ${MINION_HOME}/etc/featuresBoot.d/kafka-twin.boot
-                echo "opennms-core-ipc-twin-kafka" >> ${MINION_HOME}/etc/featuresBoot.d/kafka-twin.boot
-            fi
-        fi
-
-        if [[ $env_var =~ ^KAFKA_RPC_ ]]; then
-            rpc_name=$(echo "$env_var" | cut -d_ -f3- | tr '[:upper:]' '[:lower:]' | tr _ .)
-            updateConfig "$rpc_name" "${!env_var}" "${MINION_HOME}/etc/org.opennms.core.ipc.rpc.kafka.cfg"
-            if [[ "$rpc_name" == "bootstrap.servers" ]]; then
-                RPC_CONFIGURED="true"
-                echo "!opennms-core-ipc-rpc-jms"   > ${MINION_HOME}/etc/featuresBoot.d/kafka-rpc.boot
-                echo "opennms-core-ipc-rpc-kafka" >> ${MINION_HOME}/etc/featuresBoot.d/kafka-rpc.boot
-            fi
-        fi
-
-        if [[ $env_var =~ ^KAFKA_SINK_ ]]; then
-            sink_key=$(echo "$env_var" | cut -d_ -f3- | tr '[:upper:]' '[:lower:]' | tr _ .)
-            updateConfig "$sink_key" "${!env_var}" "${MINION_HOME}/etc/org.opennms.core.ipc.sink.kafka.cfg"
-            if [[ "$sink_key" == "bootstrap.servers" ]]; then
-                SINK_CONFIGURED="true"
-                echo "!opennms-core-ipc-sink-camel" > ${MINION_HOME}/etc/featuresBoot.d/kafka-sink.boot
-                echo "opennms-core-ipc-sink-kafka" >> ${MINION_HOME}/etc/featuresBoot.d/kafka-sink.boot
+                echo "!minion-jms" > ${MINION_HOME}/etc/featuresBoot.d/disable-activemq.boot
+                echo "!opennms-core-ipc-jms" >> ${MINION_HOME}/etc/featuresBoot.d/disable-activemq.boot
             fi
         fi
     done
-
-    if [[ "$IPC_CONFIGURED"=="true" || ("$RPC_CONFIGURED"=="true" && "$TWIN_CONFIGURED"=="true" && "$SINK_CONFIGURED"=="true") ]]; then
-        echo "!minion-jms" > ${MINION_HOME}/etc/featuresBoot.d/disable-activemq.boot
-        echo "!opennms-core-ipc-jms" >> ${MINION_HOME}/etc/featuresBoot.d/disable-activemq.boot
-    fi
 }
 
 initConfig() {

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -373,6 +373,10 @@ public class OpenNMSContainer extends GenericContainer<OpenNMSContainer> impleme
     public Properties getSystemProperties() {
         final Properties props = new Properties();
 
+        if (!IpcStrategy.JMS.equals(model.getIpcStrategy())) {
+            props.put("org.opennms.activemq.broker.disable", "true");
+        }
+
         if (IpcStrategy.KAFKA.equals(model.getIpcStrategy())) {
             props.put("org.opennms.core.ipc.strategy", "kafka");
             props.put("org.opennms.core.ipc.kafka.bootstrap.servers", KAFKA_ALIAS + ":9092");


### PR DESCRIPTION
* JIRA: https://opennms.atlassian.net/browse/NMS-17756

I have now adapted the entrypoint.sh script. It now allows the configuration of Kafka via the IPC parameter (KAFKA_IPC_BOOTSTRAP_SERVERS) as well as via the three individual features Sink, RPC and Twin (KAFKA_SINK_BOOTSTRAP_SERVERS, KAFKA_RPC_BOOTSTRAP_SERVERS and KAFKA_TWIN_BOOTSTRAP_SERVERS). In other words, as described in the installation instructions. ActiveMQ should now be deactivated in both cases.