### PR TITLE
NMS-17865: Fix antora-ui-opennms reference

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -8,7 +8,7 @@ content:
     start_path: docs
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v3.1.0/ui-bundle.zip
+    url: https://github.com/OpenNMS/antora-ui-opennms/releases/download/v3.1.1/ui-bundle.zip
 asciidoc:
   attributes:
     experimental: true


### PR DESCRIPTION
Fix reference to `antora-ui-opennms`.

This is part of a fix to remove references to `polyfill.js` which is a security vulnerability.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17865

