### PR TITLE
NMS-17865: Fix antora-playbook-local.yml in foundation-2021

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -8,7 +8,7 @@ content:
     start_path: docs
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v2.0.4/ui-bundle.zip
+    url: https://github.com/OpenNMS/antora-ui-opennms/releases/download/v3.1.1/ui-bundle.zip
 asciidoc:
   attributes:
     experimental: true


### PR DESCRIPTION
Updating `antora-ui-opennms` reference in `antora-playbook-local.yml` in `foundation-2021`. The library was updated to remove any reference to `polyfill.js` which is a security vulnerability.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17865
