### PR TITLE
NMS-17749: Zenith Connect UI, connect with Registration Rest API

### DIFF
--- a/features/zenith-connect/persistence/src/main/java/org/opennms/features/zenithconnect/persistence/api/ZenithConnectPersistenceException.java
+++ b/features/zenith-connect/persistence/src/main/java/org/opennms/features/zenithconnect/persistence/api/ZenithConnectPersistenceException.java
@@ -22,8 +22,16 @@
 package org.opennms.features.zenithconnect.persistence.api;
 
 public class ZenithConnectPersistenceException extends Exception {
+    private boolean attemptedToAddDuplicate;
+
     public ZenithConnectPersistenceException() {
         super();
+    }
+
+    public ZenithConnectPersistenceException(boolean attemptedToAddDuplicate) {
+        super();
+
+        this.attemptedToAddDuplicate = attemptedToAddDuplicate;
     }
 
     public ZenithConnectPersistenceException(String message) {
@@ -32,5 +40,9 @@ public class ZenithConnectPersistenceException extends Exception {
 
     public ZenithConnectPersistenceException(String message, Throwable e) {
         super(message, e);
+    }
+
+    public boolean isAttemptedToAddDuplicate() {
+        return attemptedToAddDuplicate;
     }
 }

--- a/features/zenith-connect/persistence/src/main/java/org/opennms/features/zenithconnect/persistence/api/ZenithConnectPersistenceService.java
+++ b/features/zenith-connect/persistence/src/main/java/org/opennms/features/zenithconnect/persistence/api/ZenithConnectPersistenceService.java
@@ -32,10 +32,22 @@ public interface ZenithConnectPersistenceService {
 
     /**
      * Add a new registration.
-     * Currently we only support a single registration.
+     * Currently we only support a single registration, so this will replace any registration that
+     * already exists.
      * Returns the added registration, including an id and createTimeMs.
+     * @param preventDuplicates If true, will check to see if the given registration appears to be
+     *     a duplicate of an existing registration (same systemId and same accessToken or refreshToken).
+     *     If so, will throw an exception. This is to prevent e.g. the UI from sending multiple
+     *     duplicate add requests.
      */
-    ZenithConnectRegistration addRegistration(ZenithConnectRegistration registration) throws ZenithConnectPersistenceException;
+    ZenithConnectRegistration addRegistration(ZenithConnectRegistration registration, boolean preventDuplicates)
+            throws ZenithConnectPersistenceException;
+
+    /**
+     * Add a new registration, ignoring preventDuplicates.
+     */
+    ZenithConnectRegistration addRegistration(ZenithConnectRegistration registration)
+            throws ZenithConnectPersistenceException;
 
     /**
      * Update an existing registration. The given id and registration.id must match an existing registration.

--- a/features/zenith-connect/persistence/src/main/java/org/opennms/features/zenithconnect/persistence/impl/ZenithConnectPersistenceServiceImpl.java
+++ b/features/zenith-connect/persistence/src/main/java/org/opennms/features/zenithconnect/persistence/impl/ZenithConnectPersistenceServiceImpl.java
@@ -152,23 +152,23 @@ public class ZenithConnectPersistenceServiceImpl implements ZenithConnectPersist
         ZenithConnectRegistrations existingRegistrations = getRegistrationsImpl();
         ZenithConnectRegistration existingRegistration = existingRegistrations.first();
 
-        if (existingRegistration != null) {
-            boolean systemIdsMatch = registration.systemId != null && existingRegistration.systemId != null &&
-                    registration.systemId.equals(existingRegistration.systemId);
+        if (existingRegistration == null) {
+            return false;
+        }
 
-            if (systemIdsMatch) {
-                boolean accessTokenMatches = registration.accessToken != null &&
-                        existingRegistration.accessToken != null &&
-                        registration.accessToken.equals(existingRegistration.accessToken);
+        boolean systemIdsMatch = registration.systemId != null && existingRegistration.systemId != null &&
+                registration.systemId.equals(existingRegistration.systemId);
 
-                boolean refreshTokenMatches = registration.refreshToken != null &&
-                        existingRegistration.refreshToken != null &&
-                        registration.refreshToken.equals(existingRegistration.refreshToken);
+        if (systemIdsMatch) {
+            boolean accessTokenMatches = registration.accessToken != null &&
+                    existingRegistration.accessToken != null &&
+                    registration.accessToken.equals(existingRegistration.accessToken);
 
-                if (accessTokenMatches || refreshTokenMatches) {
-                    return true;
-                }
-            }
+            boolean refreshTokenMatches = registration.refreshToken != null &&
+                    existingRegistration.refreshToken != null &&
+                    registration.refreshToken.equals(existingRegistration.refreshToken);
+
+            return accessTokenMatches || refreshTokenMatches;
         }
 
         return false;

--- a/features/zenith-connect/persistence/src/main/java/org/opennms/features/zenithconnect/persistence/impl/ZenithConnectPersistenceServiceImpl.java
+++ b/features/zenith-connect/persistence/src/main/java/org/opennms/features/zenithconnect/persistence/impl/ZenithConnectPersistenceServiceImpl.java
@@ -59,7 +59,12 @@ public class ZenithConnectPersistenceServiceImpl implements ZenithConnectPersist
     }
 
     /** {@inheritDoc} */
-    public ZenithConnectRegistration addRegistration(ZenithConnectRegistration registration) throws ZenithConnectPersistenceException {
+    public ZenithConnectRegistration addRegistration(ZenithConnectRegistration registration, boolean preventDuplicates)
+            throws ZenithConnectPersistenceException {
+        if (preventDuplicates && isDuplicateRegistration(registration)) {
+           throw new ZenithConnectPersistenceException(true);
+        }
+
         registration.id = UUID.randomUUID().toString();
         registration.createTimeMs = Instant.now().toEpochMilli();
 
@@ -67,6 +72,11 @@ public class ZenithConnectPersistenceServiceImpl implements ZenithConnectPersist
         setRegistrations(registrations);
 
         return registration;
+    }
+
+    public ZenithConnectRegistration addRegistration(ZenithConnectRegistration registration)
+            throws ZenithConnectPersistenceException {
+        return addRegistration(registration, false);
     }
 
     /** {@inheritDoc} */
@@ -135,5 +145,32 @@ public class ZenithConnectPersistenceServiceImpl implements ZenithConnectPersist
         } catch (JsonProcessingException e) {
             throw new ZenithConnectPersistenceException("Could not serialize Zenith Connect registrations", e);
         }
+    }
+
+    private boolean isDuplicateRegistration(ZenithConnectRegistration registration)
+            throws ZenithConnectPersistenceException {
+        ZenithConnectRegistrations existingRegistrations = getRegistrationsImpl();
+        ZenithConnectRegistration existingRegistration = existingRegistrations.first();
+
+        if (existingRegistration != null) {
+            boolean systemIdsMatch = registration.systemId != null && existingRegistration.systemId != null &&
+                    registration.systemId.equals(existingRegistration.systemId);
+
+            if (systemIdsMatch) {
+                boolean accessTokenMatches = registration.accessToken != null &&
+                        existingRegistration.accessToken != null &&
+                        registration.accessToken.equals(existingRegistration.accessToken);
+
+                boolean refreshTokenMatches = registration.refreshToken != null &&
+                        existingRegistration.refreshToken != null &&
+                        registration.refreshToken.equals(existingRegistration.refreshToken);
+
+                if (accessTokenMatches || refreshTokenMatches) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -70,6 +70,10 @@ import {
   getUsageStatisticsStatus,
   setUsageStatisticsStatus
 } from './usageStatisticsService'
+import {
+ addZenithRegistration,
+ getZenithRegistrations
+} from './zenithConnectService'
 
 export default {
   search,
@@ -125,5 +129,7 @@ export default {
   getUsageStatistics,
   getUsageStatisticsMetadata, 
   getUsageStatisticsStatus,
-  setUsageStatisticsStatus
+  setUsageStatisticsStatus,
+  addZenithRegistration,
+  getZenithRegistrations
 }

--- a/ui/src/services/zenithConnectService.ts
+++ b/ui/src/services/zenithConnectService.ts
@@ -1,0 +1,63 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { rest } from './axiosInstances'
+import { ZenithConnectRegistration, ZenithConnectRegistrations } from '@/types/zenithConnect'
+
+const baseEndpoint = '/zenith-connect'
+
+const addZenithRegistration = async (request: ZenithConnectRegistration): Promise<ZenithConnectRegistration | false> => {
+  const endpoint = `${baseEndpoint}/registrations`
+
+  try {
+    const resp = await rest.post(endpoint, request)
+
+    if (resp.status === 200 || resp.status === 201) {
+      return resp.data as ZenithConnectRegistration
+    }
+  } catch (err) {
+    return false
+  }
+
+  return false
+}
+
+const getZenithRegistrations = async (): Promise<ZenithConnectRegistrations | false> => {
+  const endpoint = `${baseEndpoint}/registrations`
+
+  try {
+    const resp = await rest.get(endpoint)
+
+    if (resp.status === 200) {
+      return resp.data as ZenithConnectRegistrations
+    }
+  } catch (err) {
+    return false
+  }
+
+  return false
+}
+
+export {
+  addZenithRegistration,
+  getZenithRegistrations
+}

--- a/ui/src/stores/zenithConnectStore.ts
+++ b/ui/src/stores/zenithConnectStore.ts
@@ -21,29 +21,78 @@
 ///
 
 import { defineStore } from 'pinia'
-import { ZenithConnectRegisterResponse, ZenithConnectRegistration } from '@/types/zenithConnect'
+import API from '@/services'
+import {
+  ZenithConnectRegistrationResponse,
+  ZenithConnectRegistration,
+  ZenithConnectRegistrations
+} from '@/types/zenithConnect'
 
 export const useZenithConnectStore = defineStore('zenithConnectStore', () => {
-  const registerResponse = ref<ZenithConnectRegisterResponse>()
-  const registrations = ref<ZenithConnectRegistration[]>([])
+  const registerResponse = ref<ZenithConnectRegistrationResponse>()
+  const registrations = ref<ZenithConnectRegistrations>()
+  const currentRegistration = ref<ZenithConnectRegistration>()
 
-  const setRegisterResponse = (response: ZenithConnectRegisterResponse) => {
+  const resetRegistration = () => {
+    const regs = registrations.value?.registrations ?? []
+
+    currentRegistration.value = regs && regs.length > 0 ? regs[0] : undefined
+  }
+
+  const addRegistration = async (registration: ZenithConnectRegistration) => {
+    const resp = await API.addZenithRegistration(registration)
+
+    if (resp) {
+      const newRegistration = resp as ZenithConnectRegistration
+
+      if (newRegistration) {
+        registrations.value = {
+          registrations: [newRegistration]
+        }
+      
+        return true
+      }
+    }
+
+    return false
+  }
+
+  const fetchRegistrations = async () => {
+    const resp = await API.getZenithRegistrations()
+
+    if (resp) {
+      const newRegistrations = resp as ZenithConnectRegistrations
+
+      if (newRegistrations) {
+        registrations.value = newRegistrations
+        resetRegistration()
+
+        return true
+      }
+    }
+
+    return false
+  }
+
+  const setRegistrationResponse = (response: ZenithConnectRegistrationResponse) => {
     registerResponse.value = response
   }
 
-  const addRegistration = (registration: ZenithConnectRegistration) => {
-    registrations.value.push(registration)
-  }
-
+  // TODO: remove
   const clearRegistrations = () => {
-    registrations.value = []
+    registrations.value = {
+      registrations: []
+    }
   }
 
   return {
+    currentRegistration,
     registerResponse,
     registrations,
     addRegistration,
     clearRegistrations,
-    setRegisterResponse
+    fetchRegistrations,
+    resetRegistration,
+    setRegistrationResponse
   }
 })

--- a/ui/src/types/zenithConnect.d.ts
+++ b/ui/src/types/zenithConnect.d.ts
@@ -1,4 +1,5 @@
-export interface ZenithConnectRegisterResponse {
+// response from Zenith
+export interface ZenithConnectRegistrationResponse {
   success: boolean
   nmsSystemId: string
   nmsDisplayName: string
@@ -6,9 +7,21 @@ export interface ZenithConnectRegisterResponse {
   refreshToken: string
 }
 
-export interface ZenithConnectRegistration extends ZenithConnectRegisterResponse{
-  id: string
-  registrationDate?: Date
-  lastConnected?: Date
-  connected: boolean
+// A Zenith Connect registration item in the OpenNMS database
+export interface ZenithConnectRegistration {
+  id?: string
+  createTimeMs?: number       // created time in UTC ms
+  systemId: string
+  displayName: string
+  zenithHost: string
+  zenithRelativeUrl: string
+  accessToken: string
+  refreshToken: string
+  registered?: boolean
+  active?: boolean
+}
+
+// List of Zenith Connect registrations in the OpenNMS database
+export interface ZenithConnectRegistrations {
+  registrations: ZenithConnectRegistration[]
 }


### PR DESCRIPTION
Update the Zenith Connect UI to use the Rest API for storing and retrieving registration info.

Update the persistence service to exclude duplicate registrations.

Clean up the UI a bit.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17749

