### PR TITLE
NMS-17883: Add DEB/RPM package dependencies and changelog

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -56,8 +56,8 @@ Description: Enterprise-grade Open-source Network Management Platform (Database)
 
 Package: opennms-server
 Architecture: all
-Depends: opennms-common (=${binary:Version}), libopennms-java (=${binary:Version}), libopennmsdeps-java (=${binary:Version}), mailx
-Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-15 | postgresql-client-14 | postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
+Depends: opennms-common (=${binary:Version}), libopennms-java (=${binary:Version}), libopennmsdeps-java (=${binary:Version}), mailx, jrrd2
+Suggests: postgresql-client-15 | postgresql-client-14 | postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
 Recommends: haveged
 Description: Enterprise-grade Open-source Network Management Platform (Daemon)
  OpenNMS is an enterprise-grade network management system written in Java.

--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -1,62 +1,23 @@
-[[releasenotes-33]]
+[[releasenotes-34]]
 
-= What's New in OpenNMS Horizon 33
-
-== System requirements
-
-* *Java 11 and 17*: OpenNMS Horizon 33 runs on JDKs 11 and 17.
-* *PostgreSQL 10 or higher*: Horizon 33 requires any supported version of PostgreSQL from 10 up to (and including) 16.
-
-== New features and important changes
-
-=== OpenNMS Plugin API
-
-The OpenNMS Plugin API has been updated to version 1.6.0, which includes some new APIs ported over from the Horizon codebase to simplify plugin development, as well as cleanups to dependencies.
-It also includes some fixes to the protocol list used by Enlinkd.
-
-=== Expanded metadata support
-
-It is now possible to use the metadata DSL in nearly all configuration files.
-For details on all of the subsystems that support the metadata DSL, see xref:operation:deep-dive/meta-data.adoc[the operation manual].
-
-=== Confd improvements
-
-Support for `confd` has been added to the Sentinel container.
-
-=== UI: structured node list
-
-An enhanced node list has been introduced with options for sorting and filtering.
+= What's New in OpenNMS Horizon 34
 
 == Breaking changes
+The default time series storage strategy is now by default RRDTool.
 
-=== Time series storage strategy
-The RrdTool strategy (MultithreadedJniRrdStrategy) is now the default strategy for time series data.
-The pure-Java JRobin strategy is deprecated and will be removed in the next major release.
+IMPORTANT: If you use JRobin, make sure you set the property.
+You can easily verify it by checking the file extension created in the directory  `${OPENNMS_HOME}/share/rrd/snmp`. The extension .jrb indicates JRobin and .rrd indicates RRDtool.
+If you miss this setting, all your timeseries files will be newely created as .rrd files and you won't have access to your JRobin files with your history.
 
-=== Passive Status Monitor
-The Passive Status Monitor previously used the time of the event's arrival as the timestamp of the status.
-As this is too imprecise for some use cases, the time field of the event is now also evaluated.
-If the field is set, it is adopted unchanged as the timestamp of the status.
-If no time is set, the timestamp is generated as before when the event arrives.
+IMPORTANT: When you have .jrb files, ensure after upgrading to Horizon 34 you explicitly configure JRobin in a file like `${OPENNMS_HOME}/etc/opennms.properties.d/timeseries.properties`.
 
-=== SNMP Metadata Provisioning Adapter
-The SNMP Metadata Provisioning Adapter is not enabled by default anymore.
-Set `enabled="true"` in the configuration file `$OPENNMS_HOME/etc/snmp-metadata-adapter-configuration.xml` to enable it.
+.Configure explicitly JRobin for Horizon 34.x if required
+[source, console]
+----
+org.opennms.rrd.strategyClass=org.opennms.netmgt.rrd.jrobin.JRobinRrdStrategy
+----
 
-=== Docker image changes
+== Deprecation of JRobin as timeseries storage
 
-The Docker images for the core, minion, and sentinel have been changed from being Ubuntu-based to using RedHat's link:https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Universal Base Image].
-This move shrinks the image a bit, makes minimal updating easier, and should simplify running in restrictive OpenShift environments.
-
-The images are based on the `ubi9-minimal` image, which is essentially a stripped down version of RHEL 9.
-This means that things will have moved around a bit in the filesystem, and that you should use `microdnf` for package management.
-
-=== Important internal updates
-
-* Our embedded Karaf container and Karaf APIs have been updated to 4.3.10
-* The OpenNMS Plugin API has been updated to 1.6.0
-* Zookeeper APIs have been updated to 3.7.x
-* If you are performing automated tests, you may need to disable the new popup that shows on first launch.  To do so set `opennms.userDataCollection.show=false` in a properties file in `$OPENNMS_HOME/etc/opennms.properties.d/`.
-
-=== Stricter validation of requisition names
-Some characters (/, \, ?, &, *, ', “) may not be used in requisition names. The UI components have already enforced the validation of requisition names. This restriction is now also enforced when creating search requests via the OpenNMS ReST API.
+The release of Horizon 34 will be the last version which supports reading and writing timeseries data using JRobin.
+The JRobin library and the JRobin timeseries strategy will be removed from Horizon 35+ moving forward.

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -98,6 +98,8 @@ Requires(pre):	jicmp >= 3.0.0
 Requires:	jicmp >= 3.0.0
 Requires(pre):	jicmp6 >= 3.0.0
 Requires:	jicmp6 >= 3.0.0
+Requires(pre):	jrrd2 >= 2.0.0
+Requires:	jrrd2 >= 2.0.0
 Requires(pre):	/usr/sbin/useradd
 Requires:	/usr/sbin/useradd
 Obsoletes:	opennms < 1.3.11


### PR DESCRIPTION
I have found that we need to adjust the RPM/DEB package dependencies. The package jrrd2 is now not a suggestion and required. The dependency for RRDTool is not required and satisfied by jrrd2 itself, see:
* https://github.com/OpenNMS/jrrd2/blob/f8a29dba62a566d6c2a043c546fe35a7ff0695a8/debian/control#L13
* https://github.com/OpenNMS/jrrd2/blob/f8a29dba62a566d6c2a043c546fe35a7ff0695a8/build-packages.sh#L38

I have also added changelog with some hints on this topic.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17883

