### PR TITLE
NMS-17899: Remove Java 11 dependencies

### DIFF
--- a/bin/functions.pl
+++ b/bin/functions.pl
@@ -349,7 +349,7 @@ sub find_git {
 }
 
 sub get_minimum_java {
-	my $minimum_java = '11';
+	my $minimum_java = '17';
 
 	my $pomfile = File::Spec->catfile($PREFIX, 'pom.xml');
 	if (-e $pomfile) {

--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -216,7 +216,7 @@
                       <goal>verify</goal>
                   </goals>
                   <configuration>
-                      <javase>11</javase>
+                      <javase>17</javase>
                       <descriptors>
                           <descriptor>file:${project.build.directory}/classes/features.xml</descriptor>
                           <descriptor>file:${project.build.directory}/classes/features-core.xml</descriptor>

--- a/container/noop-jetty-extension/pom.xml
+++ b/container/noop-jetty-extension/pom.xml
@@ -20,7 +20,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-17</Bundle-RequiredExecutionEnvironment>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Import-Package>

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: opennms
 Section: contrib/net
 Priority: optional
 Maintainer: Benjamin Reed <ranger@opennms.org>
-Build-Depends: oracle-java11-installer | jdk-11 | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | openjdk-11-jdk-headless | openjdk-11-jdk | java11-jdk | temurin-11-jdk | oracle-java17-installer | jdk-17 | adoptopenjdk-17-openj9xl | adoptopenjdk-17-openj9 | adoptopenjdk-17-hotspot | openjdk-17-jdk-headless | openjdk-17-jdk | java17-jdk | temurin-17-jdk, debhelper (>= 5.0.42), dpkg-dev, po-debconf (>= 1.0.5), rsync
+Build-Depends: oracle-java17-installer | jdk-17 | adoptopenjdk-17-openj9xl | adoptopenjdk-17-openj9 | adoptopenjdk-17-hotspot | openjdk-17-jdk-headless | openjdk-17-jdk | java17-jdk | temurin-17-jdk, debhelper (>= 5.0.42), dpkg-dev, po-debconf (>= 1.0.5), rsync
 Standards-Version: 3.7.3
 
 Package: opennms
 Architecture: all
 Depends: opennms-common (=${binary:Version}), opennms-db (=${binary:Version}), opennms-server (=${binary:Version}), opennms-webapp-jetty (=${binary:Version})
-Recommends: opennms-source (=${binary:Version}), openjdk-11-jdk-headless | openjdk-11-jdk | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | java11-jdk | temurin-11-jdk | jdk-17 | openjdk-17-jdk-headless | openjdk-17-jdk | adoptopenjdk-17-openj9xl | adoptopenjdk-17-openj9 | adoptopenjdk-17-hotspot | java17-jdk
+Recommends: opennms-source (=${binary:Version}), jdk-17 | openjdk-17-jdk-headless | openjdk-17-jdk | adoptopenjdk-17-openj9xl | adoptopenjdk-17-openj9 | adoptopenjdk-17-hotspot | java17-jdk
 Suggests: opennms-doc
 Description: Enterprise-grade Open-source Network Management Platform (Full Install)
  OpenNMS is an enterprise-grade network management system written in Java.
@@ -74,7 +74,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Daemon)
 
 Package: opennms-jmx-config-generator
 Architecture: all
-Depends: opennms-common (=${binary:Version}), jdk-11 | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | temurin-11-jdk | adoptopenjdk-17-openj9xl-jre | adoptopenjdk-17-openj9-jre | adoptopenjdk-17-hotspot-jre | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk | jdk-17
+Depends: opennms-common (=${binary:Version}), adoptopenjdk-17-openj9xl-jre | adoptopenjdk-17-openj9-jre | adoptopenjdk-17-hotspot-jre | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk | jdk-17
 Description: Enterprise-grade Open-source Network Management Platform (JMX Config Generator)
  OpenNMS is an enterprise-grade network management system written in Java.
  .

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -20,7 +20,7 @@ asciidoc:
     compatible-oia: '0.6.x'
     compatible-cassandra: '3.11.x'
     compatible-elasticsearch: '6.7.0 - 7.17.9'
-    compatible-javajdk: 'OpenJDK 11 or 17'
+    compatible-javajdk: 'OpenJDK 17'
     compatible-kafka: '1.x - 3.x'
     compatible-postgresql: '10.x - 15.x'
     compatible-rrdtool: '1.7.x'

--- a/features/config/osgi/cm/pom.xml
+++ b/features/config/osgi/cm/pom.xml
@@ -83,8 +83,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <release>17</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/features/container/sentinel/pom.xml
+++ b/features/container/sentinel/pom.xml
@@ -276,7 +276,7 @@
                 <configuration>
                     <finalName>${project.artifactId}</finalName>
                     <archiveZip>false</archiveZip>
-                    <javase>11</javase>
+                    <javase>17</javase>
                     <featuresProcessing>${project.build.directory}/internal/features-processing.xml</featuresProcessing>
                     <propertyFileEdits>${project.build.directory}/internal/assembly-property-edits.xml</propertyFileEdits>
                     <generateConsistencyReport>${project.build.directory}/consistency-report</generateConsistencyReport>

--- a/features/ui-extension/pom.xml
+++ b/features/ui-extension/pom.xml
@@ -14,8 +14,7 @@
     <name>OpenNMS :: Features :: UI Extension</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <build>

--- a/opennms-assemblies/minion/src/main/filtered/debian/control
+++ b/opennms-assemblies/minion/src/main/filtered/debian/control
@@ -3,12 +3,12 @@ Maintainer: Benjamin Reed <ranger@opennms.org>
 Section: contrib/net
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), dpkg-dev, oracle-java11-installer | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | openjdk-11-jdk-headless | openjdk-11-jdk | java11-jdk | temurin-11-jdk | oracle-java17-installer | jdk-17 | adoptopenjdk-17-openj9xl | adoptopenjdk-17-openj9 | adoptopenjdk-17-hotspot | openjdk-17-jdk-headless | openjdk-17-jdk | java17-jdk | temurin-17-jdk, rsync
+Build-Depends: debhelper (>= 9), dpkg-dev, oracle-java17-installer | jdk-17 | adoptopenjdk-17-openj9xl | adoptopenjdk-17-openj9 | adoptopenjdk-17-hotspot | openjdk-17-jdk-headless | openjdk-17-jdk | java17-jdk | temurin-17-jdk, rsync
 
 Package: opennms-minion
 Architecture: all
 Depends: adduser, openssh-client, uuid-runtime, sudo
-Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | temurin-11-jdk | openjdk-17-jre-headless | openjdk-17-jre | adoptopenjdk-17-openj9xl-jre | adoptopenjdk-17-openj9-jre | adoptopenjdk-17-hotspot-jre | temurin-17-jdk | jdk-17, haveged, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
+Recommends: openjdk-17-jre-headless | openjdk-17-jre | adoptopenjdk-17-openj9xl-jre | adoptopenjdk-17-openj9-jre | adoptopenjdk-17-hotspot-jre | temurin-17-jdk | jdk-17, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
 Conflicts: opennms-minion-container (<< 25.0.0), opennms-minion-features-core (<<25.0.0), opennms-minion-features-default (<<25.0.0)
 Provides: opennms-plugin-api (= OPA_VERSION)
 Description: distributed OpenNMS monitoring client

--- a/opennms-assemblies/sentinel/src/main/filtered/debian/control
+++ b/opennms-assemblies/sentinel/src/main/filtered/debian/control
@@ -3,12 +3,12 @@ Maintainer: Benjamin Reed <ranger@opennms.org>
 Section: contrib/net
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), dpkg-dev, oracle-java11-installer | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | openjdk-11-jdk-headless | openjdk-11-jdk | java11-jdk | temurin-11-jdk | oracle-java17-installer | jdk-17 | adoptopenjdk-17-openj9xl | adoptopenjdk-17-openj9 | adoptopenjdk-17-hotspot | openjdk-17-jdk-headless | openjdk-17-jdk | java17-jdk | temurin-17-jdk, rsync
+Build-Depends: debhelper (>= 9), dpkg-dev, oracle-java17-installer | jdk-17 | adoptopenjdk-17-openj9xl | adoptopenjdk-17-openj9 | adoptopenjdk-17-hotspot | openjdk-17-jdk-headless | openjdk-17-jdk | java17-jdk | temurin-17-jdk, rsync
 
 Package: opennms-sentinel
 Architecture: all
 Depends: adduser, openssh-client, uuid-runtime, sudo
-Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | temurin-11-jdk | openjdk-17-jre-headless | openjdk-17-jre | adoptopenjdk-17-openj9xl-jre | adoptopenjdk-17-openj9-jre | adoptopenjdk-17-hotspot-jre | temurin-17-jdk | jdk-17, haveged, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
+Recommends: openjdk-17-jre-headless | openjdk-17-jre | adoptopenjdk-17-openj9xl-jre | adoptopenjdk-17-openj9-jre | adoptopenjdk-17-hotspot-jre | temurin-17-jdk | jdk-17, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
 Provides: opennms-plugin-api (= OPA_VERSION)
 Description: horizontal scaling for OpenNMS
  OpenNMS Sentinel is a container for running a subset of OpenNMS

--- a/opennms-base-assembly/src/main/filtered/bin/runjava
+++ b/opennms-base-assembly/src/main/filtered/bin/runjava
@@ -175,7 +175,7 @@ printVersion() {
 printInstallJava() {
     warn ""
     warn "You can install a JVM by downloading one from Oracle, or by running something like"
-    warn "'apt-get install openjdk-11-jdk' or 'yum install java-11-openjdk-devel'."
+    warn "'apt-get install openjdk-17-jdk' or 'yum install java-17-openjdk-devel'."
 }
 
 #

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -212,8 +212,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <release>17</release>
           <encoding>UTF-8</encoding>
           <optimize>true</optimize>
         </configuration>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=opennms
 sonar.projectKey=OpenNMS_opennms
-sonar.java.source=11
+sonar.java.source=17
 sonar.sourceEncoding=UTF-8
 
 # skip c/++/objc, they don't process properly ATM

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -71,7 +71,6 @@ Requires(pre):  jicmp >= 3.0.0
 Requires:       jicmp6 >= 3.0.0
 Requires(pre):  jicmp6 >= 3.0.0
 Provides:	opennms-plugin-api = %{opa_version}
-Recommends:	haveged
 
 Conflicts:      %{name}-container        < %{version}-%{release}
 Conflicts:      %{name}-features-core    < %{version}-%{release}

--- a/tools/packages/opennms/jdk.spec
+++ b/tools/packages/opennms/jdk.spec
@@ -7,7 +7,7 @@
 %{!?package_epoch:%define package_epoch 1}
 %{!?my_epoch:%define my_epoch %{package_epoch}}
 %{!?my_release:%define my_release %{package_release}}
-%{!?dep_package:%define dep_package java-11-openjdk-devel}
+%{!?dep_package:%define dep_package java-17-openjdk-devel}
 
 Name:			jdk
 Summary:		OpenJDK compatible placeholder

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -114,7 +114,6 @@ Provides:	%{name}-plugin-ticketing-otrs = %{version}-%{release}
 Obsoletes:	%{name}-plugin-ticketing-otrs < %{version}
 Provides:	%{name}-plugin-ticketing-remedy = %{version}-%{release}
 Obsoletes:	%{name}-plugin-ticketing-remedy < %{version}
-Recommends:	haveged
 
 %description core
 The core backend.  This package contains the main daemon responsible

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -67,7 +67,6 @@ Requires:       /sbin/nologin
 Requires:       /usr/bin/id
 Requires:       /usr/bin/sudo
 Provides:	opennms-plugin-api = %{opa_version}
-Recommends:	haveged
 
 Prefix:        %{sentinelinstprefix}
 


### PR DESCRIPTION
Removed RPM/DEB package dependencies for OpenJDK 11. Changed source and compiler target from 11 to 17.

### Additional Reviewer Hint

Haveged is removed as a dependency which is obsolete on modern Kernel 5.6 forward.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17899

