### PR TITLE
NMS-17009: WS-Man kerberos authentication fails with Java 17 since OpenNMS 33.0.10

### DIFF
--- a/docs/modules/reference/pages/performance-data-collection/collectors/wsman.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/wsman.adoc
@@ -347,3 +347,11 @@ Use this to threshold on the number results returned by an enumeration.
     <attrib name="##ElementCount##" alias="elementCount" type="Gauge"/>
 </group>
 ----
+=== Kerberos + WS-Man over HTTPS
+When using Kerberos authentication over HTTPS `(port 5986)` WS-Man, Java 17’s HTTP/2 negotiation may trigger a `RST_STREAM: Use HTTP/1.1 for request` error.
+Put below configuration in `${OPENNMS_HOME}/etc/opennms.conf` as referenced  https://opennms.discourse.group/t/wsman-with-kerberos-gssapi/2270).aspx[here]
+
+----
+ADDITIONAL_MANAGER_OPTIONS="${ADDITIONAL_MANAGER_OPTIONS} -Dorg.apache.cxf.transport.http.forceVersion=1.1"
+----
+

--- a/docs/modules/reference/pages/performance-data-collection/collectors/wsman.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/wsman.adoc
@@ -347,9 +347,9 @@ Use this to threshold on the number results returned by an enumeration.
     <attrib name="##ElementCount##" alias="elementCount" type="Gauge"/>
 </group>
 ----
-=== Kerberos + WS-Man over HTTPS
-When using Kerberos authentication over HTTPS `(port 5986)` WS-Man, Java 17’s HTTP/2 negotiation may trigger a `RST_STREAM: Use HTTP/1.1 for request` error.
-Put below configuration in `${OPENNMS_HOME}/etc/opennms.conf` as referenced  https://opennms.discourse.group/t/wsman-with-kerberos-gssapi/2270).aspx[here]
+=== Kerberos with WS-Man over HTTPS
+When utilizing Kerberos authentication over HTTPS (port 5986) for WS-Man, Java 17's HTTP/2 negotiation may result in a `RST_STREAM: Use HTTP/1.1 for request error`.
+To resolve this issue, add the following configuration to `${OPENNMS_HOME}/etc/opennms.conf`. Refer to the related discussion  https://opennms.discourse.group/t/wsman-with-kerberos-gssapi/2270[here]
 
 ----
 ADDITIONAL_MANAGER_OPTIONS="${ADDITIONAL_MANAGER_OPTIONS} -Dorg.apache.cxf.transport.http.forceVersion=1.1"


### PR DESCRIPTION
Updated from 33.0.9 to 33.0.10 - after update WSMan datacollection doesn't succeeds anymore.
Update: seem to be a problem with Horizon 33.0.10 and Java 17 


* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17009

