### PR TITLE
NMS-17733: Add Elastic Rest Client for composable Template support

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -2079,4 +2079,11 @@
         <bundle>mvn:org.opennms.features.zenith-connect/org.opennms.features.zenith-connect.persistence/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.zenith-connect/org.opennms.features.zenith-connect.rest/${project.version}</bundle>
     </feature>
+
+    <feature name="opennms-elastic-client" description="OpenNMS :: Elastic Client" version="${project.version}">
+        <bundle>mvn:com.google.code.gson/gson/${gsonVersion}</bundle>
+        <bundle>wrap:mvn:org.elasticsearch.client/elasticsearch-rest-client/${elasticsearchClientVersion}</bundle>
+        <bundle>mvn:org.opennms.features.elastic/org.opennms.features.elastic.client/${project.version}</bundle>
+    </feature>
+
 </features>

--- a/features/elastic/client/pom.xml
+++ b/features/elastic/client/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.opennms.features</groupId>
+        <artifactId>org.opennms.features.elastic</artifactId>
+        <version>34.0.0-SNAPSHOT</version>
+    </parent>
+    <groupId>org.opennms.features.elastic</groupId>
+    <artifactId>org.opennms.features.elastic.client</artifactId>
+    <name>OpenNMS :: ElasticSearch :: Client</name>
+    <packaging>bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Karaf-Commands>*</Karaf-Commands>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>${elasticsearchClientVersion}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.shell</groupId>
+            <artifactId>org.apache.karaf.shell.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gsonVersion}</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.17.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>1.17.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/features/elastic/client/src/main/java/org/opennms/features/elastic/client/DefaultElasticRestClient.java
+++ b/features/elastic/client/src/main/java/org/opennms/features/elastic/client/DefaultElasticRestClient.java
@@ -66,7 +66,7 @@ public class DefaultElasticRestClient implements ElasticRestClient {
     }
 
 
-    public DefaultElasticRestClient(String... hosts) {
+    public DefaultElasticRestClient(String[] hosts) {
         this(hosts, null, null);
     }
 

--- a/features/elastic/client/src/main/java/org/opennms/features/elastic/client/DefaultElasticRestClient.java
+++ b/features/elastic/client/src/main/java/org/opennms/features/elastic/client/DefaultElasticRestClient.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.elastic.client;
+
+import java.io.IOException;
+import java.io.File;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+
+public class DefaultElasticRestClient implements ElasticRestClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultElasticRestClient.class);
+
+    private final String[] hosts;
+    private final String username;
+    private final String password;
+    private RestClient restClient;
+    private final AtomicBoolean connected = new AtomicBoolean(false);
+
+    public RestClient getRestClient() {
+        return restClient;
+    }
+
+
+    public DefaultElasticRestClient(String... hosts) {
+        this(hosts, null, null);
+    }
+
+    public DefaultElasticRestClient(String hostsString, String username, String password) {
+        if (hostsString == null || hostsString.trim().isEmpty()) {
+            throw new IllegalArgumentException("Hosts string must be specified");
+        }
+
+        this.hosts = Arrays.stream(hostsString.split(",")).map(String::trim).filter(h -> !h.isEmpty()).toArray(String[]::new);
+
+        this.username = (username != null && !username.isEmpty()) ? username : null;
+        this.password = (password != null && !password.isEmpty()) ? password : null;
+    }
+
+
+    public DefaultElasticRestClient(String[] hosts, String username, String password) {
+        if (hosts == null || hosts.length == 0) {
+            throw new IllegalArgumentException("At least one host must be specified");
+        }
+        this.hosts = Arrays.copyOf(hosts, hosts.length);
+        this.username = username;
+        this.password = password;
+    }
+
+    public void init() {
+        HttpHost[] httpHosts = Arrays.stream(hosts)
+                .map(host -> {
+                    String[] parts = host.split(":");
+                    String hostname = parts[0];
+                    int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 9200;
+                    return new HttpHost(hostname, port, "http");
+                })
+                .toArray(HttpHost[]::new);
+
+        // Create the low-level client
+        if (username != null && password != null) {
+            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(
+                    AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+
+            restClient = RestClient.builder(httpHosts)
+                    .setHttpClientConfigCallback(httpClientBuilder ->
+                            httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider))
+                    .build();
+        } else {
+            restClient = RestClient.builder(httpHosts).build();
+        }
+    }
+
+    @Override
+    public void connect() throws IOException {
+        if (connected.get()) {
+            LOG.info("Already connected to Elasticsearch cluster");
+            return;
+        }
+
+        LOG.info("Connecting to Elasticsearch cluster at {}", Arrays.toString(hosts));
+        Request healthRequest = new Request("GET", "/_cluster/health");
+        Response healthResponse = restClient.performRequest(healthRequest);
+        int statusCode = healthResponse.getStatusLine().getStatusCode();
+
+        if (statusCode >= 200 && statusCode < 300) {
+            String responseBody = EntityUtils.toString(healthResponse.getEntity());
+            JsonObject healthJson = JsonParser.parseReader(new StringReader(responseBody)).getAsJsonObject();
+            String clusterName = healthJson.get("cluster_name").getAsString();
+            String status = healthJson.get("status").getAsString();
+
+            LOG.info("Connected to Elasticsearch cluster '{}' with status: {}", clusterName, status);
+            connected.set(true);
+        } else {
+            throw new IOException("Failed to connect to Elasticsearch: HTTP " + statusCode);
+        }
+    }
+
+
+    @Override
+    public Map<String, String> listTemplates() throws IOException {
+        if (!connected.get()) {
+            throw new IllegalStateException("Not connected to Elasticsearch cluster");
+        }
+
+        Map<String, String> templates = new HashMap<>();
+
+        try {
+            Request request = new Request("GET", "/_index_template");
+            Response response = restClient.performRequest(request);
+
+            if (response.getStatusLine().getStatusCode() == 200) {
+                String responseBody = EntityUtils.toString(response.getEntity());
+                JsonObject templatesJson = JsonParser.parseReader(new StringReader(responseBody)).getAsJsonObject();
+
+                if (templatesJson.has("index_templates")) {
+                    JsonArray templateArray = templatesJson.getAsJsonArray("index_templates");
+                    for (JsonElement element : templateArray) {
+                        JsonObject template = element.getAsJsonObject();
+                        String name = template.get("name").getAsString();
+                        templates.put(name, template.toString());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to list templates: {}", e.getMessage(), e);
+        }
+
+        return templates;
+    }
+
+
+    @Override
+    public boolean isConnected() {
+        return connected.get();
+    }
+
+
+    @Override
+    public void close() throws IOException {
+        if (restClient != null) {
+            LOG.info("Closing Elasticsearch client");
+            restClient.close();
+            connected.set(false);
+        }
+    }
+
+    @Override
+    public boolean applyILMPolicy(String policyName, String policyBody) throws IOException {
+        if (!connected.get()) {
+            throw new IllegalStateException("Not connected to Elasticsearch cluster");
+        }
+
+        LOG.info("Applying ILM policy '{}' to Elasticsearch cluster", policyName);
+
+        try {
+            Request request = new Request("PUT", "/_ilm/policy/" + policyName);
+            request.setEntity(new StringEntity(policyBody, ContentType.APPLICATION_JSON));
+
+            Response response = restClient.performRequest(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            boolean acknowledged = statusCode >= 200 && statusCode < 300;
+
+            if (acknowledged) {
+                LOG.info("ILM policy '{}' successfully applied", policyName);
+            } else {
+                LOG.warn("ILM policy '{}' application not acknowledged, status code: {}", policyName, statusCode);
+            }
+
+            return acknowledged;
+        } catch (Exception e) {
+            LOG.error("Failed to apply ILM policy '{}': {}", policyName, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean applyComponentTemplate(String componentName, String componentBody) throws IOException {
+        if (!connected.get()) {
+            throw new IllegalStateException("Not connected to Elasticsearch cluster");
+        }
+
+        LOG.info("Applying component template '{}' to Elasticsearch cluster", componentName);
+        LOG.debug("Component template body: {}", componentBody);
+
+        try {
+            Request request = new Request("PUT", "/_component_template/" + componentName);
+            request.setEntity(new StringEntity(componentBody, ContentType.APPLICATION_JSON));
+
+            Response response = restClient.performRequest(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            String responseBody = EntityUtils.toString(response.getEntity());
+            LOG.info("Component template response (status: {}): {}", statusCode, responseBody);
+
+            boolean acknowledged = statusCode >= 200 && statusCode < 300;
+
+            if (acknowledged) {
+                LOG.info("Component template {}' successfully applied", componentName);
+            } else {
+                LOG.warn("Component template '{}' application not acknowledged, status code: {}", componentName, statusCode);
+            }
+            return acknowledged;
+        } catch (Exception e) {
+            LOG.error("Failed to apply component template '{}': {}", componentName, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean applyComposableIndexTemplate(String templateName, String templateBody) throws IOException {
+        if (!connected.get()) {
+            throw new IllegalStateException("Not connected to Elasticsearch cluster");
+        }
+
+        LOG.info("Applying composable index template '{}' to Elasticsearch cluster", templateName);
+
+        try {
+            Request request = new Request("PUT", "/_index_template/" + templateName);
+            request.setEntity(new StringEntity(templateBody, ContentType.APPLICATION_JSON));
+
+            Response response = restClient.performRequest(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            boolean acknowledged = statusCode >= 200 && statusCode < 300;
+
+            if (acknowledged) {
+                LOG.info("Composable index template '{}' successfully applied", templateName);
+            } else {
+                LOG.warn("Composable index template '{}' application not acknowledged, status code: {}", templateName, statusCode);
+            }
+
+            return acknowledged;
+        } catch (Exception e) {
+            LOG.error("Failed to apply composable index template '{}': {}", templateName, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Override
+    public int applyAllTemplatesFromDirectory(String templateDirectory) throws IOException {
+        if (!connected.get()) {
+            throw new IllegalStateException("Not connected to Elasticsearch cluster");
+        }
+
+        LOG.info("Applying all templates from directory: {}", templateDirectory);
+        int appliedCount = 0;
+
+        // ILM policies first
+        File policiesDir = new File(templateDirectory, "policies");
+        if (policiesDir.exists() && policiesDir.isDirectory()) {
+            LOG.info("Processing ILM policies from: {}", policiesDir.getAbsolutePath());
+            File[] policyFiles = policiesDir.listFiles((dir, name) -> name.endsWith(".json"));
+            if (policyFiles != null && policyFiles.length > 0) {
+                LOG.info("Found {} ILM policy files", policyFiles.length);
+                for (File policyFile : policyFiles) {
+                    try {
+                        String policyName = policyFile.getName().replaceAll("\\.json$", "");
+                        String policyContent = Files.readString(policyFile.toPath(), StandardCharsets.UTF_8);
+                        LOG.info("Applying ILM policy: {}", policyName);
+                        if (applyILMPolicy(policyName, policyContent)) {
+                            LOG.info("Successfully applied ILM policy: {}", policyName);
+                            appliedCount++;
+                        } else {
+                            LOG.warn("Failed to apply ILM policy: {}", policyName);
+                        }
+                    } catch (Exception e) {
+                        LOG.error("Error applying ILM policy from file {}: {}", policyFile.getName(), e.getMessage(), e);
+                    }
+                }
+            } else {
+                LOG.info("No ILM policy files found in {}", policiesDir.getAbsolutePath());
+            }
+        } else {
+            LOG.info("Policies directory does not exist: {}", policiesDir.getAbsolutePath());
+        }
+
+        // Component templates
+        File componentsDir = new File(templateDirectory, "components");
+        if (componentsDir.exists() && componentsDir.isDirectory()) {
+            LOG.info("Processing component templates from: {}", componentsDir.getAbsolutePath());
+            File[] componentFiles = componentsDir.listFiles((dir, name) -> name.endsWith(".json"));
+            if (componentFiles != null && componentFiles.length > 0) {
+                LOG.info("Found {} component template files", componentFiles.length);
+                for (File componentFile : componentFiles) {
+                    try {
+                        String componentName = componentFile.getName().replaceAll("\\.json$", "");
+                        String componentContent = Files.readString(componentFile.toPath(), StandardCharsets.UTF_8);
+                        LOG.info("Applying component template: {}", componentName);
+                        if (applyComponentTemplate(componentName, componentContent)) {
+                            LOG.info("Successfully applied component template: {}", componentName);
+                            appliedCount++;
+                        } else {
+                            LOG.warn("Failed to apply component template: {}", componentName);
+                        }
+                    } catch (Exception e) {
+                        LOG.error("Error applying component template from file {}: {}", componentFile.getName(), e.getMessage(), e);
+                    }
+                }
+            } else {
+                LOG.info("No component template files found in {}", componentsDir.getAbsolutePath());
+            }
+        } else {
+            LOG.info("Components directory does not exist: {}", componentsDir.getAbsolutePath());
+        }
+
+        // Index templates
+        File indexTemplatesDir = new File(templateDirectory, "index-templates");
+        if (indexTemplatesDir.exists() && indexTemplatesDir.isDirectory()) {
+            LOG.info("Processing index templates from: {}", indexTemplatesDir.getAbsolutePath());
+            File[] templateFiles = indexTemplatesDir.listFiles((dir, name) -> name.endsWith(".json"));
+            if (templateFiles != null && templateFiles.length > 0) {
+                LOG.info("Found {} index template files", templateFiles.length);
+                for (File templateFile : templateFiles) {
+                    try {
+                        String templateName = templateFile.getName().replaceAll("\\.json$", "");
+                        String templateContent = Files.readString(templateFile.toPath(), StandardCharsets.UTF_8);
+                        ;
+                        LOG.info("Applying index template: {}", templateName);
+                        if (applyComposableIndexTemplate(templateName, templateContent)) {
+                            LOG.info("Successfully applied index template: {}", templateName);
+                            appliedCount++;
+                        } else {
+                            LOG.warn("Failed to apply index template: {}", templateName);
+                        }
+                    } catch (Exception e) {
+                        LOG.error("Error applying index template from file {}: {}", templateFile.getName(), e.getMessage(), e);
+                    }
+                }
+            } else {
+                LOG.info("No index template files found in {}", indexTemplatesDir.getAbsolutePath());
+            }
+        } else {
+            LOG.info("Index templates directory does not exist: {}", indexTemplatesDir.getAbsolutePath());
+        }
+
+        LOG.info("Successfully applied {} templates/policies from {}", appliedCount, templateDirectory);
+        return appliedCount;
+    }
+}

--- a/features/elastic/client/src/main/java/org/opennms/features/elastic/client/ElasticRestClient.java
+++ b/features/elastic/client/src/main/java/org/opennms/features/elastic/client/ElasticRestClient.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.elastic.client;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Interface for an Elasticsearch client that can connect to ElasticSearch
+ * and apply composable templates dynamically.
+ */
+public interface ElasticRestClient {
+
+    /**
+     * Connects to the Elasticsearch cluster.
+     *
+     * @throws IOException if a connection error occurs
+     */
+    void connect() throws IOException;
+
+    /**
+     * Lists all templates currently registered in the Elasticsearch cluster.
+     *
+     * @return a map of template names to template definitions
+     * @throws IOException if a connection error occurs
+     */
+    Map<String, String> listTemplates() throws IOException;
+
+    /**
+     * Checks if the client is connected to the Elasticsearch cluster.
+     *
+     * @return true if connected, false otherwise
+     */
+    boolean isConnected();
+
+
+    /**
+     * Closes the client and releases any resources.
+     *
+     * @throws IOException if an error occurs during close
+     */
+    void close() throws IOException;
+
+    /**
+     * Applies an ILM policy to Elasticsearch.
+     */
+    boolean applyILMPolicy(String policyName, String policyBody) throws IOException;
+
+    /**
+     * Applies a component template to Elasticsearch.
+     */
+    boolean applyComponentTemplate(String componentName, String componentBody) throws IOException;
+
+    /**
+     * Applies a composable index template to Elasticsearch.
+     */
+    boolean applyComposableIndexTemplate(String templateName, String templateBody) throws IOException;
+
+    /**
+     * Loads and applies all templates from configured directories.
+     */
+    int applyAllTemplatesFromDirectory(String templateDirectory) throws IOException;
+}

--- a/features/elastic/client/src/main/java/org/opennms/features/elastic/client/ElasticRestClientFactory.java
+++ b/features/elastic/client/src/main/java/org/opennms/features/elastic/client/ElasticRestClientFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.features.elastic.client;
+
+import java.io.IOException;
+
+public class ElasticRestClientFactory {
+
+    private final String elasticHosts;
+
+    private final String elasticUsername;
+
+    private final String elasticPassword;
+
+    private ElasticRestClient elasticRestClient;
+
+    public ElasticRestClientFactory(String elasticHosts, String elasticUsername, String elasticPassword) {
+        this.elasticHosts = elasticHosts;
+        this.elasticUsername = elasticUsername;
+        this.elasticPassword = elasticPassword;
+    }
+
+    public ElasticRestClient createClient() {
+        if (this.elasticRestClient == null) {
+            this.elasticRestClient = new DefaultElasticRestClient(elasticHosts, elasticUsername, elasticPassword);
+        }
+        return elasticRestClient;
+    }
+
+    public void closeClient() throws IOException {
+        elasticRestClient.close();
+    }
+
+}

--- a/features/elastic/client/src/main/java/org/opennms/features/elastic/client/ElasticRestClientFactory.java
+++ b/features/elastic/client/src/main/java/org/opennms/features/elastic/client/ElasticRestClientFactory.java
@@ -51,4 +51,7 @@ public class ElasticRestClientFactory {
         elasticRestClient.close();
     }
 
+    public ElasticRestClient getClient() {
+        return elasticRestClient;
+    }
 }

--- a/features/elastic/client/src/main/java/org/opennms/features/elastic/client/commands/TemplateCommand.java
+++ b/features/elastic/client/src/main/java/org/opennms/features/elastic/client/commands/TemplateCommand.java
@@ -181,16 +181,7 @@ public class TemplateCommand implements Action {
             return;
         }
 
-        String subdir;
-        if (ilmPolicy) {
-            subdir = "policies";
-        } else if (componentTemplate) {
-            subdir = "components";
-        } else {
-            subdir = "index-templates";
-        }
-
-        Path resourcePath = Paths.get(directory, subdir, templateName + ".json");
+        Path resourcePath = Paths.get(directory, templateName + ".json");
 
         if (!Files.exists(resourcePath)) {
             System.err.println("Error: File not found: " + resourcePath);

--- a/features/elastic/client/src/main/java/org/opennms/features/elastic/client/commands/TemplateCommand.java
+++ b/features/elastic/client/src/main/java/org/opennms/features/elastic/client/commands/TemplateCommand.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.elastic.client.commands;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.http.util.EntityUtils;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.opennms.features.elastic.client.DefaultElasticRestClient;
+import org.opennms.features.elastic.client.ElasticRestClient;
+
+@Command(scope = "opennms", name = "elastic-template", description = "Manage Elasticsearch templates")
+@Service
+public class TemplateCommand implements Action {
+
+    @Reference
+    private ElasticRestClient elasticRestClient;
+
+    @Option(name = "-l", aliases = "--list", description = "List available templates")
+    private boolean list;
+
+    @Option(name = "-a", aliases = "--apply", description = "Apply a template")
+    private boolean apply;
+
+    @Option(name = "-s", aliases = "--show", description = "Show template content")
+    private boolean show;
+
+    @Option(name = "-d", aliases = "--directory", description = "Template directory")
+    private String directory;
+
+    @Option(name = "--apply-all", description = "Apply all templates from directory")
+    private boolean applyAll;
+
+    @Option(name = "--component", description = "Operate on component templates")
+    private boolean componentTemplate;
+
+    @Option(name = "--policy", description = "Operate on ILM policies")
+    private boolean ilmPolicy;
+
+    @Argument(index = 0, name = "template", description = "Template name", required = false)
+    private String templateName;
+
+    @Override
+    public Object execute() throws Exception {
+        try {
+            if (!elasticRestClient.isConnected()) {
+                System.out.println("Connecting to Elasticsearch...");
+                elasticRestClient.connect();
+            }
+
+
+            if (applyAll && directory != null) {
+                int count = ((DefaultElasticRestClient)elasticRestClient).applyAllTemplatesFromDirectory(directory);
+                System.out.println("Applied " + count + " templates and policies");
+                return null;
+            } else if (list) {
+                listResources();
+                return null;
+            } else if (show) {
+                showResource();
+                return null;
+            } else if (apply) {
+                applyResource();
+                return null;
+            }
+
+            System.out.println("Please specify an operation: --list, --show, --apply, or --apply-all");
+            return null;
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private void listResources() throws IOException {
+        String endpoint;
+        if (ilmPolicy) {
+            endpoint = "/_ilm/policy";
+        } else if (componentTemplate) {
+            endpoint = "/_component_template";
+        } else {
+            endpoint = "/_index_template";
+        }
+
+        Request request = new Request("GET", endpoint);
+        Response response = ((DefaultElasticRestClient)elasticRestClient).getRestClient().performRequest(request);
+
+        String type = ilmPolicy ? "ILM Policies" : (componentTemplate ? "Component Templates" : "Index Templates");
+        System.out.println(type + ":");
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        // Parse JSON and print names (simplified here)
+        System.out.println(responseBody);
+    }
+
+    private void showResource() throws IOException {
+        if (templateName == null) {
+            System.err.println("Error: Name is required for --show operation");
+            return;
+        }
+
+        String endpoint;
+        if (ilmPolicy) {
+            endpoint = "/_ilm/policy/" + templateName;
+        } else if (componentTemplate) {
+            endpoint = "/_component_template/" + templateName;
+        } else {
+            endpoint = "/_index_template/" + templateName;
+        }
+
+        Request request = new Request("GET", endpoint);
+
+        try {
+            Response response = ((DefaultElasticRestClient)elasticRestClient).getRestClient().performRequest(request);
+            System.out.println(EntityUtils.toString(response.getEntity()));
+        } catch (Exception e) {
+            System.err.println("Error: Resource '" + templateName + "' not found");
+        }
+    }
+
+    private void applyResource() throws IOException {
+        if (templateName == null || directory == null) {
+            System.err.println("Error: Name and directory are required for --apply operation");
+            return;
+        }
+
+        String subdir;
+        if (ilmPolicy) {
+            subdir = "policies";
+        } else if (componentTemplate) {
+            subdir = "components";
+        } else {
+            subdir = "index-templates";
+        }
+
+        Path resourcePath = Paths.get(directory, subdir, templateName + ".json");
+
+        if (!Files.exists(resourcePath)) {
+            System.err.println("Error: File not found: " + resourcePath);
+            return;
+        }
+
+        String content = new String(Files.readAllBytes(resourcePath));
+        boolean success;
+
+        if (ilmPolicy) {
+            success = ((DefaultElasticRestClient)elasticRestClient).applyILMPolicy(templateName, content);
+        } else if (componentTemplate) {
+            success = ((DefaultElasticRestClient)elasticRestClient).applyComponentTemplate(templateName, content);
+        } else {
+            success = ((DefaultElasticRestClient)elasticRestClient).applyComposableIndexTemplate(templateName, content);
+        }
+
+        String resourceType = ilmPolicy ? "policy" : (componentTemplate ? "component template" : "index template");
+        if (success) {
+            System.out.println("Successfully applied " + resourceType + ": " + templateName);
+        } else {
+            System.err.println("Failed to apply " + resourceType + ": " + templateName);
+        }
+    }
+}

--- a/features/elastic/client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/elastic/client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xsi:schemaLocation="
+		http://www.osgi.org/xmlns/blueprint/v1.0.0 
+		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+">
+
+    <!-- Configuration properties -->
+    <cm:property-placeholder id="elasticClientProperties" persistent-id="org.opennms.features.elastic.client" update-strategy="reload">
+        <cm:default-properties>
+            <cm:property name="elasticHosts" value="localhost:9200"/>
+            <cm:property name="elasticUsername" value=""/>
+            <cm:property name="elasticPassword" value=""/>
+            <cm:property name="templateDirectory" value="${karaf.etc}/elastic/templates"/>
+        </cm:default-properties>
+    </cm:property-placeholder>
+
+    <bean id="elasticRestClient" class="org.opennms.features.elastic.client.DefaultElasticRestClient"
+          init-method="init" destroy-method="close">
+        <argument value="${elasticHosts}"/>
+        <argument value="${elasticUsername}"/>
+        <argument value="${elasticPassword}"/>
+    </bean>
+
+    <service ref="elasticRestClient" interface="org.opennms.features.elastic.client.ElasticRestClient"/>
+
+
+</blueprint>

--- a/features/elastic/client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/elastic/client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,8 +18,7 @@
         </cm:default-properties>
     </cm:property-placeholder>
 
-    <bean id="elasticRestClient" class="org.opennms.features.elastic.client.DefaultElasticRestClient"
-          init-method="init" destroy-method="close">
+    <bean id="elasticRestClient" class="org.opennms.features.elastic.client.DefaultElasticRestClient" destroy-method="close">
         <argument value="${elasticHosts}"/>
         <argument value="${elasticUsername}"/>
         <argument value="${elasticPassword}"/>

--- a/features/elastic/client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/elastic/client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,7 +15,6 @@
             <cm:property name="elasticHosts" value="localhost:9200"/>
             <cm:property name="elasticUsername" value=""/>
             <cm:property name="elasticPassword" value=""/>
-            <cm:property name="templateDirectory" value="${karaf.etc}/elastic/templates"/>
         </cm:default-properties>
     </cm:property-placeholder>
 

--- a/features/elastic/client/src/test/java/org/opennms/features/elastic/client/ElasticRestClientIT.java
+++ b/features/elastic/client/src/test/java/org/opennms/features/elastic/client/ElasticRestClientIT.java
@@ -22,12 +22,11 @@
 package org.opennms.features.elastic.client;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.util.EntityUtils;
@@ -46,9 +45,9 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 public class ElasticRestClientIT {
 
-    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.7.0";
+    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:7.17.9";
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultElasticRestClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticRestClientIT.class);
 
     @ClassRule
     public static ElasticsearchContainer elasticsearch = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
@@ -61,17 +60,12 @@ public class ElasticRestClientIT {
     
     @Before
     public void setUp() throws Exception {
-        tempDirectory = Files.createTempDirectory("es-client-test");
-
-        Files.createDirectories(tempDirectory.resolve("policies"));
-        Files.createDirectories(tempDirectory.resolve("components"));
-        Files.createDirectories(tempDirectory.resolve("index-templates"));
 
         String[] hosts = {elasticsearch.getHttpHostAddress()};
         client = new DefaultElasticRestClient(hosts);
         client.connect();
 
-        Awaitility.setDefaultTimeout(20, TimeUnit.SECONDS);
+        Awaitility.setDefaultTimeout(15, TimeUnit.SECONDS);
         Awaitility.setDefaultPollInterval(500, TimeUnit.MILLISECONDS);
     }
     
@@ -82,212 +76,17 @@ public class ElasticRestClientIT {
         if (client != null) {
             client.close();
         }
-        // Delete temp directory
-        deleteDirectory(tempDirectory.toFile());
     }
 
-
-    @Test
-    public void testILMPolicy() throws IOException {
-        // Prepare ILM policy
-        String policyName = "test-policy";
-        String policyJson = "{\n" +
-                "  \"policy\": {\n" +
-                "    \"phases\": {\n" +
-                "      \"hot\": {\n" +
-                "        \"min_age\": \"0ms\",\n" +
-                "        \"actions\": {}\n" +
-                "      },\n" +
-                "      \"delete\": {\n" +
-                "        \"min_age\": \"1d\",\n" +
-                "        \"actions\": {\n" +
-                "          \"delete\": {}\n" +
-                "        }\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        
-        // Apply the policy
-        boolean result = client.applyILMPolicy(policyName, policyJson);
-        assertTrue("ILM policy application should succeed", result);
-
-        Awaitility.await().until(() -> {
-            try {
-                Request request = new Request("GET", "/_ilm/policy/" + policyName);
-                Response response = client.getRestClient().performRequest(request);
-                int statusCode = response.getStatusLine().getStatusCode();
-                String responseBody = EntityUtils.toString(response.getEntity());
-                LOG.info("ILM policy response (status: {}): {}", statusCode, responseBody);
-                return statusCode == 200 && responseBody.contains(policyName);
-            } catch (Exception e) {
-                LOG.error("Error waiting for ILM policy: {}", e.getMessage());
-                return false;
-            }
-        });
-    }
     
     @Test
-    public void testComponentTemplate() throws IOException {
-        // Prepare component template
-        String componentName = "test-component";
-        String componentJson = "{\n" +
-                "  \"template\": {\n" +
-                "    \"settings\": {\n" +
-                "      \"index\": {\n" +
-                "        \"number_of_shards\": \"1\",\n" +
-                "        \"number_of_replicas\": \"0\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        
-        // Apply the component template
-        boolean result = client.applyComponentTemplate(componentName, componentJson);
-        assertTrue("Component template application should succeed", result);
+    public void testApplyAllTemplatesFromDirectory() throws IOException, URISyntaxException {
 
-        Awaitility.await().until(() -> {
-            try {
-                Request request = new Request("GET", "/_component_template/" + componentName);
-                Response response = client.getRestClient().performRequest(request);
-                int statusCode = response.getStatusLine().getStatusCode();
-                String responseBody = EntityUtils.toString(response.getEntity());
-                LOG.info("Component template response (status: {}): {}", statusCode, responseBody);
-                return statusCode == 200 && responseBody.contains(componentName);
-            } catch (Exception e) {
-                LOG.error("Error waiting for component template: {}", e.getMessage());
-                return false;
-            }
-        });
-    }
-    
-    @Test
-    public void testComposableIndexTemplate() throws IOException {
-        // First create component templates
-        String settingsComponentName = "test-settings-component";
-        String settingsComponentJson = "{\n" +
-                "  \"template\": {\n" +
-                "    \"settings\": {\n" +
-                "      \"index\": {\n" +
-                "        \"number_of_shards\": \"1\",\n" +
-                "        \"number_of_replicas\": \"0\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        client.applyComponentTemplate(settingsComponentName, settingsComponentJson);
-        
-        String mappingsComponentName = "test-mappings-component";
-        String mappingsComponentJson = "{\n" +
-                "  \"template\": {\n" +
-                "    \"mappings\": {\n" +
-                "      \"properties\": {\n" +
-                "        \"field1\": { \"type\": \"keyword\" }\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        client.applyComponentTemplate(mappingsComponentName, mappingsComponentJson);
-        
-        // Create index template with unique pattern and high priority
-        String indexTemplateName = "test-index-template-1";
-        String indexTemplateJson = "{\n" +
-                "  \"index_patterns\": [\"test-pattern-1-*\"],\n" +
-                "  \"composed_of\": [\"test-settings-component\", \"test-mappings-component\"],\n" +
-                "  \"priority\": 600\n" +
-                "}";
-        
-        // Apply the index template
-        boolean result = client.applyComposableIndexTemplate(indexTemplateName, indexTemplateJson);
-        assertTrue("Composable index template application should succeed", result);
-
-        Awaitility.await().until(() -> {
-            try {
-                Request request = new Request("GET", "/_index_template/" + indexTemplateName);
-                Response response = client.getRestClient().performRequest(request);
-                int statusCode = response.getStatusLine().getStatusCode();
-                String responseBody = EntityUtils.toString(response.getEntity());
-                LOG.info("Index template response (status: {}): {}", statusCode, responseBody);
-                return statusCode == 200 && 
-                       responseBody.contains(indexTemplateName) &&
-                       responseBody.contains(settingsComponentName) &&
-                       responseBody.contains(mappingsComponentName);
-            } catch (Exception e) {
-                LOG.error("Error waiting for index template: {}", e.getMessage());
-                return false;
-            }
-        });
-    }
-    
-    @Test
-    public void testApplyAllTemplatesFromDirectory() throws IOException {
-        // Create test templates in the temp directory structure
-        
-        // 1. Create ILM policy
-        String policyName = "test-lifecycle";
-        String policyJson = "{\n" +
-                "  \"policy\": {\n" +
-                "    \"phases\": {\n" +
-                "      \"hot\": { \"min_age\": \"0ms\", \"actions\": {} },\n" +
-                "      \"delete\": { \"min_age\": \"1d\", \"actions\": { \"delete\": {} } }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        Files.write(tempDirectory.resolve("policies").resolve(policyName + ".json"), policyJson.getBytes());
-        
-        // 2. Create component templates
-        String settingsComponent = "settings-component";
-        String settingsJson = "{\n" +
-                "  \"template\": {\n" +
-                "    \"settings\": {\n" +
-                "      \"index\": {\n" +
-                "        \"number_of_shards\": \"1\",\n" +
-                "        \"number_of_replicas\": \"0\",\n" +
-                "        \"lifecycle\": { \"name\": \"test-lifecycle\" }\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        Files.write(tempDirectory.resolve("components").resolve(settingsComponent + ".json"), settingsJson.getBytes());
-        
-        String mappingsComponent = "mappings-component";
-        String mappingsJson = "{\n" +
-                "  \"template\": {\n" +
-                "    \"mappings\": {\n" +
-                "      \"properties\": {\n" +
-                "        \"field1\": { \"type\": \"keyword\" },\n" +
-                "        \"field2\": { \"type\": \"integer\" }\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
-        Files.write(tempDirectory.resolve("components").resolve(mappingsComponent + ".json"), mappingsJson.getBytes());
-        
-        // 3. Create index template
         String indexTemplate = "index-template";
-        String indexTemplateJson = "{\n" +
-                "  \"index_patterns\": [\"test-pattern-2-*\"],\n" +
-                "  \"composed_of\": [\"settings-component\", \"mappings-component\"],\n" +
-                "  \"priority\": 700\n" +
-                "}";
-        Files.write(tempDirectory.resolve("index-templates").resolve(indexTemplate + ".json"), indexTemplateJson.getBytes());
 
-        
-        // Check policy files
-        Path policyFilePath = tempDirectory.resolve("policies").resolve(policyName + ".json");
-        assertTrue("Policy file should exist: " + policyFilePath, Files.exists(policyFilePath));
-        // Check component files
-        Path settingsFilePath = tempDirectory.resolve("components").resolve(settingsComponent + ".json");
-        assertTrue("Settings component file should exist: " + settingsFilePath, Files.exists(settingsFilePath));
-        Path mappingsFilePath = tempDirectory.resolve("components").resolve(mappingsComponent + ".json");
-        assertTrue("Mappings component file should exist: " + mappingsFilePath, Files.exists(mappingsFilePath));
-        // Check index template file
-        Path indexTemplateFilePath = tempDirectory.resolve("index-templates").resolve(indexTemplate + ".json");
-        assertTrue("Index template file should exist: " + indexTemplateFilePath, Files.exists(indexTemplateFilePath));
-
-        
-        // Apply all templates
-        int count = client.applyAllTemplatesFromDirectory(tempDirectory.toString());
+        Path resourcePath = Paths.get(
+                Objects.requireNonNull(getClass().getClassLoader().getResource("templates")).toURI());
+        int count = client.applyAllTemplatesFromDirectory(resourcePath.toString());
         LOG.info("Applied {} templates", count);
         assertEquals("Should have applied 4 templates", 4, count);
         
@@ -302,8 +101,8 @@ public class ElasticRestClientIT {
                 return statusCode == 200 && 
                        body.contains(indexTemplate) && 
                        body.contains("composed_of") && 
-                       body.contains("settings-component") && 
-                       body.contains("mappings-component");
+                       body.contains("component-settings") && 
+                       body.contains("component-mappings");
             } catch (Exception e) {
                 LOG.error("Error verifying index template: {}", e.getMessage());
                 return false;
@@ -362,23 +161,5 @@ public class ElasticRestClientIT {
             }
         });
     }
-    
-    /**
-     * Helper method to recursively delete a directory.
-     */
-    private void deleteDirectory(File directory) {
-        if (directory.exists()) {
-            File[] files = directory.listFiles();
-            if (files != null) {
-                for (File file : files) {
-                    if (file.isDirectory()) {
-                        deleteDirectory(file);
-                    } else {
-                        file.delete();
-                    }
-                }
-            }
-            directory.delete();
-        }
-    }
+
 }

--- a/features/elastic/client/src/test/java/org/opennms/features/elastic/client/ElasticRestClientIT.java
+++ b/features/elastic/client/src/test/java/org/opennms/features/elastic/client/ElasticRestClientIT.java
@@ -69,7 +69,6 @@ public class ElasticRestClientIT {
 
         String[] hosts = {elasticsearch.getHttpHostAddress()};
         client = new DefaultElasticRestClient(hosts);
-        client.init();
         client.connect();
 
         Awaitility.setDefaultTimeout(20, TimeUnit.SECONDS);

--- a/features/elastic/client/src/test/java/org/opennms/features/elastic/client/ElasticRestClientIT.java
+++ b/features/elastic/client/src/test/java/org/opennms/features/elastic/client/ElasticRestClientIT.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.elastic.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+
+public class ElasticRestClientIT {
+
+    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.7.0";
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultElasticRestClient.class);
+
+    @ClassRule
+    public static ElasticsearchContainer elasticsearch = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+            .withEnv("xpack.security.enabled", "false")
+            .withEnv("discovery.type", "single-node")
+            .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
+    
+    private DefaultElasticRestClient client;
+    private Path tempDirectory;
+    
+    @Before
+    public void setUp() throws Exception {
+        tempDirectory = Files.createTempDirectory("es-client-test");
+
+        Files.createDirectories(tempDirectory.resolve("policies"));
+        Files.createDirectories(tempDirectory.resolve("components"));
+        Files.createDirectories(tempDirectory.resolve("index-templates"));
+
+        String[] hosts = {elasticsearch.getHttpHostAddress()};
+        client = new DefaultElasticRestClient(hosts);
+        client.init();
+        client.connect();
+
+        Awaitility.setDefaultTimeout(20, TimeUnit.SECONDS);
+        Awaitility.setDefaultPollInterval(500, TimeUnit.MILLISECONDS);
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        
+        // Close the client
+        if (client != null) {
+            client.close();
+        }
+        // Delete temp directory
+        deleteDirectory(tempDirectory.toFile());
+    }
+
+
+    @Test
+    public void testILMPolicy() throws IOException {
+        // Prepare ILM policy
+        String policyName = "test-policy";
+        String policyJson = "{\n" +
+                "  \"policy\": {\n" +
+                "    \"phases\": {\n" +
+                "      \"hot\": {\n" +
+                "        \"min_age\": \"0ms\",\n" +
+                "        \"actions\": {}\n" +
+                "      },\n" +
+                "      \"delete\": {\n" +
+                "        \"min_age\": \"1d\",\n" +
+                "        \"actions\": {\n" +
+                "          \"delete\": {}\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        
+        // Apply the policy
+        boolean result = client.applyILMPolicy(policyName, policyJson);
+        assertTrue("ILM policy application should succeed", result);
+
+        Awaitility.await().until(() -> {
+            try {
+                Request request = new Request("GET", "/_ilm/policy/" + policyName);
+                Response response = client.getRestClient().performRequest(request);
+                int statusCode = response.getStatusLine().getStatusCode();
+                String responseBody = EntityUtils.toString(response.getEntity());
+                LOG.info("ILM policy response (status: {}): {}", statusCode, responseBody);
+                return statusCode == 200 && responseBody.contains(policyName);
+            } catch (Exception e) {
+                LOG.error("Error waiting for ILM policy: {}", e.getMessage());
+                return false;
+            }
+        });
+    }
+    
+    @Test
+    public void testComponentTemplate() throws IOException {
+        // Prepare component template
+        String componentName = "test-component";
+        String componentJson = "{\n" +
+                "  \"template\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"number_of_shards\": \"1\",\n" +
+                "        \"number_of_replicas\": \"0\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        
+        // Apply the component template
+        boolean result = client.applyComponentTemplate(componentName, componentJson);
+        assertTrue("Component template application should succeed", result);
+
+        Awaitility.await().until(() -> {
+            try {
+                Request request = new Request("GET", "/_component_template/" + componentName);
+                Response response = client.getRestClient().performRequest(request);
+                int statusCode = response.getStatusLine().getStatusCode();
+                String responseBody = EntityUtils.toString(response.getEntity());
+                LOG.info("Component template response (status: {}): {}", statusCode, responseBody);
+                return statusCode == 200 && responseBody.contains(componentName);
+            } catch (Exception e) {
+                LOG.error("Error waiting for component template: {}", e.getMessage());
+                return false;
+            }
+        });
+    }
+    
+    @Test
+    public void testComposableIndexTemplate() throws IOException {
+        // First create component templates
+        String settingsComponentName = "test-settings-component";
+        String settingsComponentJson = "{\n" +
+                "  \"template\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"number_of_shards\": \"1\",\n" +
+                "        \"number_of_replicas\": \"0\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        client.applyComponentTemplate(settingsComponentName, settingsComponentJson);
+        
+        String mappingsComponentName = "test-mappings-component";
+        String mappingsComponentJson = "{\n" +
+                "  \"template\": {\n" +
+                "    \"mappings\": {\n" +
+                "      \"properties\": {\n" +
+                "        \"field1\": { \"type\": \"keyword\" }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        client.applyComponentTemplate(mappingsComponentName, mappingsComponentJson);
+        
+        // Create index template with unique pattern and high priority
+        String indexTemplateName = "test-index-template-1";
+        String indexTemplateJson = "{\n" +
+                "  \"index_patterns\": [\"test-pattern-1-*\"],\n" +
+                "  \"composed_of\": [\"test-settings-component\", \"test-mappings-component\"],\n" +
+                "  \"priority\": 600\n" +
+                "}";
+        
+        // Apply the index template
+        boolean result = client.applyComposableIndexTemplate(indexTemplateName, indexTemplateJson);
+        assertTrue("Composable index template application should succeed", result);
+
+        Awaitility.await().until(() -> {
+            try {
+                Request request = new Request("GET", "/_index_template/" + indexTemplateName);
+                Response response = client.getRestClient().performRequest(request);
+                int statusCode = response.getStatusLine().getStatusCode();
+                String responseBody = EntityUtils.toString(response.getEntity());
+                LOG.info("Index template response (status: {}): {}", statusCode, responseBody);
+                return statusCode == 200 && 
+                       responseBody.contains(indexTemplateName) &&
+                       responseBody.contains(settingsComponentName) &&
+                       responseBody.contains(mappingsComponentName);
+            } catch (Exception e) {
+                LOG.error("Error waiting for index template: {}", e.getMessage());
+                return false;
+            }
+        });
+    }
+    
+    @Test
+    public void testApplyAllTemplatesFromDirectory() throws IOException {
+        // Create test templates in the temp directory structure
+        
+        // 1. Create ILM policy
+        String policyName = "test-lifecycle";
+        String policyJson = "{\n" +
+                "  \"policy\": {\n" +
+                "    \"phases\": {\n" +
+                "      \"hot\": { \"min_age\": \"0ms\", \"actions\": {} },\n" +
+                "      \"delete\": { \"min_age\": \"1d\", \"actions\": { \"delete\": {} } }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        Files.write(tempDirectory.resolve("policies").resolve(policyName + ".json"), policyJson.getBytes());
+        
+        // 2. Create component templates
+        String settingsComponent = "settings-component";
+        String settingsJson = "{\n" +
+                "  \"template\": {\n" +
+                "    \"settings\": {\n" +
+                "      \"index\": {\n" +
+                "        \"number_of_shards\": \"1\",\n" +
+                "        \"number_of_replicas\": \"0\",\n" +
+                "        \"lifecycle\": { \"name\": \"test-lifecycle\" }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        Files.write(tempDirectory.resolve("components").resolve(settingsComponent + ".json"), settingsJson.getBytes());
+        
+        String mappingsComponent = "mappings-component";
+        String mappingsJson = "{\n" +
+                "  \"template\": {\n" +
+                "    \"mappings\": {\n" +
+                "      \"properties\": {\n" +
+                "        \"field1\": { \"type\": \"keyword\" },\n" +
+                "        \"field2\": { \"type\": \"integer\" }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        Files.write(tempDirectory.resolve("components").resolve(mappingsComponent + ".json"), mappingsJson.getBytes());
+        
+        // 3. Create index template
+        String indexTemplate = "index-template";
+        String indexTemplateJson = "{\n" +
+                "  \"index_patterns\": [\"test-pattern-2-*\"],\n" +
+                "  \"composed_of\": [\"settings-component\", \"mappings-component\"],\n" +
+                "  \"priority\": 700\n" +
+                "}";
+        Files.write(tempDirectory.resolve("index-templates").resolve(indexTemplate + ".json"), indexTemplateJson.getBytes());
+
+        
+        // Check policy files
+        Path policyFilePath = tempDirectory.resolve("policies").resolve(policyName + ".json");
+        assertTrue("Policy file should exist: " + policyFilePath, Files.exists(policyFilePath));
+        // Check component files
+        Path settingsFilePath = tempDirectory.resolve("components").resolve(settingsComponent + ".json");
+        assertTrue("Settings component file should exist: " + settingsFilePath, Files.exists(settingsFilePath));
+        Path mappingsFilePath = tempDirectory.resolve("components").resolve(mappingsComponent + ".json");
+        assertTrue("Mappings component file should exist: " + mappingsFilePath, Files.exists(mappingsFilePath));
+        // Check index template file
+        Path indexTemplateFilePath = tempDirectory.resolve("index-templates").resolve(indexTemplate + ".json");
+        assertTrue("Index template file should exist: " + indexTemplateFilePath, Files.exists(indexTemplateFilePath));
+
+        
+        // Apply all templates
+        int count = client.applyAllTemplatesFromDirectory(tempDirectory.toString());
+        LOG.info("Applied {} templates", count);
+        assertEquals("Should have applied 4 templates", 4, count);
+        
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(() -> {
+            try {
+                Request request = new Request("GET", "/_index_template/" + indexTemplate);
+                Response response = client.getRestClient().performRequest(request);
+                int statusCode = response.getStatusLine().getStatusCode();
+                String body = EntityUtils.toString(response.getEntity());
+                LOG.info("Index template verification - Status: {}, Body: {}", statusCode, body);
+
+                return statusCode == 200 && 
+                       body.contains(indexTemplate) && 
+                       body.contains("composed_of") && 
+                       body.contains("settings-component") && 
+                       body.contains("mappings-component");
+            } catch (Exception e) {
+                LOG.error("Error verifying index template: {}", e.getMessage());
+                return false;
+            }
+        });
+        
+        // Create an index that matches the pattern and verify settings & mappings are applied
+        String indexName = "test-pattern-2-index";  // Match the pattern in the template
+        LOG.info("Creating index to test template application: {}", indexName);
+        
+        try {
+            Request createIndexRequest = new Request("PUT", "/" + indexName);
+            Response createResponse = client.getRestClient().performRequest(createIndexRequest);
+            LOG.info("Index creation response: {}", createResponse.getStatusLine().getStatusCode());
+        } catch (Exception e) {
+            LOG.error("Error creating index: {}", e.getMessage());
+            Assert.fail("Failed to create index: " + e.getMessage());
+        }
+        
+        // Verify the index was created with the expected settings and mappings
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
+            try {
+                // Check settings separately
+                Request settingsRequest = new Request("GET", "/" + indexName + "/_settings");
+                Response settingsResponse = client.getRestClient().performRequest(settingsRequest);
+                String settingsBody = EntityUtils.toString(settingsResponse.getEntity());
+                LOG.info("Index settings response status: {}", settingsResponse.getStatusLine().getStatusCode());
+                
+                boolean settingsMatch = settingsResponse.getStatusLine().getStatusCode() == 200 &&
+                                       settingsBody.contains("\"number_of_shards\":\"1\"");
+                
+                if (!settingsMatch) {
+                    LOG.info("Settings don't match expected values");
+                    return false;
+                }
+                
+                // Check mappings separately
+                Request mappingsRequest = new Request("GET", "/" + indexName + "/_mapping");
+                Response mappingsResponse = client.getRestClient().performRequest(mappingsRequest);
+                String mappingsBody = EntityUtils.toString(mappingsResponse.getEntity());
+                LOG.info("Index mappings response status: {}", mappingsResponse.getStatusLine().getStatusCode());
+                
+                boolean mappingsMatch = mappingsResponse.getStatusLine().getStatusCode() == 200 &&
+                                      mappingsBody.contains("field1") &&
+                                      mappingsBody.contains("field2");
+                
+                if (!mappingsMatch) {
+                    LOG.info("Mappings don't match expected values");
+                    return false;
+                }
+                
+                return true;
+            } catch (Exception e) {
+                LOG.error("Error verifying index settings and mappings: {}", e.getMessage());
+                return false;
+            }
+        });
+    }
+    
+    /**
+     * Helper method to recursively delete a directory.
+     */
+    private void deleteDirectory(File directory) {
+        if (directory.exists()) {
+            File[] files = directory.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (file.isDirectory()) {
+                        deleteDirectory(file);
+                    } else {
+                        file.delete();
+                    }
+                }
+            }
+            directory.delete();
+        }
+    }
+}

--- a/features/elastic/client/src/test/resources/templates/component-mappings.json
+++ b/features/elastic/client/src/test/resources/templates/component-mappings.json
@@ -1,0 +1,10 @@
+{
+  "template": {
+    "mappings": {
+      "properties": {
+        "field1": { "type": "keyword" },
+        "field2": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/features/elastic/client/src/test/resources/templates/component-settings.json
+++ b/features/elastic/client/src/test/resources/templates/component-settings.json
@@ -1,0 +1,11 @@
+{
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "0",
+        "lifecycle": { "name": "test-ilm-policy" }
+      }
+    }
+  }
+}

--- a/features/elastic/client/src/test/resources/templates/index-template/index-template.json
+++ b/features/elastic/client/src/test/resources/templates/index-template/index-template.json
@@ -1,0 +1,5 @@
+{
+  "index_patterns": ["test-pattern-2-*"],
+  "composed_of": ["component-settings", "component-mappings"],
+  "priority": 700
+}

--- a/features/elastic/client/src/test/resources/templates/test-ilm-policy.json
+++ b/features/elastic/client/src/test/resources/templates/test-ilm-policy.json
@@ -1,0 +1,8 @@
+{
+  "policy": {
+    "phases": {
+      "hot": { "min_age": "0ms", "actions": {} },
+      "delete": { "min_age": "1d", "actions": { "delete": {} } }
+    }
+  }
+}

--- a/features/elastic/pom.xml
+++ b/features/elastic/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.features</artifactId>
+        <version>34.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.opennms.features</groupId>
+    <artifactId>org.opennms.features.elastic</artifactId>
+    <name>OpenNMS :: Features :: Elastic Search</name>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>client</module>
+    </modules>
+</project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -194,5 +194,6 @@
     <module>inmemory-timeseries-plugin</module>
     
     <module>grpc</module>
+    <module>elastic</module>
   </modules>
 </project>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -1040,6 +1040,11 @@
       <artifactId>org.opennms.features.ticketing.inmemory</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.features.elastic</groupId>
+      <artifactId>org.opennms.features.elastic.client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- GraphML dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1797,6 +1797,7 @@
     <elasticsearchNettyVersion>${netty4Version}</elasticsearchNettyVersion>
     <elasticsearchDriftPluginVersion>2.0.5</elasticsearchDriftPluginVersion>
     <elasticsearchTargetVersion>7.17.9</elasticsearchTargetVersion>
+    <elasticsearchClientVersion>8.7.0</elasticsearchClientVersion>
     <errorProneAnnotationsVersion>2.25.0</errorProneAnnotationsVersion>
     <esapiVersion>2.4.0.0</esapiVersion>
     <felixBridgeVersion>4.1.6</felixBridgeVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1797,7 +1797,7 @@
     <elasticsearchNettyVersion>${netty4Version}</elasticsearchNettyVersion>
     <elasticsearchDriftPluginVersion>2.0.5</elasticsearchDriftPluginVersion>
     <elasticsearchTargetVersion>7.17.9</elasticsearchTargetVersion>
-    <elasticsearchClientVersion>8.7.0</elasticsearchClientVersion>
+    <elasticsearchClientVersion>8.18.1</elasticsearchClientVersion>
     <errorProneAnnotationsVersion>2.25.0</errorProneAnnotationsVersion>
     <esapiVersion>2.4.0.0</esapiVersion>
     <felixBridgeVersion>4.1.6</felixBridgeVersion>


### PR DESCRIPTION
This is first part of providing composable template support for Flows
Add Elastic Rest Client that can apply templates from directory

All templates from a given directory and sub directories will be applied based on naming

ilm, policy, lifecycle - ILM
component, settings, mappings, aliases - COMPONENT
composable, index - INDEX



### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17733

