### PR TITLE
NMS-17900: Remove PostgreSQL 10,11,12

### DIFF
--- a/.circleci/scripts/postgres.sh
+++ b/.circleci/scripts/postgres.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 echo "##### Starting Postgres"
-docker run --rm --name postgres-onms-itest -p 5432:5432 -d postgres:10.7-alpine \
+docker run --rm --name postgres-onms-itest -p 5432:5432 -d postgres:13-alpine \
 	-c 'shared_buffers=256MB' -c 'max_connections=200' -c 'fsync=off'
 
 echo "##### Waiting for Postgres to start..."

--- a/.circleci/scripts/smoke.sh
+++ b/.circleci/scripts/smoke.sh
@@ -32,7 +32,7 @@ for CONTAINER in \
   "confluentinc/cp-kafka:latest" \
   "docker.elastic.co/elasticsearch/elasticsearch:7.17.9" \
   "opennms/dummy-http-endpoint:0.0.2" \
-  "postgres:10.7-alpine" \
+  "postgres:13-alpine" \
   "postgres:latest" \
 ; do
   ( (docker pull "$CONTAINER" || :) && echo "$CONTAINER" >> /tmp/finished-containers.txt ) &

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Source)
 
 Package: opennms-db
 Architecture: all
-Depends: opennms-common (=${binary:Version}), postgresql-15 | postgresql-14 | postgresql-13 | postgresql-12 | postgresql-11 | postgresql-10, iplike-pgsql15 (>= 2.3.0) | iplike-pgsql14 (>= 2.3.0) | iplike-pgsql13 (>= 2.3.0) | iplike-pgsql12 (>= 2.3.0) | iplike-pgsql11 (>= 2.3.0) | iplike-pgsql10 (>= 2.3.0), debconf
+Depends: opennms-common (=${binary:Version}), postgresql-15 | postgresql-14 | postgresql-13, iplike-pgsql15 (>= 2.3.0) | iplike-pgsql14 (>= 2.3.0) | iplike-pgsql13 (>= 2.3.0), debconf
 Description: Enterprise-grade Open-source Network Management Platform (Database)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -57,7 +57,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Database)
 Package: opennms-server
 Architecture: all
 Depends: opennms-common (=${binary:Version}), libopennms-java (=${binary:Version}), libopennmsdeps-java (=${binary:Version}), mailx, jrrd2
-Suggests: postgresql-client-15 | postgresql-client-14 | postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
+Suggests: postgresql-client-15 | postgresql-client-14 | postgresql-client-13
 Recommends: haveged
 Description: Enterprise-grade Open-source Network Management Platform (Daemon)
  OpenNMS is an enterprise-grade network management system written in Java.

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -22,7 +22,7 @@ asciidoc:
     compatible-elasticsearch: '6.7.0 - 7.17.9'
     compatible-javajdk: 'OpenJDK 17'
     compatible-kafka: '1.x - 3.x'
-    compatible-postgresql: '10.x - 15.x'
+    compatible-postgresql: '13.x - 15.x'
     compatible-rrdtool: '1.7.x'
     jasperreportsversion: '6.3.0'
     latest-meridian-stable: '2023'

--- a/docs/modules/deployment/pages/core/centos-rhel7/postgresql.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel7/postgresql.adoc
@@ -1,25 +1,25 @@
-.Add PostgreSQL 12 package repository
+.Add PostgreSQL 15 package repository
 [source, console]
 ----
 sudo yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 ----
 
-.Install PostgreSQL 12 client and server
+.Install PostgreSQL 15 client and server
 [source, console]
 ----
-sudo yum -y install postgresql12-server postgresql12
+sudo yum -y install postgresql15-server postgresql15
 ----
 
 .Initialize PostgreSQL database
 [source, console]
 ----
-sudo /usr/pgsql-12/bin/postgresql-12-setup initdb
+sudo /usr/pgsql-15/bin/postgresql-15-setup initdb
 ----
 
 .Enable PostgreSQL on system boot and start immediately
 [source, console]
 ----
-sudo systemctl enable --now postgresql-12
+sudo systemctl enable --now postgresql-15
 ----
 
 .Create an opennms database user and password
@@ -50,7 +50,7 @@ IMPORTANT: Change `YOUR-POSTGRES-PASSWORD` to a secure one.
 .Change the access policy for PostgreSQL
 [source, console]
 ----
-sudo vi /var/lib/pgsql/12/data/pg_hba.conf
+sudo vi /var/lib/pgsql/15/data/pg_hba.conf
 ----
 
 .Allow {page-component-title} to access the database over the local network with an MD5 hashed password
@@ -65,5 +65,5 @@ host    all             all             ::1/128                 md5<1>
 .Apply configuration changes for PostgreSQL
 [source, console]
 ----
-sudo systemctl reload postgresql-12
+sudo systemctl reload postgresql-15
 ----

--- a/docs/modules/deployment/pages/core/centos-rhel9/postgresql.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel9/postgresql.adoc
@@ -17,16 +17,16 @@ Make sure you reference your current PostgreSQL version.
 [source, console]
 ----
 sudo dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-sudo dnf -y install postgresql14-server
+sudo dnf -y install postgresql15-server
 ----
 
 .Initialize the PostgreSQL database
 [source, console]
-sudo /usr/pgsql-14/bin/postgresql-14-setup initdb
+sudo /usr/pgsql-15/bin/postgresql-15-setup initdb
 
 .Enable PostgreSQL on system boot and start immediately
 [source, console]
-sudo systemctl enable --now postgresql-14
+sudo systemctl enable --now postgresql-15
 
 .Create an opennms database user and password
 [source, console]
@@ -49,7 +49,7 @@ The superuser is required to be able to initialize and change the database schem
 [[core-centos-rhel9-pg_hba]]
 .Change the access policy for PostgreSQL
 [source, console]
-sudo vi /var/lib/pgsql/14/data/pg_hba.conf
+sudo vi /var/lib/pgsql/15/data/pg_hba.conf
 
 .Allow {page-component-title} to access the database over the local network with an MD5 hashed password
 [source, pg_hba.conf]
@@ -62,4 +62,4 @@ host    all             all             ::1/128                 md5 <1>
 
 .Apply configuration changes for PostgreSQL
 [source, console]
-sudo systemctl reload postgresql-14
+sudo systemctl reload postgresql-15

--- a/docs/modules/deployment/pages/core/docker/postgresql.adoc
+++ b/docs/modules/deployment/pages/core/docker/postgresql.adoc
@@ -11,8 +11,6 @@ vi docker-compose.yml
 [subs="verbatim,attributes"]
 ----
 ---
-version: '3'
-
 volumes:
   data-postgres: {}<1>
 

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -65,8 +65,8 @@ Requires(pre):		%{name}-webui       = %{version}-%{release}
 Requires:		%{name}-webui       = %{version}-%{release}
 Requires(pre):		%{name}-core        = %{version}-%{release}
 Requires:		%{name}-core        = %{version}-%{release}
-Requires(pre):		postgresql-server  >= 10
-Requires:		postgresql-server  >= 10
+Requires(pre):		postgresql-server  >= 13
+Requires:		postgresql-server  >= 13
 Requires(pre):		%{jdk}
 Requires:		%{jdk}
 


### PR DESCRIPTION
Removed dependencies for PostgreSQL versions reached end of life.
Updated the PostgreSQL test from 10 to the lowest maintained version 13.
Set the minimal supported version from 10 to 13 in our requirement documentation.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17900

