### PR TITLE
docs: Fix links and headline inconsistencies

### DIFF
--- a/docs/modules/deployment/pages/core/getting-started.adoc
+++ b/docs/modules/deployment/pages/core/getting-started.adoc
@@ -49,7 +49,7 @@ The following components and settings are required to set up a new {page-compone
 ifeval::["{page-component-title}" == "Meridian"]
 * Credentials to access the Meridian repositories.
 endif::[]
-* A Linux physical server, or a virtual machine running a <<system-requirements.adoc#operating-systems-core, supported Linux operating system>>.
+* A Linux physical server, or a virtual machine running a <<./system-requirements.adoc#operating-systems-core, supported Linux operating system>>.
 * Internet access to download the installation packages.
 * A working DNS server, and a localhost and server name that resolve properly.
 * A system user with administrative permissions (`sudo`) to perform installation.

--- a/docs/modules/operation/pages/deep-dive/admin/configuration/newsfeed-configuration.adoc
+++ b/docs/modules/operation/pages/deep-dive/admin/configuration/newsfeed-configuration.adoc
@@ -11,7 +11,7 @@ The {page-component-title} server makes REST queries to the https://www.opennms.
 This feature is enabled by default, but can be disabled using the configuration below.
 Disabling will remove the panel from the front page and the server will no longer make queries for the feed.
 
-If you would like to change the feed settings, you can set the following options in `${OPENNMS_HOME}/etc/opennms.properties.d/feed.properties`.
+If you would like to change the feed settings, you can set the following options in `$\{OPENNMS_HOME}/etc/opennms.properties.d/feed.properties`.
 
 [options="autowidth"]
 |===

--- a/docs/modules/operation/pages/deep-dive/events/event-tokens.adoc
+++ b/docs/modules/operation/pages/deep-dive/events/event-tokens.adoc
@@ -122,9 +122,10 @@ You can access these records using the `%asset%` token (for example, `%asset[tok
 A node may have additional hardware details stored in {page-component-title}.
 You can access these details using the `%hardware%` token (for example, `%hardware[token]%`, which returns the value of the `token` field from the node's hardware inventory).
 
+[[parameter-tokens]]
 == Parameter tokens
 
-Many events store additional information in their parameters (see <<deep-dive/events/event-definition.adoc#ga-events-anatomy-of-an-event, Anatomy of an event>>).
+Many events store additional information in their parameters (see <<./event-definition.adoc#ga-events-anatomy-of-an-event, Anatomy of an event>>).
 These parameters may start as SNMP variable bindings (varbinds).
 
 You can access event parameters using the `%parm%` token, which can take several forms:

--- a/docs/modules/operation/pages/deep-dive/events/sources/snmp-traps.adoc
+++ b/docs/modules/operation/pages/deep-dive/events/sources/snmp-traps.adoc
@@ -66,8 +66,8 @@ This block consists of <maskelement> tags, and the event will match only if all 
   <descr>&#38lt;p&#38gt;Notification that the aggregate status of a node
          has changed.&#38lt;/p&#38gt;&#38lt;table&#38gt;
          &#38lt;tr&#38gt;&#38lt;td&#38gt;&#38lt;b&#38gt;
-         c3800SysNextTrapSeqNum&#38lt;/b&#38gt;</td&#38gt;&#38lt;td&#38gt;%parm[#1]%
-         &#38lt;/td&#38gt;&#38lt;td&#38gt;&#38lt;p;&#38gt;</p&#38gt;&#38lt;/td;&#38gt;&#38lt;/tr&#38gt;&#38lt;tr&#38gt;&#38lt;td&#38gt;&#38lt;b&#38gt;
+         c3800SysNextTrapSeqNum&#38lt;/b&#38gt;&#38lt;/td&#38gt;&#38lt;td&#38gt;%parm[#1]%
+         &#38lt;/td&#38gt;&#38lt;td&#38gt;&#38lt;p;&#38gt;&#38lt;/p&#38gt;&#38lt;/td;&#38gt;&#38lt;/tr&#38gt;&#38lt;tr&#38gt;&#38lt;td&#38gt;&#38lt;b&#38gt;
          sysName&#38lt;/b&#38gt;&#38lt;/td&#38gt;&#38lt;td&#38gt;%parm[#2]%
          &#38lt;/td&#38gt;&#38lt;td&#38gt;&#38lt;p;&#38gt;&#38lt;/p&#38gt;&#38lt;/td;&#38gt;&#38lt;/tr&#38gt;&#38lt;tr&#38gt;&#38lt;td&#38gt;&#38lt;b&#38gt;
          c3800SysTrapSeverity&#38lt;/b&#38gt;&#38lt;/td&#38gt;&#38lt;td&#38gt;%parm[#3]%
@@ -76,7 +76,7 @@ This block consists of <maskelement> tags, and the event will match only if all 
          &#38lt;/td;&#38gt;&#38lt;/tr&#38gt;&#38lt;tr&#38gt;&#38lt;td&#38gt;&#38lt;b&#38gt;
          c3800SysAggregateStatus&#38lt;/b&#38gt;&#38lt;/td&#38gt;&#38lt;td&#38gt;%parm[#4]%
          &#38lt;/td&#38gt;&#38lt;td&#38gt;&#38lt;p;&#38gt;
-         clear(1) minor(2) major(3)</p>
+         clear(1) minor(2) major(3)&#38lt;/p&#38gt;
          &#38lt;/td;&#38gt;&#38lt;/tr&#38gt;&#38lt;/table&#38gt;
   </descr>
   <logmsg dest='logndisplay'><p>Cisco Event: C3900: Node Status has changed.</p></logmsg>
@@ -355,7 +355,7 @@ To configure {page-component-title} to honor `snmpTrapAddress` when present, set
 <2> Don't create new nodes when receiving an SNMP trap with an unknown source IP address.
 <3> Try to use the identifier source IP address from the `snmpTrapAddress` varbind instead of the UDP source IP address.
 
-If you are using Minions to receive traps, edit the `${MINION_HOME}/etc/org.opennms.netmgt.trapd.cfg` file on each Minion to include the following setting:
+If you are using Minions to receive traps, edit the `$\{MINION_HOME}/etc/org.opennms.netmgt.trapd.cfg` file on each Minion to include the following setting:
 
 [source, properties]
 ----

--- a/docs/modules/reference/pages/telemetryd/protocols/jti.adoc
+++ b/docs/modules/reference/pages/telemetryd/protocols/jti.adoc
@@ -7,7 +7,7 @@ The Junos Telemetry Interface (JTI) lets you push operational statistics asynchr
 Data is generated as Google protocol buffers (GPB) structured messages over UDP.
 For detailed information about JTI, see the https://www.juniper.net/documentation/en_US/junos/topics/concept/junos-telemetry-interface-oveview.html[Juniper Documentation].
 
-To enable support for JTI, edit `$OPENNMS_HOME/etc/telemetryd-configuration.xml` and set `enabled=true` for JTI protocol.
+To enable support for JTI, edit `$\{OPENNMS_HOME}/etc/telemetryd-configuration.xml` and set `enabled=true` for JTI protocol.
 
 .Enable JTI protocol in telemetryd-configuration.xml
 [source, xml]
@@ -120,7 +120,7 @@ The following globals will be passed to the script:
 === Steps to Increase Log Character Size
 By default, the log message size is limited to 500 characters with karaf logs. However, in some cases, such as when viewing detailed proto object logs, you may need to increase the character size to capture the full log details.
 
-Locate file `org.ops4j.pax.logging.cfg`  in the `${OPENNMS_HOME}/etc/` directory.
+Locate file `org.ops4j.pax.logging.cfg`  in the `$\{OPENNMS_HOME}/etc/` directory.
 
 Locate the `log4j2.pattern` property in the file. By default, it is set to limit log messages to 500 characters  see `%encode{%.-500m}`
 

--- a/docs/modules/releasenotes/pages/changelog.adoc
+++ b/docs/modules/releasenotes/pages/changelog.adoc
@@ -1,6 +1,6 @@
 [[release-33-changelog]]
 
-= Changelog
+== Changelog
 [[releasenotes-changelog-33.1.6]]
 
 == Release 33.1.6

--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -6,10 +6,10 @@
 The default time series storage strategy is now by default RRDTool.
 
 IMPORTANT: If you use JRobin, make sure you set the property.
-You can easily verify it by checking the file extension created in the directory  `${OPENNMS_HOME}/share/rrd/snmp`. The extension .jrb indicates JRobin and .rrd indicates RRDtool.
+You can easily verify it by checking the file extension created in the directory  `$\{OPENNMS_HOME}/share/rrd/snmp`. The extension .jrb indicates JRobin and .rrd indicates RRDtool.
 If you miss this setting, all your timeseries files will be newely created as .rrd files and you won't have access to your JRobin files with your history.
 
-IMPORTANT: When you have .jrb files, ensure after upgrading to Horizon 34 you explicitly configure JRobin in a file like `${OPENNMS_HOME}/etc/opennms.properties.d/timeseries.properties`.
+IMPORTANT: When you have .jrb files, ensure after upgrading to Horizon 34 you explicitly configure JRobin in a file like `$\{OPENNMS_HOME}/etc/opennms.properties.d/timeseries.properties`.
 
 .Configure explicitly JRobin for Horizon 34.x if required
 [source, console]


### PR DESCRIPTION
Fixed warning while building the docs for the following errors:

* Invalid cross references in the getting started section, event definition
* Fixing HTML encoding in XML event definition in the snmp-trap event source
* Masking environment variables so they aren't tried to be evaluated as Antora variables
* Fixing wrong headline levels in change log and what's new section
