### PR TITLE
NMS-17948 add support for "snappy" and "lz4"

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -443,6 +443,8 @@
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka_${scalaVersion}/${kafkaBundleVersion}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafkaBundleVersion}</bundle>
         <bundle dependency="true">mvn:com.github.luben/zstd-jni/${zstdJniVersion}</bundle>
+        <bundle dependency="true">mvn:org.lz4/lz4-java/${lz4JavaVersion}</bundle>
+        <bundle dependency="true">mvn:org.xerial.snappy/snappy-java/${snappyJavaVersion}</bundle>
     </feature>
     <feature name="opennms-core-ipc-sink-api" version="${project.version}" description="OpenNMS :: Core :: IPC :: Sink :: API">
         <feature>dropwizard-metrics</feature>

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/AbstractKafkaCompressionIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/AbstractKafkaCompressionIT.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.smoketest.minion;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+import org.opennms.netmgt.model.PrimaryType;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
+import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.utils.CommandTestUtils;
+import org.opennms.smoketest.utils.RestClient;
+import org.opennms.smoketest.utils.SshClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+
+public abstract class AbstractKafkaCompressionIT {
+    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+    protected static final String LOCALHOST = "127.0.0.1";
+
+    protected final OpenNMSStack stack;
+
+    public AbstractKafkaCompressionIT(OpenNMSStack stack) {
+        this.stack = stack;
+    }
+
+    @Test
+    public void verifyKafkaRpcWithTcpServiceDetection() {
+        addRequisition(stack.opennms().getRestClient(), stack.minion().getLocation(), LOCALHOST);
+        await().atMost(3, MINUTES).pollInterval(15, SECONDS)
+                .until(() -> detectTcpAtLocationMinion(), containsString("'TCP' WAS detected on 127.0.0.1"));
+    }
+
+    String detectTcpAtLocationMinion() throws Exception {
+        try (final SshClient sshClient = new SshClient(stack.opennms().getSshAddress(), "admin", "admin")) {
+            PrintStream pipe = sshClient.openShell();
+            pipe.println(String.format("detect -l %s TCP 127.0.0.1 port=8201", stack.minion().getLocation()));
+            pipe.println("logout");
+            await().atMost(90, SECONDS).until(sshClient.isShellClosedCallable());
+            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
+            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
+            LOG.info("Detect output: {}", shellOutput);
+            return shellOutput;
+        }
+    }
+
+    @Test
+    public void verifyKafkaRpcWithJdbcServiceDetection() {
+        await().atMost(3, MINUTES).pollInterval(15, SECONDS).pollDelay(0, SECONDS)
+                .until(() -> detectJdbcAtLocationMinion(), containsString("'JDBC' WAS detected"));
+    }
+
+    private String detectJdbcAtLocationMinion() throws Exception {
+        String jdbcUrl = String.format("jdbc:postgresql://%s:5432/opennms", OpenNMSContainer.DB_ALIAS);
+        try (final SshClient sshClient = stack.opennms().ssh()) {
+            final PrintStream pipe = sshClient.openShell();
+            pipe.println(String.format("detect -l %s JDBC 127.0.0.1 url=%s user=opennms password=opennms",
+                    stack.minion().getLocation(), jdbcUrl));
+            pipe.println("logout");
+            await().atMost(1, MINUTES).until(sshClient.isShellClosedCallable());
+            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
+            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
+            LOG.info("Detect output: {}", shellOutput);
+            return shellOutput;
+        }
+    }
+
+    public static void addRequisition(RestClient client, String location, String ipAddress) {
+        // Implementation remains same as original
+        Requisition requisition = new Requisition("foreignSource");
+        List<RequisitionInterface> interfaces = new ArrayList<>();
+        RequisitionInterface requisitionInterface = new RequisitionInterface();
+        requisitionInterface.setIpAddr(ipAddress);
+        requisitionInterface.setManaged(true);
+        requisitionInterface.setSnmpPrimary(PrimaryType.PRIMARY);
+        interfaces.add(requisitionInterface);
+        RequisitionNode node = new RequisitionNode();
+        node.setNodeLabel(ipAddress);
+        node.setLocation(location);
+        node.setInterfaces(interfaces);
+        node.setForeignId("foreignId");
+        requisition.insertNode(node);
+
+        client.addOrReplaceRequisition(requisition);
+        client.importRequisition("foreignSource");
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/AbstractKafkaCompressionRpcIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/AbstractKafkaCompressionRpcIT.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
 package org.opennms.smoketest.minion;
 
 import static org.awaitility.Awaitility.await;
@@ -10,19 +31,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.opennms.smoketest.containers.OpenNMSContainer;
-import org.opennms.smoketest.junit.MinionTests;
-import org.opennms.smoketest.stacks.IpcStrategy;
-import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
-import org.opennms.smoketest.stacks.StackModel;
 import org.opennms.smoketest.utils.CommandTestUtils;
 import org.opennms.smoketest.utils.RestClient;
 import org.opennms.smoketest.utils.SshClient;

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/AbstractKafkaCompressionRpcIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/AbstractKafkaCompressionRpcIT.java
@@ -1,65 +1,50 @@
-/*
- * Licensed to The OpenNMS Group, Inc (TOG) under one or more
- * contributor license agreements.  See the LICENSE.md file
- * distributed with this work for additional information
- * regarding copyright ownership.
- *
- * TOG licenses this file to You under the GNU Affero General
- * Public License Version 3 (the "License") or (at your option)
- * any later version.  You may not use this file except in
- * compliance with the License.  You may obtain a copy of the
- * License at:
- *
- *      https://www.gnu.org/licenses/agpl-3.0.txt
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied.  See the License for the specific
- * language governing permissions and limitations under the
- * License.
- */
 package org.opennms.smoketest.minion;
 
+import static org.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.MinionTests;
+import org.opennms.smoketest.stacks.IpcStrategy;
+import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.stacks.StackModel;
 import org.opennms.smoketest.utils.CommandTestUtils;
 import org.opennms.smoketest.utils.RestClient;
 import org.opennms.smoketest.utils.SshClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.List;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.containsString;
 
-public abstract class AbstractKafkaCompressionIT {
-    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+public abstract class AbstractKafkaCompressionRpcIT {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractKafkaCompressionRpcIT.class);
     protected static final String LOCALHOST = "127.0.0.1";
 
-    protected final OpenNMSStack stack;
+    protected abstract OpenNMSStack stack();
 
-    public AbstractKafkaCompressionIT(OpenNMSStack stack) {
-        this.stack = stack;
-    }
+
 
     @Test
     public void verifyKafkaRpcWithTcpServiceDetection() {
-        addRequisition(stack.opennms().getRestClient(), stack.minion().getLocation(), LOCALHOST);
+        addRequisition(stack().opennms().getRestClient(), stack().minion().getLocation(), LOCALHOST);
         await().atMost(3, MINUTES).pollInterval(15, SECONDS)
-                .until(() -> detectTcpAtLocationMinion(), containsString("'TCP' WAS detected on 127.0.0.1"));
+                .until(() -> detectTcpAtLocationMinion(stack()), containsString("'TCP' WAS detected on 127.0.0.1"));
     }
 
-    String detectTcpAtLocationMinion() throws Exception {
+    static String detectTcpAtLocationMinion(OpenNMSStack stack) throws Exception {
         try (final SshClient sshClient = new SshClient(stack.opennms().getSshAddress(), "admin", "admin")) {
             PrintStream pipe = sshClient.openShell();
             pipe.println(String.format("detect -l %s TCP 127.0.0.1 port=8201", stack.minion().getLocation()));
@@ -75,17 +60,19 @@ public abstract class AbstractKafkaCompressionIT {
     @Test
     public void verifyKafkaRpcWithJdbcServiceDetection() {
         await().atMost(3, MINUTES).pollInterval(15, SECONDS).pollDelay(0, SECONDS)
-                .until(() -> detectJdbcAtLocationMinion(), containsString("'JDBC' WAS detected"));
+                .until(this::detectJdbcAtLocationMinion, containsString("'JDBC' WAS detected"));
     }
 
     private String detectJdbcAtLocationMinion() throws Exception {
+        // Retrieve Postgres address and add form a URL
         String jdbcUrl = String.format("jdbc:postgresql://%s:5432/opennms", OpenNMSContainer.DB_ALIAS);
-        try (final SshClient sshClient = stack.opennms().ssh()) {
+        try (final SshClient sshClient = stack().opennms().ssh()) {
+            // Perform JDBC service detection on Minion
             final PrintStream pipe = sshClient.openShell();
-            pipe.println(String.format("detect -l %s JDBC 127.0.0.1 url=%s user=opennms password=opennms",
-                    stack.minion().getLocation(), jdbcUrl));
+            pipe.println(String.format("detect -l %s JDBC 127.0.0.1 url=%s user=opennms password=opennms", stack().minion().getLocation(), jdbcUrl));
             pipe.println("logout");
             await().atMost(1, MINUTES).until(sshClient.isShellClosedCallable());
+            // Sanitize the output
             String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
             shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
             LOG.info("Detect output: {}", shellOutput);
@@ -94,7 +81,6 @@ public abstract class AbstractKafkaCompressionIT {
     }
 
     public static void addRequisition(RestClient client, String location, String ipAddress) {
-        // Implementation remains same as original
         Requisition requisition = new Requisition("foreignSource");
         List<RequisitionInterface> interfaces = new ArrayList<>();
         RequisitionInterface requisitionInterface = new RequisitionInterface();
@@ -112,4 +98,6 @@ public abstract class AbstractKafkaCompressionIT {
         client.addOrReplaceRequisition(requisition);
         client.importRequisition("foreignSource");
     }
+
+
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionLz4IT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionLz4IT.java
@@ -30,15 +30,17 @@ import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
 
 @Category(MinionTests.class)
-public class KafkaCompressionLz4IT extends AbstractKafkaCompressionIT {
+public class KafkaCompressionLz4IT extends AbstractKafkaCompressionRpcIT {
     @ClassRule
-    public static OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
-            .withMinion()
-            .withIpcStrategy(IpcStrategy.KAFKA)
-            .withKafkaCompressionStrategy(KafkaCompressionStrategy.LZ4)
-            .build());
+    public static final OpenNMSStack stack =
+            OpenNMSStack.withModel(StackModel.newBuilder()
+                    .withMinion()
+                    .withIpcStrategy(IpcStrategy.KAFKA)
+                    .withKafkaCompressionStrategy(KafkaCompressionStrategy.LZ4)
+                    .build());
 
-    public KafkaCompressionLz4IT() {
-        super(stack);
+    @Override
+    protected OpenNMSStack stack() {
+        return stack;
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionLz4IT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionLz4IT.java
@@ -1,105 +1,44 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
 package org.opennms.smoketest.minion;
 
-import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.opennms.netmgt.model.PrimaryType;
-import org.opennms.netmgt.provision.persist.requisition.Requisition;
-import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
-import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
-import org.opennms.smoketest.containers.OpenNMSContainer;
 import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
-import org.opennms.smoketest.utils.CommandTestUtils;
-import org.opennms.smoketest.utils.RestClient;
-import org.opennms.smoketest.utils.SshClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.containsString;
-public class KafkaCompressionLz4IT {
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaCompressionLz4IT.class);
-
+@Category(MinionTests.class)
+public class KafkaCompressionLz4IT extends AbstractKafkaCompressionIT {
     @ClassRule
-    public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
+    public static OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
             .withMinion()
             .withIpcStrategy(IpcStrategy.KAFKA)
             .withKafkaCompressionStrategy(KafkaCompressionStrategy.LZ4)
             .build());
 
-    private static final String LOCALHOST = "127.0.0.1";
-
-    @Test
-    public void verifyKafkaRpcWithTcpServiceDetection() {
-        // Add node and interface with minion location.
-        addRequisition(stack.opennms().getRestClient(), stack.minion().getLocation(), LOCALHOST);
-        await().atMost(3, MINUTES).pollInterval(15, SECONDS)
-                .until(() -> detectTcpAtLocationMinion(stack), containsString("'TCP' WAS detected on 127.0.0.1"));
-    }
-
-    static String detectTcpAtLocationMinion(OpenNMSStack stack) throws Exception {
-        try (final SshClient sshClient = new SshClient(stack.opennms().getSshAddress(), "admin", "admin")) {
-            PrintStream pipe = sshClient.openShell();
-            pipe.println(String.format("detect -l %s TCP 127.0.0.1 port=8201", stack.minion().getLocation()));
-            pipe.println("logout");
-            await().atMost(90, SECONDS).until(sshClient.isShellClosedCallable());
-            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
-            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
-            LOG.info("Detect output: {}", shellOutput);
-            return shellOutput;
-        }
-    }
-
-    @Test
-    public void verifyKafkaRpcWithJdbcServiceDetection() {
-        await().atMost(3, MINUTES).pollInterval(15, SECONDS).pollDelay(0, SECONDS)
-                .until(this::detectJdbcAtLocationMinion, containsString("'JDBC' WAS detected"));
-    }
-
-    private String detectJdbcAtLocationMinion() throws Exception {
-        // Retrieve Postgres address and add form a URL
-        String jdbcUrl = String.format("jdbc:postgresql://%s:5432/opennms", OpenNMSContainer.DB_ALIAS);
-        try (final SshClient sshClient = stack.opennms().ssh()) {
-            // Perform JDBC service detection on Minion
-            final PrintStream pipe = sshClient.openShell();
-            pipe.println(String.format("detect -l %s JDBC 127.0.0.1 url=%s user=opennms password=opennms", stack.minion().getLocation(), jdbcUrl));
-            pipe.println("logout");
-            await().atMost(1, MINUTES).until(sshClient.isShellClosedCallable());
-            // Sanitize the output
-            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
-            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
-            LOG.info("Detect output: {}", shellOutput);
-            return shellOutput;
-        }
-    }
-
-    public static void addRequisition(RestClient client, String location, String ipAddress) {
-        Requisition requisition = new Requisition("foreignSource");
-        List<RequisitionInterface> interfaces = new ArrayList<>();
-        RequisitionInterface requisitionInterface = new RequisitionInterface();
-        requisitionInterface.setIpAddr(ipAddress);
-        requisitionInterface.setManaged(true);
-        requisitionInterface.setSnmpPrimary(PrimaryType.PRIMARY);
-        interfaces.add(requisitionInterface);
-        RequisitionNode node = new RequisitionNode();
-        node.setNodeLabel(ipAddress);
-        node.setLocation(location);
-        node.setInterfaces(interfaces);
-        node.setForeignId("foreignId");
-        requisition.insertNode(node);
-
-        client.addOrReplaceRequisition(requisition);
-        client.importRequisition("foreignSource");
+    public KafkaCompressionLz4IT() {
+        super(stack);
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionLz4IT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionLz4IT.java
@@ -1,0 +1,105 @@
+package org.opennms.smoketest.minion;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.netmgt.model.PrimaryType;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
+import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.MinionTests;
+import org.opennms.smoketest.stacks.IpcStrategy;
+import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
+import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.stacks.StackModel;
+import org.opennms.smoketest.utils.CommandTestUtils;
+import org.opennms.smoketest.utils.RestClient;
+import org.opennms.smoketest.utils.SshClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+public class KafkaCompressionLz4IT {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaCompressionLz4IT.class);
+
+    @ClassRule
+    public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
+            .withMinion()
+            .withIpcStrategy(IpcStrategy.KAFKA)
+            .withKafkaCompressionStrategy(KafkaCompressionStrategy.LZ4)
+            .build());
+
+    private static final String LOCALHOST = "127.0.0.1";
+
+    @Test
+    public void verifyKafkaRpcWithTcpServiceDetection() {
+        // Add node and interface with minion location.
+        addRequisition(stack.opennms().getRestClient(), stack.minion().getLocation(), LOCALHOST);
+        await().atMost(3, MINUTES).pollInterval(15, SECONDS)
+                .until(() -> detectTcpAtLocationMinion(stack), containsString("'TCP' WAS detected on 127.0.0.1"));
+    }
+
+    static String detectTcpAtLocationMinion(OpenNMSStack stack) throws Exception {
+        try (final SshClient sshClient = new SshClient(stack.opennms().getSshAddress(), "admin", "admin")) {
+            PrintStream pipe = sshClient.openShell();
+            pipe.println(String.format("detect -l %s TCP 127.0.0.1 port=8201", stack.minion().getLocation()));
+            pipe.println("logout");
+            await().atMost(90, SECONDS).until(sshClient.isShellClosedCallable());
+            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
+            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
+            LOG.info("Detect output: {}", shellOutput);
+            return shellOutput;
+        }
+    }
+
+    @Test
+    public void verifyKafkaRpcWithJdbcServiceDetection() {
+        await().atMost(3, MINUTES).pollInterval(15, SECONDS).pollDelay(0, SECONDS)
+                .until(this::detectJdbcAtLocationMinion, containsString("'JDBC' WAS detected"));
+    }
+
+    private String detectJdbcAtLocationMinion() throws Exception {
+        // Retrieve Postgres address and add form a URL
+        String jdbcUrl = String.format("jdbc:postgresql://%s:5432/opennms", OpenNMSContainer.DB_ALIAS);
+        try (final SshClient sshClient = stack.opennms().ssh()) {
+            // Perform JDBC service detection on Minion
+            final PrintStream pipe = sshClient.openShell();
+            pipe.println(String.format("detect -l %s JDBC 127.0.0.1 url=%s user=opennms password=opennms", stack.minion().getLocation(), jdbcUrl));
+            pipe.println("logout");
+            await().atMost(1, MINUTES).until(sshClient.isShellClosedCallable());
+            // Sanitize the output
+            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
+            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
+            LOG.info("Detect output: {}", shellOutput);
+            return shellOutput;
+        }
+    }
+
+    public static void addRequisition(RestClient client, String location, String ipAddress) {
+        Requisition requisition = new Requisition("foreignSource");
+        List<RequisitionInterface> interfaces = new ArrayList<>();
+        RequisitionInterface requisitionInterface = new RequisitionInterface();
+        requisitionInterface.setIpAddr(ipAddress);
+        requisitionInterface.setManaged(true);
+        requisitionInterface.setSnmpPrimary(PrimaryType.PRIMARY);
+        interfaces.add(requisitionInterface);
+        RequisitionNode node = new RequisitionNode();
+        node.setNodeLabel(ipAddress);
+        node.setLocation(location);
+        node.setInterfaces(interfaces);
+        node.setForeignId("foreignId");
+        requisition.insertNode(node);
+
+        client.addOrReplaceRequisition(requisition);
+        client.importRequisition("foreignSource");
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionSnappyIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionSnappyIT.java
@@ -33,6 +33,7 @@ import org.opennms.smoketest.stacks.StackModel;
 
 @Category(MinionTests.class)
 public class KafkaCompressionSnappyIT extends AbstractKafkaCompressionRpcIT {
+
     @ClassRule
     public static final OpenNMSStack stack =
             OpenNMSStack.withModel(StackModel.newBuilder()

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionSnappyIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionSnappyIT.java
@@ -1,108 +1,48 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
 package org.opennms.smoketest.minion;
 
-import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.opennms.netmgt.model.PrimaryType;
-import org.opennms.netmgt.provision.persist.requisition.Requisition;
-import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
-import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
-import org.opennms.smoketest.containers.OpenNMSContainer;
 import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
-import org.opennms.smoketest.utils.CommandTestUtils;
-import org.opennms.smoketest.utils.RestClient;
-import org.opennms.smoketest.utils.SshClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.List;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.containsString;
+
 
 @Category(MinionTests.class)
-public class KafkaCompressionSnappyIT {
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaCompressionSnappyIT.class);
-
+public class KafkaCompressionSnappyIT  extends AbstractKafkaCompressionIT {
     @ClassRule
-    public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
+    public static OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
             .withMinion()
             .withIpcStrategy(IpcStrategy.KAFKA)
             .withKafkaCompressionStrategy(KafkaCompressionStrategy.SNAPPY)
             .build());
 
-    private static final String LOCALHOST = "127.0.0.1";
-
-    @Test
-    public void verifyKafkaRpcWithTcpServiceDetection() {
-        // Add node and interface with minion location.
-        addRequisition(stack.opennms().getRestClient(), stack.minion().getLocation(), LOCALHOST);
-        await().atMost(3, MINUTES).pollInterval(15, SECONDS)
-                .until(() -> detectTcpAtLocationMinion(stack), containsString("'TCP' WAS detected on 127.0.0.1"));
-    }
-
-    static String detectTcpAtLocationMinion(OpenNMSStack stack) throws Exception {
-        try (final SshClient sshClient = new SshClient(stack.opennms().getSshAddress(), "admin", "admin")) {
-            PrintStream pipe = sshClient.openShell();
-            pipe.println(String.format("detect -l %s TCP 127.0.0.1 port=8201", stack.minion().getLocation()));
-            pipe.println("logout");
-            await().atMost(90, SECONDS).until(sshClient.isShellClosedCallable());
-            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
-            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
-            LOG.info("Detect output: {}", shellOutput);
-            return shellOutput;
-        }
-    }
-
-    @Test
-    public void verifyKafkaRpcWithJdbcServiceDetection() {
-        await().atMost(3, MINUTES).pollInterval(15, SECONDS).pollDelay(0, SECONDS)
-                .until(this::detectJdbcAtLocationMinion, containsString("'JDBC' WAS detected"));
-    }
-
-    private String detectJdbcAtLocationMinion() throws Exception {
-        // Retrieve Postgres address and add form a URL
-        String jdbcUrl = String.format("jdbc:postgresql://%s:5432/opennms", OpenNMSContainer.DB_ALIAS);
-        try (final SshClient sshClient = stack.opennms().ssh()) {
-            // Perform JDBC service detection on Minion
-            final PrintStream pipe = sshClient.openShell();
-            pipe.println(String.format("detect -l %s JDBC 127.0.0.1 url=%s user=opennms password=opennms", stack.minion().getLocation(), jdbcUrl));
-            pipe.println("logout");
-            await().atMost(1, MINUTES).until(sshClient.isShellClosedCallable());
-            // Sanitize the output
-            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
-            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
-            LOG.info("Detect output: {}", shellOutput);
-            return shellOutput;
-        }
-    }
-
-    public static void addRequisition(RestClient client, String location, String ipAddress) {
-        Requisition requisition = new Requisition("foreignSource");
-        List<RequisitionInterface> interfaces = new ArrayList<>();
-        RequisitionInterface requisitionInterface = new RequisitionInterface();
-        requisitionInterface.setIpAddr(ipAddress);
-        requisitionInterface.setManaged(true);
-        requisitionInterface.setSnmpPrimary(PrimaryType.PRIMARY);
-        interfaces.add(requisitionInterface);
-        RequisitionNode node = new RequisitionNode();
-        node.setNodeLabel(ipAddress);
-        node.setLocation(location);
-        node.setInterfaces(interfaces);
-        node.setForeignId("foreignId");
-        requisition.insertNode(node);
-
-        client.addOrReplaceRequisition(requisition);
-        client.importRequisition("foreignSource");
+    public KafkaCompressionSnappyIT() {
+        super(stack);
     }
 
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionSnappyIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionSnappyIT.java
@@ -21,6 +21,7 @@
  */
 package org.opennms.smoketest.minion;
 
+
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.opennms.smoketest.junit.MinionTests;
@@ -30,19 +31,19 @@ import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
 
 
-
-
 @Category(MinionTests.class)
-public class KafkaCompressionSnappyIT  extends AbstractKafkaCompressionIT {
+public class KafkaCompressionSnappyIT extends AbstractKafkaCompressionRpcIT {
     @ClassRule
-    public static OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
-            .withMinion()
-            .withIpcStrategy(IpcStrategy.KAFKA)
-            .withKafkaCompressionStrategy(KafkaCompressionStrategy.SNAPPY)
-            .build());
+    public static final OpenNMSStack stack =
+            OpenNMSStack.withModel(StackModel.newBuilder()
+                    .withMinion()
+                    .withIpcStrategy(IpcStrategy.KAFKA)
+                    .withKafkaCompressionStrategy(KafkaCompressionStrategy.SNAPPY)
+                    .build());
 
-    public KafkaCompressionSnappyIT() {
-        super(stack);
+    @Override
+    protected OpenNMSStack stack() {
+        return stack;
     }
 
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionSnappyIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionSnappyIT.java
@@ -1,0 +1,108 @@
+package org.opennms.smoketest.minion;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.netmgt.model.PrimaryType;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
+import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.MinionTests;
+import org.opennms.smoketest.stacks.IpcStrategy;
+import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
+import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.stacks.StackModel;
+import org.opennms.smoketest.utils.CommandTestUtils;
+import org.opennms.smoketest.utils.RestClient;
+import org.opennms.smoketest.utils.SshClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+
+@Category(MinionTests.class)
+public class KafkaCompressionSnappyIT {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaCompressionSnappyIT.class);
+
+    @ClassRule
+    public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
+            .withMinion()
+            .withIpcStrategy(IpcStrategy.KAFKA)
+            .withKafkaCompressionStrategy(KafkaCompressionStrategy.SNAPPY)
+            .build());
+
+    private static final String LOCALHOST = "127.0.0.1";
+
+    @Test
+    public void verifyKafkaRpcWithTcpServiceDetection() {
+        // Add node and interface with minion location.
+        addRequisition(stack.opennms().getRestClient(), stack.minion().getLocation(), LOCALHOST);
+        await().atMost(3, MINUTES).pollInterval(15, SECONDS)
+                .until(() -> detectTcpAtLocationMinion(stack), containsString("'TCP' WAS detected on 127.0.0.1"));
+    }
+
+    static String detectTcpAtLocationMinion(OpenNMSStack stack) throws Exception {
+        try (final SshClient sshClient = new SshClient(stack.opennms().getSshAddress(), "admin", "admin")) {
+            PrintStream pipe = sshClient.openShell();
+            pipe.println(String.format("detect -l %s TCP 127.0.0.1 port=8201", stack.minion().getLocation()));
+            pipe.println("logout");
+            await().atMost(90, SECONDS).until(sshClient.isShellClosedCallable());
+            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
+            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
+            LOG.info("Detect output: {}", shellOutput);
+            return shellOutput;
+        }
+    }
+
+    @Test
+    public void verifyKafkaRpcWithJdbcServiceDetection() {
+        await().atMost(3, MINUTES).pollInterval(15, SECONDS).pollDelay(0, SECONDS)
+                .until(this::detectJdbcAtLocationMinion, containsString("'JDBC' WAS detected"));
+    }
+
+    private String detectJdbcAtLocationMinion() throws Exception {
+        // Retrieve Postgres address and add form a URL
+        String jdbcUrl = String.format("jdbc:postgresql://%s:5432/opennms", OpenNMSContainer.DB_ALIAS);
+        try (final SshClient sshClient = stack.opennms().ssh()) {
+            // Perform JDBC service detection on Minion
+            final PrintStream pipe = sshClient.openShell();
+            pipe.println(String.format("detect -l %s JDBC 127.0.0.1 url=%s user=opennms password=opennms", stack.minion().getLocation(), jdbcUrl));
+            pipe.println("logout");
+            await().atMost(1, MINUTES).until(sshClient.isShellClosedCallable());
+            // Sanitize the output
+            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
+            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
+            LOG.info("Detect output: {}", shellOutput);
+            return shellOutput;
+        }
+    }
+
+    public static void addRequisition(RestClient client, String location, String ipAddress) {
+        Requisition requisition = new Requisition("foreignSource");
+        List<RequisitionInterface> interfaces = new ArrayList<>();
+        RequisitionInterface requisitionInterface = new RequisitionInterface();
+        requisitionInterface.setIpAddr(ipAddress);
+        requisitionInterface.setManaged(true);
+        requisitionInterface.setSnmpPrimary(PrimaryType.PRIMARY);
+        interfaces.add(requisitionInterface);
+        RequisitionNode node = new RequisitionNode();
+        node.setNodeLabel(ipAddress);
+        node.setLocation(location);
+        node.setInterfaces(interfaces);
+        node.setForeignId("foreignId");
+        requisition.insertNode(node);
+
+        client.addOrReplaceRequisition(requisition);
+        client.importRequisition("foreignSource");
+    }
+
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionZSTDRpcIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionZSTDRpcIT.java
@@ -21,109 +21,27 @@
  */
 package org.opennms.smoketest.minion;
 
-import static org.awaitility.Awaitility.await;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.Matchers.containsString;
 
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.opennms.netmgt.model.PrimaryType;
-import org.opennms.netmgt.provision.persist.requisition.Requisition;
-import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
-import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
-import org.opennms.smoketest.containers.OpenNMSContainer;
 import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
-import org.opennms.smoketest.utils.CommandTestUtils;
-import org.opennms.smoketest.utils.RestClient;
-import org.opennms.smoketest.utils.SshClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 @Category(MinionTests.class)
-public class KafkaCompressionZSTDRpcIT {
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaCompressionZSTDRpcIT.class);
-
+public class KafkaCompressionZSTDRpcIT extends AbstractKafkaCompressionIT {
     @ClassRule
-    public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
+    public static OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
             .withMinion()
             .withIpcStrategy(IpcStrategy.KAFKA)
             .withKafkaCompressionStrategy(KafkaCompressionStrategy.ZSTD)
             .build());
 
-    private static final String LOCALHOST = "127.0.0.1";
-
-    @Test
-    public void verifyKafkaRpcWithTcpServiceDetection() {
-        // Add node and interface with minion location.
-        addRequisition(stack.opennms().getRestClient(), stack.minion().getLocation(), LOCALHOST);
-        await().atMost(3, MINUTES).pollInterval(15, SECONDS)
-                .until(() -> detectTcpAtLocationMinion(stack), containsString("'TCP' WAS detected on 127.0.0.1"));
-    }
-
-    static String detectTcpAtLocationMinion(OpenNMSStack stack) throws Exception {
-        try (final SshClient sshClient = new SshClient(stack.opennms().getSshAddress(), "admin", "admin")) {
-            PrintStream pipe = sshClient.openShell();
-            pipe.println(String.format("detect -l %s TCP 127.0.0.1 port=8201", stack.minion().getLocation()));
-            pipe.println("logout");
-            await().atMost(90, SECONDS).until(sshClient.isShellClosedCallable());
-            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
-            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
-            LOG.info("Detect output: {}", shellOutput);
-            return shellOutput;
-        }
-    }
-
-    @Test
-    public void verifyKafkaRpcWithJdbcServiceDetection() {
-        await().atMost(3, MINUTES).pollInterval(15, SECONDS).pollDelay(0, SECONDS)
-                .until(this::detectJdbcAtLocationMinion, containsString("'JDBC' WAS detected"));
-    }
-
-    private String detectJdbcAtLocationMinion() throws Exception {
-        // Retrieve Postgres address and add form a URL
-        String jdbcUrl = String.format("jdbc:postgresql://%s:5432/opennms", OpenNMSContainer.DB_ALIAS);
-        try (final SshClient sshClient = stack.opennms().ssh()) {
-            // Perform JDBC service detection on Minion
-            final PrintStream pipe = sshClient.openShell();
-            pipe.println(String.format("detect -l %s JDBC 127.0.0.1 url=%s user=opennms password=opennms", stack.minion().getLocation(), jdbcUrl));
-            pipe.println("logout");
-            await().atMost(1, MINUTES).until(sshClient.isShellClosedCallable());
-            // Sanitize the output
-            String shellOutput = CommandTestUtils.stripAnsiCodes(sshClient.getStdout());
-            shellOutput = StringUtils.substringAfter(shellOutput, "detect -l");
-            LOG.info("Detect output: {}", shellOutput);
-            return shellOutput;
-        }
-    }
-
-    public static void addRequisition(RestClient client, String location, String ipAddress) {
-        Requisition requisition = new Requisition("foreignSource");
-        List<RequisitionInterface> interfaces = new ArrayList<>();
-        RequisitionInterface requisitionInterface = new RequisitionInterface();
-        requisitionInterface.setIpAddr(ipAddress);
-        requisitionInterface.setManaged(true);
-        requisitionInterface.setSnmpPrimary(PrimaryType.PRIMARY);
-        interfaces.add(requisitionInterface);
-        RequisitionNode node = new RequisitionNode();
-        node.setNodeLabel(ipAddress);
-        node.setLocation(location);
-        node.setInterfaces(interfaces);
-        node.setForeignId("foreignId");
-        requisition.insertNode(node);
-
-        client.addOrReplaceRequisition(requisition);
-        client.importRequisition("foreignSource");
+    public KafkaCompressionZSTDRpcIT() {
+        super(stack);
     }
 
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionZSTDRpcIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionZSTDRpcIT.java
@@ -21,9 +21,9 @@
  */
 package org.opennms.smoketest.minion;
 
-
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
+
 import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
@@ -32,16 +32,17 @@ import org.opennms.smoketest.stacks.StackModel;
 
 
 @Category(MinionTests.class)
-public class KafkaCompressionZSTDRpcIT extends AbstractKafkaCompressionIT {
+public class KafkaCompressionZSTDRpcIT extends AbstractKafkaCompressionRpcIT {
     @ClassRule
-    public static OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
-            .withMinion()
-            .withIpcStrategy(IpcStrategy.KAFKA)
-            .withKafkaCompressionStrategy(KafkaCompressionStrategy.ZSTD)
-            .build());
+    public static final OpenNMSStack stack =
+            OpenNMSStack.withModel(StackModel.newBuilder()
+                    .withMinion()
+                    .withIpcStrategy(IpcStrategy.KAFKA)
+                    .withKafkaCompressionStrategy(KafkaCompressionStrategy.ZSTD)
+                    .build());
 
-    public KafkaCompressionZSTDRpcIT() {
-        super(stack);
+    @Override
+    protected OpenNMSStack stack() {
+        return stack;
     }
-
 }


### PR DESCRIPTION

Minion Fails to start when client sets up lz4/snappy as compression.type in kafka-broker as default

Can we have support for compression.type lz4/snappy for communication between OpenNMS <kafka> Minion


* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17948

