### PR TITLE
NMS-18002: Prevent old jetty version from being loaded

### DIFF
--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -101,6 +101,9 @@
                         <feature>opennms-bridge-http-service</feature>
                         <feature>opennms-http-whiteboard</feature>
 
+                        <feature>jetty9.4.52.v20230823</feature>
+                        <feature>pax-jetty/9.4.52.v20230823</feature>
+
                         <feature>jetty/9.4.43.v20210629</feature>
                         <feature>pax-jetty/9.4.43.v20210629</feature>
                         <feature>ssh/${karafVersion}</feature>


### PR DESCRIPTION
* JIRA: https://opennms.atlassian.net/browse/NMS-18002