### PR TITLE
NMS-18021: Change pending Problems to pending Alarms

### DIFF
--- a/core/upgrade/src/test/resources/etc2/opennms.properties
+++ b/core/upgrade/src/test/resources/etc2/opennms.properties
@@ -451,11 +451,11 @@ opennms.eventlist.showCount=false
 # page in the OpenNMS web UI. Default: true
 #opennms.nodesWithOutages.show=true
 
-# This value allows you to set the number of nodes with problems to display on the front
+# This value allows you to set the number of nodes with alarms to display on the front
 # page in the OpenNMS web UI. Default: 16
 #opennms.nodesWithProblems.count=16
 
-# This value allows you to enable/disable the nodes with problems box on the front
+# This value allows you to enable/disable the nodes with alarms box on the front
 # page in the OpenNMS web UI. Default: true
 #
 #opennms.nodesWithProblems.show=true

--- a/docs/modules/operation/pages/deep-dive/alarms/alarm-handling.adoc
+++ b/docs/modules/operation/pages/deep-dive/alarms/alarm-handling.adoc
@@ -8,7 +8,7 @@ The following are ways you can interact with alarms.
 
 Users can acknowledge alarms to let other {page-component-title} users see that someone is aware of the alarm.
 The alarm will be moved out from `Alarm(s) outstanding` into the `Alarm(s) acknowledged` view.
-Acknowledged alarms will also be hidden from the "Nodes with Pending Problems" section of the home page.
+Acknowledged alarms will also be hidden from the "Nodes with Pending Alarms" section of the home page.
 
 .Acknowledged alarm of an HTTP outage in the alarm overview
 image::alarms/acked_alarm_overview.png["Acknowledged alarm of an HTTP outage in the alarm overview"]

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/summary-box.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/summary-box.jsp
@@ -40,13 +40,13 @@
 <c:url var="headingLink" value="alarm/list.htm"/>
 <div class="card">
   <div class="card-header">
-    <span><a href="${headingLink}">Nodes with Pending Problems</a></span>
+    <span><a href="${headingLink}">Nodes with Pending Alarms</a></span>
   </div>
   <c:choose>
     <c:when test="${empty summaries}">
       <div class="card-body">
         <p class="mb-0">
-          There are no pending problems.
+          There are no pending alarms.
         </p>
       </div>
     </c:when>
@@ -66,7 +66,7 @@
       <c:if test="${moreCount > 0}">
         <div class="card-footer text-right">
           <c:url var="moreLink" value="alarm/list.htm"/>
-          <a href="${moreLink}">All pending problems...</a>
+          <a href="${moreLink}">All pending alarms...</a>
         </div>
       </c:if>
     </c:otherwise>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/application/summary-box.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/application/summary-box.jsp
@@ -28,13 +28,13 @@
 <c:url var="headingLink" value="application/index.jsp"/>
 <div class="card">
   <div class="card-header">
-    <a href="${headingLink}">Applications with Pending Problems</a>
+    <a href="${headingLink}">Applications with Pending Alarms</a>
   </div>
   <c:choose>
     <c:when test="${empty summaries}">
       <div class="card-body">
         <p class="mb-0">
-          There are no pending problems.
+          There are no pending alarms.
         </p>
       </div>
     </c:when>
@@ -56,7 +56,7 @@
       </table>
       <c:if test="${more}">
         <div class="card-footer text-right">
-          Not all Applications with Pending Problems are shown.
+          Not all Applications with Pending Alarms are shown.
         </div>
       </c:if>
     </c:otherwise>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/bsm/summary-box.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/bsm/summary-box.jsp
@@ -27,13 +27,13 @@
 <!-- bsm/summary-box.htm -->
 <div class="card">
   <div class="card-header">
-      <a href="#">Business Services with Pending Problems</a>
+      <a href="#">Business Services with Pending Alarms</a>
   </div>
   <c:choose>
     <c:when test="${empty services}">
       <div class="card-body">
         <p class="mb-0">
-          There are no pending problems.
+          There are no pending alarms.
         </p>
       </div>
     </c:when>
@@ -55,7 +55,7 @@
       </table>
       <c:if test="${more}">
         <div class="card-footer text-right">
-          Not all Business Services with Pending Problems are shown.
+          Not all Business Services with Pending Alarms are shown.
         </div>
       </c:if>
     </c:otherwise>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/situation/summary-box.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/situation/summary-box.jsp
@@ -51,7 +51,7 @@
     <c:when test="${empty summaries}">
       <div class="card-body">
         <p class="mb-0">
-          There are no pending problems.
+          There are no pending alarms.
         </p>
       </div>
     </c:when>
@@ -93,7 +93,7 @@
       <c:if test="${moreCount > 0}">
         <div class="card-footer text-right">
           <c:url var="moreLink" value="alarm/list.htm"/>
-          <a href="alarm/list.htm?filter=situation%3Dtrue">All pending problems...</a>
+          <a href="alarm/list.htm?filter=situation%3Dtrue">All pending alarms...</a>
         </div>
       </c:if>
     </c:otherwise>


### PR DESCRIPTION
The alarm boxes for Nodes, Applications and Business services is changed from "...with Problems" to "...with Alarms" to be less confusing.

<img width="502" alt="Screenshot 2025-06-13 at 14 03 14" src="https://github.com/user-attachments/assets/ac2ebe95-d7c6-4f97-b2c9-fbb83e2f4909" />

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18021

