### PR TITLE
NMS-18022: Add tss write metrics to usage report

### DIFF
--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReportDTO.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReportDTO.java
@@ -82,6 +82,7 @@ public class UsageStatisticsReportDTO {
     private long m_coreFlowsPersisted;
     private long m_coreNewtsSamplesInserted;
     private long m_coreQueuedUpdatesCompleted;
+    private long m_coreTssWritesCompleted;
     private int m_users;
     private int m_groups;
     private long m_dcbSucceed;
@@ -434,6 +435,14 @@ public class UsageStatisticsReportDTO {
 
     public void setCoreQueuedUpdatesCompleted(long coreQueuedUpdatesCompleted) {
         this.m_coreQueuedUpdatesCompleted = coreQueuedUpdatesCompleted;
+    }
+
+    public long getCoreTssWritesCompleted() {
+        return m_coreTssWritesCompleted;
+    }
+
+    public void setCoreTssWritesCompleted(long coreTssWritesCompleted) {
+        this.m_coreTssWritesCompleted = coreTssWritesCompleted;
     }
 
     public void setSinkStrategy(String sinkStrategy) {

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReporter.java
@@ -100,6 +100,7 @@ public class UsageStatisticsReporter implements StateChangeHandler {
     private static final String JMX_OBJ_OPENNMS_FLOWS_PERSISTED = "org.opennms.netmgt.flows:name=flowsPersisted,type=meters";
     private static final String JMX_OBJ_OPENNMS_REPO_SAMPLE_INSERTED = "org.opennms.newts:name=repository.samples-inserted,type=meters";
     private static final String JMX_OBJ_OPENNMS_QUEUED = "OpenNMS:Name=Queued";
+    private static final String JMX_OBJ_OPENNMS_TSS = "org.opennms.timeseries:name=samples.write.integration";
     private static final String JMX_ATTR_FREE_PHYSICAL_MEMORY_SIZE = "FreePhysicalMemorySize";
     private static final String JMX_ATTR_TOTAL_PHYSICAL_MEMORY_SIZE = "TotalPhysicalMemorySize";
     private static final String JMX_ATTR_AVAILABLE_PROCESSORS = "AvailableProcessors";
@@ -361,6 +362,10 @@ public class UsageStatisticsReporter implements StateChangeHandler {
         Object coreQueuedUpdatesCompletedObj = getJmxAttribute(JMX_OBJ_OPENNMS_QUEUED, JMX_ATTR_UPDATES_COMPLETED);
         if (coreQueuedUpdatesCompletedObj != null) {
             usageStatisticsReport.setCoreQueuedUpdatesCompleted((long) coreQueuedUpdatesCompletedObj);
+        }
+        Object coreTssWritesCompletedObj = getJmxAttribute(JMX_OBJ_OPENNMS_TSS, JMX_ATTR_COUNT);
+        if (coreTssWritesCompletedObj != null) {
+            usageStatisticsReport.setCoreTssWritesCompleted((long) coreTssWritesCompletedObj);
         }
     }
 

--- a/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReportDTOTest.java
+++ b/features/datachoices/src/test/java/org/opennms/features/datachoices/internal/usagestatistics/UsageStatisticsReportDTOTest.java
@@ -73,6 +73,7 @@ public class UsageStatisticsReportDTOTest {
             "\"coreFlowsPersisted\":0," +
             "\"coreNewtsSamplesInserted\":0," +
             "\"coreQueuedUpdatesCompleted\":0," +
+            "\"coreTssWritesCompleted\":0," +
             "\"databaseProductName\":null," +
             "\"databaseProductVersion\":null," +
             "\"dcbFailed\":0," +


### PR DESCRIPTION
https://opennms.atlassian.net/browse/NMS-18022

Adds a metric to the usage report for metrics written to TSS `integration` strategies by pulling `count` from `org.opennms.timeseries:name=samples.write.integration`

