### PR TITLE
NMS-18020: Not able to uninstall opennms flows feature from OpenNMS

### DIFF
--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -26,13 +26,12 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Karaf-Commands>*</Karaf-Commands>
-
+                    <!--    keep flows api import resolution optional to avoid the error while uninstalling the flows feature       -->
                         <Import-Package>
                             org.opennms.netmgt.flows.api;resolution:=optional,
                             org.opennms.netmgt.flows.filter.api;resolution:=optional,
                             *
                         </Import-Package>
-
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
On karaf shell, try to uninstall  opennms-flows.

It fails with below error:

```
feature:uninstall opennms-flows
Error executing command: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=datachoices; type=karaf.feature; version="[34.0.0.SNAPSHOT,34.0.0.SNAPSHOT]"; filter:="(&(osgi.identity=datachoices)(type=karaf.feature)(version>=34.0.0.SNAPSHOT)(version<=34.0.0.SNAPSHOT))" [caused by: Unable to resolve datachoices/34.0.0.SNAPSHOT: missing requirement [datachoices/34.0.0.SNAPSHOT] osgi.identity; osgi.identity=datachoices; type=osgi.bundle; version="[34.0.0.SNAPSHOT,34.0.0.SNAPSHOT]"; resolution:=mandatory [caused by: Unable to resolve datachoices/34.0.0.SNAPSHOT: missing requirement [datachoices/34.0.0.SNAPSHOT] osgi.wiring.package; filter:="(&(osgi.wiring.package=org.opennms.netmgt.flows.api)(version>=34.0.0)(!(version>=35.0.0)))"]]
```

keep  flows api `import resolution optional` to avoid the error while  uninstalling the flows feature 

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18020

