### PR TITLE
NMS-18042: Fix BMP Aggregator parser to handle IPv6 peers correctly

### DIFF
--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/Aggregator.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/Aggregator.java
@@ -24,20 +24,30 @@ package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.path
 import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint16;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
+import org.opennms.netmgt.telemetry.listeners.utils.BufferUtils;
 
 import com.google.common.base.MoreObjects;
 
 import io.netty.buffer.ByteBuf;
+
 
 public class Aggregator implements Attribute {
     public final int as;              // uint16
     public final InetAddress address; // uint32
 
     public Aggregator(final ByteBuf buffer, final PeerFlags flags) {
+        if (buffer.readableBytes() < 6) {
+            throw new IllegalArgumentException("Insufficient bytes for Aggregator attribute: expected at least 6 bytes, got " + buffer.readableBytes());
+        }
         this.as = uint16(buffer);
-        this.address = flags.parseAddress(buffer);
+        try {
+            this.address = InetAddress.getByAddress(BufferUtils.bytes(buffer, 4));
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid IP address in Aggregator attribute", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
### All Contributors

* [X] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

A juniper MX240 that has a large number of IPv4 and IPv6 peers, that when connected to OpenNMS via BMP would throw the following exception and terminate the session almost immediately.

Invalid packet: java.lang.IndexOutOfBoundsException: readerIndex(2) + length(16) exceeds writerIndex(8)

This occurred in the Aggregator path attribute parser, which incorrectly assumed that the aggregator’s IP address length depended on the peer’s address family (via PeerFlags). For IPv6 peers, it attempted to read 16 bytes instead of the correct 4 bytes.

This patch should always read 2 bytes for ASN and 4 bytes for IP address.

The patch was tested on OpenNMS Horizon 33.1.7


JIRA: https://opennms.atlassian.net/browse/NMS-18042