### PR TITLE
NMS-18053: Update the "nodeDeleted" Event in opennms.pollerd.events.xml

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
@@ -338,7 +338,6 @@
       <descr>&lt;p>%parm[nodelabel]% (%parm[foreignSource]%:%parm[foreignId]%) in location %parm[location]% was deleted from requisition %parm[foreignSource]%.&lt;/p>
              &lt;p>This can have multiple reasons.
              &lt;ul>
-             &lt;li>OpenNMS default config will delete any node that is down for seven consecutive days.&lt;/li>
              &lt;li>It was removed from the corresponding requisition %parm[foreignSource]%. This can be done manually using the web UI or using provisiond import schedules.&lt;/li>
              &lt;li>It was manually deleted using the "Delete nodes" entry in the Admin menu.&lt;/li>
              &lt;li>It was removed using the ReST API&lt;/li>


### PR DESCRIPTION
Removed the verbiage for "deleting a node if it's down for X number of days." No longer needed as we no longer include this in the downtime model in the Pollerd config.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18053

