### PR TITLE
NMS-18061: Fix plugin issues after menu redesign

### DIFF
--- a/ui/src/components/Plugin/utils.ts
+++ b/ui/src/components/Plugin/utils.ts
@@ -94,12 +94,20 @@ const addStylesheet = (url: string) => {
   head.prepend(link)
 }
 
-const getJSPath = (baseUrl: string, extensionId: string, rootPath: string, fileName: string) => {
-  return `${baseUrl}/plugins/ui-extension/module/${extensionId}?path=${rootPath}/${fileName}`
+/**
+ * Get the Rest url for the UiExtensionService Rest API (see features/ui-extension).
+ * Accessing this url will return the Javascript module code for the plugin.
+ */
+const getJSPath = (baseRestUrl: string, extensionId: string, rootPath: string, fileName: string) => {
+  return `${baseRestUrl}/plugins/ui-extension/module/${extensionId}?path=${rootPath}/${fileName}`
 }
 
-const getCSSPath = (baseUrl: string, extensionId: string) => {
-  return `${baseUrl}/plugins/ui-extension/css/${extensionId}`
+/**
+ * Get the Rest url for the UiExtensionService Rest API (see features/ui-extension).
+ * Accessing this url will return the CSS code for the plugin.
+ */
+const getCSSPath = (baseRestUrl: string, extensionId: string) => {
+  return `${baseRestUrl}/plugins/ui-extension/css/${extensionId}`
 }
 
 export { externalComponent, addStylesheet, getJSPath, getCSSPath }

--- a/ui/src/containers/Plugin.vue
+++ b/ui/src/containers/Plugin.vue
@@ -6,7 +6,7 @@
 import { addStylesheet, getCSSPath, getJSPath } from '@/components/Plugin/utils'
 import Container from '@/components/Plugin/Container.vue'
 
-const baseUrl = import.meta.env.VITE_BASE_REST_URL
+const baseRestUrl = import.meta.env.VITE_BASE_REST_URL
 const externalJsUrl = ref<string>('')
 
 const props = defineProps({
@@ -25,8 +25,8 @@ const props = defineProps({
 })
 
 const addResources = () => {
-  externalJsUrl.value = getJSPath(baseUrl, props.extensionId, props.resourceRootPath, props.moduleFileName)
-  const externalCssUrl = getCSSPath(baseUrl, props.extensionId)
+  externalJsUrl.value = getJSPath(baseRestUrl, props.extensionId, props.resourceRootPath, props.moduleFileName)
+  const externalCssUrl = getCSSPath(baseRestUrl, props.extensionId)
   addStylesheet(externalCssUrl)
 }
 

--- a/ui/src/main/main.ts
+++ b/ui/src/main/main.ts
@@ -49,7 +49,7 @@ import { externalComponent, getJSPath } from '../components/Plugin/utils'
 (window as any)['VRouter'] = router
 
 // plugin scripts must be loaded before app to use their routes
-const baseUrl = import.meta.env.VITE_BASE_REST_URL
+const baseRestUrl = import.meta.env.VITE_BASE_REST_URL
 const plugins = await API.getPlugins()
 
 for (const plugin of plugins) {
@@ -78,7 +78,7 @@ for (const plugin of plugins) {
   }
 
   try {
-    const js = getJSPath(baseUrl, plugin.extensionId, plugin.resourceRootPath, plugin.moduleFileName)
+    const js = getJSPath(baseRestUrl, plugin.extensionId, plugin.resourceRootPath, plugin.moduleFileName)
     await externalComponent(js)
   } catch (e) {
     console.error('Error attempting to load plugin: ', e)

--- a/ui/src/menu/App.vue
+++ b/ui/src/menu/App.vue
@@ -10,12 +10,15 @@ import Menubar from '@/components/Menu/Menubar.vue'
 import SideMenu from '@/components/Menu/SideMenu.vue'
 
 import { useMenuStore } from '@/stores/menuStore'
+import { usePluginStore } from '@/stores/pluginStore'
 
 const menuStore = useMenuStore()
+const pluginStore = usePluginStore()
 
 onMounted(() => {
   menuStore.getMainMenu()
   menuStore.getNotificationSummary()
+  pluginStore.getPlugins()
 })
 </script>
 

--- a/ui/vite.config.menu.ts
+++ b/ui/vite.config.menu.ts
@@ -57,6 +57,9 @@ export default defineConfig({
     'process.env': process.env
   },
   root: './src/menu',
+  // make sure we get environment variables from .env files in the main ui directory
+  // path is relative to 'root' defined just above
+  envDir: '../..',
   build: {
     emptyOutDir: true,
     outDir: './dist-menu',
@@ -64,9 +67,9 @@ export default defineConfig({
     copyPublicDir: false,
     rollupOptions: {
       output: {
-        entryFileNames: `assets/[name].js`,
-        chunkFileNames: `assets/[name].js`,
-        assetFileNames: `assets/[name].[ext]`
+        entryFileNames: 'assets/[name].js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name].[ext]'
       }
     }
   }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -81,6 +81,9 @@ export default defineConfig({
     }
   },
   root: './src/main',
+  // make sure we get environment variables from .env files in the main ui directory
+  // path is relative to 'root' defined just above
+  envDir: '../..',
   build: {
     emptyOutDir: true,
     outDir: './dist',


### PR DESCRIPTION
Fix some issues with launching plugin UIs after the menu redesign.

Make sure to call the `plugins` API to get the plugins in the menu for the legacy pages. We were calling this in the Vue SPA menu but not the menu for the legacy pages.

Some renaming and comments were added to clarify things. For future reference, when user clicks on `Plugins > PluginName` in the Vue menu, it loads a component which dynamically loads a Vue component via a Javascript module. The URL for the JS module is actually a `GET` request to the OpenNMS `features/ui-extension` Rest API. There's a path parameter in the Rest API which is the plugin `id` and there's a `path` query string which is a partial resource path to the Javascript `.es.js` file containing the plugin UI code. The Rest API returns the actual JS code with a `Content-Type` of `application/json`, i.e. a js module. A similar thing happens with the CSS as well.

Needed an `envDir` entry in the `vite.config.js` and `vite.config.menu.js` files to make sure the environment variables are read from the top-level `.env` and `.env.development` files, otherwise they would be read from the `root` directory, e.g `./src/main` or `./src/menu` (so path would be `./src/main/.env` which doesn't exist). We don't want to duplicate those `.env` files.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18061

