### PR TITLE
FE: Node List advanced filters drawer

### DIFF
--- a/ui/src/components/Nodes/NodesAdvanceFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodesAdvanceFiltersDrawer.vue
@@ -1,0 +1,229 @@
+<template>
+  <FeatherDrawer
+    id="left-drawer"
+    data-test="left-drawer"
+    @shown="() => nodeStructureStore.drawerState.visible"
+    v-model="nodeStructureStore.drawerState.visible"
+    :labels="{ close: 'close', title: 'Advanced Node Filters' }"
+    width="60em"
+  >
+    <div class="feather-drawer-custom-padding">
+      <section>
+        <h3>Advanced Filters</h3>
+      </section>
+      <div class="spacer-large"></div>
+      <div class="spacer-large"></div>
+      <div>Choose one or more attributes to find a service.</div>
+      <div class="spacer-large"></div>
+      <FeatherAutocomplete
+        class="my-autocomplete"
+        label="Categories"
+        type="multi"
+        v-model="selectedFilters.categories"
+        :loading="loading"
+        :results="categoryResults"
+        @search="handleCategorySearch"
+        :allow-new="false"
+        text-prop="_text"
+        @update:modelValue="(items: any) => updateFilter('categories', items)"
+      ></FeatherAutocomplete>
+      <FeatherAutocomplete
+        class="filter-autocomplete"
+        label="Flows"
+        type="multi"
+        v-model="selectedFilters.flows"
+        :loading="flowsLoading"
+        :results="flowResults"
+        @search="handleFlowSearch"
+        @update:modelValue="(items: any) => updateFilter('flows', items)"
+        text-prop="_text"
+      ></FeatherAutocomplete>
+      <FeatherAutocomplete
+        class="last-filter-autocomplete"
+        label="Locations"
+        type="multi"
+        v-model="selectedFilters.locations"
+        :loading="locationsLoading"
+        :results="locationResults"
+        @search="handleLocationSearch"
+        @update:modelValue="(items: any) => updateFilter('locations', items)"
+      >
+      </FeatherAutocomplete>
+      <div class="spacer-medium"></div>
+      <div>
+        <h4 class="title">Extended Search</h4>
+        <div class="spacer-medium"></div>
+        <ExtendedSearchPanel />
+      </div>
+      <div class="footer">
+        <FeatherButton
+          primary
+          @click="applySelectedFilters()"
+        >
+          Apply Filters
+        </FeatherButton>
+        <FeatherButton
+          secondary
+          @click="nodeStructureStore.closeInstancesDrawerModal()"
+        >
+          Close
+        </FeatherButton>
+      </div>
+    </div>
+  </FeatherDrawer>
+</template>
+
+<script lang="ts" setup>
+import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { FeatherDrawer } from '@featherds/drawer'
+import { FeatherButton } from '@featherds/button'
+import { ref } from 'vue'
+import { FeatherAutocomplete, IAutocompleteItemType } from '@featherds/autocomplete'
+import { MonitoringLocation } from '@/types'
+import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
+
+const nodeStructureStore = useNodeStructureStore()
+const selectedFilters = reactive({
+  categories: [] as IAutocompleteItemType[],
+  flows: [] as IAutocompleteItemType[],
+  locations: [] as IAutocompleteItemType[]
+})
+
+
+const categoryResults = ref([] as IAutocompleteItemType[])
+const loading = ref(false)
+const searchTimeout = ref<number>(-1)
+const flowsLoading = ref(false)
+const flowResults = ref<IAutocompleteItemType[]>([])
+const locationsLoading = ref(false)
+const locationResults = ref<IAutocompleteItemType[]>([])
+
+watch(() => nodeStructureStore.drawerState.visible, (visible) => {
+  if (visible) {
+    selectedFilters.categories = [...nodeStructureStore.selectedCategories]
+    selectedFilters.flows = [...nodeStructureStore.selectedFlows]
+    selectedFilters.locations = [...nodeStructureStore.selectedLocations]
+  }
+})
+
+const handleCategorySearch = (query: string) => {
+  loading.value = true
+  clearTimeout(searchTimeout.value)
+
+  searchTimeout.value = window.setTimeout(() => {
+    const categoriesArray = Array.isArray(nodeStructureStore.categories)
+      ? nodeStructureStore.categories
+      : []
+
+    const filteredCategories = categoriesArray
+      .filter((category) =>
+        category.name && category.name.toLowerCase().includes(query.toLowerCase())
+      )
+      .map((category) => ({
+        _text: category.name,
+        _value: category.id,
+      } as IAutocompleteItemType))
+    categoryResults.value = filteredCategories
+    loading.value = false
+  }, 500)
+}
+
+const handleFlowSearch = (query: string) => {
+  flowsLoading.value = true
+  clearTimeout(searchTimeout.value)
+
+  searchTimeout.value = window.setTimeout(() => {
+    flowResults.value = [
+      { _text: 'Egress', _value: 'lastEgressFlow' },
+      { _text: 'Ingress', _value: 'lastIngressFlow' }
+    ].filter(flow => flow._text.toLowerCase().includes(query.toLowerCase()))
+    flowsLoading.value = false
+  }, 500)
+}
+
+const handleLocationSearch = (query: string) => {
+  locationsLoading.value = true
+  clearTimeout(searchTimeout.value)
+
+  searchTimeout.value = window.setTimeout(() => {
+    locationResults.value = nodeStructureStore.monitoringLocations
+      .filter(location => location.name.toLowerCase().includes(query.toLowerCase()))
+      .map(location => ({
+        _text: location.name,
+        _value: location.name,
+        longitude: location.longitude,
+        latitude: location.latitude,
+        geolocation: location.geolocation,
+        tags: location.tags,
+        priority: location.priority,
+        'location-name': location['location-name'],
+        'monitoring-area': location['monitoring-area']
+      }))
+    locationsLoading.value = false
+  }, 500)
+}
+
+const updateFilter = (key: keyof typeof selectedFilters, items: IAutocompleteItemType[]) => {
+  selectedFilters[key] = items
+}
+
+const applySelectedFilters = () => {
+  nodeStructureStore.setSelectedCategoriess(selectedFilters.categories)
+  nodeStructureStore.setSelectedFlowss(selectedFilters.flows)
+  const monitoringLocations = selectedFilters.locations.map(item => ({
+    name: item._text,
+    longitude: item.longitude,
+    latitude: item.latitude,
+    geolocation: item.geolocation,
+    tags: item.tags,
+    priority: item.priority,
+    'location-name': item['location-name'],
+    'monitoring-area': item['monitoring-area']
+  } as MonitoringLocation))
+
+  nodeStructureStore.setSelectedLocations(monitoringLocations)
+  nodeStructureStore.closeInstancesDrawerModal()
+}
+</script>
+<style lang="scss" scoped>
+@import "@featherds/table/scss/table";
+@import "@featherds/styles/mixins/elevation";
+@import "@featherds/styles/mixins/typography";
+@import "@featherds/styles/themes/variables";
+
+.feather-drawer-custom-padding {
+  padding: 20px;
+}
+
+.spacer-large {
+  margin-bottom: 2rem;
+}
+
+.spacer-medium {
+  margin-bottom: 0.25rem;
+}
+
+.footer {
+  display: flex;
+  padding-top: 20px;
+}
+
+.inventory-auto {
+  min-width: 400px;
+
+  :deep(.feather-autocomplete-input) {
+    min-width: 100px;
+  }
+
+  :deep(.feather-autocomplete-content) {
+    display: block;
+  }
+}
+
+.last-filter-autocomplete{
+  :deep(.feather-input-sub-text) {
+    display: none !important;
+  }
+}
+</style>
+

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -8,10 +8,10 @@
     <div class="feather-col-12">
       <div class="card">
         <div class="feather-row">
-          <div class="feather-col-2">
+          <!-- <div class="feather-col-2">
             <NodeStructurePanel />
-          </div>
-          <div :class="`feather-col-10`">
+          </div> -->
+          <div :class="`feather-col-12`">
             <NodesTable />
           </div>
         </div>

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -29,9 +29,11 @@ import {
   NodeColumnSelectionItem,
   NodeQueryFilter,
   NodePreferences,
-  SetOperator
+  SetOperator,
+  DrawerState
 } from '@/types'
 import { useNodeQuery } from '@/components/Nodes/hooks/useNodeQuery'
+import { IAutocompleteItemType } from '@featherds/autocomplete'
 
 const {
   getDefaultNodeQueryFilter,
@@ -54,12 +56,21 @@ export const defaultColumns: NodeColumnSelectionItem[] = [
   { id: 'flows', label: 'Flows', selected: true, order: 9 }
 ]
 
+const defaultDrawerState: DrawerState = {
+  visible: false,
+  isAdvanceFilterModal: false
+}
+
 export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   const categories = ref<Category[]>([])
   const categoryCount = computed(() => categories.value.length)
   const monitoringLocations = ref<MonitoringLocation[]>([])
   const columns = ref<NodeColumnSelectionItem[]>(defaultColumns)
   const queryFilter = ref<NodeQueryFilter>(getDefaultNodeQueryFilter())
+  const drawerState = ref<DrawerState>(defaultDrawerState)
+  const selectedCategories = ref<IAutocompleteItemType[]>([])
+  const selectedFlows = ref<IAutocompleteItemType[]>([])
+  const selectedLocations = ref<MonitoringLocation[]>([])
 
   const getCategories = async () => {
     const resp = await API.getCategories()
@@ -135,7 +146,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
   /**
    * Set filter with IP address, clearing out any other extended search params (currently these are mutually exclusive extended searches).
-  */
+   */
   const setFilterWithIpAddress = async (ipAddress: string) => {
     queryFilter.value = {
       ...queryFilter.value,
@@ -148,7 +159,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
   /**
    * Set filter with SNMP parameters, clearing out any other extended search params.
-  */
+   */
   const setFilterWithSnmpParams = async (key: string, value: string) => {
     // key should be an actual property of NodeQuerySnmpParams
     const snmpParams = {
@@ -167,7 +178,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
   /**
    * Set filter with sys parameters, clearing out any other extended search params.
-  */
+   */
   const setFilterWithSysParams = async (key: string, value: string) => {
     // key should be an actual on of NodeQuerySysParams
     const sysParams = {
@@ -186,7 +197,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
   /**
    * Set filter with foreign source parameters, clearing out any other extended search params.
-  */
+   */
   const setFilterWithForeignSourceParams = async (key: string, value: string) => {
     // key should be an actual property of NodeQueryForeignSourceParams
     const foreignSourceParams = {
@@ -204,7 +215,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   }
 
   const updateNodeColumnSelection = async (column: NodeColumnSelectionItem) => {
-    const newColumns = [...columns.value].map(c => {
+    const newColumns = [...columns.value].map((c) => {
       if (c.id === column.id) {
         return {
           ...c,
@@ -219,11 +230,12 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
   const clearAllFilters = async (mode?: SetOperator) => {
     const filter = getDefaultNodeQueryFilter()
-    queryFilter.value = !mode ? filter :
-      {
-        ...filter,
-        categoryMode: mode
-      }
+    queryFilter.value = !mode
+      ? filter
+      : {
+          ...filter,
+          categoryMode: mode
+        }
   }
 
   const getNodePreferences = async () => {
@@ -268,12 +280,60 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value = filter
   }
 
+  const openInstancesDrawerModal = () => {
+    drawerState.value.visible = true
+  }
+
+  const closeInstancesDrawerModal = () => {
+    drawerState.value.visible = false
+  }
+
+  const removeCategory = (item: IAutocompleteItemType) => {
+    selectedCategories.value = selectedCategories.value.filter((i) => i._value !== item._value)
+    queryFilter.value.selectedCategories = queryFilter.value.selectedCategories.filter((c) => c.id !== item._value)
+  }
+
+  const removeLocation = (item: IAutocompleteItemType) => {
+    const locationName = item.name
+    queryFilter.value.selectedMonitoringLocations = queryFilter.value.selectedMonitoringLocations.filter(
+      (loc) => loc.name !== locationName
+    )
+  }
+
+  const setSelectedCategoriess = (items: IAutocompleteItemType[]) => {
+    selectedCategories.value = items
+    // Also update the query filter
+    queryFilter.value.selectedCategories = items.map((item) => ({
+      id: item._value as number,
+      name: item._text as string,
+      authorizedGroups: [] as string[]
+    }))
+  }
+
+  const setSelectedFlowss = (items: IAutocompleteItemType[]) => {
+    selectedFlows.value = items
+    queryFilter.value.selectedFlows = items.map((item) => item._text as string)
+  }
+
+  const removeFlow = (item: IAutocompleteItemType) => {
+    selectedFlows.value = selectedFlows.value.filter((i) => i._text !== item._text)
+    queryFilter.value.selectedFlows = queryFilter.value.selectedFlows.filter((f) => f !== item._text)
+  }
+
+  const setSelectedLocations = async (locations: MonitoringLocation[]) => {
+    queryFilter.value = {
+      ...queryFilter.value,
+      selectedMonitoringLocations: [...locations]
+    }
+  }
+
   return {
     categories,
     categoryCount,
     columns,
     monitoringLocations,
     queryFilter,
+    drawerState,
     clearAllFilters,
     getCategories,
     getMonitoringLocations,
@@ -291,6 +351,21 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     setSelectedCategories,
     setSelectedFlows,
     setSelectedMonitoringLocations,
-    updateNodeColumnSelection
+    updateNodeColumnSelection,
+    openInstancesDrawerModal,
+    closeInstancesDrawerModal,
+    selectedCategories,
+    selectedFlows,
+    selectedLocations,
+    // setSelectedCategory,
+    // setSelectedFlow,
+    // setSelectedLocation,
+    removeCategory,
+    removeFlow,
+    removeLocation,
+    setSelectedCategoriess,
+    setSelectedFlowss,
+    setSelectedLocations
   }
 })
+

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -203,6 +203,11 @@ export interface MonitoringLocation {
   area: string    // mapped from 'monitoring-area' after API GET call response
 }
 
+export interface DrawerState {
+  visible: boolean;
+  isAdvanceFilterModal: boolean;
+}
+
 export interface SnmpInterface {
   collect: boolean
   collectFlag: string
@@ -590,4 +595,10 @@ export interface IpInterfaceInfo {
   managed: boolean
   primaryLabel: string
   primaryType: string
+}
+
+export enum FilterTypeEnum {
+  Category = 'category',
+  Flow = 'flow',
+  Location = 'location'
 }


### PR DESCRIPTION
Description
Filter icon button next to the Search Input should open a drawer, Advanced Filters

Categories dropdown should contain items as in Node Structure page Categories section

Locations dropdown should contain items as in Node Structure page Locations section

When user clicks Apply Filters, the filters display as chips to the right of the Filter button. User can click chips to remove the filter.

This should have the same effects as choosing Categories and Locations in the current "Filtering" section. However use "Match All" rather than "Match Any".

Hide but do not remove the current Node Structure "Filtering" and "Extended Search" sections. We can remove once the new design is working.

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18044

