### PR TITLE
FE: Update Node List column customization

### DIFF
--- a/ui/src/components/Nodes/ColumnSelectionDrawer.vue
+++ b/ui/src/components/Nodes/ColumnSelectionDrawer.vue
@@ -1,0 +1,203 @@
+<template>
+  <FeatherDrawer
+    id="left-drawer"
+    data-test="left-drawer"
+    @shown="() => nodeStructureStore.columnsDrawerState.visible"
+    v-model="nodeStructureStore.columnsDrawerState.visible"
+    :labels="{ close: 'close', title: 'Customize Cloumns' }"
+    width="55em"
+  >
+    <div class="feather-drawer-custom-padding">
+      <section>
+        <h3>Customize the available columns</h3>
+        <p>Select what columns you wish to showcase</p>
+      </section>
+
+      <div class="spacer-large"></div>
+
+      <!-- Render each column -->
+      <div
+        v-for="(col, index) in selectedColumns"
+        :key="index"
+        class="column-row"
+      >
+        <FeatherButton
+          icon="Apps"
+          text
+        >
+          <FeatherIcon
+            class="close-icon"
+            :icon="Apps"
+          />
+        </FeatherButton>
+        <FeatherSelect
+          v-model="selectedColumns[index]"
+          :options="getAvailableOptions(index)"
+          text-prop="name"
+          value-prop="value"
+          :placeholder="'Select column...'"
+          :label="`Column ${index + 1}`"
+          class="columns-selector"
+        />
+        <FeatherButton
+          icon="Cancel"
+          text
+          @click="removeColumn(index)"
+        >
+          <FeatherIcon
+            class="close-icon"
+            :icon="Cancel"
+          />
+        </FeatherButton>
+      </div>
+
+      <div class="spacer-medium"></div>
+      <div class="button-column">
+        <FeatherButton
+          secondary
+          :disabled="selectedColumns.length >= 10"
+          @click="addColumn"
+        >
+          Add Column
+        </FeatherButton>
+        <FeatherButton
+          primary
+          @click="customizeTable"
+        >
+          Customize Table
+        </FeatherButton>
+      </div>
+    </div>
+  </FeatherDrawer>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, watch } from 'vue'
+import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { FeatherButton } from '@featherds/button'
+import { FeatherDrawer } from '@featherds/drawer'
+import { FeatherIcon } from '@featherds/icon'
+import { FeatherSelect, ISelectItemType } from '@featherds/select'
+import Cancel from '@featherds/icon/navigation/Cancel'
+import Apps from "@featherds/icon/navigation/Apps"
+import { NodeColumnSelectionItem } from '@/types'
+import { saveNodePreferences } from '@/services/localStorageService'
+
+const nodeStructureStore = useNodeStructureStore()
+const columns = computed<NodeColumnSelectionItem[]>(() => nodeStructureStore.columns)
+const selectedColumns = ref<ISelectItemType[]>([])
+
+const initializeSelectedColumns = () => {
+  selectedColumns.value = columns.value
+    .filter(col => col.selected)
+    .sort((a, b) => a.order - b.order)
+    .map(col => ({ name: col.label, value: col.id }))
+}
+const getAvailableOptions = (currentIndex: number) => {
+  const currentSelection = selectedColumns.value[currentIndex]?.value
+  return columns.value
+    .filter(col =>
+      !selectedColumns.value.some((sc, i) => i !== currentIndex && sc.value === col.id) ||
+      col.id === currentSelection
+    )
+    .map(col => ({ name: col.label, value: col.id }))
+}
+const addColumn = () => {
+  if (selectedColumns.value.length < 10) {
+    selectedColumns.value = [
+      ...selectedColumns.value,
+      { name: '', value: '' }
+    ]
+  }
+}
+const removeColumn = (index: number) => {
+  selectedColumns.value = selectedColumns.value.filter((_, i) => i !== index)
+}
+const customizeTable = async() => {
+  const nodePrefs = await nodeStructureStore.getNodePreferences()
+  saveNodePreferences(nodePrefs)
+  nodeStructureStore.columnsDrawerState.visible = false
+}
+
+watch(
+  [() => nodeStructureStore.columns, selectedColumns],
+  ([newColumns], [oldColumns, oldSelected]) => {
+    if (newColumns !== oldColumns) {
+      initializeSelectedColumns()
+    }
+    const selectedIds = selectedColumns.value.map(c => c.value).filter(id => id !== '')
+    nodeStructureStore.columns.forEach((col) => {
+      col.selected = selectedIds.includes(col.id)
+      col.order = selectedIds.indexOf(col.id)
+    })
+  },
+  { immediate: true, deep: true }
+)
+</script>
+<style lang="scss" scoped>
+@import "@featherds/table/scss/table";
+@import "@featherds/styles/mixins/elevation";
+@import "@featherds/styles/mixins/typography";
+@import "@featherds/styles/themes/variables";
+
+.feather-drawer-custom-padding {
+  padding: 20px;
+}
+
+.spacer-large {
+  margin-bottom: 2rem;
+}
+
+.spacer-medium {
+  margin-bottom: 0.25rem;
+}
+
+.footer {
+  display: flex;
+  padding-top: 20px;
+}
+
+.column-row {
+  display: flex;
+  gap: 1rem;
+  width: 80%;
+  margin-bottom: 1rem;
+  border: 1px solid var($border-on-surface);
+  padding-left: 10px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  border-radius: 5px;
+}
+
+.column-header {
+  font-weight: bold;
+  width: 100px;
+}
+
+button.primary {
+  margin-top: 2rem;
+  background-color: #1d2f75;
+  color: white;
+  padding: 0.5em 1.5em;
+  border: none;
+}
+
+.columns-selector {
+    width: 80%;
+}
+
+:deep(.feather-input-sub-text) {
+    display: none;
+}
+
+.button-column{
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items:flex-start;
+   :deep(.btn + .btn) {
+  margin-left: 0 !important;
+}
+}
+</style>
+

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -9,13 +9,10 @@
             :onJsonDownload="onJsonDownload"
           />
           <FeatherButton
-            icon="Open Preferences"
-            @click="openPreferences"
+            secondary
+            @click="() => nodeStructureStore.openColumnsDrawerModal()"
           >
-            <FeatherIcon
-              :icon="settingsIcon"
-              class="node-actions-icon"
-            />
+            Customize
           </FeatherButton>
         </div>
       </div>
@@ -257,13 +254,8 @@
     :node="dialogNode"
   >
   </NodeDetailsDialog>
-
-  <NodePreferencesDialog
-    @close="preferencesVisible = false"
-    :visible="preferencesVisible"
-  >
-  </NodePreferencesDialog>
   <NodeAdvancedFiltersDrawer />
+  <ColumnSelectionDrawer />
 </template>
 
 <script setup lang="ts">
@@ -308,6 +300,7 @@ import Cancel from '@featherds/icon/navigation/Cancel'
 import { FeatherChip, FeatherChipList } from '@featherds/chips'
 import NodeAdvancedFiltersDrawer from './NodeAdvancedFiltersDrawer.vue'
 import { IAutocompleteItemType } from '@featherds/autocomplete'
+import ColumnSelectionDrawer from './ColumnSelectionDrawer.vue'
 
 const menuStore = useMenuStore()
 const nodeStructureStore = useNodeStructureStore()
@@ -338,7 +331,6 @@ const navigateColumns = (direction: Direction) => {
     visibleColumnStart.value += visibleColumnsCount
   }
 }
-
 
 const sortStates: any = reactive({
   id: SORT.NONE,

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -1,21 +1,21 @@
 ///
 /// Licensed to The OpenNMS Group, Inc (TOG) under one or more
-/// contributor license agreements.  See the LICENSE.md file
+/// contributor license agreements. See the LICENSE.md file
 /// distributed with this work for additional information
 /// regarding copyright ownership.
 ///
 /// TOG licenses this file to You under the GNU Affero General
 /// Public License Version 3 (the "License") or (at your option)
-/// any later version.  You may not use this file except in
-/// compliance with the License.  You may obtain a copy of the
+/// any later version. You may not use this file except in
+/// compliance with the License. You may obtain a copy of the
 /// License at:
 ///
-///      https://www.gnu.org/licenses/agpl-3.0.txt
+/// https://www.gnu.org/licenses/agpl-3.0.txt
 ///
 /// Unless required by applicable law or agreed to in writing,
 /// software distributed under the License is distributed on an
 /// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-/// either express or implied.  See the License for the specific
+/// either express or implied. See the License for the specific
 /// language governing permissions and limitations under the
 /// License.
 ///
@@ -61,13 +61,21 @@ const defaultDrawerState: DrawerState = {
   isAdvanceFilterModal: false
 }
 
+const getDefaultDrawerState = (): DrawerState => {
+  return {
+    visible: false,
+    isAdvanceFilterModal: false
+  }
+}
+
 export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   const categories = ref<Category[]>([])
   const categoryCount = computed(() => categories.value.length)
   const monitoringLocations = ref<MonitoringLocation[]>([])
   const columns = ref<NodeColumnSelectionItem[]>(defaultColumns)
   const queryFilter = ref<NodeQueryFilter>(getDefaultNodeQueryFilter())
-  const drawerState = ref<DrawerState>(defaultDrawerState)
+  const drawerState = ref<DrawerState>(getDefaultDrawerState())
+  const columnsDrawerState = ref<DrawerState>(getDefaultDrawerState())
   const selectedCategories = ref<IAutocompleteItemType[]>([])
   const selectedFlows = ref<IAutocompleteItemType[]>([])
   const selectedLocations = ref<MonitoringLocation[]>([])
@@ -113,10 +121,10 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   }
 
   // const setSelectedCategories = async (cats: Category[]) => {
-  //   queryFilter.value = {
-  //     ...queryFilter.value,
-  //     selectedCategories: [...cats]
-  //   }
+  // queryFilter.value = {
+  // ...queryFilter.value,
+  // selectedCategories: [...cats]
+  // }
   // }
 
   const setCategoryMode = async (mode: SetOperator) => {
@@ -127,10 +135,10 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   }
 
   // const setSelectedFlows = async (flows: string[]) => {
-  //   queryFilter.value = {
-  //     ...queryFilter.value,
-  //     selectedFlows: [...flows]
-  //   }
+  // queryFilter.value = {
+  // ...queryFilter.value,
+  // selectedFlows: [...flows]
+  // }
   // }
 
   const setSelectedMonitoringLocations = async (locations: MonitoringLocation[]) => {
@@ -145,8 +153,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   }
 
   /**
-   * Set filter with IP address, clearing out any other extended search params (currently these are mutually exclusive extended searches).
-   */
+  * Set filter with IP address, clearing out any other extended search params (currently these are mutually exclusive extended searches).
+  */
   const setFilterWithIpAddress = async (ipAddress: string) => {
     queryFilter.value = {
       ...queryFilter.value,
@@ -158,8 +166,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   }
 
   /**
-   * Set filter with SNMP parameters, clearing out any other extended search params.
-   */
+  * Set filter with SNMP parameters, clearing out any other extended search params.
+  */
   const setFilterWithSnmpParams = async (key: string, value: string) => {
     // key should be an actual property of NodeQuerySnmpParams
     const snmpParams = {
@@ -177,8 +185,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   }
 
   /**
-   * Set filter with sys parameters, clearing out any other extended search params.
-   */
+  * Set filter with sys parameters, clearing out any other extended search params.
+  */
   const setFilterWithSysParams = async (key: string, value: string) => {
     // key should be an actual on of NodeQuerySysParams
     const sysParams = {
@@ -196,8 +204,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   }
 
   /**
-   * Set filter with foreign source parameters, clearing out any other extended search params.
-   */
+  * Set filter with foreign source parameters, clearing out any other extended search params.
+  */
   const setFilterWithForeignSourceParams = async (key: string, value: string) => {
     // key should be an actual property of NodeQueryForeignSourceParams
     const foreignSourceParams = {
@@ -233,9 +241,9 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value = !mode
       ? filter
       : {
-          ...filter,
-          categoryMode: mode
-        }
+        ...filter,
+        categoryMode: mode
+      }
   }
 
   const getNodePreferences = async () => {
@@ -245,7 +253,6 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
       nodeColumns,
       nodeFilter: { ...queryFilter.value }
     } as NodePreferences
-
     return nodePrefs
   }
 
@@ -288,6 +295,13 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     drawerState.value.visible = false
   }
 
+  const openColumnsDrawerModal = () => {
+    columnsDrawerState.value.visible = true
+  }
+
+  const closeColumnsDrawerModal = () => {
+    columnsDrawerState.value.visible = false
+  }
   const removeCategory = (item: IAutocompleteItemType) => {
     selectedCategories.value = selectedCategories.value.filter((i) => i._value !== item._value)
     queryFilter.value.selectedCategories = queryFilter.value.selectedCategories.filter((c) => c.id !== item._value)
@@ -334,6 +348,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     monitoringLocations,
     queryFilter,
     drawerState,
+    columnsDrawerState,
     clearAllFilters,
     getCategories,
     getMonitoringLocations,
@@ -362,7 +377,9 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     removeLocation,
     setSelectedCategories,
     setSelectedFlows,
-    setSelectedLocations
+    setSelectedLocations,
+    openColumnsDrawerModal,
+    closeColumnsDrawerModal,
+
   }
 })
-


### PR DESCRIPTION
Updates to the column customization feature on the Structured Node / New Node List page.

The gear button should be changed to a Feather secondary button, "Customize".

Clicking opens a drawer, "Customize the available columns".

See Figma for example.

In the drawer, user can add, remove and rearrange columns. As columns are chosen, the dropdowns to add more columns only display columns that have not yet been chosen.

When done, it should have same behavior as current, it updates the store and also stores the column preferences in localStorage.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18045

