### PR TITLE
FE: Update Node List column customization

### DIFF
--- a/ui/src/components/Nodes/ColumnSelectionDrawer.vue
+++ b/ui/src/components/Nodes/ColumnSelectionDrawer.vue
@@ -4,13 +4,13 @@
     data-test="left-drawer"
     @shown="() => nodeStructureStore.columnsDrawerState.visible"
     v-model="nodeStructureStore.columnsDrawerState.visible"
-    :labels="{ close: 'close', title: 'Customize Cloumns' }"
+    :labels="{ close: 'close', title: 'Customize Columns' }"
     width="55em"
   >
     <div class="feather-drawer-custom-padding">
       <section>
         <h3>Customize the available columns</h3>
-        <p>Select what columns you wish to showcase</p>
+        <p>Select which columns you wish to showcase</p>
       </section>
 
       <div class="spacer-large"></div>


### PR DESCRIPTION
Updates to the column customization feature on the Structured Node / New Node List page.

The gear button should be changed to a Feather secondary button, "Customize".

Clicking opens a drawer, "Customize the available columns".

See Figma for example.

In the drawer, user can add, remove and rearrange columns. As columns are chosen, the dropdowns to add more columns only display columns that have not yet been chosen.

When done, it should have same behavior as current, it updates the store and also stores the column preferences in localStorage.
### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18045

