### PR TITLE
NMS-18160: Upgrade snmp4j to 2.8.15

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -706,9 +706,6 @@
     <feature name="opennms-snmp" version="${project.version}" description="OpenNMS :: Core :: SNMP">
         <feature>commons-lang</feature>
         <feature>org.json</feature>
-        <bundle>wrap:mvn:org.snmp4j/snmp4j-log4j/2.8.11</bundle>
-        <bundle>mvn:org.apache.logging.log4j/log4j-api/${log4j2Version}</bundle>
-        <bundle>mvn:org.apache.logging.log4j/log4j-core/${log4j2Version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.logging/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.implementations.snmp4j/${project.version}</bundle>

--- a/container/karaf/src/main/filtered-resources/etc/system.properties
+++ b/container/karaf/src/main/filtered-resources/etc/system.properties
@@ -169,8 +169,8 @@ karaf.require.successful.features.boot = false
 # the karaf.lock.slave.block property (false by default):
 # karaf.lock.slave.block=true
 
-# OPENNMS: Enable SNMP4J Log4j logging
-snmp4j.LogFactory=org.snmp4j.log.Log4jLogFactory
+# OPENNMS: Enable SNMP4J SLF4J logging
+snmp4j.LogFactory=org.opennms.netmgt.snmp.snmp4j.Slf4jLogFactory
 
 # OPENNMS: Disable SIGTERM in karaf as OpenNMS should handle SIGTERM.
 karaf.handle.sigterm = false

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Slf4jLogFactory.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Slf4jLogFactory.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.snmp.snmp4j;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.snmp4j.log.LogAdapter;
+import org.snmp4j.log.LogFactory;
+import org.snmp4j.log.LogLevel;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.Collections;
+
+/**
+ * Custom SNMP4J LogFactory implementation that bridges to SLF4J.
+ * This replaces the need for snmp4j-log4j dependency while maintaining
+ * all logging functionality.
+ */
+public class Slf4jLogFactory extends LogFactory {
+
+    @Override
+    protected LogAdapter createLogger(String name) {
+        return new Slf4jLogAdapter(LoggerFactory.getLogger(name));
+    }
+
+
+    @Override
+    public LogAdapter getRootLogger() {
+        return new Slf4jLogAdapter(LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME));
+    }
+
+    @Override
+    public Iterator<?> loggers() {
+        // SLF4J doesn't provide a way to enumerate all loggers
+        // Return empty iterator as this is rarely used
+        return Collections.emptyIterator();
+    }
+
+    /**
+     * SLF4J-based LogAdapter implementation for SNMP4J
+     */
+    private static class Slf4jLogAdapter implements LogAdapter, Comparable<Object> {
+        private final Logger logger;
+
+        public Slf4jLogAdapter(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public void debug(Serializable message) {
+            logger.debug(String.valueOf(message));
+        }
+
+        @Override
+        public void info(CharSequence message) {
+            logger.info(String.valueOf(message));
+        }
+
+        @Override
+        public void warn(Serializable message) {
+            logger.warn(String.valueOf(message));
+        }
+
+        @Override
+        public void error(Serializable message) {
+            logger.error(String.valueOf(message));
+        }
+
+        @Override
+        public void error(CharSequence message, Throwable throwable) {
+            logger.error(String.valueOf(message), throwable);
+        }
+
+        @Override
+        public void fatal(Object message) {
+            logger.error(String.valueOf(message));
+        }
+
+        @Override
+        public void fatal(CharSequence message, Throwable throwable) {
+            logger.error(String.valueOf(message), throwable);
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return logger.isDebugEnabled();
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return logger.isInfoEnabled();
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return logger.isWarnEnabled();
+        }
+
+        @Override
+        public LogLevel getLogLevel() {
+            if (logger.isDebugEnabled()) {
+                return LogLevel.DEBUG;
+            } else if (logger.isInfoEnabled()) {
+                return LogLevel.INFO;
+            } else if (logger.isWarnEnabled()) {
+                return LogLevel.WARN;
+            } else {
+                return LogLevel.ERROR;
+            }
+        }
+
+        @Override
+        public LogLevel getEffectiveLogLevel() {
+            return getLogLevel();
+        }
+
+        @Override
+        public void setLogLevel(LogLevel level) {
+            // SLF4J log levels are typically configured externally
+            // This method is a no-op as SLF4J doesn't support runtime level changes
+        }
+
+        @Override
+        public String getName() {
+            return logger.getName();
+        }
+
+        @Override
+        public Iterator<?> getLogHandler() {
+            // SLF4J doesn't expose appenders directly
+            // Return empty iterator as this is rarely used
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public int compareTo(Object o) {
+            if (o instanceof Slf4jLogAdapter) {
+                return getName().compareTo(((Slf4jLogAdapter) o).getName());
+            }
+            return 0;
+        }
+    }
+}

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/snmp4j/Snmp4jTrapReceiverIT.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/snmp4j/Snmp4jTrapReceiverIT.java
@@ -54,7 +54,6 @@ import org.snmp4j.CommandResponderEvent;
 import org.snmp4j.PDU;
 import org.snmp4j.PDUv1;
 import org.snmp4j.Snmp;
-import org.snmp4j.log.Log4jLogFactory;
 import org.snmp4j.log.LogFactory;
 import org.snmp4j.security.AuthMD5;
 import org.snmp4j.security.PrivDES;
@@ -70,7 +69,7 @@ public class Snmp4jTrapReceiverIT extends MockSnmpAgentITCase implements Command
 
     @BeforeClass
     public static void setupSnmp4jLogging() {
-        LogFactory.setLogFactory(new Log4jLogFactory());
+        LogFactory.setLogFactory(new Slf4jLogFactory());
         MockLogAppender.setupLogging(true, "DEBUG");
     }
 

--- a/core/upgrade/src/test/resources/etc2/opennms.properties
+++ b/core/upgrade/src/test/resources/etc2/opennms.properties
@@ -75,7 +75,7 @@ org.opennms.snmp.snmp4j.forwardRuntimeExceptions=false
 
 # By default, SNMP4J does not do any logging internally, but it's easy to
 # enable.  See log4j.properties to adjust log levels for these messages.
-snmp4j.LogFactory=org.snmp4j.log.Log4jLogFactory
+snmp4j.LogFactory=org.opennms.netmgt.snmp.snmp4j.Slf4jLogFactory
 
 # Net-SNMP agents prior to release 5.4.1 on 64-bit platforms exhibit a bug
 # that causes the discovery of a node's interfaces to fail. A workaround has

--- a/dependencies/snmp4j/pom.xml
+++ b/dependencies/snmp4j/pom.xml
@@ -27,11 +27,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.snmp4j</groupId>
-      <artifactId>snmp4j-log4j</artifactId>
-      <version>2.8.11</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <scope>runtime</scope>

--- a/features/container/minion/src/main/filtered-resources/etc/system.properties
+++ b/features/container/minion/src/main/filtered-resources/etc/system.properties
@@ -164,5 +164,5 @@ karaf.require.successful.features.boot = false
 # the karaf.lock.slave.block property (false by default):
 # karaf.lock.slave.block=true
 
-# OPENNMS: Enable SNMP4J Log4j logging
-snmp4j.LogFactory=org.snmp4j.log.Log4jLogFactory
+# OPENNMS: Enable SNMP4J SLF4J logging
+snmp4j.LogFactory=org.opennms.netmgt.snmp.snmp4j.Slf4jLogFactory

--- a/features/container/sentinel/pom.xml
+++ b/features/container/sentinel/pom.xml
@@ -285,7 +285,7 @@
                         <karaf.clean.cache>true</karaf.clean.cache>
                         <karaf.local.user>admin</karaf.local.user>
                         <karaf.require.successful.features.boot>true</karaf.require.successful.features.boot>
-                        <snmp4j.LogFactory>org.snmp4j.log.Log4jLogFactory</snmp4j.LogFactory>
+                        <snmp4j.LogFactory>org.opennms.netmgt.snmp.snmp4j.Slf4jLogFactory</snmp4j.LogFactory>
                     </system>
 
                     <!-- repositories -->

--- a/features/container/sentinel/src/main/filtered-resources/etc/system.properties
+++ b/features/container/sentinel/src/main/filtered-resources/etc/system.properties
@@ -164,5 +164,5 @@ karaf.require.successful.features.boot = true
 # the karaf.lock.slave.block property (false by default):
 # karaf.lock.slave.block=true
 
-# OPENNMS: Enable SNMP4J Log4j logging
-snmp4j.LogFactory=org.snmp4j.log.Log4jLogFactory
+# OPENNMS: Enable SNMP4J SLF4J logging
+snmp4j.LogFactory=org.opennms.netmgt.snmp.snmp4j.Slf4jLogFactory

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -76,7 +76,7 @@ org.opennms.snmp.snmp4j.forwardRuntimeExceptions=false
 
 # By default, SNMP4J does not do any logging internally, but it's easy to
 # enable.  See log4j.properties to adjust log levels for these messages.
-snmp4j.LogFactory=org.snmp4j.log.Log4jLogFactory
+snmp4j.LogFactory=org.opennms.netmgt.snmp.snmp4j.Slf4jLogFactory
 
 # Net-SNMP agents prior to release 5.4.1 on 64-bit platforms exhibit a bug
 # that causes the discovery of a node's interfaces to fail. A workaround has

--- a/tests/mock-snmp-agent/src/main/java/org/opennms/mock/snmp/MockSnmpAgent.java
+++ b/tests/mock-snmp-agent/src/main/java/org/opennms/mock/snmp/MockSnmpAgent.java
@@ -53,7 +53,6 @@ import org.snmp4j.agent.mo.snmp.StorageType;
 import org.snmp4j.agent.mo.snmp.TransportDomains;
 import org.snmp4j.agent.mo.snmp.VacmMIB;
 import org.snmp4j.log.ConsoleLogFactory;
-import org.snmp4j.log.Log4jLogFactory;
 import org.snmp4j.log.LogAdapter;
 import org.snmp4j.log.LogFactory;
 import org.snmp4j.mp.MPv1;
@@ -94,7 +93,7 @@ public class MockSnmpAgent extends BaseAgent implements Runnable {
     static {
         try {
             Class.forName("org.apache.log4j.Logger");
-            LogFactory.setLogFactory(new Log4jLogFactory());
+            LogFactory.setLogFactory(new ConsoleLogFactory());
         } catch (Exception e) {
             LogFactory.setLogFactory(new ConsoleLogFactory());
         }


### PR DESCRIPTION
Upgrade snmp4j to 2.8.15
Upgrade snmp4j-agent to 2.7.9

Also add our own logger Slf4jLogFactory instead of depending upon snmp4j-log4j.



* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18160

