### PR TITLE
NMS-17976: Menu redesign fix legacy font styles

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/account/selfService/PasswordGateActionServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/account/selfService/PasswordGateActionServlet.java
@@ -70,7 +70,9 @@ public class PasswordGateActionServlet extends AbstractBasePasswordChangeActionS
         final RequestCache requestCache = new HttpSessionRequestCache();
         final DefaultSavedRequest savedRequest = (DefaultSavedRequest) requestCache.getRequest(request, response);
         final String servletPath = savedRequest != null ? savedRequest.getServletPath() : null;
-        final String path = servletPath != null && !servletPath.isEmpty() ? servletPath : "/index.jsp";
+        final String path = servletPath != null && !servletPath.isEmpty() &&
+                !servletPath.endsWith("/ui-components/assets/index.js")
+                ? servletPath : "/index.jsp";
 
         return request.getContextPath() + path;
     }

--- a/opennms-webapp/src/main/webapp/WEB-INF/menu-template-alt.json
+++ b/opennms-webapp/src/main/webapp/WEB-INF/menu-template-alt.json
@@ -560,6 +560,7 @@
           "name": "REST API Reference Documentation",
           "url": "https://docs.opennms.com/meridian/2024/development/rest/rest-api.html",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": "",
           "roles": null
         },
@@ -568,6 +569,7 @@
           "name": "Source Code",
           "url": "https://github.com/OpenNMS/opennms",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": "",
           "roles": null
         }

--- a/opennms-webapp/src/main/webapp/WEB-INF/menu-template-default.json
+++ b/opennms-webapp/src/main/webapp/WEB-INF/menu-template-default.json
@@ -626,17 +626,10 @@
         },
         {
           "id": "restApiReferenceDocumentation",
-          "name": "REST APIv1 Reference Documentation",
+          "name": "REST API Reference Documentation",
           "url": "https://docs.opennms.com/meridian/2024/development/rest/rest-api.html",
           "isExternalLink": true,
-          "locationMatch": "",
-          "roles": null
-        },
-        {
-          "id": "restApiReferenceDocumentation",
-          "name": "REST APIv2 Reference Documentation",
-          "url": "https://docs.opennms.com/meridian/2024/development/rest/rest-api.html",
-          "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": "",
           "roles": null
         },
@@ -645,6 +638,7 @@
           "name": "Source Code",
           "url": "https://github.com/OpenNMS/opennms",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": "",
           "roles": null
         }
@@ -702,6 +696,7 @@
           "name": "Professional Support",
           "url": "https://www.opennms.com/support",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": null,
           "roles": null
         },
@@ -710,6 +705,7 @@
           "name": "Chat",
           "url": "https://chat.opennms.org",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": null,
           "roles": null
         },
@@ -718,6 +714,7 @@
           "name": "Community Support (Discourse)",
           "url": "https://opennms.discourse.group",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": null,
           "roles": null
         },
@@ -726,6 +723,7 @@
           "name": "Public Issue Tracker",
           "url": "https://issues.opennms.org/secure/Dashboard.jspa",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": null,
           "roles": null
         },

--- a/opennms-webapp/src/main/webapp/WEB-INF/menu-template.json
+++ b/opennms-webapp/src/main/webapp/WEB-INF/menu-template.json
@@ -626,17 +626,10 @@
         },
         {
           "id": "restApiReferenceDocumentation",
-          "name": "REST APIv1 Reference Documentation",
+          "name": "REST API Reference Documentation",
           "url": "https://docs.opennms.com/meridian/2024/development/rest/rest-api.html",
           "isExternalLink": true,
-          "locationMatch": "",
-          "roles": null
-        },
-        {
-          "id": "restApiReferenceDocumentation",
-          "name": "REST APIv2 Reference Documentation",
-          "url": "https://docs.opennms.com/meridian/2024/development/rest/rest-api.html",
-          "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": "",
           "roles": null
         },
@@ -645,6 +638,7 @@
           "name": "Source Code",
           "url": "https://github.com/OpenNMS/opennms",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": "",
           "roles": null
         }
@@ -702,6 +696,7 @@
           "name": "Professional Support",
           "url": "https://www.opennms.com/support",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": null,
           "roles": null
         },
@@ -710,6 +705,7 @@
           "name": "Chat",
           "url": "https://chat.opennms.org",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": null,
           "roles": null
         },
@@ -718,6 +714,7 @@
           "name": "Community Support (Discourse)",
           "url": "https://opennms.discourse.group",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": null,
           "roles": null
         },
@@ -726,6 +723,7 @@
           "name": "Public Issue Tracker",
           "url": "https://issues.opennms.org/secure/Dashboard.jspa",
           "isExternalLink": true,
+          "linkTarget": "_blank",
           "locationMatch": null,
           "roles": null
         },

--- a/opennms-webapp/src/main/webapp/admin/product-update-enrollment/index.jsp
+++ b/opennms-webapp/src/main/webapp/admin/product-update-enrollment/index.jsp
@@ -60,8 +60,8 @@
 </style>
 
 <div>
-If you would like to receive more information about OpenNMS Horizon, Meridian and other products, please click
-Enable below and you will be redirected to the main page where you can enter your information.
+    <span>If you would like to receive more information about OpenNMS Horizon, Meridian and other products, please click
+    Enable below and you will be redirected to the main page where you can enter your information.</span>
 </div>
 <div class="admin-product-update-enrollment-form-wrapper">
     <form id="admin-product-update-enrollment-form">

--- a/ui/src/components/Menu/Menubar.vue
+++ b/ui/src/components/Menu/Menubar.vue
@@ -166,6 +166,7 @@ onMounted(async () => {
 </script>
 
 <style lang="scss" scoped>
+@use "@featherds/styles/mixins/typography" as typo;
 @import "@featherds/dropdown/scss/mixins";
 @import "@featherds/styles/mixins/elevation";
 @import "@featherds/styles/mixins/typography";
@@ -197,6 +198,17 @@ onMounted(async () => {
 .quick-add-node-wrapper {
   margin-left: 1em;
   margin-right: 1em;
+
+  .btn {
+    :deep(.btn-content) {
+      @include typo.button();
+      color: var(--feather-primary-text-on-color);
+      font-family: var(--feather-header-font-family);
+      font-size: var(--feather-button-font-size);
+      font-weight: var(--feather-button-font-weight);
+      letter-spacing: var(--feather-button-letter-spacing);
+    }
+  }
 }
 
 .notice-status-display {

--- a/ui/src/menu/main.ts
+++ b/ui/src/menu/main.ts
@@ -24,6 +24,7 @@ import { createApp, h } from 'vue'
 import { createPinia } from 'pinia'
 import '@featherds/styles'
 import '@featherds/styles/themes/open-light.css'
+import '../styles/opennms-feather-styles.scss'
 import App from './App.vue'
 
 // id of div to mount this Vue app onto, expected to exist in the embedding web application

--- a/ui/src/styles/opennms-feather-styles.scss
+++ b/ui/src/styles/opennms-feather-styles.scss
@@ -1,0 +1,26 @@
+@use "@featherds/styles/mixins/_typography.scss" as typo;
+
+/**
+* Add some additional base styles that weren't included in the base Feather typography.
+* These help override legacy OpenNMS Bootstrap styles so that all text on legacy pages
+* has a Feather font style.
+*/
+input,
+label,
+li,
+select,
+span,
+td,
+text,
+th {
+  @include typo.body-small();
+  color: inherit;
+  // Feather has the following, which seem a little too much. Legacy OpenNMS fonts were a bit narrower,
+  // so we adjust these a bit below.
+  // letter-spacing: var(--feather-body-small-letter-spacing);  // .25004px
+  // line-height: var(--feather-body-small-line-height);        // 1.5rem or 24px
+  //
+  // For p, we leave it alone as the slightly larger spacing is more readable for paragraphs of text.
+  letter-spacing: normal;
+  line-height: 1.3rem;
+}


### PR DESCRIPTION
Menu redesign - fix font styles on legacy pages, all pages now use Feather fonts (except the Vaadin-based pages).

Menu items that go to external links now open in separate tabs. Some updates to the menus.

Opening this PR as advisory only since it's mostly cosmetic. Going to merge to the feature branch so I can prepare a PR to merge this feature to `develop`.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17976

