### PR TITLE
fix: race condition in `SituationRestServicesIT`.

### DIFF
--- a/smoke-test/src/test/java/org/opennms/smoketest/rest/SituationRestServicesIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/rest/SituationRestServicesIT.java
@@ -135,6 +135,7 @@ public class SituationRestServicesIT {
 
     @Test
     public void test2_addAlarm() {
+        final int beforeCount = fetchRelatedCount();
         restClient.sendEvent(
                 getServiceProblemEvent("Minor", "uei.opennms.org/traps/A10/axLowerPowerSupplyFailure")
         );
@@ -164,13 +165,13 @@ public class SituationRestServicesIT {
                 .then()
                 .statusCode(200);
 
-        int before = fetchRelatedCount() - 1;
-        int after  = fetchRelatedCount();
-        assertEquals("Should add exactly one alarm", before + 1, after);
+        await().atMost(2, TimeUnit.MINUTES).until(() -> fetchRelatedCount() == beforeCount + 1);
+        assertEquals("Should add exactly one alarm", beforeCount + 1, fetchRelatedCount());
     }
 
     @Test
     public void test3_removeAlarm() {
+        final int beforeCount = fetchRelatedCount();
         AlarmDao dao = stack.postgres().getDaoFactory().getDao(AlarmDaoHibernate.class);
         OnmsAlarm target = await().atMost(2, TimeUnit.MINUTES).pollInterval(10, TimeUnit.SECONDS)
                 .until(DaoUtils.findMatchingCallable(
@@ -196,9 +197,8 @@ public class SituationRestServicesIT {
                 .then()
                 .statusCode(200);
 
-        int before = fetchRelatedCount() + 1;
-        int after  = fetchRelatedCount();
-        assertEquals("Should remove exactly one alarm", before - 1, after);
+        await().atMost(2, TimeUnit.MINUTES).until(() -> fetchRelatedCount() == beforeCount - 1);
+        assertEquals("Should remove exactly one alarm", beforeCount - 1, fetchRelatedCount());
     }
 
     @Test


### PR DESCRIPTION
The tests `test2_addAlarm` and `test3_removeAlarm` contained race conditions. They were making assertions about the state of situations immediately after performing an asynchronous operation, without waiting for the operation to complete. This led to flaky test failures.

I refactored the tests to be deterministic. They now capture the state *before* the operation, perform the operation, and then use `await()` to wait for the expected state change to occur before making an assertion. This ensures the tests are robust and correctly verify the intended behavior.
