### PR TITLE
NMS-18170 Enable Static OpenConfig Configuration on Minion for Flow Collection Initiation

### DIFF
--- a/features/telemetry/distributed/common/src/main/java/org/opennms/netmgt/telemetry/distributed/common/MapBasedConnectorDef.java
+++ b/features/telemetry/distributed/common/src/main/java/org/opennms/netmgt/telemetry/distributed/common/MapBasedConnectorDef.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.telemetry.distributed.common;
+
+import org.opennms.netmgt.telemetry.config.api.ConnectorDefinition;
+import org.opennms.netmgt.telemetry.config.api.PackageDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+public class MapBasedConnectorDef  extends  MapBasedQueueDef implements ConnectorDefinition {
+    private final String name;
+    private final String className;
+    private final String queueName;
+    private final String serviceName;
+    private final Map<String, String> parameters;
+
+    /**
+     * Constructor for Blueprint util:properties or CM Dictionary injection.
+     */
+    public MapBasedConnectorDef(PropertyTree tree) {
+        super(tree);
+        this.name = tree.getRequiredString("name");
+        this.className = tree.getRequiredString("class-name");
+        this.queueName = tree.getRequiredString("queue");
+        this.serviceName = tree.getRequiredString("service-name");
+        this.parameters = tree.getMap("parameters");
+
+    }
+
+    /**
+     * Convenience constructor for Blueprint util:map injection.
+     */
+    public MapBasedConnectorDef(Map<String, String> flatMap) {
+        this(PropertyTree.from(flatMap));
+    }
+
+    @Override public String getName()           { return name; }
+    @Override public String getClassName()      { return className; }
+    @Override public String getQueueName()      { return queueName; }
+    @Override public String getServiceName()    { return serviceName; }
+
+    @Override
+    public List<? extends PackageDefinition> getPackages() {
+        return List.of();
+    }
+
+    @Override public Map<String, String> getParameterMap() { return parameters; }
+
+}

--- a/features/telemetry/distributed/minion/pom.xml
+++ b/features/telemetry/distributed/minion/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Karaf-Commands>*</Karaf-Commands>
           </instructions>
         </configuration>
       </plugin>
@@ -48,6 +49,11 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.karaf.shell</groupId>
+      <artifactId>org.apache.karaf.shell.core</artifactId>
+    </dependency>
+
     <!--<dependency>-->
       <!--<groupId>org.opennms.features.telemetry</groupId>-->
       <!--<artifactId>org.opennms.features.telemetry.daemon</artifactId>-->

--- a/features/telemetry/distributed/minion/src/main/java/org/opennms/netmgt/telemetry/distributed/minion/ConnectorManager.java
+++ b/features/telemetry/distributed/minion/src/main/java/org/opennms/netmgt/telemetry/distributed/minion/ConnectorManager.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.netmgt.telemetry.distributed.minion;
+
+import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.telemetry.api.receiver.Connector;
+import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
+import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetrySinkModule;
+import org.opennms.netmgt.telemetry.distributed.common.MapBasedConnectorDef;
+import org.opennms.netmgt.telemetry.distributed.common.PropertyTree;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+
+public class ConnectorManager implements ManagedService, Connector {
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectorManager.class);
+
+    Map<String, String> configMap;
+
+    private MessageDispatcherFactory messageDispatcherFactory;
+
+    private DistPollerDao distPollerDao;
+
+    private TelemetryRegistry telemetryRegistry;
+
+    private BundleContext bundleContext;
+
+    final Entity entity = new Entity();
+
+    public ConnectorManager() {
+    }
+
+    public void start() {
+        LOG.error(" connector listener is started");
+    }
+
+    public void stop() {
+        LOG.info("ConnectorListener stopping…");
+
+        if (entity.connector != null) {
+            try {
+                entity.connector.close();
+            } catch (IOException e) {
+                LOG.warn("Error stopping connector", e);
+            }
+        }
+
+        stopQueues(entity.queueNames);
+
+    }
+
+    @Override
+    public void updated(Dictionary<String, ?> props) throws ConfigurationException {
+        String enabledProp = props != null
+                ? (String) props.get("enabled")
+                : "false";
+        boolean enabled = Boolean.parseBoolean(enabledProp);
+
+
+        if (!enabled) {
+            stop();
+            LOG.info("Connector disabled – cleaned up and exiting updated()");
+            return;
+        }
+
+        stopQueues(entity.queueNames);
+
+        final PropertyTree definition = PropertyTree.from(configMap);
+        final MapBasedConnectorDef connectorDef = new MapBasedConnectorDef(definition);
+
+        if (telemetryRegistry.getDispatcher(connectorDef.getQueueName()) != null) {
+            throw new IllegalArgumentException("A queue with name " + connectorDef.getQueueName() + " is already defined. Bailing.");
+        }
+        final TelemetrySinkModule sinkModule = new TelemetrySinkModule(connectorDef);
+        sinkModule.setDistPollerDao(distPollerDao);
+        final AsyncDispatcher<TelemetryMessage> dispatcher = messageDispatcherFactory.createAsyncDispatcher(sinkModule);
+        final String queueName = Objects.requireNonNull(connectorDef.getQueueName());
+        telemetryRegistry.registerDispatcher(queueName, dispatcher);
+        entity.queueNames.add(connectorDef.getQueueName());
+        entity.connector = telemetryRegistry.getConnector(connectorDef);
+
+        String nodeIdStr  = get(props, "nodeId",  "1");
+        String host       = get(props, "hostname", "127.0.0.1");
+        String portStr    = get(props, "port",     "0");
+        String mode       = get(props, "mode",     "jti");
+        String paths      = get(props, "paths",    "/interfaces/interface/state/counters");
+
+        int nodeId;
+        try {
+            nodeId = Integer.parseInt(nodeIdStr);
+        } catch (NumberFormatException e) {
+            throw new ConfigurationException("nodeId", "Invalid integer: " + nodeIdStr);
+        }
+
+        int port;
+        try {
+            port = Integer.parseInt(portStr);
+        } catch (NumberFormatException e) {
+            throw new ConfigurationException("port", "Invalid integer: " + portStr);
+        }
+
+        InetAddress ip;
+        try {
+            ip = InetAddress.getByName(host);
+        } catch (UnknownHostException e) {
+            throw new ConfigurationException("hostname", "Invalid host: " + host);
+        }
+
+        Map<String,String> entry = new HashMap<>();
+        entry.put("hostname", host);
+        entry.put("port",     Integer.toString(port));
+        entry.put("mode",     mode);
+        entry.put("paths",    paths);
+
+        List<Map<String,String>> paramList = List.of(entry);
+        entity.connector.stream(nodeId, ip, paramList);
+
+    }
+
+    String get(Dictionary<String,?> d, String key, String def) {
+        Object v = (d != null ? d.get(key) : null);
+        return (v != null ? v.toString() : def);
+    }
+
+
+    private void stopQueues(Set<String> queueNames) {
+        Objects.requireNonNull(queueNames);
+        for (String queueName : queueNames) {
+            try {
+                final AsyncDispatcher<TelemetryMessage> dispatcher = telemetryRegistry.getDispatcher(queueName);
+                if(dispatcher != null) {
+                    dispatcher.close();
+                }
+            } catch (Exception ex) {
+                LOG.error("Failed to close dispatcher.", ex);
+            } finally {
+                telemetryRegistry.removeDispatcher(queueName);
+            }
+        }
+    }
+
+    public void connect(int nodeId, InetAddress ipAddress, List<Map<String, String>> pathList) {
+        entity.connector.stream(nodeId, ipAddress, pathList);
+    }
+
+    @Override
+    public void stream(int nodeId, InetAddress ipAddress, List<Map<String, String>> paramList) {
+        entity.connector.stream(nodeId, ipAddress, paramList);
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+
+    private static class Entity {
+        private Connector connector;
+        private final Set<String> queueNames = new HashSet<>();
+    }
+
+
+    public Map<String, String> getConfigMap() {
+        return configMap;
+    }
+
+    public void setConfigMap(Map<String, String> configMap) {
+        this.configMap = configMap;
+    }
+
+    public MessageDispatcherFactory getMessageDispatcherFactory() {
+        return messageDispatcherFactory;
+    }
+
+    public void setMessageDispatcherFactory(MessageDispatcherFactory messageDispatcherFactory) {
+        this.messageDispatcherFactory = messageDispatcherFactory;
+    }
+
+    public DistPollerDao getDistPollerDao() {
+        return distPollerDao;
+    }
+
+    public void setDistPollerDao(DistPollerDao distPollerDao) {
+        this.distPollerDao = distPollerDao;
+    }
+
+    public void setBundleContext(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    public void setTelemetryRegistry(TelemetryRegistry telemetryRegistry) {
+        this.telemetryRegistry = telemetryRegistry;
+    }
+
+}

--- a/features/telemetry/distributed/minion/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/distributed/minion/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,6 +11,20 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 ">
 
+
+    <bean id="openconfigDefinitionMap" class="java.util.HashMap">
+        <argument>
+            <map key-type="java.lang.String" value-type="java.lang.String">
+                <entry key="name" value="OpenConfig-Connector"/>
+                <entry key="class-name"
+                       value="org.opennms.netmgt.telemetry.protocols.openconfig.connector.OpenConfigConnector"/>
+                <entry key="queue" value="OpenConfig"/>
+                <entry key="service-name" value="OpenConfig"/>
+            </map>
+        </argument>
+    </bean>
+
+
     <reference id="distPollerDao" interface="org.opennms.netmgt.dao.api.DistPollerDao"/>
     <reference id="messageDispatcherFactory" interface="org.opennms.core.ipc.sink.api.MessageDispatcherFactory" />
     <reference id="telemetryRegistry" interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" />
@@ -21,10 +35,33 @@
         <property name="bundleContext" ref="blueprintBundleContext"/>
         <property name="telemetryRegistry" ref="telemetryRegistry" />
     </bean>
+
+    <bean id="connectorListener"
+          class="org.opennms.netmgt.telemetry.distributed.minion.ConnectorManager"
+          init-method="start"
+          destroy-method="stop">
+        <property name="configMap" ref="openconfigDefinitionMap"/>
+        <property name="messageDispatcherFactory" ref="messageDispatcherFactory"/>
+        <property name="distPollerDao" ref="distPollerDao"/>
+        <property name="telemetryRegistry" ref="telemetryRegistry"/>
+        <property name="bundleContext" ref="blueprintBundleContext"/>
+    </bean>
+
+
     <service interface="org.osgi.service.cm.ManagedServiceFactory" ref="listenerManager">
         <service-properties>
             <entry key="service.pid" value="org.opennms.features.telemetry.listeners"/>
         </service-properties>
     </service>
     <service interface="org.opennms.netmgt.telemetry.api.TelemetryManager" ref="listenerManager" />
+
+    <service interface="org.osgi.service.cm.ManagedService"
+             ref="connectorListener">
+        <service-properties>
+            <entry key="service.pid"
+                   value="org.opennms.features.telemetry.openconfig"/>
+        </service-properties>
+    </service>
+
+
 </blueprint>

--- a/features/telemetry/registry/src/main/java/org/opennms/netmgt/telemetry/protocols/registry/impl/TelemetryRegistryImpl.java
+++ b/features/telemetry/registry/src/main/java/org/opennms/netmgt/telemetry/protocols/registry/impl/TelemetryRegistryImpl.java
@@ -128,6 +128,10 @@ public class TelemetryRegistryImpl implements TelemetryRegistry {
         this.parserRegistryDelegate = parserRegistryDelegate;
     }
 
+    public void setConnectorRegistryDelegate(TelemetryServiceRegistry<ConnectorDefinition, Connector> connectorRegistryDelegate) {
+        this.connectorRegistryDelegate = connectorRegistryDelegate;
+    }
+
     @Override
     public MetricRegistry getMetricRegistry() {
         return metricRegistry;

--- a/features/telemetry/registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,6 +25,12 @@
         <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="parserRegistry" />
     </reference-list>
 
+    <bean id="connectorRegistry" class="org.opennms.netmgt.telemetry.protocols.registry.impl.TelemetryConnectorRegistryImpl" />
+    <reference-list interface="org.opennms.netmgt.telemetry.api.receiver.ConnectorFactory" availability="optional">
+        <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="connectorRegistry" />
+    </reference-list>
+
+
     <!-- Metrics -->
     <bean id="telemetryMetricRegistry" class="com.codahale.metrics.MetricRegistry"/>
     <service ref="telemetryMetricRegistry" interface="com.codahale.metrics.MetricSet">
@@ -50,6 +56,7 @@
         <property name="listenerRegistryDelegate" ref="listenerRegistry"/>
         <property name="parserRegistryDelegate" ref="parserRegistry"/>
         <property name="metricRegistry" ref="telemetryMetricRegistry"/>
+        <property name="connectorRegistryDelegate" ref="connectorRegistry"/>
     </bean>
     <service interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" ref="telemetryRegistry" />
 </blueprint>

--- a/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/ConnectorCommands.java
+++ b/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/ConnectorCommands.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.telemetry.shell;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.opennms.netmgt.telemetry.api.receiver.Connector;
+
+@Command(scope = "opennms", name = "telemetry-connector", description = "Lists configured telemetry connectors")
+@Service
+public class ConnectorCommands implements Action {
+
+    @Reference
+    private Connector connectorService;
+
+    @Argument(
+            index = 0,
+            name = "nodeId",
+            description = "Numeric node ID",
+            required = true,
+            multiValued = false
+    )
+    int nodeId;
+
+    @Argument(
+            index = 1,
+            name = "host",
+            description = "Hostname or IP address",
+            required = true,
+            multiValued = false
+    )
+    String host;
+
+    @Argument(
+            index = 2,
+            name = "port",
+            description = "Port number (1–65535)",
+            required = true,
+            multiValued = false
+    )
+    String portStr;
+
+    @Argument(
+            index = 3,
+            name = "mode",
+            description = "Mode of operation",
+            required = true,
+            multiValued = false
+    )
+    String mode;
+
+    @Argument(
+            index = 4,
+            name = "paths",
+            description = "Comma-separated list of paths",
+            required = true,
+            multiValued = false
+    )
+
+    String paths;
+
+    @Override
+    public Object execute() throws Exception {
+
+        InetAddress ipAddress;
+        try {
+            ipAddress = InetAddress.getByName(host);
+        } catch (UnknownHostException e) {
+            System.err.printf("Invalid host: %s%n", host);
+            return null;
+        }
+
+
+        int port;
+        try {
+            port = Integer.parseInt(portStr);
+            if (port < 1 || port > 65535) {
+                throw new NumberFormatException();
+            }
+        } catch (NumberFormatException e) {
+            System.err.printf("Invalid port: %s (must be 1–65535)%n", portStr);
+            return null;
+        }
+
+        List<String> pathList = Arrays.stream(paths.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        if (pathList.isEmpty()) {
+            System.err.println("At least one path must be provided.");
+            return null;
+        }
+
+
+        List<Map<String, String>> paramList = new ArrayList<>();
+        for (String p : pathList) {
+            Map<String, String> entry = new HashMap<>();
+            entry.put("hostname", host);
+            entry.put("port", String.valueOf(port));
+            entry.put("mode", mode);
+            entry.put("path", p);
+            paramList.add(entry);
+        }
+
+
+        try {
+            connectorService.stream(nodeId, ipAddress, paramList);
+            System.out.printf(
+                    "Streaming started: nodeId=%d, host=%s, port=%d, mode=%s, paths=%s%n",
+                    nodeId, host, port, mode, pathList
+            );
+        } catch (Exception e) {
+            System.err.println("Failed to start stream: " + e.getMessage());
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Below is configuration to make static connection 

config:edit org.opennms.features.telemetry.openconfig
config:property-set enabled true
config:property-set nodeId <nodeid>
config:property-set hostname <hostname>
config:property-set port <port>
config:property-set mode <mode>
config:property-set paths <path>
config:update
`

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18170 

