### PR TITLE
NMS-18175: Ensure user is not redirected to an asset file after login

### DIFF
--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/LoginModuleUtils.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/LoginModuleUtils.java
@@ -23,6 +23,7 @@ package org.opennms.web.springframework.security;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -40,9 +41,14 @@ import org.opennms.netmgt.config.users.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.util.StringUtils;
 
 public abstract class LoginModuleUtils {
     public static volatile Logger LOG = LoggerFactory.getLogger(LoginModuleUtils.class);
+
+    private static final String[] INVALID_SAVED_REQUEST_URL_SUFFIXES = new String[] {
+        ".css", ".js", ".ttf"
+    };
 
     protected LoginModuleUtils() {}
 
@@ -132,5 +138,18 @@ public abstract class LoginModuleUtils {
             principals.addAll(ps);
         }
         return principals;
+    }
+
+    /**
+     * Do not save asset files in the saved request cache.
+     */
+    public static boolean isInvalidSavedRequestUrl(String url) {
+        if (StringUtils.isEmpty(url)) {
+            return true;
+        }
+
+        String urlLower = url.toLowerCase();
+
+        return Arrays.stream(INVALID_SAVED_REQUEST_URL_SUFFIXES).anyMatch(urlLower::endsWith);
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/account/selfService/PasswordGateActionServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/account/selfService/PasswordGateActionServlet.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpSession;
 import org.opennms.netmgt.config.UserFactory;
 import org.opennms.netmgt.config.UserManager;
 import org.opennms.netmgt.config.users.User;
+import org.opennms.web.springframework.security.LoginModuleUtils;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
@@ -71,7 +72,7 @@ public class PasswordGateActionServlet extends AbstractBasePasswordChangeActionS
         final DefaultSavedRequest savedRequest = (DefaultSavedRequest) requestCache.getRequest(request, response);
         final String servletPath = savedRequest != null ? savedRequest.getServletPath() : null;
         final String path = servletPath != null && !servletPath.isEmpty() &&
-                !servletPath.endsWith("/ui-components/assets/index.js")
+                !LoginModuleUtils.isInvalidSavedRequestUrl(servletPath)
                 ? servletPath : "/index.jsp";
 
         return request.getContextPath() + path;

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminPasswordGateIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminPasswordGateIT.java
@@ -63,19 +63,19 @@ public class AdminPasswordGateIT extends OpenNMSSeleniumIT {
      * otherwise there are issues when the AbstractOpenNMSSeleniumHelper.m_watcher TestWatcher Rule
      * fires.
      */
-    // @Test
-    @Ignore("Need to fix this to work with the new menu.")
+    @Test
     public void testAdminPasswordGate() {
         // login with "admin/admin", do not skip the password gate but instead change the password
         LOG.debug("Test admin login and password change");
         logout();
-        loginAndChangePassword("index.jsp", true);
+        loginAndChangePassword("index.jsp", false);
 
         // logout, then login with "admin/newPassword", should go directly to main page
         LOG.debug("Test admin login with new password");
         logout();
         // skip cookie deletion, we need to retain for authorization for resetPassword Rest API call
-        login(PASSWORD_GATE_USERNAME, ALTERNATE_ADMIN_PASSWORD, true, true, true, true);
+        // do not navigate to login page, we should already be there
+        login(PASSWORD_GATE_USERNAME, ALTERNATE_ADMIN_PASSWORD, true, true, false, true);
         assertTrue(driver.getCurrentUrl().contains("index.jsp"));
         verifyOnMainPage();
 
@@ -86,7 +86,10 @@ public class AdminPasswordGateIT extends OpenNMSSeleniumIT {
         LOG.debug("Test admin login with default password and skip");
         logout();
         loginAndSkip();
+    }
 
+    @Ignore("Not currently working. RequestCache may not be saving correct page.")
+    public void testAdminPasswordGateRetainsRequestedPage() {
         // logout and try to go to a non-login page
         // user will be redirected to login page, login with "admin/admin"
         // will get password gate page, click Skip, then should redirect to original page
@@ -94,7 +97,7 @@ public class AdminPasswordGateIT extends OpenNMSSeleniumIT {
         logout();
         nodePage();
         waitFor("login.jsp");
-        login(PASSWORD_GATE_USERNAME, PASSWORD_GATE_PASSWORD, true, true, false, false);
+        login(PASSWORD_GATE_USERNAME, PASSWORD_GATE_PASSWORD, true, false, false, false);
         waitFor("element/nodeList.htm");
 
         // logout and try to go to a non-login page

--- a/smoke-test/src/test/java/org/opennms/smoketest/AngularLoginRedirectIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AngularLoginRedirectIT.java
@@ -111,7 +111,7 @@ public class AngularLoginRedirectIT extends OpenNMSSeleniumIT {
         setImplicitWait();
     }
 
-    @Ignore("Need to fix")
+    @Test
     public void testAngularLogout() throws IOException {
         for (Check eachCheck : checks) {
             LOG.info("{}: Run test for page", eachCheck.url);

--- a/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportIT.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -115,7 +114,7 @@ public class DatabaseReportIT extends OpenNMSSeleniumIT {
         Assert.assertTrue(true);
     }
 
-    @Ignore("Need to fix")
+    @Test
     public void verifyReportExecution() {
         LOG.info("Verifying report '{}'", reportName);
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -246,12 +246,12 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         clickMenuItem("internalLogsMenu", "Instrumentation Log Reader");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Instrumentation Log Reader')]")));
 
-        // TODO: Fix this test!
-//        // User Profile Menu
-//        clickMenuItem("userProfileMenu", "Change Password");
-//        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='form-input-wrapper']//label[contains(text()[normalize-space()], 'Change Password')]")));
-//        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//button[@id='btn_change_password']")));
-//        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//button[@id='btn_skip']")));
+        // User Profile Menu
+        clickMenuItem("userProfileMenu", "Change Password");
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[contains(text()[normalize-space()], 'Please enter the old and new passwords and confirm.')]")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'Current Password')]")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'New Password')]")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'Confirm New Password')]")));
 
         // API Documentation Menu
         // Omit clicking for now, some of these are external links

--- a/smoke-test/src/test/java/org/opennms/smoketest/UIRefreshIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/UIRefreshIT.java
@@ -28,7 +28,6 @@ import javax.ws.rs.core.Response;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.opennms.netmgt.model.OnmsNode;
@@ -62,13 +61,7 @@ public class UIRefreshIT extends OpenNMSSeleniumIT {
         assertEquals("ItsRainingItsPouring", node.getLabel());
 
         // Switch to the new UI
-        // Commenting-out for now - the "UI Preview" button has been removed
-        // Need to find a better way of testing for existence of new UI
-        /*
-        wait.until(pageContainsText("UI Preview"));
-        clickElement(By.id("ui-preview-btn"));
-        wait.until(pageContainsText("Back to main page"));
-         */
+        clickMenuItem("inventoryMenu", "Structured Node List");
     }
 
     @After
@@ -77,7 +70,6 @@ public class UIRefreshIT extends OpenNMSSeleniumIT {
     }
 
     @Test
-    @Ignore("Cannot get to new UI via UI Preview button, need to rework this test")
     public void canRender() {
         // The node label should be displayed on the landing page
         wait.until(pageContainsText("ItsRainingItsPouring"));
@@ -91,5 +83,4 @@ public class UIRefreshIT extends OpenNMSSeleniumIT {
         driver.navigate().refresh();
         wait.until(pageContainsText("Recent Events"));
     }
-
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1007,26 +1007,26 @@
   resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.4.0.tgz#3bbb984085dbd6d982494538b523be1ce6562972"
   integrity sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==
 
-"@swagger-api/apidom-ast@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-beta.44.tgz#cf3e9d19afb23dda32756dbe79af679711833919"
-  integrity sha512-+IOyUl0Gl125t3/ULi6Bc7HbvSMHqOSXmDqL9qAYrOxIaQVasHgIq+sye6g/3TsqAE8xZ7gtfsaA53UlclotFg==
+"@swagger-api/apidom-ast@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-beta.45.tgz#a1a05a38c5b29cc17630e3a4d3f5ce4890563427"
+  integrity sha512-2npCF6V4QYSRv8USSmQ9jmsnNrjhTww4C84+cetNpxvTYXmEi9bRwIfzn2LH7DedsZsOJOMucVbJkCcRB/VC2Q==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     unraw "^3.0.0"
 
-"@swagger-api/apidom-core@>=1.0.0-beta.41 <1.0.0-rc.0", "@swagger-api/apidom-core@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-core/-/apidom-core-1.0.0-beta.44.tgz#7b36a9737f2af4905a293481f3424ca1204c573c"
-  integrity sha512-6TXqyO/aJv1QgY/iTiNVI0ECedKIMIOM5KlblWZfm1uy4djNy1FA8Z3x49WESNlYRklEiYHZ/3HVthoLa6hSOA==
+"@swagger-api/apidom-core@>=1.0.0-beta.41 <1.0.0-rc.0", "@swagger-api/apidom-core@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-core/-/apidom-core-1.0.0-beta.45.tgz#e6fda8037fe534556a512247940a5904fc66b43e"
+  integrity sha512-JEKf/bIl0RgaYAILlSDjuWhcg/+gbrI6p6OZuXR7EVxPlPNBAsme98UYyICA9AENyi2fzxwCP5eDRFl4cIzMHQ==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-ast" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
+    "@swagger-api/apidom-ast" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     minim "~0.23.8"
     ramda "~0.30.0"
@@ -1034,263 +1034,263 @@
     short-unique-id "^5.3.2"
     ts-mixer "^6.0.3"
 
-"@swagger-api/apidom-error@>=1.0.0-beta.41 <1.0.0-rc.0", "@swagger-api/apidom-error@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-error/-/apidom-error-1.0.0-beta.44.tgz#e60a564834e885c8c8f5a6f546e01567fc4d1f6e"
-  integrity sha512-GwLzYvDsXPmhJYKibS86RS6Kkdj7h2bFrTuqQ2f9FV9mdgG7EOh3yC6tNdd0Q/WvcFzd5i+APNX0PrYg/kfLiw==
+"@swagger-api/apidom-error@>=1.0.0-beta.41 <1.0.0-rc.0", "@swagger-api/apidom-error@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-error/-/apidom-error-1.0.0-beta.45.tgz#e8dfcc0ce46e55f74a7fe3940e01639b1eed3df4"
+  integrity sha512-kEy7blIEF77BnoqLhGW3h3I+evPHrtZwKe4fSw22UEUJUTG1Daw9FhaSgfBNptifZzzdLgiVDujrIOI6SpkH3Q==
   dependencies:
     "@babel/runtime-corejs3" "^7.20.7"
 
-"@swagger-api/apidom-json-pointer@>=1.0.0-beta.41 <1.0.0-rc.0", "@swagger-api/apidom-json-pointer@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-json-pointer@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-beta.44.tgz#4b60d108f95626afc43699e68ca445dc2ff9af64"
-  integrity sha512-2/E3+LFuqnTUay14+Qv3doXzPZMrS/Ed638Gd8byB4XNUY/0zQYwHTEca5QOxadNFh86zG+DnQQl+DC3ARkmTg==
+"@swagger-api/apidom-json-pointer@>=1.0.0-beta.41 <1.0.0-rc.0", "@swagger-api/apidom-json-pointer@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-json-pointer@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-beta.45.tgz#7833407769be6f870b0231f33ac0af0ad7e3798a"
+  integrity sha512-s8eMDc/zL5W9mtBRbjEGPDt9yNJlpq9S+7/ACLjlSg1J3toadZmNiyR0svVLroVzVZHD5aGClGRpdammbO/PhQ==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
     "@swaggerexpert/json-pointer" "^2.10.1"
 
-"@swagger-api/apidom-ns-api-design-systems@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-beta.44.tgz#3c6832cb8172bb1a4cdbc57bc0e65e0cd470148e"
-  integrity sha512-4lz7pIzD0J1X2/pSsYYxu3pH2xDXVpxvjZJDEB81LElxq5IOuGvtKK38Na0tM9pv3oYyJTWbUdT3Ili9O7URyQ==
+"@swagger-api/apidom-ns-api-design-systems@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-beta.45.tgz#299956f7e961bb6955e5e6b6b4b42cf563da6013"
+  integrity sha512-uX+lkOi1g32mIhBVtMm5a304H68GIR4IXf/wiD6mdf2iwjfR0+drn/4NmirZqrNvlMtmf1a6VSe4u6KE3OBIpw==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-openapi-3-1" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-openapi-3-1" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.3"
 
-"@swagger-api/apidom-ns-arazzo-1@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-arazzo-1@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.0.0-beta.44.tgz#4c63324299f9f7f3b6d57258fc06a092800eeb9a"
-  integrity sha512-Ui0eTJf1mX+MTuxvBWDl7RQ7jtZhPRBT1OfqMYCOneKbajZtka+U9fNUWgRwIuieRn3bHr3T5+s3jRK5AKZ7nQ==
+"@swagger-api/apidom-ns-arazzo-1@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-arazzo-1@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.0.0-beta.45.tgz#52bbd07933e5ebf48a4b5c83a5ea6bb8f3249e08"
+  integrity sha512-ZjzTvby6Zvu7vh6uabRCGsnhAPeefxgJQ7DPKLELe9KyzcT+OqorjDtfaESFy4zzIMokalJcja/in29yTS+kxw==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-2020-12" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-2020-12" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.3"
 
-"@swagger-api/apidom-ns-asyncapi-2@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-asyncapi-2@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-beta.44.tgz#cc9f10860ee4e8f3b149ec3e81bef7339c7a6da6"
-  integrity sha512-RGA1348E0gfSCpaD7nwYW2377ArDPyhnkzckeLafBYwhCDjOtjZTbJZ5ljnvAQmpv37pmy+ev/uIFUCpyIJ0qQ==
+"@swagger-api/apidom-ns-asyncapi-2@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-asyncapi-2@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-beta.45.tgz#bc4ee0651a9432e07de9a014ce8e41ce1a3448bf"
+  integrity sha512-OQY2cSs5oZo0/rlGa8hHfgu7DFQ6lDhBC+IAKp0E7gF27oH2Yy9BEHlxHUA3iUeCMxDfIo021+Qc8FpNqivtxA==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-draft-7" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-draft-7" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.3"
 
-"@swagger-api/apidom-ns-json-schema-2019-09@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.0.0-beta.44.tgz#ee996cc001ca80daa35fb0834d895d391df3a8f9"
-  integrity sha512-wPRDhIueKa20jZ1zvu//I48p9AzbJdC/KHsicJoRW7y0HgIZpG0AIB6fc1N0p/8NMibOq0JEIdIVYYvhmW9pAg==
+"@swagger-api/apidom-ns-json-schema-2019-09@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.0.0-beta.45.tgz#b32be6556ec0b4e02c24a44462032aaa0a4cf6b9"
+  integrity sha512-StoPoa1yI5gBfPZ57LhA41f+JNJ/JnrsWZnmDlJG8W2hyjJAeyVkOo0qoVpt40240WZmH2EuywIFrdD+n+hrLA==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-draft-7" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-draft-7" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.4"
 
-"@swagger-api/apidom-ns-json-schema-2020-12@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.0.0-beta.44.tgz#57fa259a3faa2186cb1e2c1f36b5d3fc5641c39c"
-  integrity sha512-QwE0gnDO8GfGEpZdWDjFAkoBH+6atPk/oeX/OFjFOOkwMJXSZiIQbx69xefS1XEMSg40aOHKIjpeSTzErirEfg==
+"@swagger-api/apidom-ns-json-schema-2020-12@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.0.0-beta.45.tgz#a25750172fa45a8afcbfe07232ecd7d7c9095335"
+  integrity sha512-l70stVPz1kGIiM7t55twYhfI2GwDKLOjfr+Py1Rknyo75LYw08QhppZ7PxWamgvKmoYfBnGeaoC+18Q2dn2Bhg==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-2019-09" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-2019-09" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.4"
 
-"@swagger-api/apidom-ns-json-schema-draft-4@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-beta.44.tgz#1149d28b6940eaaf6f9f16e017bf1354dfee9092"
-  integrity sha512-p392XjvmJ9NTxIzQ5/l33rzOm4hx4XDRWe+SwuciTg4NsuNQupTq3zrvXagCVepzYBlSg/1k0SYCm7yVRR+VJw==
+"@swagger-api/apidom-ns-json-schema-draft-4@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-beta.45.tgz#efab0adffffa8007551ff2a28cc4b6ea91b9334d"
+  integrity sha512-tlDz4+Ko+ylVWSpSprZM9WoBMfmBxoUxcxvbkcafCJTO4MCQuytYaW3p/BIMscCsa0LP1eR4ycMY8h445ur58Q==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-ast" "^1.0.0-beta.44"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
+    "@swagger-api/apidom-ast" "^1.0.0-beta.45"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.4"
 
-"@swagger-api/apidom-ns-json-schema-draft-6@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-beta.44.tgz#01cfead77f07e49dc22bddce9f8ba70c0307932d"
-  integrity sha512-aodklkUWZ774je8VMDge/OFpDNeefZc+5jKymtMip1uYbVLmO7ByvkqSR665xXqOA8VMEzsG+q59L+4UX3jObA==
+"@swagger-api/apidom-ns-json-schema-draft-6@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-beta.45.tgz#79a9ccea9005ece9993e1be4de73d9504a740182"
+  integrity sha512-wBkk2AqDddZvf1VixAuwFu9LRTJya3yL+FAmg4KyMGrA32VOFYupe9jc1RmV/noTfGwf5AWZVnuGo9xiI2z4Wg==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-draft-4" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-draft-4" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.4"
 
-"@swagger-api/apidom-ns-json-schema-draft-7@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-beta.44.tgz#273c03c75a317daa13774bd228c4b3b6fa9dbe16"
-  integrity sha512-CbPRkDusgxBBF4MuBz8T88CYmqnqOUd3VqbTHU948Q2KqvcleI2W+HiTgJfBew0XkEiIwbWwRPdfBuuWZwVtyg==
+"@swagger-api/apidom-ns-json-schema-draft-7@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-beta.45.tgz#d1b514b31e9e1153e18ebf22978a0ec55092c42a"
+  integrity sha512-EggsaTXUw0j8PmcO+IxnoJ7TyXz8sNarPlB2EGNqVT3qEwGQn96qXZ8pZab0sr1iStIWzyAaXMKrnmlcSIDpSQ==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-draft-6" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-draft-6" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.4"
 
-"@swagger-api/apidom-ns-openapi-2@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-openapi-2@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-beta.44.tgz#4e18d79a9d07fb7975c8674e7cb0519e4895f322"
-  integrity sha512-T5PSrtqFcUpIPKJq7Z0aAQthxm4S5F5Ke5Nuk9UDfvD6FHDsk8nRc+GSleSt/Je4X0aqc/G2ZsztH1b5bWZ06g==
+"@swagger-api/apidom-ns-openapi-2@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-openapi-2@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-beta.45.tgz#b8bebab2ca5d2f2c976487baa3226c7167c45bee"
+  integrity sha512-OY/FM8lDB6MzJfTgqHPj6k6Kk62Uho5gynsZLyroxgTz+Ez9zSdgA+p8+mdE4hBQxfwSnUtaiFMWgAzY+12Q9A==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-draft-4" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-draft-4" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.3"
 
-"@swagger-api/apidom-ns-openapi-3-0@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-openapi-3-0@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-beta.44.tgz#170c5a7e4ac7e24ab0678e5610183f3fb89f2078"
-  integrity sha512-2S3mymU47rWVBxJipA1qseVXE11Q4N3gKu/joxw40V6qB1UhCTzl4IjJaYhGKE+eGkJ3i6CCocHHlNlnTX0Pcg==
+"@swagger-api/apidom-ns-openapi-3-0@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-openapi-3-0@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-beta.45.tgz#e07b057f269ebfe2508fa7930021226b7b5efc93"
+  integrity sha512-HaacHMmYfMp9UNSTONVxGRQDlQn8yEIOklHowI+/u8SRqdV87dE9UQhp8AMGw2hfnYiyt8ADFdPsLnYR6LEq7g==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-draft-4" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-draft-4" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.3"
 
-"@swagger-api/apidom-ns-openapi-3-1@>=1.0.0-beta.41 <1.0.0-rc.0", "@swagger-api/apidom-ns-openapi-3-1@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-openapi-3-1@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-beta.44.tgz#4869dbdd13d98f44a7aae2d3169f47cc35cd7e1c"
-  integrity sha512-pSxoB/xZq1B7vjt2kC8DObpaMZgZ4qdLplVJFZgh23ohnU6D/ubaJhe04kS0vxVMpwrcEjYU44t7paMLEUr1nA==
+"@swagger-api/apidom-ns-openapi-3-1@>=1.0.0-beta.41 <1.0.0-rc.0", "@swagger-api/apidom-ns-openapi-3-1@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-ns-openapi-3-1@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-beta.45.tgz#46cd6fbc8e0136652ffd7a13dda12331afb60730"
+  integrity sha512-irU2jMOZNWf/lAXc/JuWohHs55MQe7Rb36xzAqoyOjauk2nj/ougy5b+xvG3dLZu3ZKc/X9kmimPPLTs7P2Xhw==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-ast" "^1.0.0-beta.44"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-json-pointer" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-json-schema-2020-12" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-openapi-3-0" "^1.0.0-beta.44"
+    "@swagger-api/apidom-ast" "^1.0.0-beta.45"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-json-pointer" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-json-schema-2020-12" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-openapi-3-0" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
     ts-mixer "^6.0.3"
 
 "@swagger-api/apidom-parser-adapter-api-design-systems-json@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-beta.44.tgz#3a5f4d663e236492947dc80e9826b317dbd41282"
-  integrity sha512-mhPA7qn0NXh84Vw2hwtK+9sOplV3bf9HJiZ1M3YyjTnhXGVf3lBNvi2f2OzLPdiYwNTG0p3N43f3v+SQzLVbKg==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-beta.45.tgz#8516041a28e7bde1d950f330515c0b90a0c79148"
+  integrity sha512-F8Glj81vrYc9oghEeM1Pfo8qbOptEl3tPOU3hQIqDM4pqMRuB3vwYfoZLVnwpewXacBRgwUiXXnaWV7alMnPzg==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-api-design-systems" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-api-design-systems" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-beta.44.tgz#8e6c9443e3e62a4ea972349c75fa08897e20746d"
-  integrity sha512-So6M95X5G3PQ4AboP6HzA30c7XdpYXDognslELAvZpl8OEG8nVaKyqn7+lRsK2pG6oBSYBaqEialZNZly7Np5Q==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-beta.45.tgz#307988780050793c381d0c678f241bd23e29cbb8"
+  integrity sha512-Xdhk2yffGD2KcncTs8uNeiKBeBvr0njRRlhfSKdewb91SHXqyh2eKf168M6UPdT0dg3QQKdCT5lV+meKcYGpkw==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-api-design-systems" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-api-design-systems" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-arazzo-json-1@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.0.0-beta.44.tgz#5785f0bbb3be1783d1ba40f9dd6ceea4c1fa6dc3"
-  integrity sha512-avgDrkdSpbAzEb6++qdEqckO7Yyh538FBnk1A9+OfkYSj7k83yx5azngAmr66tBG3oSSCELTmEpXM+oyBGHH/Q==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.0.0-beta.45.tgz#3fcb63fdb89df6444330ac91cecc7dddb9c42673"
+  integrity sha512-SMJseBO32aHPXskwYThT2y3Py2B8B4gKqGXl+ZlMGCaM72Fnnr0hbqtI8wt2v58F97qVlTYvXvTSfQGUuUh/Kg==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-arazzo-1" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-arazzo-1" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.0.0-beta.44.tgz#35d0ae7b38acc50d2abd53fac09c9ca46c984909"
-  integrity sha512-kUxujeqr0Av8IY1T5xxZXaj/0tV/dQGqCDv9cLcnivKEp2gnCFxwkdKMlRCosMpPOb+ApOcUYtgGYM/RnkyGbg==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.0.0-beta.45.tgz#4239b1bde87b7ca419fcd6162664014f54f2e54d"
+  integrity sha512-w9v3E0F9OKSUoK2DtMphpUO2Dd+op+YrwHAYyZTbKL48DEd+Ez5L9wW1bURpfNMSaRjm5H9BrMM2eVdSz8TFQw==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-arazzo-1" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-arazzo-1" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-asyncapi-json-2@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-beta.44.tgz#2b50d2516082c4abc453bbff3e50866308637bb6"
-  integrity sha512-Q+qc+tTucc5Ol1ikeEVbt9DasnlXhM8MtY6Ej6ylDS+eSPzZMw09vU2V6Tk/QWSoSDHSqZMHt9G12SHI78LrbA==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-beta.45.tgz#117cb744c79bbd01e886164cec8b29f7c721d467"
+  integrity sha512-7txrflmTsG2400mHq6rswnxi6+r+H7vtL0Mfb0lMj4docaSODnTdEiNjG35jaQaBMbMEtRPokJ6i4018SNFy3Q==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-asyncapi-2" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-asyncapi-2" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-beta.44.tgz#ee6456c1fd6bed77ecc451e9c7083863df7ba51f"
-  integrity sha512-E4PVQLIWI3QG7UVHL23Qf4GUQCzTyRfiiMHt34gySTtFIE9OV48hIax3J85dF2DMR1CXtzj86zQTacYYe84EUQ==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-beta.45.tgz#6b894b443520b5bb92b306cd919fe57fb08345ba"
+  integrity sha512-laxCy1UmLjlUGRRlcEEQLHWmzwnUq750SFjnBUJe70DxNrBr68UqlLqKC/kGkpOOgsf+NMWhqSkS8WQ/eLsQww==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-asyncapi-2" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-asyncapi-2" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
-"@swagger-api/apidom-parser-adapter-json@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-parser-adapter-json@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-beta.44.tgz#a82ee29764af6ad796769d0147bf26e378ab047d"
-  integrity sha512-KeMu0tHLXNNJaZkR0blzHl3KvCfkde414h9FMosBH+zh4KLA0wmly1Mn+9tzvAbBa7vqxKmHg1o/7vDU2ZGA3Q==
+"@swagger-api/apidom-parser-adapter-json@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-parser-adapter-json@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-beta.45.tgz#dcc1a7fc0d94b566b9eedf522f274a8ff28bc4e7"
+  integrity sha512-5fFln56FM/6xEvGEAjk+GvTcmts8P5nnCPNDQpxc/PVDcLxC0gzyp5bjkOLmj9nZXqCQRzm/PH0bmxGQv4JSmg==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-ast" "^1.0.0-beta.44"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
+    "@swagger-api/apidom-ast" "^1.0.0-beta.45"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
@@ -1299,92 +1299,92 @@
     web-tree-sitter "=0.24.5"
 
 "@swagger-api/apidom-parser-adapter-openapi-json-2@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-beta.44.tgz#9db8e5e6e262050b3a31a91551aa11b5c2be4ced"
-  integrity sha512-F3Um4/raAob3M/CLOCrl1qrOb/Z+E1elMGpGupyk3uqgj0xQ0otlwzJS+2gz0LAJHofzq2WLZGDRsKlPaepTtQ==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-beta.45.tgz#c12359478533c916fd35bf9a4a0fb235bb2fd9a3"
+  integrity sha512-lFRbbCGyGilEkNLgZyJeHK2sUsmtEKljkvyZytjGXshd45lLkHD+/1vByKhClbyoA+aIk8lzLpeaMECbOH+a9w==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-openapi-2" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-openapi-2" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-openapi-json-3-0@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-beta.44.tgz#ea742942c4fd0dc0eb764831a85b5f179a8cf2f4"
-  integrity sha512-Jw0BxctNKmDifDh5Jo3exhp9VtWz/OZR8qqCL1y65ySvIr4MkCkvEmGTvfdXGZrxwhPVm5QDmJ5/X0MKHi/ZDQ==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-beta.45.tgz#a25d77d9bceb96b663541cde3db977c26b52646c"
+  integrity sha512-AMCSLQhWcsTvlAhZMIwGezXBxhqLnnQQPkZHwKBFA1sD0FLZJKmIs1bxuEuo3iKNHKfDvbKJLQsr6OOqCg1MtQ==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-openapi-3-0" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-openapi-3-0" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-openapi-json-3-1@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-beta.44.tgz#eecc70b5d8efcc4b7cbd3609b6f48a3695c8fd1f"
-  integrity sha512-NWeHqHBr/XpQkDnomMCzENujzYx/zE9Jo7NgzPhDMH3kgS/3snwrgNRFRDMCazwDqdjWfhivHdE5biqsOGEe7A==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-beta.45.tgz#7a1e70f11afb8f62fa7fcdae1644439b6f48a690"
+  integrity sha512-rnao77rKeLHrpfM/QRzsOVNaaqZVYv4QID35GDOkuIHjjDNTjmquUsuWscAtI32P7tJHmPrLAJWKxb48W02mmw==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-openapi-3-1" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-openapi-3-1" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-json" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-openapi-yaml-2@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-beta.44.tgz#06730daf38407341c331b4bd031aad98bb7b4ea7"
-  integrity sha512-TfgItza/SrM5YsLhEdl75HHGwlnVKVveWh2miF1MTsI9K3k3I4Zv0nUnKNlH+R9TY6DXUr7c52c4Jf672VyLxQ==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-beta.45.tgz#ea39e67e4c0d5ccf5dd325e4afb672f415d1cf25"
+  integrity sha512-zilhJHYEV0cGde6ZdAfB+/4OnzHW8OCLO7bXmtoXdsxwJV0DHnwjrq2FgOlwqWBPWRIlyFwBwdUO0Rd5P4re3g==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-openapi-2" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-openapi-2" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-beta.44.tgz#17ab0251a09081c19d7e609b13080007d3315a8e"
-  integrity sha512-g0+N/XpJTMioHfXGh5roTXPZO6AounZCpMfe2GpfdHLRN4hpxzffd+xZLVMmcaFt1x3XYAhBFCxNXIumg5Pw5A==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-beta.45.tgz#8b1e0c460822b79ed29d2263fde4f541fda0741b"
+  integrity sha512-loof/awV/RNIaCHqr4+uVVjdSayAvNyxjLszyd0moAQv/247mfjvCH0h9VLIlpjI4kf+C3q4bhyYYaeVl9MSVg==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-openapi-3-0" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-openapi-3-0" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
 "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@^1.0.0-beta.40 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-beta.44.tgz#ad48cc9a7e51cdbd4b2c501b55fe13096fa58442"
-  integrity sha512-cddGQ9XUafxv6ERO53JOxryZL968TwjNfsc/9NB9KYHTv32sk73cncIh5KfmGd7SH5UExmGv4YD93n7r2i7ePw==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-beta.45.tgz#aac8c0a27612d5a8b88692634f0b6fde974f1756"
+  integrity sha512-h2oHGosYXditkPJ66aGEsvz6zpM6N26ay1ZRhk9LjuSA8S4BqFYY+MbJVD6C0LLP6Mn5jvDWCUq7yB0DTWNxpg==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-ns-openapi-3-1" "^1.0.0-beta.44"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-ns-openapi-3-1" "^1.0.0-beta.45"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
     ramda-adjunct "^5.0.0"
 
-"@swagger-api/apidom-parser-adapter-yaml-1-2@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-parser-adapter-yaml-1-2@^1.0.0-beta.44":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-beta.44.tgz#26931203ee2e92eb326f33af7c5186258e42dfaf"
-  integrity sha512-2UUKNaI9CESIN1f8skTzVHTVujuJyK5T0SE6THQ8wcihPhyoRaCUU4kcSSx22IxPIABFQ21+RYZ0sM3D5dOZ2Q==
+"@swagger-api/apidom-parser-adapter-yaml-1-2@^1.0.0-beta.40 <1.0.0-rc.0", "@swagger-api/apidom-parser-adapter-yaml-1-2@^1.0.0-beta.45":
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-beta.45.tgz#313ce1f12f99d608e9135d6d3b8c9bcae59d2d5c"
+  integrity sha512-/Emcfl4Va1GJB7kU2DWZBrqAn6dLi/sclPa4z0sjg+2EtOJ9l9zw3sKc4d7cEY5PX2QzgD8bFxBYrP9lU03IZw==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-ast" "^1.0.0-beta.44"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
+    "@swagger-api/apidom-ast" "^1.0.0-beta.45"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
     "@tree-sitter-grammars/tree-sitter-yaml" "=0.7.1"
     "@types/ramda" "~0.30.0"
     ramda "~0.30.0"
@@ -1393,13 +1393,13 @@
     web-tree-sitter "=0.24.5"
 
 "@swagger-api/apidom-reference@>=1.0.0-beta.41 <1.0.0-rc.0":
-  version "1.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-beta.44.tgz#c2eb2101d0ecd93ee2a29c6b59d741d90097ffbe"
-  integrity sha512-qXaL0H8ehmMX7NLYKSrIVl1ayE5e2jsvZ3ApcksmHYWUKsbuDTfKB7pKR78VporRv+SRXiq2WGeeYY1bCuCHKA==
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-beta.45.tgz#c0c4657cbbddb19b7949bd5c47214590369c2d32"
+  integrity sha512-1EbK7P6oki5mR8bho+E0yoc9JwhOT/vboTjidolH8Fjw/WuE6GcMHX+8OBcwcgjt9hXWsY3YfvZFwK7baxkPnQ==
   dependencies:
     "@babel/runtime-corejs3" "^7.26.10"
-    "@swagger-api/apidom-core" "^1.0.0-beta.44"
-    "@swagger-api/apidom-error" "^1.0.0-beta.44"
+    "@swagger-api/apidom-core" "^1.0.0-beta.45"
+    "@swagger-api/apidom-error" "^1.0.0-beta.45"
     "@types/ramda" "~0.30.0"
     axios "^1.9.0"
     minimatch "^7.4.3"
@@ -1715,11 +1715,11 @@
   integrity sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==
 
 "@types/node@>=20":
-  version "24.1.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.1.0.tgz#0993f7dc31ab5cc402d112315b463e383d68a49c"
-  integrity sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==
+  version "24.2.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.2.0.tgz#cde712f88c5190006d6b069232582ecd1f94a760"
+  integrity sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==
   dependencies:
-    undici-types "~7.8.0"
+    undici-types "~7.10.0"
 
 "@types/ramda@~0.30.0":
   version "0.30.2"
@@ -4544,10 +4544,10 @@ ufo@^1.5.4:
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.1.tgz#ac2db1d54614d1b22c1d603e3aef44a85d8f146b"
   integrity sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==
 
-undici-types@~7.8.0:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
-  integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
+undici-types@~7.10.0:
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.10.0.tgz#4ac2e058ce56b462b056e629cc6a02393d3ff350"
+  integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
 
 undici@5.28.4:
   version "5.28.4"


### PR DESCRIPTION
In some cases, especially when a user changed their password, user would be redirected to an asset file (like a CSS, JS or TTF file) instead of to a real page (jsp/htm) after logging in.

This PR includes code to make sure we aren't saving any of those asset files in the Spring security Saved Request Cache.

There may be a better way to do this, but this works for the immediate problem. There are still issues about when you are not logged in and navigate to some page other than the home page; you don't redirect properly to the original requested page. There are some issues because of the Admin Password Gate page.

Reenabled some smoke tests for the login process, but the ones dealing with that redirect are still being ignored for now.

Also fixed some other smoke tests that had been ignored: `DatabaseReportIT`, `AngularLoginRedirectIT`, `UIRefreshIT`. 

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18175
* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17985
