### PR TITLE
Docs: Fix incorrect xreference for trap reception

### DIFF
--- a/docs/modules/operation/pages/deep-dive/admin/configuration/newsfeed-configuration.adoc
+++ b/docs/modules/operation/pages/deep-dive/admin/configuration/newsfeed-configuration.adoc
@@ -11,7 +11,7 @@ The {page-component-title} server makes REST queries to the https://www.opennms.
 This feature is enabled by default, but can be disabled using the configuration below.
 Disabling will remove the panel from the front page and the server will no longer make queries for the feed.
 
-If you would like to change the feed settings, you can set the following options in `${OPENNMS_HOME}/etc/opennms.properties.d/feed.properties`.
+If you would like to change the feed settings, you can set the following options in `$\{OPENNMS_HOME}/etc/opennms.properties.d/feed.properties`.
 
 [options="autowidth"]
 |===

--- a/docs/modules/operation/pages/deep-dive/events/sources/snmp-traps.adoc
+++ b/docs/modules/operation/pages/deep-dive/events/sources/snmp-traps.adoc
@@ -355,7 +355,7 @@ To configure {page-component-title} to honor `snmpTrapAddress` when present, set
 <2> Don't create new nodes when receiving an SNMP trap with an unknown source IP address.
 <3> Try to use the identifier source IP address from the `snmpTrapAddress` varbind instead of the UDP source IP address.
 
-If you are using Minions to receive traps, edit the `${MINION_HOME}/etc/org.opennms.netmgt.trapd.cfg` file on each Minion to include the following setting:
+If you are using Minions to receive traps, edit the `$\{MINION_HOME}/etc/org.opennms.netmgt.trapd.cfg` file on each Minion to include the following setting:
 
 [source, properties]
 ----

--- a/docs/modules/operation/pages/deep-dive/events/sources/snmp-traps.adoc
+++ b/docs/modules/operation/pages/deep-dive/events/sources/snmp-traps.adoc
@@ -12,7 +12,7 @@ It receives SNMP traps via the xref:reference:daemons/daemon-config-files/trapd.
 == Before you begin
 There are a few tasks you must complete before your server can receive SNMP traps:
 
-. Configure the port on which to receive SNMP traps (see xref:deployment:core/getting-started.adoc#receive-snmp-traps[Receive SNMP traps/informs]).
+. Configure the port on which to receive SNMP traps (see xref:reference:configuration/receive-snmp-traps.adoc[Receive SNMP traps/informs]).
 By default, {page-component-title} listens on a non-standard port for trap messages.
 . Ensure that SNMP-capable devices on your network are configured to send traps to {page-component-title}.
 


### PR DESCRIPTION
DOCS DOCS DOCS DOCS DOCS DOCS 

The event-sources/snmp-traps document contained an invalid reference starting in 2023; this fixes the reference.

Also fixes some invalid variable references because I was in there.

