### PR TITLE
NMS-18181: Updates to QuickAddNode, remove SNMPv3 params

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/QuickAddNode.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/QuickAddNode.js
@@ -36,7 +36,7 @@ const QuickNode = require('../model/QuickNode');
   const quickAddPanelBasicView = require('../../views/quick-add-panel-basic.html');
   const quickAddPanelSnmpView = require('../../views/quick-add-panel-snmp.html');
   const quickAddPanelCategoriesView = require('../../views/quick-add-panel-categories.html');
-  const quickAddPanelCliView = require('../../views/quick-add-panel-cli.html');
+  // const quickAddPanelCliView = require('../../views/quick-add-panel-cli.html');
   const quickAddPanelHelpView = require('../../views/quick-add-panel-help.html');
 
   angular.module('onms-requisitions')
@@ -61,7 +61,7 @@ const QuickNode = require('../model/QuickNode');
     $scope.quickAddPanelBasicView = quickAddPanelBasicView;
     $scope.quickAddPanelSnmpView = quickAddPanelSnmpView;
     $scope.quickAddPanelCategoriesView = quickAddPanelCategoriesView;
-    $scope.quickAddPanelCliView = quickAddPanelCliView;
+    // $scope.quickAddPanelCliView = quickAddPanelCliView;
     $scope.quickAddPanelHelpView = quickAddPanelHelpView;
 
     /**

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/QuickAddNodeModal.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/QuickAddNodeModal.js
@@ -33,7 +33,7 @@ require('../services/Requisitions');
   const quickAddPanelBasicView = require('../../views/quick-add-panel-basic.html');
   const quickAddPanelSnmpView = require('../../views/quick-add-panel-snmp.html');
   const quickAddPanelCategoriesView = require('../../views/quick-add-panel-categories.html');
-  const quickAddPanelCliView = require('../../views/quick-add-panel-cli.html');
+  // const quickAddPanelCliView = require('../../views/quick-add-panel-cli.html');
   const quickAddPanelHelpView = require('../../views/quick-add-panel-help.html');
 
   angular.module('onms-requisitions')
@@ -60,7 +60,7 @@ require('../services/Requisitions');
     $scope.quickAddPanelBasicView = quickAddPanelBasicView;
     $scope.quickAddPanelSnmpView = quickAddPanelSnmpView;
     $scope.quickAddPanelCategoriesView = quickAddPanelCategoriesView;
-    $scope.quickAddPanelCliView = quickAddPanelCliView;
+    // $scope.quickAddPanelCliView = quickAddPanelCliView;
     $scope.quickAddPanelHelpView = quickAddPanelHelpView;
 
     /**

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/quick-add-node-standalone.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/quick-add-node-standalone.html
@@ -26,10 +26,12 @@
         <div class="card-header"><span>Surveillance Category Memberships (optional)</span></div>
         <div class="card-body" ng-include="quickAddPanelCategoriesView"></div>
       </div>
+      <!--
       <div class="card">
         <div class="card-header"><span>CLI Authentication Parameters (optional)</span></div>
         <div class="card-body" ng-include="quickAddPanelCliView"></div>
       </div>
+      -->
       <div class="form-group">
         <button type="button" class="btn btn-primary" id="provision" ng-click="provision()" ng-disabled="isInvalid()">Provision</button>
         <button type="button" class="btn btn-primary" id="reset" ng-click="reset()">Reset</button>

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/quick-add-node.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/quick-add-node.html
@@ -21,9 +21,11 @@
         <ng-include src="quickAddPanelCategoriesView"></ng-include>
       </uib-tab>
 
+      <!--
       <uib-tab heading="CLI Authentication" id="tab-cli-auth-parameters">
         <ng-include src="quickAddPanelCliView"></ng-include>
       </uib-tab>
+      -->
 
       <uib-tab heading="Help" id="tab-help">
         <ng-include src="quickAddPanelHelpView"></ng-include>

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/quick-add-panel-help.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/quick-add-panel-help.html
@@ -29,16 +29,26 @@ the OpenNMS system.
 requisitioned. If no values are specified here, OpenNMS' system-wide SNMP
 configuration will be used to determine the appropriate values for the IP
 address entered in the <em>Basic Attributes</em> section. If the node does not
-support SNMP, the "No SNMP" box should be checked. Configuring SNMPv3
+support SNMP, the "No SNMP" box should be checked.
+
+<!--
+Configuring SNMPv3
 parameters via the web UI is not supported; contact your OpenNMS administrator
 if this node requires SNMPv3 parameters that differ from those in the
 system-wide configuration.
+-->
 </p>
 
+<!--
 <p>
 <em>CLI Authentication Parameters</em> are optional and will be used only if one
 or more provisioning adapters are configured to use them. Typically this is the
 case if OpenNMS is integrated with an external configuration management system.
+</p>
+-->
+
+<p>
+If you need to add SNMPv3 authentication details, you can do so from the SNMP Agent Configuration page.
 </p>
 
 </div>


### PR DESCRIPTION
Updated the Quick Add Node page to remove the CLI Authentication parameters and change some wording.

Note, I commented-out code instead of deleting it, just makes it easier to debug. We will eventually be replacing this page with a completely new one.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18181
