### PR TITLE
FE: Font references are incorrect

### DIFF
--- a/ui/src/main/index.html
+++ b/ui/src/main/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/OpenNMS_Favicon.svg" />
+    <link rel="shortcut icon" href="../favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenNMS Web Console</title>
   </head>

--- a/ui/src/menu/index.html
+++ b/ui/src/menu/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/OpenNMS_Favicon.svg" />
+    <link rel="shortcut icon" href="../favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenNMS Web Console</title>
   </head>

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -87,6 +87,14 @@ export default defineConfig({
   build: {
     emptyOutDir: true,
     outDir: './dist',
-    target: 'esnext'
+    target: 'esnext',
+    copyPublicDir: false,
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/[name].js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name].[ext]'
+      }
+    }
   }
 })


### PR DESCRIPTION
### Description

The font references in the generated code for ui-components have url(/assets/...), however the fonts are found in opennms/ui-components/assets.

Either figure out how to fix the generated code output, or else make sure all the fonts are in /assets

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-17984

