### PR TITLE
NMS-18047: Node list including IP search, fix other issues

### DIFF
--- a/ui/src/components/Nodes/ColumnSelectionDrawer.vue
+++ b/ui/src/components/Nodes/ColumnSelectionDrawer.vue
@@ -1,7 +1,7 @@
 <template>
   <FeatherDrawer
-    id="left-drawer"
-    data-test="left-drawer"
+    id="column-selection-drawer"
+    data-test="column-selection-drawer"
     @shown="() => nodeStructureStore.columnsDrawerState.visible"
     v-model="nodeStructureStore.columnsDrawerState.visible"
     :labels="{ close: 'close', title: 'Customize Columns' }"
@@ -66,9 +66,6 @@
 </template>
 
 <script lang="ts" setup>
-import { saveNodePreferences } from '@/services/localStorageService'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
-import { NodeColumnSelectionItem } from '@/types'
 import { FeatherButton } from '@featherds/button'
 import { FeatherDrawer } from '@featherds/drawer'
 import { FeatherIcon } from '@featherds/icon'
@@ -76,6 +73,9 @@ import Apps from '@featherds/icon/navigation/Apps'
 import Cancel from '@featherds/icon/navigation/Cancel'
 import { FeatherSelect, ISelectItemType } from '@featherds/select'
 import Draggable from 'vuedraggable'
+import { saveNodePreferences } from '@/services/localStorageService'
+import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { NodeColumnSelectionItem } from '@/types'
 import { defaultColumns } from './utils'
 
 const nodeStructureStore = useNodeStructureStore()
@@ -88,8 +88,10 @@ const initializeSelectedColumns = (columns: NodeColumnSelectionItem[]) => {
     .sort((a, b) => a.order - b.order)
     .map(col => ({ name: col.label, value: col.id }))
 }
+
 const getAvailableOptions = (currentIndex: number) => {
   const currentSelection = selectedColumns.value[currentIndex]?.value
+
   return columns.value
     .filter(col =>
       !selectedColumns.value.some((sc, i) => i !== currentIndex && sc.value === col.id) ||
@@ -97,6 +99,7 @@ const getAvailableOptions = (currentIndex: number) => {
     )
     .map(col => ({ name: col.label, value: col.id }))
 }
+
 const addColumn = () => {
   if (selectedColumns.value.length < 10) {
     selectedColumns.value = [
@@ -105,9 +108,11 @@ const addColumn = () => {
     ]
   }
 }
+
 const removeColumn = (index: number) => {
   selectedColumns.value = selectedColumns.value.filter((_, i) => i !== index)
 }
+
 const customizeTable = async() => {
   nodeStructureStore.columns = selectedColumns.value.map((col, index) => ({
     id: col.value as string,
@@ -115,20 +120,24 @@ const customizeTable = async() => {
     selected: true,
     order: index
   }))
+
   const nodePrefs = await nodeStructureStore.getNodePreferences()
   saveNodePreferences(nodePrefs)
   nodeStructureStore.columnsDrawerState.visible = false
 }
+
 const resetColumns = async () => {
   nodeStructureStore.columns = [...defaultColumns]
   const nodePrefs = await nodeStructureStore.getNodePreferences()
   saveNodePreferences(nodePrefs)
   nodeStructureStore.columnsDrawerState.visible = false
 }
+
 watch(() => nodeStructureStore.columns, (newColumns) => {
   initializeSelectedColumns(newColumns)
 }, { immediate: true, deep: true })
 </script>
+
 <style lang="scss" scoped>
 @import "@featherds/table/scss/table";
 @import "@featherds/styles/mixins/elevation";
@@ -137,6 +146,8 @@ watch(() => nodeStructureStore.columns, (newColumns) => {
 
 .feather-drawer-custom-padding {
   padding: 20px;
+  height: 100%;
+  overflow: auto;
 }
 
 .spacer-large {
@@ -190,9 +201,10 @@ button.primary {
   flex-direction: column;
   gap: 1rem;
   align-items:flex-start;
-   :deep(.btn + .btn) {
-  margin-left: 0 !important;
-}
+
+ :deep(.btn + .btn) {
+    margin-left: 0 !important;
+  }
 }
 </style>
 

--- a/ui/src/components/Nodes/NodeStructurePanel.vue
+++ b/ui/src/components/Nodes/NodeStructurePanel.vue
@@ -130,11 +130,11 @@ const onClearFlows = () => {
 }
 
 const onClearLocations = () => {
-  nodeStructureStore.setSelectedMonitoringLocations([])
+  nodeStructureStore.updateSelectedMonitoringLocations([])
 }
 
 const onClearAll = () => {
-  nodeStructureStore.clearAllFilters(SetOperator.Union)
+  nodeStructureStore.clearAllFiltersAndSelections()
 }
 
 /**
@@ -166,7 +166,7 @@ const onFlowClick = (flow: string) => {
 
 const onLocationClick = (loc: MonitoringLocation) => {
   const newSelection = getNewSelection(loc, isLocationSelected(loc), nodeStructureStore.queryFilter.selectedMonitoringLocations, x => x.name !== loc.name)
-  nodeStructureStore.setSelectedMonitoringLocations(newSelection)
+  nodeStructureStore.updateSelectedMonitoringLocations(newSelection)
 }
 </script>
 

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -16,7 +16,7 @@
           </FeatherButton>
           <FeatherButton
             secondary
-            @click="() => nodeStructureStore.clearAllFilters()"
+            @click="() => nodeStructureStore.clearAllFiltersAndSelections()"
           >
             Clear Filters
           </FeatherButton>
@@ -31,7 +31,7 @@
               <FeatherInput
                 v-model="currentSearch"
                 @update:modelValue="searchFilterHandler"
-                label="Search node label"
+                label="Search node label or full IP address"
               >
                 <template #pre>
                   <FeatherIcon :icon="Search" />
@@ -48,7 +48,7 @@
             </div>
           </div>
           <div class="chip-container">
-            <FeatherChipList label="Tags">
+            <FeatherChipList label="SearchParams">
               <FeatherChip
                 v-for="(cat, index) in nodeStructureStore.selectedCategories"
                 :key="`cat-${index}`"
@@ -74,7 +74,7 @@
                     @click="removeItem(flow, FilterTypeEnum.Flow)"
                   />
                 </template>
-                {{ `FLow: ${flow._text}` }}
+                {{ `Flow: ${flow._text}` }}
               </FeatherChip>
 
               <FeatherChip
@@ -85,10 +85,23 @@
                   <FeatherIcon
                     :icon="cancelIcon"
                     class="icon"
-                    @click="removeItem(loc, FilterTypeEnum.Location)"
+                    @click="removeItem(loc, FilterTypeEnum.MonitoringLocation)"
                   />
                 </template>
                 {{ `Location: ${loc.name}` }}
+              </FeatherChip>
+
+              <FeatherChip
+                v-if="hasExtendedSearchParams"
+              >
+                <template #icon>
+                  <FeatherIcon
+                    :icon="cancelIcon"
+                    class="icon"
+                    @click="removeExtendedSearchItem"
+                  />
+                </template>
+                {{ 'Extended Search' }}
               </FeatherChip>
             </FeatherChipList>
           </div>
@@ -325,7 +338,7 @@ const nodeStructureStore = useNodeStructureStore()
 const nodeStore = useNodeStore()
 const { showSnackBar } = useSnackbar()
 const { generateBlob, generateDownload, getExportData } = useNodeExport()
-const { buildUpdatedNodeStructureQueryParameters } = useNodeQuery()
+const { buildUpdatedNodeStructureQueryParameters, hasAnyExtendedSearchValues } = useNodeQuery()
 const visibleColumnStart = ref(0)
 const visibleColumnsCount = 5
 
@@ -387,7 +400,6 @@ const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 
 const dialogVisible = ref(false)
 const dialogNode = ref<Node>()
-// const preferencesVisible = ref(false)
 const tableCssClasses = computed<string[]>(() => getTableCssClasses(nodeStructureStore.columns))
 const queryParameters = ref<QueryParameters>(nodeStore.nodeQueryParameters)
 const pageNumber = ref(1)
@@ -465,10 +477,6 @@ const onNodeInfo = (node: Node) => {
   dialogVisible.value = true
 }
 
-// const openPreferences = () => {
-//   preferencesVisible.value = true
-// }
-
 const computeNodeLink = (nodeId: number | string) => {
   return `${mainMenu.value.baseHref}${mainMenu.value.baseNodeUrl}${nodeId}`
 }
@@ -481,6 +489,10 @@ const onNodeLinkClick = (nodeId: number | string) => {
   window.location.assign(computeNodeLink(nodeId))
 }
 
+const hasExtendedSearchParams = computed(() => {
+  return hasAnyExtendedSearchValues(nodeStructureStore.queryFilter.extendedSearch)
+})
+
 const removeItem = (item: IAutocompleteItemType, type: FilterTypeEnum) => {
   switch (type) {
     case FilterTypeEnum.Category:
@@ -489,12 +501,16 @@ const removeItem = (item: IAutocompleteItemType, type: FilterTypeEnum) => {
     case FilterTypeEnum.Flow:
       nodeStructureStore.removeFlow(item)
       break
-    case FilterTypeEnum.Location:
-      nodeStructureStore.removeLocation(item)
+    case FilterTypeEnum.MonitoringLocation:
+      nodeStructureStore.removeMonitoringLocation(item)
       break
     default:
       console.warn(`Unknown filter type: ${type}`)
   }
+}
+
+const removeExtendedSearchItem = () => {
+  nodeStructureStore.removeExtendedSearch()
 }
 
 const updateQuery = (options?: { orderBy?: string, order?: SORT }) => {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -601,7 +601,7 @@ export interface IpInterfaceInfo {
 export enum FilterTypeEnum {
   Category = 'category',
   Flow = 'flow',
-  Location = 'location'
+  MonitoringLocation = 'location'
 }
 
 export enum Direction {


### PR DESCRIPTION
On the new Node List page, user can now search for a full IP address along with node label, in the search term input box.

Search is an `"or"` search, will match either node label or IP address.

Note, if user enters an IP address in the Extended Search, then only that will be valid and any IP in the search term input will be ignored.

Fixed an issue where the Monitoring Locations filter was not retaining values.

Added a "chip" if user adds any Extended Search items.

Renamed some methods to better show intent.

Reduced timeout on `FeatherAutocomplete` for filter selection, since values are already in memory (they are fetched prior to the filter drawer opening).

Column Customization and Filter Selection drawers now scroll vertically if needed.

Various other fixes and cleanup.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18047
* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18226
