### PR TITLE
NMS-18276: Move menu template docs to Development section

### DIFF
--- a/docs/modules/development/nav.adoc
+++ b/docs/modules/development/nav.adoc
@@ -18,6 +18,8 @@
 
 * xref:graph/graph.adoc[]
 
+* xref:menu/menu-templates.adoc[]
+
 * xref:rest/CORS.adoc[]
 
 * xref:rest/rest-api.adoc[]

--- a/docs/modules/development/pages/menu/menu-templates.adoc
+++ b/docs/modules/development/pages/menu/menu-templates.adoc
@@ -37,7 +37,8 @@ The menu template structure can be found in the Java code in: `org.opennms.web.r
 
 | baseHref, homeUrl, formattedDateTime, formattedDate, formattedTime,
 noticeStatus, username, baseNodeUrl, zenithConnectEnabled, zenithConnectBaseUrl,
-zenithConnectRelativeUrl, copyrightDates, version
+zenithConnectRelativeUrl, copyrightDates, version,
+userTileProviders
 | These are filled in at runtime with values. Any values you enter will be ignored.
 
 | displayAddNodeButton
@@ -45,10 +46,6 @@ zenithConnectRelativeUrl, copyrightDates, version
 
 | sideMenuInitialExpand
 | Whether the side menu is initially expanded.
-
-| userTileProviders
-| Tile provider information for the Geographical Map.
-We strongly suggest using the values provided in the existing templates.
 
 | helpMenu, selfServiceMenu, userNotificationMenu, provisionMenu, flowsMenu, configurationMenu
 | Control some specific menus. Most of these are deprecated and may be removed in a future version, we suggest not editing them.

--- a/docs/modules/development/pages/menu/menu-templates.adoc
+++ b/docs/modules/development/pages/menu/menu-templates.adoc
@@ -4,7 +4,6 @@
 
 The menu organization is configured by the use of JSON menu templates.
 Currently these can be found in the `opennms/jetty-webapps/opennms/WEB-INF` folder in your {page-component-title} installation.
-Eventually these will be moved to the `opennms/etc` folder.
 
 The `menu-template.json` file controls the menu configuration.
 It is read by the Rest API v2 Menu service and displayed by the UI.

--- a/docs/modules/operation/nav.adoc
+++ b/docs/modules/operation/nav.adoc
@@ -18,7 +18,6 @@
 
 ** Menu
 *** xref:deep-dive/menu/introduction.adoc[]
-*** xref:deep-dive/menu/menu-templates.adoc[]
 
 ** User Management
 *** xref:deep-dive/user-management/user-config.adoc[]

--- a/docs/modules/operation/pages/deep-dive/menu/introduction.adoc
+++ b/docs/modules/operation/pages/deep-dive/menu/introduction.adoc
@@ -95,4 +95,4 @@ The older/legacy JSP and Vaadin pages have a Vue menu app embedded into them con
 The organization of the side menu is controlled by JSON menu templates and
 is user-customizable.
 
-See the xref:operation:deep-dive/menu/menu-templates.adoc[menu templates documentation].
+See the xref:development:menu/menu-templates.adoc[menu templates documentation].


### PR DESCRIPTION
Move the menu templates documentation from `Operation > Deep Dive > Menus` to `Development > Menus`.

While these can be edited, we are not officially supporting editing them for users, so we want to take this out of `Operation`, but still include it in documentation for reference.

Also removed reference to moving the templates to `etc`, we are holding off on that for now.

Also fixed `userTileProviders` to denote that it is a read-only field and any user edits are ignored.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18274
* * Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18276
