### PR TITLE
DOCS: Clarify setting heap and open file descriptors

### DIFF
--- a/docs/modules/deployment/pages/core/centos-rhel/initialize-core.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel/initialize-core.adoc
@@ -53,21 +53,13 @@ sudo /opt/opennms/bin/runjava -s
 sudo /opt/opennms/bin/install -dis
 ----
 
-[[initialize-core-cap]]
-._Assign CAP_NET_RAW capabilities_
-{page-component-title} runs as a non-root user, which requires having a Linux kernel greater than 3.10.
-If you run on an older kernel and you cannot upgrade your OS, you need to assign `CAP_NET_RAW` capabilities:
-
-. Run `systemctl edit opennms.service` and add the following code to the `[Service]` section:
-+
-[source, properties]
+.Define any necessary xref:operation:deep-dive/admin/configuration/startup.adoc[startup configuration], such as open file descriptors or maximum Java heap
+[source, console]
 ----
-AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE
+echo "JAVA_HEAP_SIZE=16384" | sudo tee ${OPENNMS_HOME}/etc/opennms.conf
+echo "MAXIMUM_FILE_DESCRIPTORS=512000" | sudo tee ${OPENNMS_HOME}/etc/opennms.conf
 ----
-
-Reload the systemd unit with `systemctl daemon-reload` and restart the service with `systemctl restart opennms`.
-
-(For more background on this issue, see https://opennms.discourse.group/t/h29-wont-start-with-permission-error-to-open-icmp-socket/2387[H29+ won't start with permission error to open ICMP socket] on Discourse.)
+NOTE: These values are provided as examples; ideal values will vary based on your environment and workload
 
 .Enable {page-component-title} core instance on system boot and start immediately
 [source, console]

--- a/docs/modules/deployment/pages/core/debian-ubuntu/initialize-core.adoc
+++ b/docs/modules/deployment/pages/core/debian-ubuntu/initialize-core.adoc
@@ -53,23 +53,13 @@ sudo /usr/share/opennms/bin/runjava -s
 sudo /usr/share/opennms/bin/install -dis
 ----
 
-._Binding to privileged ports_
-
-The core service user must be able to send ICMP echo requests.
-During setup, the permissions for `net.ipv4.ping_group_range` are set permanently on boot via `/etc/sysctl.d/99-opennms-non-root-icmp.conf`.
-Some system kernels do not honor this setting; in those cases, additional configuration is required to allow binding to privileged ports.
-We recommend creating a systemd overlay to add the necessary settings to the service configuration:
-
-. Run `systemctl edit opennms.service` and add the following line to the `[Service]` section:
-+
-[source, properties]
+.Define any necessary xref:operation:deep-dive/admin/configuration/startup.adoc[startup configuration], such as open file descriptors or maximum Java heap
+[source, console]
 ----
-AmbientCapabilities=CAP_NET_RAW CAP_NET_BIND_SERVICE
+echo "JAVA_HEAP_SIZE=16384" | sudo tee ${OPENNMS_HOME}/etc/opennms.conf
+echo "MAXIMUM_FILE_DESCRIPTORS=512000" | sudo tee ${OPENNMS_HOME}/etc/opennms.conf
 ----
-
-Reload the systemd unit with `systemctl daemon-reload` and restart the service with `systemctl restart opennms`.
-
-(For more background on this issue, see https://opennms.discourse.group/t/h29-wont-start-with-permission-error-to-open-icmp-socket/2387[H29+ won't start with permission error to open ICMP socket] on Discourse.)
+NOTE: These values are provided as examples; ideal values will vary based on your environment and workload
 
 .Enable {page-component-title} core instance on system boot and start immediately
 [source, console]


### PR DESCRIPTION
DOCS DOCS DOCS DOCS DOCS DOCS DOCS DOCS DOCS DOCS 

...And remove the outdated info about AmbientCapabilities; the `opennms.service` unit file already ships with this set.