### PR TITLE
NMS-18266: Fix baseHref for ui-components references

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmFilterController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmFilterController.java
@@ -123,7 +123,7 @@ public class AlarmFilterController extends MultiActionController implements Init
                 //AlertTag.addAlertToRequest(successView, "Favorite was created successfully", AlertType.SUCCESS);
                 return successView;
             }
-            error = "An error occured while creating the favorite";
+            error = "An error occurred while creating the favorite";
         } catch (FilterFavoriteService.FilterFavoriteException ex) {
             error = ex.getMessage();
         }

--- a/opennms-webapp/src/main/webapp/includes/bootstrap.jsp
+++ b/opennms-webapp/src/main/webapp/includes/bootstrap.jsp
@@ -200,7 +200,7 @@
   </c:if>
 
   <%-- Vue side menu --%>
-  <link rel="stylesheet" href="${baseHref}/opennms/ui-components/assets/index.css" media="screen" />
+  <link rel="stylesheet" href="<%= __baseHref %>ui-components/assets/index.css" media="screen" />
 </head>
 
 <%-- The <body> tag is unmatched in this file (its matching tag is in the
@@ -249,7 +249,7 @@
       <!-- both superQuiet and fromVaadin are true -->
       <% if (oldMenuValue == null || !oldMenuValue.equals("true")) { %>
         <div id="opennms-sidemenu-container"></div>
-        <script type="module" src="${baseHref}/opennms/ui-components/assets/index.js"></script>
+        <script type="module" src="<%= __baseHref %>ui-components/assets/index.js"></script>
       <% } %>
     </c:if>
   </c:when>
@@ -273,7 +273,7 @@
       <c:otherwise>
         <% if (oldMenuValue == null || !oldMenuValue.equals("true")) { %>
           <div id="opennms-sidemenu-container"></div>
-          <script type="module" src="${baseHref}/opennms/ui-components/assets/index.js"></script>
+          <script type="module" src="<%= __baseHref %>ui-components/assets/index.js"></script>
         <% } %>
       </c:otherwise>
     </c:choose>


### PR DESCRIPTION
Menu was not showing up on some alarm pages. Partly due to local `baseHref` variable being defined differently on those pages.

Update `bootstrap.jsp` to use `__baseHref` as the base for including `ui-components`. This not only fixes these issues but is more correct.


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18266
* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18221
