### PR TITLE
NMS-18269: Fix double-shift for search input focus

### DIFF
--- a/ui/src/components/Menu/Menubar.vue
+++ b/ui/src/components/Menu/Menubar.vue
@@ -138,7 +138,8 @@ const shiftCheck = (e: KeyboardEvent) => {
     if (shiftCodes.includes(lastShift.lastKey)) {
       if (Date.now() - lastShift.timeSinceLastKey < shiftDelay) {
         clearShiftCheck()
-        const elem: HTMLInputElement | null = document.querySelector('.menubar-search textarea')
+
+        const elem: HTMLInputElement | null = document.querySelector('#opennms-sidemenu-container .onms-search-input-wrapper input.search-input')
 
         if (elem) {
           elem.focus()


### PR DESCRIPTION
Double-pressing a shift key should focus the main search input in the menu bar.

Just needed to fix the CSS selector used to get the input element.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18269

