### PR TITLE
NMS-18281: Self service menu is icon-only, remove user profile menu

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/menu-template-default.json
+++ b/opennms-webapp/src/main/webapp/WEB-INF/menu-template-default.json
@@ -585,31 +585,6 @@
       "type": "separator"
     },
     {
-      "id": "userProfileMenu",
-      "name": "User Profile",
-      "url": "#",
-      "locationMatch": null,
-      "icon": "action/Person",
-      "roles": null,
-      "items": [
-       {
-         "id": "logout",
-         "name": "Log Out",
-         "url": "j_spring_security_logout",
-         "locationMatch": null,
-         "action": "logout",
-         "roles": null
-       },
-       {
-         "id": "changePassword",
-         "name": "Change Password",
-         "url": "account/selfService/newPasswordEntry",
-         "locationMatch": null,
-         "roles": null
-       }
-      ]
-    },
-    {
       "id": "apiDocumentationMenu",
       "name": "API Documentation",
       "url": "#",

--- a/opennms-webapp/src/main/webapp/WEB-INF/menu-template.json
+++ b/opennms-webapp/src/main/webapp/WEB-INF/menu-template.json
@@ -585,31 +585,6 @@
       "type": "separator"
     },
     {
-      "id": "userProfileMenu",
-      "name": "User Profile",
-      "url": "#",
-      "locationMatch": null,
-      "icon": "action/Person",
-      "roles": null,
-      "items": [
-       {
-         "id": "logout",
-         "name": "Log Out",
-         "url": "j_spring_security_logout",
-         "locationMatch": null,
-         "action": "logout",
-         "roles": null
-       },
-       {
-         "id": "changePassword",
-         "name": "Change Password",
-         "url": "account/selfService/newPasswordEntry",
-         "locationMatch": null,
-         "roles": null
-       }
-      ]
-    },
-    {
       "id": "apiDocumentationMenu",
       "name": "API Documentation",
       "url": "#",

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -130,6 +130,11 @@ public abstract class AbstractOpenNMSSeleniumHelper {
 
     public static final File DOWNLOADS_FOLDER = new File("target/downloads");
 
+    private enum SelfServiceMenuType {
+        LOGOUT,
+        CHANGE_PASSWORD
+    }
+
     public WebDriverWait wait = null;
     public WebDriverWait requisitionWait = null;
 
@@ -609,32 +614,51 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         return foundElement[0];
     }
 
-    protected void clickLogout() {
-        LOG.debug("Clicking logout");
+    private void clickSelfServiceItem(final SelfServiceMenuType itemType) {
+        LOG.debug("Clicking self service item: {}", itemType);
+
+        final String SELF_SERVICE_BUTTON_XPATH = "//div[@id='opennms-sidemenu-container']//div[contains(@class, 'self-service-menubar-dropdown')]//featherbutton[@class='self-service-menubar-dropdown-button-dark']";
+        final String LOGOUT_XPATH = "//div[@id='opennms-sidemenu-container']//div[@class='self-service-menubar-dropdown-item-content']//a[@name='self-service-logout']";
+        final String CHANGE_PASSWORD_XPATH = "//div[@id='opennms-sidemenu-container']//div[@class='self-service-menubar-dropdown-item-content']//a[@name='self-service-changePassword']";
 
         final int timeout = 5;
         final WebDriverWait shortWait = new WebDriverWait(getDriver(), Duration.ofSeconds(1));
 
-        final String SELF_SERVICE_BUTTON_XPATH = "//div[@id='opennms-sidemenu-container']//div[contains(@class, 'self-service-menubar-dropdown')]//featherbutton[@class='self-service-menubar-dropdown-button-dark']";
-        final String LOGOUT_XPATH = "//div[@id='opennms-sidemenu-container']//div[@class='self-service-menubar-dropdown-item-content']//a[@name='self-service-logout']";
-
         Unreliables.retryUntilSuccess(timeout, TimeUnit.SECONDS, () -> {
+            String itemXpath = LOGOUT_XPATH;
+
+            if (itemType == SelfServiceMenuType.LOGOUT) {
+                itemXpath = LOGOUT_XPATH;
+            } else if (itemType == SelfServiceMenuType.CHANGE_PASSWORD) {
+                itemXpath = CHANGE_PASSWORD_XPATH;
+            }
+
             final Actions action = new Actions(getDriver());
 
-            // Find the self service menu and hover over it so that the dropdown menu appears`
+            // Find the self service menu and hover over it so that the dropdown menu appears
             final WebElement selfServiceMenu = findElementByXpath(SELF_SERVICE_BUTTON_XPATH);
             shortWait.until(ExpectedConditions.visibilityOf(selfServiceMenu ));
 
             action.moveToElement(selfServiceMenu).build().perform();
 
-            // Find and click the logout link item on the dropdown menu
-            final WebElement logoutLink = findElementByXpath(LOGOUT_XPATH);
+            // Find and click the link item on the dropdown menu
+            WebElement linkToClick = findElementByXpath(itemXpath);
 
-            shortWait.until(ExpectedConditions.visibilityOf(logoutLink));
-            logoutLink.click();
+            shortWait.until(ExpectedConditions.visibilityOf(linkToClick));
+            linkToClick.click();
 
             return null;
         });
+    }
+
+    protected void clickLogout() {
+        LOG.debug("Clicking logout");
+        clickSelfServiceItem(SelfServiceMenuType.LOGOUT);
+    }
+
+    protected void clickChangePassword() {
+        LOG.debug("Clicking self service menu, change password item");
+        clickSelfServiceItem(SelfServiceMenuType.CHANGE_PASSWORD);
     }
 
     protected void frontPage() {

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -245,13 +245,6 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         clickMenuItem("internalLogsMenu", "Instrumentation Log Reader");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Instrumentation Log Reader')]")));
 
-        // User Profile Menu
-        clickMenuItem("userProfileMenu", "Change Password");
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[contains(text()[normalize-space()], 'Please enter the old and new passwords and confirm.')]")));
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'Current Password')]")));
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'New Password')]")));
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'Confirm New Password')]")));
-
         // API Documentation Menu
         // Omit clicking for now, some of these are external links
         foundElement = findMenuItemLink("apiDocumentationMenu", "REST Open API Documentation");
@@ -397,6 +390,17 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         reportsPage();
         findElementByLink("Statistics Reports").click();
         findElementByXpath("//div[@class='card-header']/span[text()='Statistics Report List']");
+    }
+
+    @Test
+    public void testSelfServiceMenu() {
+        LOG.debug("In testSelfServiceMenu");
+
+        clickChangePassword();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[contains(text()[normalize-space()], 'Please enter the old and new passwords and confirm.')]")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'Current Password')]")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'New Password')]")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//form[@name='goForm']//label[contains(text()[normalize-space()], 'Confirm New Password')]")));
     }
 
     @Test

--- a/ui/src/components/Menu/UserNotificationsMenuItem.vue
+++ b/ui/src/components/Menu/UserNotificationsMenuItem.vue
@@ -1,6 +1,6 @@
 <template>
   <FeatherDropdown
-    class="menubar-dropdown"
+    class="user-notification-menubar-dropdown"
     :modelValue="displayMenu"
     @update:modelValue="(val: any) => updateDisplay(val)"
   >
@@ -264,11 +264,7 @@ const onNotificationItemClick = (item: OnmsNotification) => {
   }
 }
 
-.feather-menu.menubar-dropdown {
-  margin-right: 1em;
-}
-
-.menubar-dropdown {
+.user-notification-menubar-dropdown {
   margin-left: 2px;
 
   :deep(.feather-dropdown) {

--- a/ui/src/components/Menu/UserSelfServiceMenuItem.vue
+++ b/ui/src/components/Menu/UserSelfServiceMenuItem.vue
@@ -8,13 +8,23 @@
       <div @mouseenter="showMenu" class="self-service-menubar-icon-wrapper">
         <FeatherButton link href="#" v-bind="attrs" v-on="on" class="self-service-menubar-dropdown-button-dark">
           <FeatherIcon :icon="IconAccountCircle" class="self-service-top-icon" />
-          <span class="font-weight-bold">
-            {{ mainMenu.username }}
-          </span>
           <FeatherIcon class="self-service-arrow-dropdown" :icon="ArrowDropDown" />
         </FeatherButton>
       </div>
     </template>
+
+    <FeatherDropdownItem
+      @click="onUserProfileMenuClick"
+    >
+      <div class="self-service-menubar-dropdown-item-content">
+        <a :href="computeLink('')" class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper" name="self-service-user">
+          <FeatherIcon :icon="IconAccountCircle" class="self-service-icon" />
+          <span class="left-margin-small">
+            {{ ellipsify(mainMenu.username || '', 40) }}
+          </span>
+        </a>
+      </div>
+    </FeatherDropdownItem>
 
     <FeatherDropdownItem
        v-for="item in menuItems"
@@ -42,6 +52,7 @@ import IconAccountCircle from '@featherds/icon/action/AccountCircle'
 import IconHelp from '@featherds/icon/action/Help'
 import IconLogout from '@featherds/icon/action/LogOut'
 import IconSecurity from '@featherds/icon/network/Security'
+import { ellipsify } from '@/lib/utils'
 import { performLogout } from '@/services/logoutService'
 import { useMenuStore } from '@/stores/menuStore'
 import {
@@ -93,6 +104,11 @@ const createIcon = (menuItem: MenuItem) => {
 const computeLink = (url: string) => {
   const baseLink = mainMenu.value?.baseHref || import.meta.env.VITE_BASE_URL || ''
   return `${baseLink}${url}`
+}
+
+const onUserProfileMenuClick = () => {
+  const link = computeLink('')
+  window.location.assign(link)
 }
 
 const onMenuItemClick = async (item: MenuItem) => {


### PR DESCRIPTION
Make the self service menu just an icon, remove the username from it since username could be an arbitrary length.

Include the username in the first item of the dropdown, we ellipsify it if needed. Links to main page, eventually could like to a user profile page.

Remove user profile menu from side menu since all functionality is now in the top self service menu.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18281
* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18282