### PR TITLE
NMS-18184: Exclude selfmonitor requisition on Quick Add Node

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/QuickAddNode.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/QuickAddNode.js
@@ -26,11 +26,10 @@ const QuickNode = require('../model/QuickNode');
 
 /**
 * @author Alejandro Galue <agalue@opennms.org>
-* @copyright 2014-2022 The OpenNMS Group, Inc.
+* @copyright 2014-2025 The OpenNMS Group, Inc.
 */
 
 (function() {
-
   'use strict';
 
   const quickAddPanelBasicView = require('../../views/quick-add-panel-basic.html');
@@ -138,6 +137,7 @@ const QuickNode = require('../model/QuickNode');
       $scope.isSaving = true;
       growl.info('The node ' + _.escape($scope.node.nodeLabel) + ' is being added to requisition ' + _.escape($scope.node.foreignSource) + '. Please wait...');
       const successMessage = 'The node ' + _.escape($scope.node.nodeLabel) + ' has been added to requisition ' + _.escape($scope.node.foreignSource);
+
       RequisitionsService.quickAddNode($scope.node).then(
         function() { // success
           $scope.reset();
@@ -258,6 +258,12 @@ const QuickNode = require('../model/QuickNode');
     */
     $scope.addRequisition = function() {
       bootbox.prompt('A requisition is required, please enter the name for a new requisition', function(foreignSource) {
+        if (foreignSource && RequisitionsService.isExcludedRequisitionName(foreignSource)) {
+          const errMessage = 'You cannot add a node to this requisition.';
+          $scope.errorHandler(errMessage);
+          return;
+        }
+
         if (foreignSource) {
           RequisitionsService.addRequisition(foreignSource).then(
             function() { // success
@@ -272,7 +278,7 @@ const QuickNode = require('../model/QuickNode');
             $scope.errorHandler
           );
         } else {
-          window.location.href = Util.getBaseHref() + 'admin/opennms/index.jsp'; // TODO Is this the best way ?
+          window.location.href = Util.getBaseHref() + 'admin/index.jsp'; // TODO Is this the best way ?
         }
       });
     };
@@ -289,7 +295,11 @@ const QuickNode = require('../model/QuickNode');
     if (!foreignSources) {
       RequisitionsService.getRequisitionNames().then(
         function(requisitions) { // success
-          $scope.foreignSources = requisitions;
+          const filteredRequisitions = (requisitions || []).filter(function(r) {
+            return Boolean(r) && !RequisitionsService.isExcludedRequisitionName(r);
+          });
+          $scope.foreignSources = filteredRequisitions;
+
           // If there is NO requisitions, the user has to create a new one
           if ($scope.foreignSources.length === 0) {
             $scope.addRequisition();
@@ -300,7 +310,5 @@ const QuickNode = require('../model/QuickNode');
     } else {
       $scope.foreignSources = foreignSources;
     }
-
   }]);
-
 }());

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Requisition.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Requisition.js
@@ -200,6 +200,11 @@ require('../services/Synchronize');
     * @methodOf RequisitionController
     */
     $scope.addNode = function() {
+      if (RequisitionsService.isExcludedRequisitionName($scope.foreignSource)) {
+        bootbox.alert('Cannot add a node to a requisition with this name.');
+        return;
+      }
+
       $window.location.href = Configuration.baseHref + '#/requisitions/' + encodeURIComponent($scope.foreignSource) + '/nodes/__new__' + $scope.getVerticalLayout();
     };
 

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/services/Requisitions.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/services/Requisitions.js
@@ -21,7 +21,7 @@
  */
 /**
 * @author Alejandro Galue <agalue@opennms.org>
-* @copyright 2014-2022 The OpenNMS Group, Inc.
+* @copyright 2014-2025 The OpenNMS Group, Inc.
 */
 
 const RequisitionsData = require('../model/RequisitionsData');
@@ -76,6 +76,8 @@ const RequisitionNode  = require('../model/RequisitionNode');
     requisitionsService.internal.monitoringLocationsUrl = 'rest/monitoringLocations';
     requisitionsService.internal.snmpConfigUrl = 'rest/snmpConfig';
     requisitionsService.internal.errorHelp = ' Check the OpenNMS logs for more details, or try again later.';
+
+    requisitionsService.internal.excludedRequisitionNames = ['selfmonitor', 'minions'];
 
     // Timeouts
 
@@ -1474,7 +1476,22 @@ const RequisitionNode  = require('../model/RequisitionNode');
       return requisitionsService.internal.addQuickNode(quickNode);
     };
 
+    /**
+    * @description Checks whether a requisition name should not be used to add a node to.
+    * We do not want users adding a node via "Quick Add Node" to these specific requisitions.
+    *
+    * @name RequisitionsService:isExcludedRequisitionName
+    * @ngdoc method
+    * @methodOf RequisitionsService
+    * @param {string} reqName The requisition name to check.
+    * @returns {boolean}
+    */
+    requisitionsService.isExcludedRequisitionName = function(reqName) {
+      const lowerName = (reqName || '').toLowerCase();
+
+      return requisitionsService.internal.excludedRequisitionNames.includes(lowerName);
+    };
+
     return requisitionsService;
   }]);
-
 }());

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -601,6 +601,7 @@ public abstract class AbstractOpenNMSSeleniumHelper {
 
         final String TOP_MENU_PREFIX = "opennms-menu-id-";
         final String TOP_MENU_XPATH = "//div[@id='opennms-sidebar-control-content']/ul[@id='opennms-sidebar-control-menu']/li[@id='$ID']";
+        final String TOP_MENU_ONLY_XPATH = "//div[@id='opennms-sidebar-control-content']/ul[@id='opennms-sidebar-control-menu']/li/a[@id='$ID']";
         final String POPUP_MENU_ITEMS_XPATH = "//div[@id='opennms-sidebar-control-content']/ul/div[contains(@class, 'feather-popover-container')]/div[@class='popover']/ul[@id='opennms-sidebar-control-menu-opennms-menu-id-$ID-menu']/li/a[contains(@class, 'feather-list-item')]";
 
         final WebDriverWait shortWait = new WebDriverWait(getDriver(), Duration.ofSeconds(1));
@@ -610,9 +611,12 @@ public abstract class AbstractOpenNMSSeleniumHelper {
 
         Unreliables.retryUntilTrue(timeout, TimeUnit.SECONDS, () -> {
             final Actions action = new Actions(getDriver());
-            final String topMenuXpath = TOP_MENU_XPATH.replace("$ID", TOP_MENU_PREFIX + menuItemId);
-            final WebElement topMenuElement = findElementByXpath(topMenuXpath);
 
+            final String topMenuXpath = isTopMenuItem ?
+                TOP_MENU_ONLY_XPATH.replace("$ID", TOP_MENU_PREFIX + menuItemId) :
+                TOP_MENU_XPATH.replace("$ID", TOP_MENU_PREFIX + menuItemId);
+
+            final WebElement topMenuElement = findElementByXpath(topMenuXpath);
             shortWait.until(ExpectedConditions.visibilityOf(topMenuElement));
 
             if (isTopMenuItem) {

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -285,10 +285,10 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         // Omitting for now - need to fix!
         // Vaadin Topology page
-//        frontPage();
-//        clickTopMenuItem("topologiesMenu");
-//        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[contains(text(), 'Selection Context')]")));
-//        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[starts-with(@id, 'opennmstopology-')]")));
+        frontPage();
+        clickTopMenuItem("topologiesMenu");
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[contains(text(), 'Selection Context')]")));
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[starts-with(@id, 'opennmstopology-')]")));
 
         // Navigation on Vue UI pages
         frontPage();
@@ -322,9 +322,9 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         // Omitting for now - need to fix!
         // Geographical map page
-//        frontPage();
-//        clickTopMenuItem("mapsMenu");
-//        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='geo-map']")));
+        frontPage();
+        clickTopMenuItem("mapsMenu");
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='geo-map']")));
 
         // Omitting this for now - it takes too long for the Swagger API page to display
         // clickMenuItem("apiDocumentationMenu", "REST Open API Documentation");


### PR DESCRIPTION
On the Quick Add Node page, do not allow the user to choose the `selfmonitor` requisition to add nodes to.

User will get an error if they try to do this.

Also on the requisition edit page, display an alert and do not allow a user to add a node to the `selfmonitor` requisition.

This PR doesn't fix the popup window. We are planning on redoing the entire Quick Add Node page, so this is just a temporary fix to prevent users from adding nodes to the `selfmonitor` requisition.

Fixed an issue where when user clicked `Cancel` on the popup they were redirected to a non-existent page. Fixed a few typos.

Also: fixed smoke test for `MenuHeaderIT` for items where the top-level menu item is a direct link.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18184
