### PR TITLE
NMS-18285: Do not display Plugins menu if there are no plugins installed

### DIFF
--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -186,8 +186,6 @@ const topPanels = computed<MenuListEntry[]>(() => {
   // Plugins menu
   if (plugins.value && plugins.value.length > 0) {
     allMenus.push(createPluginsMenu(false))
-  } else {
-    allMenus.push(createPluginsMenu(true))
   }
 
   return allMenus.map(i => createTopMenuListEntry(i) as MenuListEntry)


### PR DESCRIPTION
We were displaying the Plugins menu even when no plugins were installed.

We were displaying the fake menu items instead of just not displaying the top level Plugins menu at all.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18285
