### PR TITLE
fix: Typo in constant name for evaluation time series strategy

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/TimeSeries.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/TimeSeries.java
@@ -38,7 +38,7 @@ public abstract class TimeSeries {
 
     private static final String NEWTS_TIME_SERIES_STRATEGY_NAME = "newts";
 
-    private static final String EVALUETE_TIME_SERIES_STRATEGY_NAME = "evaluate";
+    private static final String EVALUATE_TIME_SERIES_STRATEGY_NAME = "evaluate";
 
     private static final String TCP_TIME_SERIES_STRATEGY_NAME = "tcp";
 
@@ -47,7 +47,7 @@ public abstract class TimeSeries {
     public static enum Strategy {
         RRD(RRD_TIME_SERIES_STRATEGY_NAME, "RRDTool or JRobin"),
         NEWTS(NEWTS_TIME_SERIES_STRATEGY_NAME, "Newts"),
-        EVALUATE(EVALUETE_TIME_SERIES_STRATEGY_NAME, "Evaluate (Sizing mode, all data discarded)"),
+        EVALUATE(EVALUATE_TIME_SERIES_STRATEGY_NAME, "Evaluate (Sizing mode, all data discarded)"),
         TCP(TCP_TIME_SERIES_STRATEGY_NAME, "TCP (protobuf)"),
         INTEGRATION(INTEGRATION_LAYER_TIME_SERIES_STRATEGY_NAME, "Integration (the timeseries integration layer, to be used for TimeseriesStorage implementations)");
 


### PR DESCRIPTION
Fixed the typo in constant name.

