### PR TITLE
NMS-18325, NMS-18533: Restrict SCV Rest to admin, fix role check in UI

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -101,6 +101,12 @@
     <intercept-url pattern="/rest/filesystem/**" method="POST" access="ROLE_FILESYSTEM_EDITOR"/>
     <intercept-url pattern="/rest/filesystem/**" method="PUT" access="ROLE_FILESYSTEM_EDITOR"/>
 
+    <!-- SCV should be admin-only -->
+    <intercept-url pattern="/rest/scv/**" method="GET" access="ROLE_ADMIN" />
+    <intercept-url pattern="/rest/scv/**" method="DELETE" access="ROLE_ADMIN" />
+    <intercept-url pattern="/rest/scv/**" method="POST" access="ROLE_ADMIN" />
+    <intercept-url pattern="/rest/scv/**" method="PUT" access="ROLE_ADMIN" />
+
     <!-- Allow certain actions for the ROLE_USER role -->
     <intercept-url pattern="/rest/resources/generateId" method="POST" access="ROLE_REST,ROLE_ADMIN,ROLE_USER" />
 

--- a/ui/src/services/whoAmIService.ts
+++ b/ui/src/services/whoAmIService.ts
@@ -25,14 +25,12 @@ import { WhoAmIResponse } from '@/types'
 
 const endpoint = '/whoami'
 
-const getWhoAmI = async (): Promise<WhoAmIResponse> => {
+const getWhoAmI = async (): Promise<WhoAmIResponse | false> => {
   try {
     const resp = await rest.get(endpoint)
-    return resp.data
+    return resp.data as WhoAmIResponse
   } catch (err) {
-    return {
-      roles: [] as string[]
-    } as WhoAmIResponse
+    return false
   }
 }
 

--- a/ui/src/stores/authStore.ts
+++ b/ui/src/stores/authStore.ts
@@ -30,7 +30,11 @@ export const useAuthStore = defineStore('authStore', () => {
 
   const getWhoAmI = async () => {
     const resp = await API.getWhoAmI()
-    whoAmI.value = resp
+
+    if (resp) {
+      whoAmI.value = resp
+      loaded.value = true
+    }
   }
 
   return {


### PR DESCRIPTION
This PR fixes 2 issues.

Updates Spring security configuration to restrict Rest API requests for SCV to admin role only.

In investigating that, I noticed that we were not properly checking role access in Vue API routing. It was missing setting a flag when we receive the role info.

If a user did not have, say, the `ROLE_ADMIN` role, they would not see a menu item for SCV or other admin-only screens, and would not be able to actually do anything on those pages (well, except for the SCV fix above), but they could still manually type in the correct URL and view the page (though it wouldn't have any real data since Rest API calls would fail). 

This fixes that issue. If a user does not have the correct role, they won't even be able to manually navigate to the UI page.

Note, we need to backport both of these fixes to probably `foundation-2023` and subsequent, will do that separately.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18325
* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18533
