### PR TITLE
NMS-18548: Restrict SCV Rest to admin, fix role check in UI

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -101,6 +101,12 @@
     <intercept-url pattern="/rest/filesystem/**" method="POST" access="ROLE_FILESYSTEM_EDITOR"/>
     <intercept-url pattern="/rest/filesystem/**" method="PUT" access="ROLE_FILESYSTEM_EDITOR"/>
 
+    <!-- SCV should be admin-only -->
+    <intercept-url pattern="/rest/scv/**" method="GET" access="ROLE_ADMIN" />
+    <intercept-url pattern="/rest/scv/**" method="DELETE" access="ROLE_ADMIN" />
+    <intercept-url pattern="/rest/scv/**" method="POST" access="ROLE_ADMIN" />
+    <intercept-url pattern="/rest/scv/**" method="PUT" access="ROLE_ADMIN" />
+
     <!-- Allow certain actions for the ROLE_USER role -->
     <intercept-url pattern="/rest/resources/generateId" method="POST" access="ROLE_REST,ROLE_ADMIN,ROLE_USER" />
 

--- a/ui/src/services/whoAmIService.ts
+++ b/ui/src/services/whoAmIService.ts
@@ -25,14 +25,12 @@ import { WhoAmIResponse } from '@/types'
 
 const endpoint = '/whoami'
 
-const getWhoAmI = async (): Promise<WhoAmIResponse> => {
+const getWhoAmI = async (): Promise<WhoAmIResponse | false> => {
   try {
     const resp = await rest.get(endpoint)
-    return resp.data
+    return resp.data as WhoAmIResponse
   } catch (err) {
-    return {
-      roles: [] as string[]
-    } as WhoAmIResponse
+    return false
   }
 }
 

--- a/ui/src/stores/authStore.ts
+++ b/ui/src/stores/authStore.ts
@@ -30,7 +30,11 @@ export const useAuthStore = defineStore('authStore', () => {
 
   const getWhoAmI = async () => {
     const resp = await API.getWhoAmI()
-    whoAmI.value = resp
+    
+    if (resp) {
+      whoAmI.value = resp
+      loaded.value = true
+    }
   }
 
   return {


### PR DESCRIPTION
Ensure that the SCV Rest service can only be accessed by users with the admin (`ROLE_ADMIN`) role.

Also ensures that non-admin users cannot manually route to the SCV web UI screen.

This is the same as NMS-18325 and NMS-18533 but backported to `foundation-2024`.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18548
