### PR TITLE
NMS-18195: Update menu icons, update ui README

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
@@ -71,7 +71,7 @@
       "name": "Inventory",
       "url": "#",
       "locationMatch": null,
-      "icon": "network/Server",
+      "icon": "network/Inventory",
       "roles": null,
       "items": [
         {
@@ -320,7 +320,7 @@
       "name": "Distributed Monitoring",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/ViewDetails",
+      "icon": "network/DistributedMonitoring",
       "roles": null,
       "items": [
         {
@@ -440,7 +440,7 @@
       "name": "Administration",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/ManageProfile",
+      "icon": "network/Configuration",
       "roles": null,
       "items": [
         {

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -85,7 +85,7 @@
       "name": "Inventory",
       "url": "#",
       "locationMatch": null,
-      "icon": "network/Server",
+      "icon": "network/Inventory",
       "roles": null,
       "items": [
         {
@@ -130,7 +130,7 @@
       "name": "Monitoring",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/View",
+      "icon": "network/Monitoring",
       "roles": null,
       "items": [
         {
@@ -222,7 +222,7 @@
       "name": "Distributed Monitoring",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/ViewDetails",
+      "icon": "network/DistributedMonitoring",
       "roles": null,
       "items": [
         {
@@ -253,7 +253,7 @@
       "name": "Manage Inventory",
       "url": "#",
       "locationMatch": null,
-      "icon": "network/Server",
+      "icon": "network/InventoryAlt",
       "roles": null,
       "items": [
         {
@@ -439,7 +439,7 @@
       "name": "Administration",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/Workflow",
+      "icon": "network/Configuration",
       "roles": null,
       "items": [
         {
@@ -560,7 +560,7 @@
       "name": "API Documentation",
       "url": "#",
       "locationMatch": null,
-      "icon": "network/ApiEndpoints",
+      "icon": "network/ApiConfig",
       "roles": null,
       "items": [
         {

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
@@ -36,7 +36,7 @@
       "name": "Info",
       "url": "#",
       "locationMatch": null,
-      "icon": "network/Server",
+      "icon": "network/Inventory",
       "roles": null,
       "items": [
         {
@@ -302,7 +302,7 @@
       "name": "Administration",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/ManageProfile",
+      "icon": "network/Configuration",
       "roles": null,
       "items": [
         {

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -85,7 +85,7 @@
       "name": "Inventory",
       "url": "#",
       "locationMatch": null,
-      "icon": "network/Server",
+      "icon": "network/Inventory",
       "roles": null,
       "items": [
         {
@@ -130,7 +130,7 @@
       "name": "Monitoring",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/View",
+      "icon": "network/Monitoring",
       "roles": null,
       "items": [
         {
@@ -222,7 +222,7 @@
       "name": "Distributed Monitoring",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/ViewDetails",
+      "icon": "network/DistributedMonitoring",
       "roles": null,
       "items": [
         {
@@ -253,7 +253,7 @@
       "name": "Manage Inventory",
       "url": "#",
       "locationMatch": null,
-      "icon": "network/Server",
+      "icon": "network/InventoryAlt",
       "roles": null,
       "items": [
         {
@@ -439,7 +439,7 @@
       "name": "Administration",
       "url": "#",
       "locationMatch": null,
-      "icon": "action/Workflow",
+      "icon": "network/Configuration",
       "roles": null,
       "items": [
         {
@@ -560,7 +560,7 @@
       "name": "API Documentation",
       "url": "#",
       "locationMatch": null,
-      "icon": "network/ApiEndpoints",
+      "icon": "network/ApiConfig",
       "roles": null,
       "items": [
         {

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,27 +1,17 @@
 # Vue 3 + Typescript + Vite
 
-This template should help you start developing with Vue 3, Typescript 4.9, and Vite 4.
+This template should help you start developing with Vue 3, Typescript 5, and Vite 4.
 
 ## Build instructions
 
-This project requires Node 18+.
+This project requires Node 18+. Node 22+ is recommended. npm 10.8+ is recommended.
 
 You will also need [yarn](https://yarnpkg.com/getting-started/install)
 
-To install packages and run dev server
+To install packages and build (see Developer workflow below for more):
 ```
 yarn install
-yarn dev
-```
-
-Build for prod
-```
-yarn build
-```
-
-Build/watch in dev mode
-```
-yarn watch:dev
+yarn build:all
 ```
 
 Run unit tests
@@ -51,17 +41,35 @@ Developer workflow for development -> build -> fast deploy. There may be issues 
 
 - write your code
 
-- from your `~/projects/opennms/ui` directory, run `yarn dev` or `yarn watch:dev` to build in development mode (or `yarn build` for production / minified mode)
+- any time you update dependencies, or on initial build, from your `~/projects/opennms/ui` directory, run `yarn install`
 
-- have a console window open in the target directory where the built/deployed files need to be, e.g., `~/projects/opennms/target/opennms-XX.X.X-SNAPSHOT/jetty-webapps/opennms/ui`
+- from your `~/projects/opennms/ui` directory, run `yarn build:all` (or `yarn build:all:dev` for non-minified mode)
 
-- after build completes, run `cp ~/projects/opennms/ui/dist/assets/*.* assets` to copy all the built JS and other asset files, then run `cp ~/projects/opennms/ui/dist/index.html .` to copy the new `index.html` file
+- have a console window open in the target directory where the built/deployed files need to be, e.g., `~/projects/opennms/target/opennms-XX.X.X-SNAPSHOT/jetty-webapps/opennms/ui` and `~/projects/opennms/target/opennms-XX.X.X-SNAPSHOT/jetty-webapps/opennms/ui-components`
 
-- from `target/snapshot/jetty-webapps/opennms/ui`, occasionally run `rm assets/*.*` to clear out old files
+- after build completes, run the following to copy all the built JS and CSS asset files and new `index.html` files into your OpenNMS instance.
 
-- refresh your browser, which points at `http://localhost:8980/opennms/ui/index.html#/nodes` or similar
+`ui` is for the Vue SPA UI app, `ui-components` is for the Vue menu app that is embedded in legacy JSP/Vaadin pages
+
+```
+cd ~/projects/opennms/target/opennms-XX.X.X-SNAPSHOT/jetty-webapps/opennms/ui
+cp ~/projects/opennms/ui/src/main/dist/assets/*.* assets
+cp ~/projects/opennms/ui/src/main/dist/index.html .
+
+cd ~/projects/opennms/target/opennms-XX.X.X-SNAPSHOT/jetty-webapps/opennms/ui-components
+cp ~/projects/opennms/ui/src/menu/dist-menu/assets/*.* assets
+cp ~/projects/opennms/ui/src/menu/dist-menu/index.html .
+```
+
+- from `target/snapshot/jetty-webapps/opennms/ui` and `target/snapshot/jetty-webapps/opennms/ui-components`, occasionally run `rm assets/*.*` to clear out old files
+
+- refresh your browser, which points at `http://localhost:8980/opennms` and choose a menu item to go to a Vue SPA page, or else see the Vue Menu on legacy pages
 
 - test and debug code, use browser `F12 Developer Tools` to set breakpoints, view console output, inspect elements, etc.
+
+- often `console.log` or `console.dir` statements in the code are more helpful for debugging than the browser debugger
+
+- run `yarn lint` to check for any linting/formatting errors. `yarn lint --fix` may fix them, but you should always double check
 
 ## Prettier
 Formatting should use the .prettierrc file. For VSCode, install the Prettier extension, go to the IDE Settings and set this formatter to take precedence.
@@ -75,4 +83,3 @@ Formatting should use the .prettierrc file. For VSCode, install the Prettier ext
 The SPA assets are currently hosted on Jetty via the /opennms application.
 
 The [SpaRoutingFilter](opennms-web-api/src/main/java/org/opennms/web/servlet/SpaRoutingFilter.java) serve up the `index.html` page for URLs that do not refer to project assets.
-

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,8 @@
     "build:all": "yarn run build && yarn run build:menu",
     "build:menu": "vue-tsc --noEmit && vite build --config ./vite.config.menu.ts --base=/opennms/ui/",
     "build:dev": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --minify false",
+    "build:dev:menu": "vue-tsc --noEmit && vite build --config ./vite.config.menu.ts --base=/opennms/ui/ --minify false",
+    "build:all:dev": "yarn run build:dev && yarn run build:dev:menu",
     "watch": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --watch",
     "watch:dev": "vue-tsc --noEmit && vite build --base=/opennms/ui/ --minify false --watch",
     "serve": "vite preview",

--- a/ui/src/components/Configuration/ConfigurationHelper.ts
+++ b/ui/src/components/Configuration/ConfigurationHelper.ts
@@ -790,7 +790,7 @@ const validateCronTab = (item: LocalConfiguration, oldErrors: LocalErrors) => {
  */
 const validateHost = (host: string) => {
   // no spaces, may starts and ends with brackets, may contain (but not start with) hyphen or dot or colon, cannot be over 49 chars (e.g. IPv6 - vmware://[2001:db8:0:8d3:0:8a2e:70:7344])
-  const customHostnameRegex = /^(?:(\$\{[^}]+\}|\w+):(\$\{[^}]+\}|\S+)@)?(?!.*\.\.)(?![.-])(?!.*[.-]$)((?:(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])|\[?(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}\]?|(?:[a-zA-Z\d](?:[a-zA-Z\d\-]{0,61}[a-zA-Z\d])?(?:\.[a-zA-Z\d](?:[a-zA-Z\d\-]{0,61}[a-zA-Z\d])?)*))(?::([0-9]{1,5}))?$/
+  const customHostnameRegex = /^(?:(\$\{[^}]+\}|\w+):(\$\{[^}]+\}|\S+)@)?(?!.*\.\.)(?![.-])(?!.*[.-]$)((?:(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])|\[?(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}\]?|(?:[a-zA-Z\d](?:[a-zA-Z\d-]{0,61}[a-zA-Z\d])?(?:\.[a-zA-Z\d](?:[a-zA-Z\d-]{0,61}[a-zA-Z\d])?)*))(?::([0-9]{1,5}))?$/
 
   // Either IPv4, IPv6, a valid domain name, or passes custom regex
   const isHostValid =

--- a/ui/src/components/Menu/useMenuIcons.ts
+++ b/ui/src/components/Menu/useMenuIcons.ts
@@ -41,8 +41,13 @@ import IconLineChart from '@featherds/icon/datavis/LineChart'
 import IconApiConfig from '@featherds/icon/network/ApiConfig'
 import IconApiEndpoints from '@featherds/icon/network/ApiEndpoints'
 import IconBuild from '@featherds/icon/network/Build'
+import IconConfiguration from '@featherds/icon/network/Configuration'
+import IconDistributedMonitoring from '@featherds/icon/network/DistributedMonitoring'
 import IconInstances from '@featherds/icon/network/Instances'
 import IconLogsAlt from '@featherds/icon/network/LogsAlt'
+import IconInventory from '@featherds/icon/network/Inventory'
+import IconInventoryAlt from '@featherds/icon/network/InventoryAlt'
+import IconMonitoring from '@featherds/icon/network/Monitoring'
 import IconNetworkConnection from '@featherds/icon/network/Connection'
 import IconNetworkServer from '@featherds/icon/network/Server'
 import IconNodes from '@featherds/icon/network/Nodes'
@@ -91,9 +96,14 @@ const useMenuIcons = () => {
             case 'ApiConfig': return IconApiConfig
             case 'ApiEndpoints': return IconApiEndpoints
             case 'Build': return IconBuild
+            case 'Configuration': return IconConfiguration
             case 'Connection': return IconNetworkConnection
+            case 'DistributedMonitoring': return IconDistributedMonitoring
             case 'Instances': return IconInstances
+            case 'Inventory': return IconInventory
+            case 'InventoryAlt': return IconInventoryAlt
             case 'LogsAlt': return IconLogsAlt
+            case 'Monitoring': return IconMonitoring
             case 'Server': return IconNetworkServer
             case 'Nodes': return IconNodes
             default: return null

--- a/ui/src/components/ZenithConnect/ZenithConnectRegisterResult.vue
+++ b/ui/src/components/ZenithConnect/ZenithConnectRegisterResult.vue
@@ -88,7 +88,6 @@
 import { FeatherButton } from '@featherds/button'
 import { FeatherIcon } from '@featherds/icon'
 import ContentCopy from '@featherds/icon/action/ContentCopy'
-import { v4 as uuidv4 } from 'uuid'
 import { useRoute } from 'vue-router'
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
 import useSnackbar from '@/composables/useSnackbar'


### PR DESCRIPTION
Feather 0.12.42 added a few more icons which we can use in the menu, particularly for Inventory, Manage Inventory, Distributed Monitoring and a gears icons for Administration.

These have been incorporated into the code and menu templates.

In addition, I noticed some things in the ui `README.md` file for the Developer Workflow that needed to be updated.

Also a few linting fixes.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18195
