### PR TITLE
NMS-18549: Fix CSP issue with tile providers (release 34.x)

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/web.xml
@@ -109,7 +109,7 @@
     <init-param>
       <description>Sets the header value.</description>
       <param-name>value</param-name>
-      <param-value>default-src 'none' ; frame-src 'self' ; manifest-src 'self' ; media-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://fonts.googleapis.com  https://fonts.gstatic.com; connect-src 'self' ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; base-uri 'self' ; form-action 'self' ; img-src 'self' https://tiles.opennms.org https://*.tile.openstreetmap.org https://*.tile.opentopomap.org data:</param-value>
+      <param-value>default-src 'none' ; frame-src 'self' ; manifest-src 'self' ; media-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://fonts.googleapis.com  https://fonts.gstatic.com; connect-src 'self' ; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; base-uri 'self' ; form-action 'self' ; img-src 'self' https://tiles.opennms.org https://tile.openstreetmap.org https://*.tile.openstreetmap.org https://tile.opentopomap.org https://*.tile.opentopomap.org data:</param-value>
     </init-param>
   </filter>
 


### PR DESCRIPTION
Updating our Content Security Policy to include variations for `openstreetmap.org` and `opentopomap.org` tile provider URLs.

It appears something has changed with either our `tiles.opennms.org` server or with where the redirect is going. Tile images are being blocked due to the CSP policy, meaning that Geographical Map tile images are not displaying.

This PR is to update `release-34.x`. The fix will then be backported to `foundation-2023` or possibly earlier.

*UPDATE:* There were configuration issues with the `tiles.opennms.org` server as well which have now been addressed.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18549
