### PR TITLE
NMS-18544: Update deploy base image with JMX Prometheus exporter 1.4.0

### DIFF
--- a/opennms-container/common.mk
+++ b/opennms-container/common.mk
@@ -12,7 +12,7 @@ endif
 VERSION                 := $(shell ../../.circleci/scripts/pom2version.sh ../../pom.xml)
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:ubi9-3.6.0.b293-jre-17
+BASE_IMAGE              := opennms/deploy-base:ubi9-3.6.1.b295-jre-17
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKER_REGISTRY         := docker.io
 DOCKER_ORG              := opennms

--- a/opennms-container/core/Dockerfile
+++ b/opennms-container/core/Dockerfile
@@ -23,7 +23,7 @@
 ##
 # Use Java base image and setup required RPMs as cacheable image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.6.0.b293-jre-17"
+ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.6.1.b295-jre-17"
 
 FROM ${BASE_IMAGE} AS core-tarball
 

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -26,7 +26,7 @@
 # To avoid issues, we rearrange the directories in pre-stage to avoid injecting these
 # as additional layers into the final image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.6.0.b293-jre-17"
+ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.6.1.b295-jre-17"
 
 FROM ${BASE_IMAGE} AS minion-base
 

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -23,7 +23,7 @@
 ##
 # Use Java base image and setup required RPMs as cacheable image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.6.0.b293-jre-17"
+ARG BASE_IMAGE="opennms/deploy-base:ubi9-3.6.1.b295-jre-17"
 
 FROM ${BASE_IMAGE} AS sentinel-tarball
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MockCloudContainer.java
@@ -44,7 +44,7 @@ public class MockCloudContainer extends GenericContainer<MockCloudContainer> {
     private static final Path CLOUD_MOCK_PATH_CONTAINER = Path.of("/").resolve(CLOUD_MOCK_PATH_HOST.getFileName());
     private static final String CLOUD_MOCK_MAIN = "org.opennms.plugins.cloud.ittest.MockCloudMain";
     public MockCloudContainer() {
-        super(DockerImageName.parse("opennms/deploy-base:ubi9-3.6.0.b293-jre-17"));
+        super(DockerImageName.parse("opennms/deploy-base:ubi9-3.6.1.b295-jre-17"));
         withCopyFileToContainer(MountableFile.forHostPath(CLOUD_MOCK_PATH_HOST), CLOUD_MOCK_PATH_CONTAINER.toString())
                 .withCommand("/usr/bin/java", "-cp", CLOUD_MOCK_PATH_CONTAINER.toString(), CLOUD_MOCK_MAIN)
                 .withExposedPorts(PORT)


### PR DESCRIPTION
Update the OCI deploy base image with JMX Prometheus exporter 1.4.0 which was bumped from 1.3.0.

Use deploy base image with changes from https://github.com/OpenNMS/deploy-base/commit/f5e7225eec912d4837a82457cefcc0cc05ac7be5

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18544

