### PR TITLE
NMS-18323 OpenConfig JTI gRPC Stream Persists After Channel Closure

### DIFF
--- a/features/openconfig/telemetry-client/src/main/java/org/opennms/features/openconfig/telemetry/OpenConfigClientImpl.java
+++ b/features/openconfig/telemetry-client/src/main/java/org/opennms/features/openconfig/telemetry/OpenConfigClientImpl.java
@@ -321,7 +321,7 @@ public class OpenConfigClientImpl implements OpenConfigClient {
 
         @Override
         public void onNext(OpenConfigData value) {
-            handler.accept(host, port, value.toByteArray());
+            if(!closed.get()) {handler.accept(host, port, value.toByteArray());}
         }
 
         @Override
@@ -329,7 +329,7 @@ public class OpenConfigClientImpl implements OpenConfigClient {
             LOG.error("Received error on stream for host {}", InetAddressUtils.str(host), t);
             handler.onError(t.getMessage());
             close();
-            executor.execute(() -> scheduleSubscription(handler));
+           if(!closed.get()){ executor.execute(() -> scheduleSubscription(handler));}
         }
 
         @Override
@@ -337,7 +337,7 @@ public class OpenConfigClientImpl implements OpenConfigClient {
             LOG.info("Response stream closed for host {}", InetAddressUtils.str(host));
             handler.onError("OpenConfig Server closed connection for host " + InetAddressUtils.str(host));
             close();
-            executor.execute(() -> scheduleSubscription(handler));
+            if(!closed.get()){   executor.execute(() -> scheduleSubscription(handler));}
         }
     }
 
@@ -356,7 +356,7 @@ public class OpenConfigClientImpl implements OpenConfigClient {
 
         @Override
         public void onNext(Gnmi.SubscribeResponse subscribeResponse) {
-            if(subscribeResponse != null) {
+            if(subscribeResponse != null && !closed.get()) {
                 handler.accept(host, port, subscribeResponse.toByteArray());
             }
         }
@@ -366,7 +366,7 @@ public class OpenConfigClientImpl implements OpenConfigClient {
             LOG.error("Received error on stream for host {}", InetAddressUtils.str(host), t);
             handler.onError(t.getMessage());
             close();
-            executor.execute(() -> scheduleSubscription(handler));
+           if(!closed.get()){ executor.execute(() -> scheduleSubscription(handler));}
         }
 
         @Override
@@ -374,7 +374,7 @@ public class OpenConfigClientImpl implements OpenConfigClient {
             LOG.info("Response stream closed for host {}", InetAddressUtils.str(host));
             handler.onError("OpenConfig Server closed connection for host " + InetAddressUtils.str(host));
             close();
-            executor.execute(() -> scheduleSubscription(handler));
+            if(!closed.get()){   executor.execute(() -> scheduleSubscription(handler));}
         }
     }
 


### PR DESCRIPTION
HubSpot
Description

When a gRPC client closes its connection to the OpenConfig JTI (Juniper Telemetry Interface) server, the telemetry data stream from server  still coming and passes to OpenNMS core adapter.

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18323

