### PR TITLE
NMS-18773: Remove unwanted menu header

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
@@ -15,6 +15,11 @@
   "version": "",
   "menus": [
     {
+      "id": "emptyHeader",
+      "name": "",
+      "type": "header"
+    },
+    {
       "id": "operationsMenu",
       "name": "Operations",
       "url": "#",

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -15,6 +15,11 @@
   "version": "",
   "menus": [
     {
+      "id": "emptyHeader",
+      "name": "",
+      "type": "header"
+    },
+    {
       "id": "dashboardsMenu",
       "name": "Dashboards",
       "url": "#",

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
@@ -15,6 +15,11 @@
   "version": "",
   "menus": [
     {
+      "id": "emptyHeader",
+      "name": "",
+      "type": "header"
+    },
+    {
       "id": "searchMenu",
       "name": "Search",
       "url": "#",

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -15,6 +15,11 @@
   "version": "",
   "menus": [
     {
+      "id": "emptyHeader",
+      "name": "",
+      "type": "header"
+    },
+    {
       "id": "dashboardsMenu",
       "name": "Dashboards",
       "url": "#",

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -245,6 +245,13 @@ const topPanels = computed<MenuListEntry[]>(() => {
         height: 1.25em;
         padding: 0 0.5rem;
       }
+
+      // tighten vertical space between expand/collapse button and first actual menu item
+      // note, menu-template.json has a "dummy" first menu item of type="header" so the the
+      // hard-coded "Menu" header is not emitted. This overrides the min-height of the empty li
+      li:first-child.feather-list-header {
+        min-height: 0.1rem;
+      }
     }
 
     // when dock is closed, want the separator not quite fully across horizontally, but closer to fully across than when it's open


### PR DESCRIPTION
The Feather Sidemenu component adds a hard-coded "Menu" header item if there are no header items.

In our current configuration, we don't really need this header item at the top and it just takes up vertical space.

This PR adds a "dummy" header menu item to suppress this behavior, plus some CSS to tighten up the spacing.

See NMS-18772 for updating the Feather component itself.

Example of what we are removing, the top "Menu" line:

<img width="321" height="268" alt="menu-header" src="https://github.com/user-attachments/assets/f039f014-d8c6-452a-8224-6735a027051f" />


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-18773

