### PR TITLE
Update page-size configuration in newts.adoc

### DIFF
--- a/docs/modules/deployment/pages/time-series-storage/newts/newts.adoc
+++ b/docs/modules/deployment/pages/time-series-storage/newts/newts.adoc
@@ -54,7 +54,7 @@ datastax-java-driver {
     local-datacenter = datacenter1<3>
   }
   basic.request {
-    page-size = 20000<4>
+    page-size = 0<4>
   }
   advanced.auth-provider {
     class = PlainTextAuthProvider<5>
@@ -67,7 +67,7 @@ datastax-java-driver {
 <1> `Hostname:port` or `IP address:port` of one or more Cassandra cluster nodes.
 <2> Name of the keyspace which is initialized and used.
 <3> The local datacenter as defined by your Cassandra configuration
-<4> Increasing the page-size is recomended to avoid unexpected gaps in graph data.
+<4> Setting the page-size to 0 is recommended to disable query paging, avoiding unexpected gaps in graph data.
 <5> The authentication provider to use with the supplied credentials
 
 .(Optional) If your {page-component-title} data collection or polling intervals have been modified, set the query minimum and heartbeat rates:


### PR DESCRIPTION
Updating doc's to mention the following below:

Setting the page-size to 0 is recommended to disable query paging, avoiding unexpected gaps in graph data.