### PR TITLE
NMS-19630: Deprecate and disable the legacy SNMP Config JSP UI

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/search-actions.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/search-actions.xml
@@ -87,7 +87,7 @@
     </action>
     <action>
         <label>Configure SNMP Community Names by IP Address</label>
-        <url>admin/snmpConfig?action=default</url>
+        <url>ui/index.html#/snmp-config</url>
         <roles>
             <role>ROLE_ADMIN</role>
         </roles>
@@ -108,7 +108,7 @@
     </action>
     <action>
         <label>Configure External Requisitions</label>
-        <url>ui/index.html/#/configuration</url>
+        <url>ui/index.html#/configuration</url>
         <roles>
             <role>ROLE_ADMIN</role>
         </roles>

--- a/opennms-webapp/src/main/java/org/opennms/web/admin/nodeManagement/SnmpConfigServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/admin/nodeManagement/SnmpConfigServlet.java
@@ -42,19 +42,21 @@ import com.google.common.base.Strings;
 
 /**
  * A servlet that handles configuring SNMP.
- * 
+ *
+ * @deprecated This servlet is deprecated and will be removed in a future release. Please use the new SNMP Agent Configuration page instead.
+ *
  * @author <a href="mailto:brozow@opennms.org">Matt Brozowski</a>
  * @author <a href="mailto:david@opennms.org">David Hustace</a>
  * @author <a href="mailto:tarus@opennms.org">Tarus Balog</a>
- * @author <A HREF="mailto:gturner@newedgenetworks.com">Gerald Turner </A>
- * @author <A HREF="http://www.opennms.org/">OpenNMS </A>
+ * @author <a href="mailto:gturner@newedgenetworks.com">Gerald Turner</a>
+ * @author <a href="http://www.opennms.org/">OpenNMS</a>
  * @version $Id: $
  * @since 1.8.1
  */
+@Deprecated(forRemoval = true)
 public class SnmpConfigServlet extends HttpServlet {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(SnmpConfigServlet.class);
-
 
 	public static enum SnmpConfigServletAction {
 		Default("default"), 
@@ -83,7 +85,10 @@ public class SnmpConfigServlet extends HttpServlet {
 	/** {@inheritDoc} */
         @Override
 	public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		process(request, response);
+		throw new ServletException("This page has been deprecated. Please use the new SNMP Agent Configuration page instead.");
+
+		// previous implementation:
+		// process(request, response);
 	}
 
 	/*

--- a/opennms-webapp/src/main/webapp/admin/index.jsp
+++ b/opennms-webapp/src/main/webapp/admin/index.jsp
@@ -73,12 +73,6 @@
         document.manageSnmp.submit();
     }
 
-    function snmpConfigPost()
-    {
-        document.snmpConfig.action = "admin/snmpConfig?action=default";
-        document.snmpConfig.submit();
-    } 
-     
     function networkConnection()
     {
         document.networkConnection.submit();
@@ -112,11 +106,6 @@
     <input type="hidden"/>
 </form>
 
-<form method="post" name="snmpConfig" action="admin/snmpConfig">
-    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
-    <input type="hidden"/>
-</form>
-
 <div class="row">
   <div class="col-md-6">
     <div class="card">
@@ -147,10 +136,10 @@
             <li><a href="admin/categories.htm">Manage Surveillance Categories</a></li>
             <li><a href="admin/discovery/edit-config.jsp">Configure Discovery</a></li>
             <li><a href="admin/discovery/edit-scan.jsp">Run Single Discovery Scan</a></li>
-            <li><a href="javascript:snmpConfigPost()">Configure SNMP Community Names by IP Address</a></li>
+            <li><a href="ui/index.html#/snmp-config">Configure SNMP Community Names by IP Address</a></li>
             <li><a href="javascript:addInterfacePost()">Manually Add an Interface</a></li>
             <li><a href="javascript:deletePost()">Delete Nodes</a></li>
-            <li><a href="ui/index.html/#/configuration">Configure External Requisitions</a></li>
+            <li><a href="ui/index.html#/configuration">Configure External Requisitions</a></li>
             <li><a href="admin/geoservice/index.jsp">Configure Geocoder Service</a></li>
             <li><a href="/opennms/ui/index.html#/scv">Secure Credentials Vault</a></li>
         </ul>
@@ -333,10 +322,11 @@
             (or any combination of the four) for any interface/node for any time.  
         </p>
 
-        <P><B>Configure SNMP Community Names by IP Address</b>: Configure the Community String used in SNMP Data Collection and other SNMP operations. OpenNMS is shipped with a community string of "public".
+        <p><b>Configure SNMP Community Names by IP Address</b>: Configure the Community String used in SNMP Data Collection
+            and other SNMP operations. OpenNMS is shipped with a community string of "public".
             If you have set a different <em>read</em> community on your devices you must put it here to be able to collect data from
             these devices.
-        </P>
+        </p>
 
         <p><b>Manage and Unmanage Interfaces and Services</b>: <em>Managing</em> an interface or service means that
             OpenNMS performs tests on this interface or service. If you want to explicitly enable or disable testing you
@@ -349,12 +339,11 @@
         <p><b>Manage SNMP Collections and Data Collection Groups</b>: Manage SNMP Collections and the content
             of the files for data collection groups.</p>
 
-        <P><B>Configure SNMP Data Collection per Interface</b>: This interface will allow you
+        <p><b>Configure SNMP Data Collection per Interface</b>: This interface will allow you
             to configure which IP and non-IP interfaces are used in SNMP Data Collection.
-        </P>
+        </p>
 
         <p><b>Configure thresholds</b>: Allows you to add, remove, or modify thresholds.</p>
-
 
         <p><b>Manage Applications</b>: Configure and administer 
         the operation of perspective pollers that report back to this OpenNMS server to provide distributed

--- a/opennms-webapp/src/main/webapp/admin/nodemanagement/index.jsp
+++ b/opennms-webapp/src/main/webapp/admin/nodemanagement/index.jsp
@@ -120,7 +120,7 @@
       final String primaryIpAddress = InetAddressUtils.str(onmsIpInterface.getIpAddress());
       %>
         <p>
-          <a href="admin/snmpConfig?action=get&ipAddress=<%=primaryIpAddress%>#updateForm">Configure SNMP Community Strings</a>
+          <a href="ui/index.html#/snmp-config/lookup?ipAddress=<%=primaryIpAddress%>">Configure SNMP Community Strings</a>
         </p>
       <%
     }

--- a/opennms-webapp/src/main/webapp/admin/snmpConfig.jsp
+++ b/opennms-webapp/src/main/webapp/admin/snmpConfig.jsp
@@ -285,6 +285,10 @@ if (request.getAttribute("success") != null) {
       <div class="card-header">
         <span>SNMP Config Lookup</span>
       </div>
+      <div style="padding: 10px;" class="alert alert-info">
+        Note, this page has been deprecated. Please use the side menu or <a href="ui/index.html#/snmp-config">click here</a> to
+        navigate to the new SNMP Agent Configuration page. This page will be removed in a future release.
+      </div>
       <div class="card-body">
         <form role="form" class="form" method="post" name="snmpConfigGetForm" action="admin/snmpConfig?action=get">
           <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
@@ -307,7 +311,7 @@ if (request.getAttribute("success") != null) {
           </div>
           <div class="form-group form-row">
             <div class="col-sm-9 col-sm-offset-2">
-              <button type="submit" class="btn btn-secondary" name="getConfig">Look up</button>
+              <button type="submit" class="btn btn-secondary" name="getConfig" disabled>Look up</button>
             </div>
           </div>
         </form>
@@ -669,7 +673,7 @@ if (request.getAttribute("success") != null) {
 
             <div class="form-group form-row">
               <div class="col-sm-9 col-sm-offset-3">
-                <button type="submit" class="btn btn-secondary" name="saveConfig">Save Config</button>
+                <button type="submit" class="btn btn-secondary" name="saveConfig" disabled>Save Config</button>
                 <button type="button" class="btn btn-secondary" name="cancelButton" onClick="cancel();">Cancel</button>
               </div>
             </div>

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminPageIT.java
@@ -59,7 +59,7 @@ public class AdminPageIT extends OpenNMSSeleniumIT {
         new String[] { "Manage Surveillance Categories", "//span[text()='Surveillance Categories']" },
         new String[] { "Configure Discovery", "//span[text()='General Settings']" },
         new String[] { "Run Single Discovery Scan", "//span[text()='Exclude Ranges']" },
-        new String[] { "Configure SNMP Community Names by IP Address", "//span[text()='SNMP Config Lookup']" },
+        new String[] { "Configure SNMP Community Names by IP Address", "//h2[text()='Manage SNMP Configuration']" },
         new String[] { "Manually Add an Interface", "//span[text()='Enter IP Address']" },
         new String[] { "Delete Nodes", "//span[text()='Delete Nodes']" },
         new String[] { "Configure External Requisitions", "//h1[contains(text(), 'Configuration')]" },

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminSnmpConfigForIpPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminSnmpConfigForIpPageIT.java
@@ -32,6 +32,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.opennms.smoketest.selenium.ResponseData;
@@ -39,6 +40,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 
+// TODO: Remove when legacy SNMP UI is removed (Horizon 37)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
 
@@ -52,7 +54,7 @@ public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
         findElementByLink("Configure SNMP Community Names by IP Address").click();
     }
 
-    @Test
+    @Ignore("The legacy SNMP Config UI pages have been deprecated and hidden.")
     public void verifyLocationDropdown() throws IOException, InterruptedException {
         boolean created = false;
         try {
@@ -87,7 +89,7 @@ public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
     /**
      * Tests if getting the current snmp configuration for a specific ip address works.
      */
-    @Test
+    @Ignore("The legacy SNMP Config UI pages have been deprecated and hidden.")
     public void testGetIpInformation() throws Exception {
         // v2c
         new Select(findElementByName("version")).selectByVisibleText("v2c");
@@ -130,7 +132,7 @@ public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
     /**
      * Tests that only one "version specifics" area is visible at the time. 
      */
-    @Test
+    @Ignore("The legacy SNMP Config UI pages have been deprecated and hidden.")
     public void testVersionHandling() {
         new Select(findElementByName("version")).selectByVisibleText("v1");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//span[text()='v1/v2c specific parameters']")));
@@ -149,7 +151,7 @@ public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
     /**
      * Tests if the validation of the integer fields in the "saveConfig" form works fine.
      */
-    @Test
+    @Ignore("The legacy SNMP Config UI pages have been deprecated and hidden.")
     public void testIntegerValidation() {
         final String defaultValidationErrorTemplate = "%s is not a valid %s. Please enter a number greater than 0 or leave it empty.";
         final String geZeroValidationErrorTemplate = "%s is not a valid %s. Please enter a number greater than or equal to 0, or leave it empty.";
@@ -218,7 +220,7 @@ public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
      * Tests if the ip address validation in the "saveConfig" form works fine.
      * @throws Exception
      */
-    @Test
+    @Ignore("The legacy SNMP Config UI pages have been deprecated and hidden.")
     public void testIpValidation() throws Exception {
         //invalid first and empty last ip
         gotoPage();
@@ -262,7 +264,7 @@ public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
     /**
      * Tests that the cancel button works as expected.
      */
-    @Test
+    @Ignore("The legacy SNMP Config UI pages have been deprecated and hidden.")
     public void testCancelButton() {
         findElementByName("cancelButton").click();
         // this takes you to the admin page
@@ -273,7 +275,7 @@ public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
     /**
      * Tests that one or both save options can be selected, but that there must be at least one selection.
      */
-    @Test
+    @Ignore("The legacy SNMP Config UI pages have been deprecated and hidden.")
     public void testSaveOptions() {
         // OK
         enterText(By.name("firstIPAddress"), "1.1.1.1");
@@ -328,5 +330,4 @@ public class AdminSnmpConfigForIpPageIT extends OpenNMSSeleniumIT {
             assertEquals("Expected a failure on field '" + fieldLabel + "' with value " + fieldValue, String.format(errorMessageTemplate, fieldValue, fieldLabel), alertText);
         }
     }
-
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/SnmpConfigPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/SnmpConfigPageIT.java
@@ -30,6 +30,7 @@ import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// TODO: Remove when legacy SNMP UI is removed (Horizon 37)
 public class SnmpConfigPageIT extends OpenNMSSeleniumIT {
     private static Logger LOG = LoggerFactory.getLogger(SnmpConfigPageIT.class);
 
@@ -37,7 +38,7 @@ public class SnmpConfigPageIT extends OpenNMSSeleniumIT {
      * Checks whether Snmp config data is saved and
      * correctly retrieved in the Web UI (see NMS-13512)
      */
-    @Test
+    @Ignore("The legacy SNMP Config UI pages have been deprecated and hidden.")
     public void lookupSaveAndLookupAgain() {
         // lookup IP 1.2.3.4
         lookupIpAddress("1.2.3.4");

--- a/ui/src/components/SnmpConfiguration/SnmpConfigLookupPanel.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigLookupPanel.vue
@@ -67,6 +67,11 @@ import { SnmpLookupEditMode, useSnmpConfigStore } from '@/stores/snmpConfigStore
 import { SnmpAgentConfig } from '@/types/snmpConfig'
 import { DEFAULT_MONITORING_LOCATION } from '@/lib/constants'
 
+const props = defineProps<{
+  autoLookupIpAddress?: string
+  autoLookupLocation?: string
+}>()
+
 const snackbar = useSnackbar()
 const store = useSnmpConfigStore()
 const lookupIpAddress = ref('')
@@ -144,9 +149,32 @@ const onLookup = async () => {
   }
 }
 
-onMounted(() => {
+watch(() => props.autoLookupIpAddress, (ip) => {
   resetValues()
-})
+
+  // auto-lookup mode for url like '/snmp-config/lookup?ipAddress=X&location=Y'
+  if (ip) {
+    lookupIpAddress.value = ip
+    
+    const locationIsDefault = !props.autoLookupLocation || props.autoLookupLocation.localeCompare(DEFAULT_MONITORING_LOCATION, undefined, { sensitivity: 'base' }) === 0
+    const locationName = locationIsDefault ? DEFAULT_MONITORING_LOCATION : props.autoLookupLocation
+    const matched = monitoringLocations.value.find(loc => loc._value === locationName)
+    
+    // If non-default location is provided, check if it matches any of the available monitoring locations.
+    // Note, this could also happen if the monitoring locations are still loading and haven't been populated yet.
+    // User can then manually select the location and trigger lookup.
+    if (!locationIsDefault && !matched) {
+      snackbar.showSnackBar({
+        msg: `Monitoring location ${locationName} from URL is not valid. Please select a valid monitoring location.`,
+        error: true
+      })
+      return
+    }
+
+    lookupMonitoringLocation.value = matched ?? { _text: locationName, _value: locationName }
+    onLookup()
+  }
+}, { immediate: true })
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/SnmpConfiguration/SnmpConfigLookupTab.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigLookupTab.vue
@@ -3,6 +3,8 @@
     <div class="main-section">
       <SnmpConfigLookupPanel
         v-if="store.snmpLookupEditMode === SnmpLookupEditMode.Lookup"
+        :autoLookupIpAddress="autoLookupIpAddress"
+        :autoLookupLocation="autoLookupLocation"
         @lookup-complete="onLookupComplete"
       />
       <div class="snmp-config-details" v-if="store.snmpLookupEditMode === SnmpLookupEditMode.Edit">
@@ -23,14 +25,20 @@
 </template>
 
 <script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
 import useSnackbar from '@/composables/useSnackbar'
-import { getDefaultSnmpDefinition, SnmpLookupEditMode, useSnmpConfigStore } from '@/stores/snmpConfigStore'
+import { ActiveTabs, getDefaultSnmpDefinition, SnmpLookupEditMode, useSnmpConfigStore } from '@/stores/snmpConfigStore'
 import { SnmpAgentConfig, SnmpDefinition } from '@/types/snmpConfig'
 import SnmpConfigLookupPanel from './SnmpConfigLookupPanel.vue'
 import SnmpConfigDefinitionBasicInformation from './SnmpConfigDefinitionBasicInformation.vue'
 
+const route = useRoute()
+const router = useRouter()
 const snackbar = useSnackbar()
 const store = useSnmpConfigStore()
+
+const autoLookupIpAddress = computed(() => route.query.ipAddress as string | undefined)
+const autoLookupLocation = computed(() => route.query.location as string | undefined)
 
 const lookupConfig = ref<SnmpAgentConfig>()
 const currentDefinition = ref<SnmpDefinition>(getDefaultSnmpDefinition())
@@ -44,10 +52,23 @@ const resetValues = () => {
   ipAddress.value = ''
 }
 
-const handleBackButtonClick = () => {
+const clearLookupRoute = () => {
+  if (route.query.ipAddress) {
+    return router.replace('/snmp-config')
+  }
+}
+
+const handleBackButtonClick = async () => {
   resetValues()
+  await clearLookupRoute()
   store.setSnmpLookupEditMode(SnmpLookupEditMode.Lookup)
 }
+
+watch(() => store.activeTab, async (tab) => {
+  if (tab !== ActiveTabs.Lookup) {
+    await clearLookupRoute()
+  }
+})
 
 const onLookupComplete = (config: SnmpAgentConfig, ip: string) => {
   lookupConfig.value = config

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -20,7 +20,7 @@
 /// License.
 ///
 
-import { createRouter, createWebHashHistory } from 'vue-router'
+import { createRouter, createWebHashHistory, RouteLocationNormalized } from 'vue-router'
 import { Plugin } from '@/types'
 import DeviceConfigBackup from '@/containers/DeviceConfigBackup.vue'
 import Home from '@/containers/Home.vue'
@@ -35,6 +35,7 @@ import useRole from '@/composables/useRole'
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
 import { useMenuStore } from '@/stores/menuStore'
+import { ActiveTabs, SnmpLookupEditMode, useSnmpConfigStore } from '@/stores/snmpConfigStore'
 
 const { adminRole, filesystemEditorRole, dcbRole, snmpRole, rolesAreLoaded } = useRole()
 const menuStore = computed(() => useMenuStore())
@@ -66,6 +67,22 @@ const isLegacyPlugin = (plugin: Plugin) => {
 
 const zenithConnectEnabled = computed<boolean>(() => menuStore.value?.mainMenu?.zenithConnectEnabled ?? false)
 
+const checkSnmpRole = (from: RouteLocationNormalized, isLookup?: boolean) => {
+  if (!snmpRole.value) {
+    showSnackBar({ msg: 'Must have the proper SNMP role(s) to access SNMP Config.' })
+    router.push(from.path)
+    return
+  }
+
+  if (isLookup) {
+    // SNMP Config auto-lookup mode. This sets the store to ensure the lookup tab is active and in lookup mode.
+    // Then SnmpConfigLookupTab will get the 'ipAddress' and 'location' query params and perform the lookup.
+    const store = useSnmpConfigStore()
+    store.setActiveTab(ActiveTabs.Lookup)
+    store.setSnmpLookupEditMode(SnmpLookupEditMode.Lookup)
+  }
+}
+
 const router = createRouter({
   history: createWebHashHistory('/opennms/ui'),
   routes: [
@@ -94,8 +111,11 @@ const router = createRouter({
           }
         }
 
-        if (rolesAreLoaded.value) checkRoles()
-        else whenever(rolesAreLoaded, () => checkRoles())
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
       }
     },
     {
@@ -110,8 +130,11 @@ const router = createRouter({
           }
         }
 
-        if (rolesAreLoaded.value) checkRoles()
-        else whenever(rolesAreLoaded, () => checkRoles())
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
       }
     },
     {
@@ -126,8 +149,11 @@ const router = createRouter({
           }
         }
 
-        if (rolesAreLoaded.value) checkRoles()
-        else whenever(rolesAreLoaded, () => checkRoles())
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
       }
     },
     {
@@ -196,8 +222,11 @@ const router = createRouter({
           }
         }
 
-        if (rolesAreLoaded.value) checkRoles()
-        else whenever(rolesAreLoaded, () => checkRoles())
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
       }
     },
     {
@@ -212,8 +241,11 @@ const router = createRouter({
           }
         }
 
-        if (rolesAreLoaded.value) checkRoles()
-        else whenever(rolesAreLoaded, () => checkRoles())
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
       }
     },
     {
@@ -221,15 +253,23 @@ const router = createRouter({
       name: 'SNMP Config',
       component: () => import('@/containers/SnmpConfiguration.vue'),
       beforeEnter: (to, from) => {
-        const checkRoles = () => {
-          if (!snmpRole.value) {
-            showSnackBar({ msg: 'Must have the proper SNMP role(s) to access SNMP Config.' })
-            router.push(from.path)
-          }
+        if (rolesAreLoaded.value) {
+          checkSnmpRole(from)
+        } else {
+          whenever(rolesAreLoaded, () => checkSnmpRole(from))
         }
-
-        if (rolesAreLoaded.value) checkRoles()
-        else whenever(rolesAreLoaded, () => checkRoles())
+      }
+    },
+    {
+      path: '/snmp-config/lookup',
+      name: 'SNMP Config Lookup',
+      component: () => import('@/containers/SnmpConfiguration.vue'),
+      beforeEnter: (to, from) => {
+        if (rolesAreLoaded.value) {
+          checkSnmpRole(from, true)
+        } else {
+          whenever(rolesAreLoaded, () => checkSnmpRole(from, true))
+        }
       }
     },
     {
@@ -244,8 +284,11 @@ const router = createRouter({
           }
         }
 
-        if (rolesAreLoaded.value) checkRoles()
-        else whenever(rolesAreLoaded, () => checkRoles())
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
       }
     },
     {

--- a/ui/tests/components/Menu/menu-template-test.json
+++ b/ui/tests/components/Menu/menu-template-test.json
@@ -101,7 +101,7 @@
         {
           "id": "snmpAgentConfiguration",
           "name": "SNMP Agent Configuration",
-          "url": "admin/snmpConfig",
+          "url": "ui/index.html#/snmp-config",
           "locationMatch": "",
           "roles": null
         },

--- a/ui/tests/components/Menu/utils.test.ts
+++ b/ui/tests/components/Menu/utils.test.ts
@@ -154,7 +154,7 @@ describe('Menu utils', () => {
         id: 'snmpAgentConfiguration',
         type: 'item',
         title: 'SNMP Agent Configuration',
-        href: `${baseHref}admin/snmpConfig`,
+        href: `${baseHref}ui/index.html#/snmp-config`,
         target: '_self'
       })
       expect(integrationItems[1]).toMatchObject({


### PR DESCRIPTION
As we are replacing the legacy JSP SNMP Config UI with the new Vue one, we need to deprecate and hide the old one.

This removes any links to the old page, but doesn't remove the route. If user manages to get to the old page, the buttons are disabled and there's a note saying it's deprecated with a link to the new page. The servlet will throw an error if any write or lookup actions are performed on it.

Searching for `Configure SNMP Community Names by IP Address` or similar will link to the new page.

We will leave actually removing all the old code for another issue.

Also added new functionality to the new SNMP Config UI to be able to do an auto-lookup from a link. This handles an existing link from the Node Management page.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19630

