### PR TITLE
NMS-19616: Fix issue with email disappearing from Destination Paths

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/admin/notification/DestinationWizardServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/admin/notification/DestinationWizardServlet.java
@@ -341,17 +341,25 @@ public class DestinationWizardServlet extends HttpServlet {
             for (int i = 0; i < targets.length; i++) {
                 String name = targets[i].getName();
                 // don't overwrite the email target command
-                if (!(targets[i].getCommands().size() == 1 && "email".equals(targets[i].getCommands().get(0)))) {
+                boolean isEmailCommand = targets[i].getCommands().size() == 1 &&
+                    ("email".equals(targets[i].getCommands().get(0)) || "javaEmail".equals(targets[i].getCommands().get(0)));
+
+                if (!isEmailCommand) {
                     targets[i].clearCommands();
+
                     String[] commands = request.getParameterValues(name + "Commands");
+
                     for (int j = 0; j < commands.length; j++) {
                         targets[i].addCommand(commands[j]);
                     }
                 }
+
                 String[] autoNotify =  request.getParameterValues(name + "AutoNotify");
-                if(autoNotify[0] == null) {
+
+                if (autoNotify[0] == null) {
                     autoNotify[0] = "auto";
                 }
+
                 targets[i].setAutoNotify(autoNotify[0]);
             }
 

--- a/opennms-webapp/src/main/webapp/admin/notification/chooseCommands.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/chooseCommands.jsp
@@ -132,21 +132,23 @@
         try {
           targets = DestinationPathFactory.getInstance().getTargetList(index, path);
         
-        for (int i = 0; i < targets.length; i++)
-        {
-            buffer.append("<tr><td>").append(targets[i].getName()).append("</td>");
-            // don't let user pick commands for email addresses
-            if (!(targets[i].getCommands().size() == 1 && "email".equals(targets[i].getCommands().get(0))))
-            {
-                buffer.append("<td>").append(buildCommandSelect(path, index, targets[i].getName())).append("</td>");
-            }
-            else
-            {
-                buffer.append("<td>").append("email adddress").append("</td>");
-            }
-            buffer.append("<td>").append(buildAutoNotifySelect(targets[i].getName(), targets[i].getAutoNotify().orElse(null))).append("<td>");
-            buffer.append("</tr>");
-        }
+          for (int i = 0; i < targets.length; i++)
+          {
+              buffer.append("<tr><td>").append(targets[i].getName()).append("</td>");
+              // don't let user pick commands for email addresses
+              boolean isEmailCommand = targets[i].getCommands().size() == 1 &&
+                  ("email".equals(targets[i].getCommands().get(0)) || "javaEmail".equals(targets[i].getCommands().get(0)));
+              boolean isEmailAddress = targets[i].getName().contains("@");
+
+              if (isEmailCommand && isEmailAddress) {
+                  buffer.append("<td>").append("email address").append("</td>");
+              } else {
+                  buffer.append("<td>").append(buildCommandSelect(path, index, targets[i].getName())).append("</td>");
+              }
+
+              buffer.append("<td>").append(buildAutoNotifySelect(targets[i].getName(), targets[i].getAutoNotify().orElse(null))).append("<td>");
+              buffer.append("</tr>");
+          }
         } catch (Throwable e)
         {
             throw new ServletException("couldn't get list of targets for path " + path.getName(), e);

--- a/opennms-webapp/src/main/webapp/admin/notification/chooseTargets.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/chooseTargets.jsp
@@ -318,7 +318,11 @@ public Map<String,Boolean> getUsers(Collection<Target> targets) throws ServletEx
 
         try {
             for (Target target : targets) {
-                if (target.getCommands().size() == 1 && "email".equals(target.getCommands().get(0))) {
+                boolean isEmailCommand = target.getCommands().size() == 1 &&
+                    ("email".equals(target.getCommands().get(0)) || "javaEmail".equals(target.getCommands().get(0)));
+                boolean isEmailAddress = target.getName().contains("@");
+
+                if (isEmailCommand && isEmailAddress) {
                     emails.put(target.getName(), target.getName());
                 }
             }
@@ -333,10 +337,13 @@ public Map<String,Boolean> getUsers(Collection<Target> targets) throws ServletEx
     public Collection<String> getTargetNames(Collection<Target> targets) {
         Collection<String> targetNames = new ArrayList<>();
         for (Target target : targets) {
-            if (target.getCommands().size() == 1 && "email".equals(target.getCommands().get(0))) {
-                continue;
+            boolean isEmailCommand = target.getCommands().size() == 1 &&
+                ("email".equals(target.getCommands().get(0)) || "javaEmail".equals(target.getCommands().get(0)));
+
+            if (!isEmailCommand) {
+                targetNames.add(target.getName());
             }
-            targetNames.add(target.getName());
         }
         return targetNames;
-    }%>
+    }
+%>


### PR DESCRIPTION
Fix issue where email addresses were disappearing from the `Notifications > Destination Paths > Path Outline > Initial Targets` edit screen. In addition, `destinationPaths.xml` was not being saved correctly as some items may have been removed as a user moves through the `Destination Wizard`.

### Additional info

`DestinationWizardServlet` saves email targets with `addCommand("javaEmail")`, but `getEmails()` and `getTargetNames()` in `chooseTargets.jsp` were only matching "email". This caused email addresses to vanish from the display when editing an existing destination path.                                                                                                                      

Both `getEmails()` and `getTargetNames()` have been updated to match either "email" or "javaEmail". The `contains("@")` guard has been added to `getEmails()` to prevent a target whose command happens to be javaEmail/email from being misclassified as an email entry.
                                                                              
Added additional checks to prevent the user from picking commands for email addresses.

Also in `DestinationWizardServlet` we fix the code to prevent `clearCommands()` from stripping the command off of email targets.

These issues resulted in corrupted `destinationPaths.xml` files being saved with items missing or invalid commands.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19616