### PR TITLE
NMS-19682: bump PostgreSQL max version to 18 and JDBC driver to 42.7.10

### DIFF
--- a/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
+++ b/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
@@ -73,7 +73,7 @@ public class Migrator {
     private static final Logger LOG = LoggerFactory.getLogger(Migrator.class);
     private static final Pattern POSTGRESQL_VERSION_PATTERN = Pattern.compile("^(?:PostgreSQL|EnterpriseDB) (\\d+\\.\\d+)");
     private static final float POSTGRESQL_MIN_VERSION_INCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.minVersion", "10.0"));
-    private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "17.0"));
+    private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "19.0"));
 
     private static final String IPLIKE_SQL_RESOURCE = "iplike.sql";
 

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Source)
 
 Package: opennms-db
 Architecture: all
-Depends: opennms-common (=${binary:Version}), postgresql-15 | postgresql-14 | postgresql-13 | postgresql-12 | postgresql-11 | postgresql-10, iplike-pgsql15 (>= 2.3.0) | iplike-pgsql14 (>= 2.3.0) | iplike-pgsql13 (>= 2.3.0) | iplike-pgsql12 (>= 2.3.0) | iplike-pgsql11 (>= 2.3.0) | iplike-pgsql10 (>= 2.3.0), debconf
+Depends: opennms-common (=${binary:Version}), postgresql-18 | postgresql-17 | postgresql-16 | postgresql-15 | postgresql-14 | postgresql-13 | postgresql-12 | postgresql-11 | postgresql-10, debconf
 Description: Enterprise-grade Open-source Network Management Platform (Database)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -57,7 +57,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Database)
 Package: opennms-server
 Architecture: all
 Depends: opennms-common (=${binary:Version}), libopennms-java (=${binary:Version}), libopennmsdeps-java (=${binary:Version}), mailx
-Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-15 | postgresql-client-14 | postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
+Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-18 | postgresql-client-17 | postgresql-client-16 | postgresql-client-15 | postgresql-client-14 | postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
 Recommends: haveged
 Description: Enterprise-grade Open-source Network Management Platform (Daemon)
  OpenNMS is an enterprise-grade network management system written in Java.

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -22,11 +22,11 @@ asciidoc:
     compatible-elasticsearch: '6.7.0 - 7.17.9'
     compatible-javajdk: 'OpenJDK 11 or 17'
     compatible-kafka: '1.x - 3.x'
-    compatible-postgresql: '10.x - 15.x'
+    compatible-postgresql: '10.x - 18.x'
     compatible-rrdtool: '1.7.x'
     jasperreportsversion: '6.3.0'
     latest-meridian-stable: '2023'
-    postgresql-version: '15'
+    postgresql-version: '18'
     jmx-prom-exporter-version: '1.3.0'
 nav:
 - modules/ROOT/index.adoc

--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -5,7 +5,7 @@
 == System requirements
 
 * *Java 11 and 17*: OpenNMS Horizon 33 runs on JDKs 11 and 17.
-* *PostgreSQL 10 or higher*: Horizon 33 requires any supported version of PostgreSQL from 10 up to (and including) 16.
+* *PostgreSQL 10 or higher*: Horizon 33 requires any supported version of PostgreSQL from 10 up to (and including) 18.
 
 == New features and important changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -1920,7 +1920,7 @@
     <paxExamVersion>4.13.5</paxExamVersion>
     <pktsVersion>3.0.10</pktsVersion>
     <protobufVersion>3.25.5</protobufVersion>
-    <postgresqlVersion>42.5.5</postgresqlVersion>
+    <postgresqlVersion>42.7.10</postgresqlVersion>
     <powermockVersion>2.0.9</powermockVersion>
     <okhttpVersion>4.9.3</okhttpVersion>
     <okioVersion>3.6.0</okioVersion>


### PR DESCRIPTION
- Raise POSTGRESQL_MAX_VERSION_EXCLUSIVE from 17.0 to 19.0 to allow PostgreSQL 18 connections through the version gate in Migrator.java
- Upgrade postgresql JDBC driver from 42.5.5 to 42.7.10 for PostgreSQL 18 compatibility (requires Java 11+, already met)
- Update docs/antora.yml: compatible-postgresql to '10.x - 18.x' and postgresql-version to '18'
- Update debian/control: add postgresql-18 packages, remove iplike-pgsql dependency, add postgresql-client-18 to Suggests
- Update whatsnew.adoc: reflect supported range up to (and including) 18

### Reviewer Hint

I've removed the hard dependency on the in C implemented stored procedure iplike. The problem here, larger deployments justify the optimised stored procedure have a PostgreSQL database on dedicated machines. The iplike RPM or DEB package needs to be installed on the PostgreSQL database, not the Core system. Additionally, we cleanly fall back to the PL scripting language on IPLIKE when the stored procedure isn't installed in Postgres.

This change justifies making the next version a minor version bump for Meridian 2024.1.0, 2025.1.0, and Horizon 35.1.0. From a semver.org perspective, we now allow Meridian 2024.1.x, 2025.1.x and Horizon 35.1.x users to use PostgreSQL 16, 17, and 18 instead of 15.

Technically, we also need to bump the minimal PostgreSQL version 10.x to 14.x. I've specifically avoided introducing this change here in Meridian. The consequence would be that it could break people's deployment in a minor release update and would force them to upgrade PostgreSQL <14 to at least 14.x or newer. I would like to avoid that here. We should bump the minimal PostgreSQL version to 14.x in develop for Horizon 36 in a dedicated PR.

Additionally, we can ensure that we have iplike-pgsql{16,17,18}.{rpm,deb} available for Meridian and Horizon on Cloudsmith and {deb,yum}.opennms.org.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19682

