### PR TITLE
NMS-19682: upgrade minimum PostgreSQL requirement to 14.x

### DIFF
--- a/.circleci/scripts/postgres.sh
+++ b/.circleci/scripts/postgres.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 echo "##### Starting Postgres"
-docker run --rm --name postgres-onms-itest -p 5432:5432 -e POSTGRES_PASSWORD=postgres -d postgres:13-alpine \
-	-c 'shared_buffers=256MB' -c 'max_connections=200' -c 'fsync=off' 
+docker run --rm --name postgres-onms-itest -p 5432:5432 -e POSTGRES_PASSWORD=postgres -d postgres:14.22-alpine \
+	-c 'shared_buffers=256MB' -c 'max_connections=200' -c 'fsync=off'
 
 echo "##### Waiting for Postgres to start..."
 WAIT=0

--- a/.circleci/scripts/smoke.sh
+++ b/.circleci/scripts/smoke.sh
@@ -62,7 +62,7 @@ for CONTAINER in \
   "confluentinc/cp-kafka:latest" \
   "docker.elastic.co/elasticsearch/elasticsearch:7.17.9" \
   "opennms/dummy-http-endpoint:0.0.2" \
-  "postgres:13-alpine" \
+  "postgres:14.22-alpine" \
   "postgres:latest" \
 ; do
   (docker pull "$CONTAINER" || true) &

--- a/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
+++ b/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
@@ -72,7 +72,7 @@ public class Migrator {
 
     private static final Logger LOG = LoggerFactory.getLogger(Migrator.class);
     private static final Pattern POSTGRESQL_VERSION_PATTERN = Pattern.compile("^(?:PostgreSQL|EnterpriseDB) (\\d+\\.\\d+)");
-    private static final float POSTGRESQL_MIN_VERSION_INCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.minVersion", "10.0"));
+    private static final float POSTGRESQL_MIN_VERSION_INCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.minVersion", "14.0"));
     private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "19.0"));
 
     private static final String IPLIKE_SQL_RESOURCE = "iplike.sql";

--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -1,60 +1,17 @@
-[[releasenotes-35]]
+[[releasenotes-36]]
 
-= What's New in OpenNMS Horizon 35
-
-== System requirements and Dependencies ==
-
-* Java 17: Horizon 35 requires JDK 17.
-* PostgreSQL 13 or higher: This version of Horizon requires a supported version of PostgreSQL.
-* Elasticsearch: Horizon 35 requires Elasticsearch 8 for flow processing.
-
-== New features and important changes
-
-=== JoeSNMP removed
-The SNMP implementation JoeSNMP was removed in Horizon 36.
-
-=== Event Configuration Moved to Database
-
-Event definitions are now stored in the database, enabling dynamic management without requiring eventd restarts. Core OpenNMS events are pre-loaded automatically. Vendor-specific event files are available in `$\{OPENNMS_HOME}/etc/examples/events/` and can be uploaded through the UI or REST API as needed.
-
-See xref:operation:deep-dive/events/event-configuration.adoc[Event Configuration] for details.
-
-* Legacy file-based event configuration (`etc/eventconf.xml`) is deprecated; changes to these files are not reflected in the running system.
-* Vendor event files moved from `etc/events/` to `etc/examples/events/` and must be uploaded manually.
-
-=== Simplified Datasource Configuration
-
-The `opennms-datasources.xml` configuration file has been simplified by making the `factory` and `class-name` attributes optional with sensible defaults. The `factory` attribute now defaults to `org.opennms.core.db.HikariCPConnectionFactory` and the `class-name` attribute defaults to `org.postgresql.Driver`. Existing configurations with these attributes explicitly set will continue to work unchanged. New installations and users updating their configurations can omit these attributes for cleaner, more maintainable configuration files.
-
-=== Simplified Service Configuration
-
-The `service-configuration.xml` configuration file has been simplified by moving service implementation details (class names, attributes, and invoke methods) to defaults in the classpath. Users now only need to specify the service name and enabled status. A complete reference configuration is available in `etc/examples/service-configuration.xml.default`. Existing configurations continue to work unchanged.
-
-=== Removed TestLoadLibraries Service
-
-The `TestLoadLibraries` service has been removed as a separate service entry in `service-configuration.xml`. Its functionality (testing ICMP and localhost resolution) is now executed automatically as part of the Manager service initialization. This simplifies the service configuration and reduces the number of service entries that must be managed.
-
-=== OpenConfig Support on Minion
-
-OpenConfig telemetry streaming is now supported on Minion. See xref:reference:telemetryd/protocols/openconfig.adoc#minion-setup[Set up OpenConfig on Minion] for configuration details.
-
+= What's New in OpenNMS Horizon 36
 
 == Breaking changes
 
-=== Debian path updates
+=== At least PostgreSQL 14.0 is required
 
-With this release, we’re streamlining the installation process for OpenNMS on both Debian and RPM-based systems by standardizing the installation location to `/opt/opennms`. This update provides a consistent deployment path, simplifies future upgrades, and minimizes conflicts caused by differing directories.
-
-Before upgrading, we strongly recommend backing up your existing installation including configuration files, databases, and any custom scripts or integrations to prevent data loss or disruption.
-
-To preserve local changes in `/etc/opennms`, copy the folder to `/opt/opennms/etc` while keeping file ownership and permissions intact. 
-
-Prepare `/opt/opennms/etc` with the following commands:
-
-```
-sudo install -d -o opennms -g opennms /opt/opennms/etc
-sudo -u opennms cp -r /etc/opennms/* /opt/opennms/etc
-```
+OpenNMS {page-component-title} now requires PostgreSQL 14.x or newer.
+If you are running an older version, you must upgrade to PostgreSQL 14 or later.
+Attempting a schema upgrade with `install -dis` will result in an error.
+If upgrading PostgreSQL to at least version 14 isn’t possible and you’re completely blocked, the -Q flag lets you skip the version check.
+Use this only as a last resort, since it may affect compatibility.
+Be aware that doing so takes you beyond supported configurations — here be dragons.
 
 === Ticketing plugin is now automatic
 
@@ -65,10 +22,3 @@ The `NullTicketerPlugin` and the `opennms.ticketer.plugin` property have been re
 If you have `opennms.ticketer.plugin=org.opennms.netmgt.ticketd.NullTicketerPlugin` in a custom properties file under `etc/opennms.properties.d/`, remove that entry before upgrading.
 If you previously set `opennms.ticketer.plugin=org.opennms.netmgt.ticketd.OSGiBasedTicketerPlugin`, that entry is now redundant and can be removed.
 The `opennms.alarmTroubleTicketEnabled` property is no longer required but can still be used to explicitly enable or disable ticketing.
-
-=== Removed JRobin implementation
-
-JRobin, the pure-Java RRD implementation has been removed.
-The class `org.opennms.netmgt.rrd.jrobin.JRobinRrdStrategy` is no longer available.
-The Utilities to convert and analyze JRobin files (`.jrb`) are still available and usable.
-

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/PostgreSQLContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/PostgreSQLContainer.java
@@ -59,7 +59,7 @@ public class PostgreSQLContainer extends org.testcontainers.containers.PostgreSQ
     private HibernateDaoFactory daoFactory;
 
     public PostgreSQLContainer() {
-        super("postgres:10.7-alpine");
+        super("postgres:14.22-alpine");
         withNetwork(Network.SHARED)
                 .withNetworkAliases(OpenNMSContainer.DB_ALIAS)
                 .withCreateContainerCmdModifier(TestContainerUtils::setGlobalMemAndCpuLimits);


### PR DESCRIPTION
Bumps the minimum supported PostgreSQL version from 10/13 to 14.x:
- CI integration test image: postgres:13-alpine → postgres:14.22-alpine
- Smoke test container: postgres:10.7-alpine → postgres:14.22-alpine
- Migrator minimum version check: 10.0 → 14.0
- Release notes updated to document the breaking PostgreSQL 14+ requirement

BREAKING CHANGE: OpenNMS Horizon 36 requires PostgreSQL 14 or newer. Running `install -dis` on an older version will fail unless the -Q flag is used.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19682

