### PR TITLE
NMS-16566: Update nodeLostService event to track failure reason in alarms

### DIFF
--- a/core/schema/src/main/liquibase/36.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/36.0.0/changelog.xml
@@ -19,4 +19,49 @@
         </createTable>
     </changeSet>
 
+    <!-- Update nodeLostService event to include failure reason in logmsg
+         and enable description update-on-reduction so alarm reflects
+         the current poll failure reason -->
+    <changeSet author="mmassengill" id="36.0.0-update-nodeLostService-reason-tracking">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="eventconf_events"/>
+                <sqlCheck expectedResult="1">
+                    SELECT COUNT(*) FROM eventconf_events
+                    WHERE uei = 'uei.opennms.org/nodes/nodeLostService'
+                    AND xml_content NOT LIKE '%parm[eventReason]%'
+                </sqlCheck>
+            </and>
+        </preConditions>
+
+        <comment>Add failure reason to nodeLostService logmsg and enable alarm description update on reduction</comment>
+
+        <!-- Update logmsg to include the reason parameter -->
+        <sql>
+            UPDATE eventconf_events
+            SET xml_content = REPLACE(
+                xml_content,
+                '%service% outage identified on interface %interface%.',
+                '%service% outage identified on interface %interface%. Reason: %parm[eventReason]%'
+            ),
+            last_modified = NOW()
+            WHERE uei = 'uei.opennms.org/nodes/nodeLostService'
+            AND xml_content NOT LIKE '%parm[eventReason]%';
+        </sql>
+
+        <!-- Add update-field for description on reduction -->
+        <sql>
+            UPDATE eventconf_events
+            SET xml_content = REPLACE(
+                xml_content,
+                'auto-clean="false"/>',
+                'auto-clean="false">&lt;update-field field-name="descr" update-on-reduction="true"/>&lt;/alarm-data>'
+            ),
+            last_modified = NOW()
+            WHERE uei = 'uei.opennms.org/nodes/nodeLostService'
+            AND xml_content LIKE '%auto-clean="false"/>%'
+            AND xml_content NOT LIKE '%update-on-reduction%';
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/core/schema/src/main/liquibase/36.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/36.0.0/changelog.xml
@@ -29,7 +29,7 @@
                 <sqlCheck expectedResult="1">
                     SELECT COUNT(*) FROM eventconf_events
                     WHERE uei = 'uei.opennms.org/nodes/nodeLostService'
-                    AND xml_content NOT LIKE '%parm[eventReason]%'
+                    AND xml_content NOT LIKE '%update-on-reduction%'
                 </sqlCheck>
             </and>
         </preConditions>
@@ -46,7 +46,7 @@
             ),
             last_modified = NOW()
             WHERE uei = 'uei.opennms.org/nodes/nodeLostService'
-            AND xml_content NOT LIKE '%parm[eventReason]%';
+            AND xml_content NOT LIKE '%update-on-reduction%';
         </sql>
 
         <!-- Add update-field for description on reduction -->

--- a/opennms-config/src/test/resources/etc/events/opennms.pollerd.events.xml
+++ b/opennms-config/src/test/resources/etc/events/opennms.pollerd.events.xml
@@ -442,9 +442,12 @@
             resolved.&lt;/p></descr>
       <logmsg dest="logndisplay">
             %service% outage identified on interface %interface%.
+            Reason: %parm[eventReason]%
         </logmsg>
       <severity>Minor</severity>
-      <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%service%" alarm-type="1" auto-clean="false"/>
+      <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%service%" alarm-type="1" auto-clean="false">
+        <update-field field-name="descr" update-on-reduction="true"/>
+      </alarm-data>
    </event>
    <event>
       <uei>uei.opennms.org/nodes/nodeRegainedService</uei>


### PR DESCRIPTION
I believe this will partially address: NMS-16566 (there is a lot more in that epic that I'm working on but this will partially address the concern raised) and I think it's a good quality of life improvement that's shockingly minimal.

I am adding this in develop as changing an alarm like this may have consequences I'm not thinking about.  Let me know if you come up with any.  I'm also unclear on the liquibase changes so those need to be reviewed here.

This adds %parm[eventReason]% to the nodeLostService logmsg template and enables description update-on-reduction in the alarm-data. This ensures the alarm's log message and description always reflect the current poll failure reason when a service stays down but the error changes (e.g., 404 to 500). Prior reasons should be preserved in the individual event history.