### PR TITLE
NMS-19685: DnsMonitor ignores retries on most failures

### DIFF
--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/DnsMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/DnsMonitor.java
@@ -217,6 +217,7 @@ final public class DnsMonitor extends AbstractServiceMonitor {
                 LOG.debug(reason1, e);
                 return PollStatus.unavailable(reason1);
             } catch (final IOException e) {
+                LOG.debug("IOException for address '{}', will retry if possible", addr);
                 // do nothing, retry if possible
             }
         }

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/DnsMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/DnsMonitor.java
@@ -217,11 +217,7 @@ final public class DnsMonitor extends AbstractServiceMonitor {
                 LOG.debug(reason1, e);
                 return PollStatus.unavailable(reason1);
             } catch (final IOException e) {
-                if (! timeoutTracker.shouldRetry()) {
-                    String reason1 = "IOException while polling address: " + addr + " " + e.getMessage();
-                    LOG.debug(reason1, e);
-                    return PollStatus.unavailable(reason1);
-                }
+                // do nothing, retry if possible
             }
         }
         String reason = "Never received valid DNS response for address: " + addr;

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/DnsMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/DnsMonitor.java
@@ -217,9 +217,11 @@ final public class DnsMonitor extends AbstractServiceMonitor {
                 LOG.debug(reason1, e);
                 return PollStatus.unavailable(reason1);
             } catch (final IOException e) {
-                String reason1 = "IOException while polling address: " + addr + " " + e.getMessage();
-                LOG.debug(reason1, e);
-                return PollStatus.unavailable(reason1);
+                if (! timeoutTracker.shouldRetry()) {
+                    String reason1 = "IOException while polling address: " + addr + " " + e.getMessage();
+                    LOG.debug(reason1, e);
+                    return PollStatus.unavailable(reason1);
+                }
             }
         }
         String reason = "Never received valid DNS response for address: " + addr;


### PR DESCRIPTION
Currently, DnsMonitor only retries on `InterruptedIOException`, but should retry on any `IOException` if retries are possible.

Reported by Jesús Palacio over on the public Discourse.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19685
* https://opennms.discourse.group/t/dnsmonitor-retry-parameter-not-working-for-timeout-failures-horizon-35-0-4/4759

