### PR TITLE
NMS-19708: Do not display errors when SNMP config IPs are blank

### DIFF
--- a/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionBasicInformation.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionBasicInformation.vue
@@ -76,6 +76,7 @@ import { convertSnmpVersionToString } from '@/services/snmpConfigService'
 import { getDefaultSnmpDefinition } from '@/stores/snmpConfigStore'
 import { SnmpAgentConfig, SnmpDefinition, SnmpConfigFormErrors, IpAddressRange } from '@/types/snmpConfig'
 import SnmpConfigDetailsPanel from './SnmpConfigDetailsPanel.vue'
+import { checkForDuplicateDefinitionItems } from '@/lib/snmpValidator'
 
 const props = defineProps<{
   isCreate: boolean,
@@ -197,12 +198,28 @@ const removeChip = (item: DefinitionBadgeItem) => {
 }
 
 const onAddRange = (firstIp: string, lastIp: string, ipMatch: string) => {
-  if ((!firstIp && !lastIp && !ipMatch) || (ipMatch && (firstIp || lastIp))) {
+  // should not occur since the add range button in SnmpConfigDetailsPanel is disabled unless at least one of these fields has a value, but guard against it just in case
+  if (!firstIp && !lastIp && !ipMatch) {
+    errors.value = {
+      invalidRangeConfig: 'Cannot add an empty range.'
+    }
+
+    emit('validation-error', errors.value)
     return
   }
 
-  // SnmpConfigDetailsPanel already handles trying to add a range/specific if the definition already has an ipMatch.
-  // Here we handle trying to add an ipMatch when the definition already has ranges/specifics (or vice versa), which is also not allowed.
+  // should not occur since SnmpConfigDetailsPanel does not allow entering an ipMatch if there are already range/specific values (or vice versa), but guard against it just in case
+  if (ipMatch && (firstIp || lastIp)) {
+    errors.value = {
+      mixingRangeWithIpMatch: 'You cannot mix range/specific with IP Match expressions in the same definition.'
+    }
+
+    emit('validation-error', errors.value)
+    return
+  }
+
+  // SnmpConfigDetailsPanel already handles trying to add a range/specific if the definition input fields already have an ipMatch (or vice-versa).
+  // Here we handle trying to add an ipMatch when the existing definition already has ranges/specifics (or vice versa), which is also not allowed.
   const currentHasRangesOrSpecifics = Boolean(currentDefinition.value?.range?.length || currentDefinition.value?.specific?.length)
   const currentHasIpMatch = Boolean(currentDefinition.value?.ipMatch?.length)
   const isAddingIpMatch = Boolean(ipMatch)
@@ -210,7 +227,6 @@ const onAddRange = (firstIp: string, lastIp: string, ipMatch: string) => {
 
   if ((isAddingIpMatch && currentHasRangesOrSpecifics) || (isAddingRangeOrSpecific && currentHasIpMatch)) {
     errors.value = {
-      ...errors.value,
       mixingRangeWithIpMatch: 'You cannot mix range/specific with IP Match expressions in the same definition.'
     }
 
@@ -220,6 +236,17 @@ const onAddRange = (firstIp: string, lastIp: string, ipMatch: string) => {
 
   if (firstIp && lastIp) {
     const newRange = { begin: firstIp, end: lastIp } as IpAddressRange
+
+    const duplicateError = checkForDuplicateDefinitionItems(currentDefinition.value, newRange, undefined, undefined)
+
+    if (duplicateError) {
+      errors.value = {
+        duplicateRangeItem: duplicateError
+      }
+
+      emit('validation-error', errors.value)
+      return
+    }
 
     if (currentDefinition.value.range) {
       currentDefinition.value.range = [
@@ -232,6 +259,17 @@ const onAddRange = (firstIp: string, lastIp: string, ipMatch: string) => {
   }
 
   if (firstIp && !lastIp) {
+    const duplicateError = checkForDuplicateDefinitionItems(currentDefinition.value, undefined, firstIp, undefined)
+    
+    if (duplicateError) {
+      errors.value = {
+        duplicateRangeItem: duplicateError
+      }
+
+      emit('validation-error', errors.value)
+      return
+    }
+
     if (currentDefinition.value.specific) {
       currentDefinition.value.specific = [
         ...currentDefinition.value.specific,
@@ -243,6 +281,17 @@ const onAddRange = (firstIp: string, lastIp: string, ipMatch: string) => {
   }
 
   if (ipMatch) {
+    const duplicateError = checkForDuplicateDefinitionItems(currentDefinition.value, undefined, undefined, ipMatch)
+
+    if (duplicateError) {
+      errors.value = {
+        duplicateRangeItem: duplicateError
+      }
+
+      emit('validation-error', errors.value)
+      return
+    }
+
     if (currentDefinition.value.ipMatch) {
       currentDefinition.value.ipMatch = [
         ...currentDefinition.value.ipMatch,

--- a/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionsTab.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionsTab.vue
@@ -70,9 +70,11 @@ const handleBackButtonClick = () => {
 }
 
 const onValidationError = (errors: SnmpConfigFormErrors) => {
-  if (errors.mixingRangeWithIpMatch) {
+  const invalidRange = errors.invalidRangeConfig || errors.mixingRangeWithIpMatch || errors.duplicateRangeItem
+
+  if (invalidRange) {
     snackbar.showSnackBar({
-      msg: 'You cannot mix range/specific with IP Match expressions in the same definition.',
+      msg: 'Cannot add range. ' + invalidRange,
       error: true
     })
 

--- a/ui/src/components/SnmpConfiguration/SnmpConfigDetailsPanel.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigDetailsPanel.vue
@@ -23,7 +23,7 @@
               <FeatherInput
                 label=""
                 data-test="snmp-definition-first-ip-address"
-                :error="errors.firstIpAddress ?? errors.invalidRangeConfig"
+                :error="errors.firstIpAddress"
                 v-model.trim="firstIpAddress"
                 hint="First IP Address in range or specific IP"
               >
@@ -33,7 +33,7 @@
               <FeatherInput
                 label=""
                 data-test="snmp-definition-last-ip-address"
-                :error="errors.lastIpAddress ?? errors.invalidRangeConfig"
+                :error="errors.lastIpAddress"
                 v-model.trim="lastIpAddress"
                 hint="Last IP Address in range (leave blank if not a range)"
               >
@@ -47,7 +47,7 @@
               <FeatherInput
                 label=""
                 data-test="snmp-definition-ipmatch-expression"
-                :error="errors.ipMatch ?? errors.invalidRangeConfig"
+                :error="errors.ipMatch"
                 v-model.trim="ipMatchValue"
                 hint="IPLIKE Expression (cannot be used with First/Last IP)"
               >
@@ -64,6 +64,11 @@
               </FeatherButton>
             </div>
           </div>
+        </div>
+      </div>
+      <div class="feather-row" v-if="errors.invalidRangeConfig">
+        <div class="feather-col-12">
+          <span class="label text-danger">{{ errors.invalidRangeConfig }}</span>
         </div>
       </div>
     </FeatherCard>
@@ -429,12 +434,12 @@ const onFieldUpdate = (updatedConfig: SnmpBaseConfiguration) => {
   Object.assign(formConfig, updatedConfig)
 
   if (!isLoading.value) {
-    handleValidate()
+    handleValidate(false)
   }
 }
 
 const onAddRange = () => {
-  handleValidate()
+  handleValidate(false)
 
   if (!isValid.value) {
     emit('validation-error', errors.value)
@@ -508,17 +513,16 @@ const handleCancel = () => {
   emit('cancel')
 }
 
-const handleValidate = (isSaving?: boolean) => {
+const handleValidate = (isSaving: boolean) => {
   const version = String(snmpVersion.value?._value || '')
-  // if we are not displaying IPs, or if we are saving, pass a fake valid IP to avoid validation errors
-  const fakeValidIp = '10.0.0.0'
 
   const currentErrors = validateDefinition(
     formConfig,
     version,
-    props.displayIps && !isSaving ? firstIpAddress.value : fakeValidIp,
+    firstIpAddress.value,
     lastIpAddress.value,
     ipMatchValue.value,
+    isSaving,
     scvEnabledKeys.value
   )
 
@@ -571,6 +575,10 @@ onMounted(() => {
 .snmp-config-definition-details {
   .label {
     font-weight: 600;
+  }
+
+  .text-danger {
+    color: var(variables.$error);
   }
 
   .show-context-fields-label {

--- a/ui/src/components/SnmpConfiguration/SnmpConfigLookupTab.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigLookupTab.vue
@@ -28,7 +28,7 @@
 import { useRoute, useRouter } from 'vue-router'
 import useSnackbar from '@/composables/useSnackbar'
 import { ActiveTabs, getDefaultSnmpDefinition, SnmpLookupEditMode, useSnmpConfigStore } from '@/stores/snmpConfigStore'
-import { SnmpAgentConfig, SnmpDefinition } from '@/types/snmpConfig'
+import { SnmpAgentConfig, SnmpConfigFormErrors, SnmpDefinition } from '@/types/snmpConfig'
 import SnmpConfigLookupPanel from './SnmpConfigLookupPanel.vue'
 import SnmpConfigDefinitionBasicInformation from './SnmpConfigDefinitionBasicInformation.vue'
 
@@ -104,7 +104,18 @@ const onLookupComplete = (config: SnmpAgentConfig, ip: string) => {
   } as SnmpDefinition
 }
 
-const onDetailsValidationError = () => {
+const onDetailsValidationError = (errors: SnmpConfigFormErrors) => {
+  const invalidRange = errors.invalidRangeConfig || errors.mixingRangeWithIpMatch || errors.duplicateRangeItem
+
+  if (invalidRange) {
+    snackbar.showSnackBar({
+      msg: 'Cannot add range. ' + invalidRange,
+      error: true
+    })
+
+    return
+  }
+
   snackbar.showSnackBar({ msg: 'Save failed. Please fix invalid values.', error: true })
 }
 

--- a/ui/src/lib/snmpValidator.ts
+++ b/ui/src/lib/snmpValidator.ts
@@ -21,7 +21,7 @@
 ///
 
 import { isIP } from 'is-ip'
-import { SnmpBaseConfiguration, SnmpConfigFormErrors, SnmpProfileFormErrors, SnmpSecurityLevel } from '@/types/snmpConfig'
+import { IpAddressRange, SnmpBaseConfiguration, SnmpConfigFormErrors, SnmpDefinition, SnmpProfileFormErrors, SnmpSecurityLevel } from '@/types/snmpConfig'
 import { DEFAULT_SNMP_V3_SECURITY_LEVEL } from './constants'
 import { SCV_PREFIX_REGEX, validateScvPattern } from './scvValidator'
 
@@ -130,6 +130,7 @@ export const validateDefinition = (
   firstIpAddress: string,
   lastIpAddress: string,
   ipMatch: string,
+  isSaving: boolean,
   scvEnabledKeys: Set<string> = new Set()
 ): SnmpConfigFormErrors => {
   const errors: SnmpConfigFormErrors = {}
@@ -142,37 +143,72 @@ export const validateDefinition = (
     errors.snmpVersion = 'SNMP Version must be one of: ' + SNMP_VERSIONS.join(', ')
   }
 
-  const isRange = firstIpAddress && lastIpAddress
-  const isSpecific = firstIpAddress && !lastIpAddress
-  const isIpMatch = !firstIpAddress && !lastIpAddress && ipMatch
-  const isRangeOrSpecific = isRange || isSpecific
+  // If we are saving, we do not want to validate the IP address form fields, since in that case they are being ignored 
+  // and the actual definition ranges are already in the badges
+  if (!isSaving) {
+    const isEmptyIps = !firstIpAddress && !lastIpAddress && !ipMatch
+    const isRange = firstIpAddress && lastIpAddress
+    const isSpecific = firstIpAddress && !lastIpAddress
+    const isLastIpRangeOnly = !firstIpAddress && lastIpAddress
+    const isIpMatch = ipMatch.length > 0
+    const isRangeOrSpecific = isRange || isSpecific
 
-  // error if neither range, specific or ipMatch is provided, or if ipMatch is provided along with range or specific
-  if ((!isRange && !isSpecific && !isIpMatch) || (isRangeOrSpecific && isIpMatch)) {
-    errors.invalidRangeConfig = 'You must specify either a range, specific or IP Match expression'
-  }
-
-  if (isRange || isSpecific) {
-    if (!isIP(firstIpAddress)) {
-      errors.firstIpAddress = 'First IP Address must be a valid IP address'
+    if ((isRangeOrSpecific || isLastIpRangeOnly) && isIpMatch) {
+      errors.invalidRangeConfig = 'You cannot specify an IP Match expression along with a range or specific IP address'
     }
-  }
 
-  if (isRange) {
-    if (!isIP(lastIpAddress)) {
-      errors.lastIpAddress = 'If provided, last IP Address must be a valid IP address'
-    }
-  }
+    if (!isEmptyIps) {
+      if (isRange || isSpecific) {
+        if (!isIP(firstIpAddress)) {
+          errors.firstIpAddress = 'First IP Address must be a valid IP address'
+        }
+      }
 
-  if (isIpMatch) {
-    if (!IPLIKE_REGEX.test(ipMatch)) {
-      errors.ipMatch = IP_MATCH_ERROR
+      if (isRange) {
+        if (!isIP(lastIpAddress)) {
+          errors.lastIpAddress = 'If provided, last IP Address must be a valid IP address'
+        }
+      }
+
+      if (isLastIpRangeOnly) {
+        errors.lastIpAddress = 'Last IP Address cannot be provided without a first IP address'
+      }
+
+      if (isIpMatch) {
+        if (!IPLIKE_REGEX.test(ipMatch)) {
+          errors.ipMatch = IP_MATCH_ERROR
+        }
+      }
     }
   }
 
   const snmpConfigErrors = validateSnmpConfiguration(config, snmpVersion, scvEnabledKeys)
 
   return { ...errors, ...snmpConfigErrors }
+}
+
+export const checkForDuplicateDefinitionItems = (existingDefinition: SnmpDefinition, newRange?: IpAddressRange, newSpecific?: string, newIpMatch?: string): string | null => {
+  if (newRange) {
+    for (const range of existingDefinition.range) {
+      if (range.begin === newRange.begin && range.end === newRange.end) {
+        return `Duplicate range: ${newRange.begin} - ${newRange.end}`
+      }
+    }
+  }
+
+  if (newSpecific) {
+    if (existingDefinition.specific.includes(newSpecific)) {
+      return `Duplicate specific IP address: ${newSpecific}`
+    }
+  }
+
+  if (newIpMatch) {
+    if (existingDefinition.ipMatch.includes(newIpMatch)) {
+      return `Duplicate IP Match expression: ${newIpMatch}`
+    }
+  }
+
+  return null
 }
 
 export const validateProfile = (

--- a/ui/src/types/snmpConfig.ts
+++ b/ui/src/types/snmpConfig.ts
@@ -140,6 +140,7 @@ export interface SnmpConfigFormErrors {
   snmpVersion?: string
   invalidRangeConfig?: string
   mixingRangeWithIpMatch?: string
+  duplicateRangeItem?: string
   firstIpAddress?: string
   lastIpAddress?: string
   ipMatch?: string

--- a/ui/tests/lib/snmpValidator.test.ts
+++ b/ui/tests/lib/snmpValidator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { IP_MATCH_ERROR, validateDefinition, validateProfile, validateSnmpConfiguration } from '@/lib/snmpValidator'
-import { SnmpBaseConfiguration } from '@/types/snmpConfig'
+import { IP_MATCH_ERROR, checkForDuplicateDefinitionItems, validateDefinition, validateProfile, validateSnmpConfiguration } from '@/lib/snmpValidator'
+import { IpAddressRange, SnmpBaseConfiguration, SnmpDefinition } from '@/types/snmpConfig'
 
 describe('snmpValidator', () => {
   describe('validateDefinition', () => {
@@ -14,159 +14,238 @@ describe('snmpValidator', () => {
 
     describe('SNMP Version validation', () => {
       it('should return error when SNMP version is missing', () => {
-        const errors = validateDefinition(validConfig, '', '192.168.1.1', '', '')
+        const errors = validateDefinition(validConfig, '', '192.168.1.1', '', '', false)
         expect(errors.snmpVersion).toBe('SNMP Version is required')
       })
 
       it('should return error when SNMP version is invalid', () => {
-        const errors = validateDefinition(validConfig, 'v4', '192.168.1.1', '', '')
+        const errors = validateDefinition(validConfig, 'v4', '192.168.1.1', '', '', false)
         expect(errors.snmpVersion).toBe('SNMP Version must be one of: v1, v2c, v3')
       })
 
       it('should pass validation with valid SNMP versions', () => {
         const versions = ['v1', 'v2c', 'v3']
         versions.forEach(version => {
-          const errors = validateDefinition(validConfig, version, '192.168.1.1', '', '')
+          const errors = validateDefinition(validConfig, version, '192.168.1.1', '', '', false)
           expect(errors.snmpVersion).toBeUndefined()
         })
       })
     })
 
     describe('IP Address validation', () => {
-      it('should return invalidRangeConfig error when no range, specific, or ipMatch is provided', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '', '', '')
-        expect(errors.invalidRangeConfig).toBe('You must specify either a range, specific or IP Match expression')
+      it('should not return invalidRangeConfig error when no range, specific, or ipMatch is provided', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '', '', false)
+        expect(errors.invalidRangeConfig).toBeUndefined()
       })
 
       it('should not return invalidRangeConfig when a specific IP is provided', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '', '', false)
         expect(errors.invalidRangeConfig).toBeUndefined()
       })
 
       it('should not return invalidRangeConfig when a range is provided', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '192.168.1.255', '')
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '192.168.1.255', '', false)
         expect(errors.invalidRangeConfig).toBeUndefined()
       })
 
       it('should not return invalidRangeConfig when an ipMatch is provided', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '', '', '192.168.1.*')
+        const errors = validateDefinition(validConfig, 'v2c', '', '', '192.168.1.*', false)
         expect(errors.invalidRangeConfig).toBeUndefined()
       })
 
       it('should return error when first IP address is invalid (specific)', () => {
-        const errors = validateDefinition(validConfig, 'v2c', 'invalid-ip', '', '')
+        const errors = validateDefinition(validConfig, 'v2c', 'invalid-ip', '', '', false)
         expect(errors.firstIpAddress).toBe('First IP Address must be a valid IP address')
       })
 
       it('should return error when first IP address is invalid (range)', () => {
-        const errors = validateDefinition(validConfig, 'v2c', 'invalid-ip', '192.168.1.255', '')
+        const errors = validateDefinition(validConfig, 'v2c', 'invalid-ip', '192.168.1.255', '', false)
         expect(errors.firstIpAddress).toBe('First IP Address must be a valid IP address')
       })
 
       it('should pass validation with valid IPv4 specific address', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '', '', false)
         expect(errors.firstIpAddress).toBeUndefined()
       })
 
       it('should pass validation with valid IPv6 specific address', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '2001:0db8:85a3:0000:0000:8a2e:0370:7334', '', '')
+        const errors = validateDefinition(validConfig, 'v2c', '2001:0db8:85a3:0000:0000:8a2e:0370:7334', '', '', false)
         expect(errors.firstIpAddress).toBeUndefined()
       })
 
       it('should return error when last IP address is invalid in a range', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', 'invalid-ip', '')
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', 'invalid-ip', '', false)
         expect(errors.lastIpAddress).toBe('If provided, last IP Address must be a valid IP address')
       })
 
       it('should not validate last IP address when it is empty (specific mode)', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '', '', false)
         expect(errors.lastIpAddress).toBeUndefined()
       })
 
+      it('should return error when last IP address is provided but first IP address is empty', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '192.168.1.255', '', false)
+        expect(errors.firstIpAddress).toBeUndefined()
+        expect(errors.lastIpAddress).toBe('Last IP Address cannot be provided without a first IP address')
+      })
+
       it('should pass validation with valid range', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '192.168.1.255', '')
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '192.168.1.255', '', false)
         expect(errors.firstIpAddress).toBeUndefined()
         expect(errors.lastIpAddress).toBeUndefined()
       })
 
       it('should not validate IP addresses when only ipMatch is provided', () => {
-        const errors = validateDefinition(validConfig, 'v2c', '', '', '192.168.1.*')
+        const errors = validateDefinition(validConfig, 'v2c', '', '', '192.168.1.*', false)
         expect(errors.firstIpAddress).toBeUndefined()
         expect(errors.lastIpAddress).toBeUndefined()
+      })
+
+      it('should return error when IP Match is provided but first and last IP addresses are not empty', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.254', '192.168.1.255', '192.168.1.*', false)
+        expect(errors.firstIpAddress).toBeUndefined()
+        expect(errors.lastIpAddress).toBeUndefined()
+        expect(errors.ipMatch).toBeUndefined()
+        expect(errors.invalidRangeConfig).toBe('You cannot specify an IP Match expression along with a range or specific IP address')
+      })
+
+      it('should return error when IP Match is provided but first IP address is not empty', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.254', '', '192.168.1.*', false)
+        expect(errors.firstIpAddress).toBeUndefined()
+        expect(errors.lastIpAddress).toBeUndefined()
+        expect(errors.ipMatch).toBeUndefined()
+        expect(errors.invalidRangeConfig).toBe('You cannot specify an IP Match expression along with a range or specific IP address')
+      })
+
+      it('should return error when IP Match is provided but first IP address is empty but last IP address is provided', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '192.168.1.255', '192.168.1.*', false)
+        expect(errors.firstIpAddress).toBeUndefined()
+        expect(errors.lastIpAddress).toBe('Last IP Address cannot be provided without a first IP address')
+        expect(errors.ipMatch).toBeUndefined()
+        expect(errors.invalidRangeConfig).toBe('You cannot specify an IP Match expression along with a range or specific IP address')
       })
 
       it('should return error for invalid IP match expressions', () => {
         const invalidIplikeExpressions = ['invalid-ip', 'iplike 192.168.*.*', '192.168.*']
 
         invalidIplikeExpressions.forEach(expr => {
-          const errors = validateDefinition(validConfig, 'v2c', '', '', expr)
+          const errors = validateDefinition(validConfig, 'v2c', '', '', expr, false)
           expect(errors.ipMatch).toBe(IP_MATCH_ERROR)
         })
       })
     })
 
-    describe('Port validation', () => {
+    describe('all IPs are empty', () => {
+      it('should not set invalidRangeConfig when all IPs are empty', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '', '', false)
+        expect(errors.invalidRangeConfig).toBeUndefined()
+      })
+
+      it('should not set firstIpAddress when all IPs are empty', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '', '', false)
+        expect(errors.firstIpAddress).toBeUndefined()
+      })
+
+      it('should not set lastIpAddress when all IPs are empty', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '', '', false)
+        expect(errors.lastIpAddress).toBeUndefined()
+      })
+
+      it('should not set ipMatch when all IPs are empty', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '', '', false)
+        expect(errors.ipMatch).toBeUndefined()
+      })
+    })
+
+    describe('isSaving: true', () => {
+      it('should not set firstIpAddress when first IP is invalid when isSaving mode is true', () => {
+        const errors = validateDefinition(validConfig, 'v2c', 'invalid-ip', '', '', true)
+        expect(errors.firstIpAddress).toBeUndefined()
+      })
+
+      it('should not set lastIpAddress when last IP is invalid when isSaving mode is true', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', 'invalid-ip', '', true)
+        expect(errors.lastIpAddress).toBeUndefined()
+      })
+
+      it('should not set lastIpAddress when last IP is provided without a first IP when isSaving mode is true', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '192.168.1.255', '', true)
+        expect(errors.lastIpAddress).toBeUndefined()
+      })
+
+      it('should not set ipMatch when IP match expression is invalid when isSaving mode is true', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '', '', 'invalid-ip', true)
+        expect(errors.ipMatch).toBeUndefined()
+      })
+
+      it('should not set invalidRangeConfig when both IPs and ipMatch are provided when isSaving mode is true', () => {
+        const errors = validateDefinition(validConfig, 'v2c', '192.168.1.1', '192.168.1.255', '192.168.1.*', true)
+        expect(errors.invalidRangeConfig).toBeUndefined()
+      })
+    })
+
+    describe.each([false, true])('Port validation (isSaving: %s)', (isSaving) => {
       it('should return error when port is less than 1', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, port: 0 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.port).toBe('Port must be a number between 1 and 65535')
       })
 
       it('should return error when port is a negative number', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, port: -1 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.port).toBe('Port must be a number between 1 and 65535')
       })
 
       it('should return error when port is greater than 65535', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, port: 65536 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.port).toBe('Port must be a number between 1 and 65535')
       })
 
       it('should return error when port is not a number', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, port: NaN }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.port).toBe('Port must be a number between 1 and 65535')
       })
 
       it('should pass validation with valid port', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, port: 161 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.port).toBeUndefined()
       })
     })
 
-    describe('Max Request Size validation', () => {
+    describe.each([false, true])('Max Request Size validation (isSaving: %s)', (isSaving) => {
       it('should return error when maxRequestSize is less than 484', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, maxRequestSize: 483 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.maxRequestSize).toBe('If provided, Max Request Size must be a number greater than or equal to 484')
       })
 
       it('should pass validation when maxRequestSize is 484', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, maxRequestSize: 484 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.maxRequestSize).toBeUndefined()
       })
 
       it('should pass validation with valid maxRequestSize', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, maxRequestSize: 65535 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.maxRequestSize).toBeUndefined()
       })
     })
 
-    describe('Security Level validation', () => {
+    describe.each([false, true])('Security Level validation (isSaving: %s)', (isSaving) => {
       it('should ignore security level when SNMP version is not v3', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, securityLevel: 5 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.securityLevel).toBeUndefined()
       })
 
       it('should return error when security level is invalid', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, securityLevel: 5 }
-        const errors = validateDefinition(config, 'v3', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v3', '192.168.1.1', '', '', isSaving)
         expect(errors.securityLevel).toBe('Security Level must be one of: 1 (NoAuthNoPriv), 2 (AuthNoPriv), 3 (AuthPriv)')
       })
 
@@ -174,16 +253,16 @@ describe('snmpValidator', () => {
         const validLevels = [1, 2, 3]
         validLevels.forEach(level => {
           const config: SnmpBaseConfiguration = { ...validConfig, securityLevel: level }
-          const errors = validateDefinition(config, 'v3', '192.168.1.1', '', '')
+          const errors = validateDefinition(config, 'v3', '192.168.1.1', '', '', isSaving)
           expect(errors.securityLevel).toBeUndefined()
         })
       })
     })
 
-    describe('Auth Protocol validation', () => {
+    describe.each([false, true])('Auth Protocol validation (isSaving: %s)', (isSaving) => {
       it('should return error when auth protocol is invalid', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, authProtocol: 'INVALID' }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.authProtocol).toBe('Auth Protocol must be one of: MD5, SHA, SHA-224, SHA-256, SHA-512')
       })
 
@@ -191,22 +270,22 @@ describe('snmpValidator', () => {
         const validProtocols = ['MD5', 'SHA', 'SHA-224', 'SHA-256', 'SHA-512']
         validProtocols.forEach(protocol => {
           const config: SnmpBaseConfiguration = { ...validConfig, authProtocol: protocol }
-          const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+          const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
           expect(errors.authProtocol).toBeUndefined()
         })
       })
 
       it('should pass validation when auth protocol is empty string', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, authProtocol: '' }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.authProtocol).toBeUndefined()
       })
     })
 
-    describe('Privacy Protocol validation', () => {
+    describe.each([false, true])('Privacy Protocol validation (isSaving: %s)', (isSaving) => {
       it('should return error when privacy protocol is invalid', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, privacyProtocol: 'INVALID' }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.privacyProtocol).toBe('Privacy Protocol must be one of: DES, AES, AES192, AES256')
       })
 
@@ -214,40 +293,40 @@ describe('snmpValidator', () => {
         const validProtocols = ['DES', 'AES', 'AES192', 'AES256']
         validProtocols.forEach(protocol => {
           const config: SnmpBaseConfiguration = { ...validConfig, privacyProtocol: protocol }
-          const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+          const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
           expect(errors.privacyProtocol).toBeUndefined()
         })
       })
 
       it('should pass validation when privacy protocol is empty string', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, privacyProtocol: '' }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.privacyProtocol).toBeUndefined()
       })
     })
 
-    describe('Numeric fields validation', () => {
+    describe.each([false, true])('Numeric fields validation (isSaving: %s)', (isSaving) => {
       it('should return error when timeout is not an integer', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, timeout: 3.5 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.timeout).toBe('Timeout must be an integer greater than or equal to 0')
       })
 
       it('should return error when retry is not an integer', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, retry: 2.7 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.retry).toBe('Retries must be an integer greater than or equal to 0')
       })
 
       it('should return error when maxVarsPerPdu is not an integer', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, maxVarsPerPdu: 10.5 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.maxVarsPerPdu).toBe('Max Vars Per PDU must be an integer greater than or equal to 0')
       })
 
       it('should return error when maxRepetitions is not an integer', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, maxRepetitions: 5.3 }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.maxRepetitions).toBe('Max Repetitions must be an integer greater than or equal to 0')
       })
 
@@ -259,7 +338,7 @@ describe('snmpValidator', () => {
           maxVarsPerPdu: 10,
           maxRepetitions: 2
         }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '', '', isSaving)
         expect(errors.timeout).toBeUndefined()
         expect(errors.retry).toBeUndefined()
         expect(errors.maxVarsPerPdu).toBeUndefined()
@@ -270,90 +349,90 @@ describe('snmpValidator', () => {
     describe('Empty validation', () => {
       it('should return an error for an empty configuration', () => {
         const config: SnmpBaseConfiguration = {}
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '192.168.1.255', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '192.168.1.255', '', false)
         expect(Object.keys(errors)).toHaveLength(0)
       })
     })
 
-    describe('SCV expression validation', () => {
+    describe.each([false, true])('SCV expression validation (isSaving: %s)', (isSaving) => {
       const scvEnabledKeys = new Set(['readCommunity'])
       const ip = '192.168.1.1'
 
       it('should pass when readCommunity is a valid SCV expression', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:my-key}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should pass when readCommunity is a valid two-subkey SCV expression', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:alias:key}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should return error when readCommunity starts with ${ but is not a valid SCV expression', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:key-}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBe('Invalid SCV expression')
       })
 
       it('should return error when readCommunity is a malformed SCV prefix with no key', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBe('Invalid SCV expression')
       })
 
       it('should pass when readCommunity is a valid SCV expression with underscores', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:_alias_:my_key}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should pass when readCommunity is a valid SCV expression with dots', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:group.name:item.key}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should not validate readCommunity as SCV when it does not start with ${', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: 'public' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should not validate readCommunity as SCV when scvEnabledKeys is empty', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:key-}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '')
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, new Set())
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should pass when readCommunity is a valid SCV expression with a default value', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:my-key|my-default}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should pass when readCommunity is a valid two-subkey SCV expression with a default value', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:alias:key|my-default}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should pass when readCommunity SCV default value contains special characters', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:key|p@$$w0rd!}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBeUndefined()
       })
 
       it('should return error when readCommunity SCV has a pipe but empty default value', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:key|}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBe('Invalid SCV expression')
       })
 
       it('should return error when readCommunity SCV default value contains a pipe character', () => {
         const config: SnmpBaseConfiguration = { ...validConfig, readCommunity: '${scv:key|val|extra}' }
-        const errors = validateDefinition(config, 'v2c', ip, '', '', scvEnabledKeys)
+        const errors = validateDefinition(config, 'v2c', ip, '', '', isSaving, scvEnabledKeys)
         expect(errors.readCommunity).toBe('Invalid SCV expression')
       })
     })
@@ -371,7 +450,7 @@ describe('snmpValidator', () => {
           maxVarsPerPdu: 10,
           maxRepetitions: 2
         }
-        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '192.168.1.255', '')
+        const errors = validateDefinition(config, 'v2c', '192.168.1.1', '192.168.1.255', '', false, new Set())
         expect(Object.keys(errors)).toHaveLength(0)
       })
     })
@@ -609,6 +688,81 @@ describe('snmpValidator', () => {
     it('should return no errors when both fields are provided', () => {
       const errors = validateProfile('My Profile', 'IPADDR != \'0.0.0.0\'')
       expect(Object.keys(errors)).toHaveLength(0)
+    })
+  })
+
+  describe('checkForDuplicateDefinitionItems', () => {
+    const emptyDefinition: SnmpDefinition = { range: [], specific: [], ipMatch: [] }
+
+    describe('no new items provided', () => {
+      it('should return null when definition is empty and no new items are provided', () => {
+        expect(checkForDuplicateDefinitionItems(emptyDefinition)).toBeNull()
+      })
+
+      it('should return null when definition has items but no new items are provided', () => {
+        const definition: SnmpDefinition = {
+          range: [{ begin: '10.0.0.1', end: '10.0.0.255' }],
+          specific: ['192.168.1.1'],
+          ipMatch: ['10.0.0.*']
+        }
+        expect(checkForDuplicateDefinitionItems(definition)).toBeNull()
+      })
+    })
+
+    describe('range duplicate detection', () => {
+      const existingRange: IpAddressRange = { begin: '10.0.0.1', end: '10.0.0.255' }
+      const definition: SnmpDefinition = { range: [existingRange], specific: [], ipMatch: [] }
+
+      it('should return error when newRange is a duplicate', () => {
+        expect(checkForDuplicateDefinitionItems(definition, { begin: '10.0.0.1', end: '10.0.0.255' }))
+          .toBe('Duplicate range: 10.0.0.1 - 10.0.0.255')
+      })
+
+      it('should return null when newRange has a different begin', () => {
+        expect(checkForDuplicateDefinitionItems(definition, { begin: '10.0.0.2', end: '10.0.0.255' })).toBeNull()
+      })
+
+      it('should return null when newRange has a different end', () => {
+        expect(checkForDuplicateDefinitionItems(definition, { begin: '10.0.0.1', end: '10.0.0.254' })).toBeNull()
+      })
+
+      it('should return null when definition has no ranges', () => {
+        expect(checkForDuplicateDefinitionItems(emptyDefinition, { begin: '10.0.0.1', end: '10.0.0.255' })).toBeNull()
+      })
+    })
+
+    describe('specific duplicate detection', () => {
+      const definition: SnmpDefinition = { range: [], specific: ['192.168.1.1'], ipMatch: [] }
+
+      it('should return error when newSpecific is a duplicate', () => {
+        expect(checkForDuplicateDefinitionItems(definition, undefined, '192.168.1.1'))
+          .toBe('Duplicate specific IP address: 192.168.1.1')
+      })
+
+      it('should return null when newSpecific is not in existing specifics', () => {
+        expect(checkForDuplicateDefinitionItems(definition, undefined, '192.168.1.2')).toBeNull()
+      })
+
+      it('should return null when definition has no specifics', () => {
+        expect(checkForDuplicateDefinitionItems(emptyDefinition, undefined, '192.168.1.1')).toBeNull()
+      })
+    })
+
+    describe('ipMatch duplicate detection', () => {
+      const definition: SnmpDefinition = { range: [], specific: [], ipMatch: ['10.0.0.*'] }
+
+      it('should return error when newIpMatch is a duplicate', () => {
+        expect(checkForDuplicateDefinitionItems(definition, undefined, undefined, '10.0.0.*'))
+          .toBe('Duplicate IP Match expression: 10.0.0.*')
+      })
+
+      it('should return null when newIpMatch is not in existing ipMatches', () => {
+        expect(checkForDuplicateDefinitionItems(definition, undefined, undefined, '10.0.1.*')).toBeNull()
+      })
+
+      it('should return null when definition has no ipMatches', () => {
+        expect(checkForDuplicateDefinitionItems(emptyDefinition, undefined, undefined, '10.0.0.*')).toBeNull()
+      })
     })
   })
 })


### PR DESCRIPTION
NMS-19708: Do not display errors when SNMP config IPs are blank in the form.

On any SNMP Config details screen, error messages for IP address and ipMatch were displaying even if user hadn't entered anything in those fields. This removes those errors, until the user enters values and clicks `Add` button.

In addition, this PR revamps some of the validation logic:

- ignores IP range input fields on `Save` since what is saved is what is displayed in the IP range badges
- fixes various combinations of IP range inputs, disallow range/specific plus ipMatch
- disallows mixing range/specific and ipMatch when adding a range item to an existing definition
- disallows duplicate entries
- ensures correct error messages are displayed

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19708

