### PR TITLE
NMS-19171: MIB Compiler UI for uploading files

### DIFF
--- a/features/mib-compiler/rest/pom.xml
+++ b/features/mib-compiler/rest/pom.xml
@@ -49,7 +49,27 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-dao</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.lib</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.db</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.services</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/MibCompilerRestService.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/MibCompilerRestService.java
@@ -21,11 +21,17 @@
  */
 package org.opennms.features.mibcompiler.rest;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
+import org.opennms.features.mibcompiler.rest.model.MibCompilerFileText;
+
 import javax.ws.rs.Produces;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -36,10 +42,39 @@ public interface MibCompilerRestService {
     @POST
     @Path("/upload")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-    Response uploadMib(byte[] mibContent, @QueryParam("filename") String filename);
+    @Produces(MediaType.APPLICATION_JSON)
+    Response uploadMib(byte[] mibContent, @QueryParam("filename") String filename) throws Exception;
 
-    @POST
+    @GET
     @Path("/compile")
     @Consumes(MediaType.APPLICATION_JSON)
-    Response compileMib(@QueryParam("name") String name);
+    @Produces(MediaType.APPLICATION_JSON)
+    Response compileMib(@PathParam("name") String name) throws Exception;
+
+    @GET
+    @Path("/files")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response listPendingAndCompiledFiles() throws Exception;
+
+    @DELETE
+    @Path("/files/{location}/{fileName:.+}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response deleteFile(@PathParam("location") String location,
+                        @PathParam("fileName") String fileName) throws Exception;
+
+    @GET
+    @Path("/files/{location}/{fileName:.+}/text")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getFileText(@PathParam("location") String location,
+                                @PathParam("fileName") String fileName) throws Exception;
+
+    @PUT
+    @Path("/files/pending/{fileName:.+}/text")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response setFileText(@PathParam("fileName") String fileName,
+                         MibCompilerFileText body) throws Exception;
 }

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/MibCompilerRestService.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/MibCompilerRestService.java
@@ -21,7 +21,7 @@
  */
 package org.opennms.features.mibcompiler.rest;
 
-import org.opennms.features.mibcompiler.rest.model.MibCompilerFileText;
+import org.opennms.features.mibcompiler.rest.model.MibCompilerGenerateEventsRequest;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.Consumes;
@@ -44,11 +44,11 @@ public interface MibCompilerRestService {
     @Produces(MediaType.APPLICATION_JSON)
     Response uploadMib(byte[] mibContent, @QueryParam("filename") String filename) throws Exception;
 
-    @GET
+    @POST
     @Path("/compile")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    Response compileMib(@PathParam("name") String name) throws Exception;
+    Response compileMib(@QueryParam("name") String name) throws Exception;
 
     @GET
     @Path("/files")
@@ -76,4 +76,10 @@ public interface MibCompilerRestService {
     @Produces(MediaType.APPLICATION_JSON)
     Response setFileText(@QueryParam("fileName") String fileName,
                          byte[] mibContent) throws Exception;
+
+    @POST
+    @Path("/generate-events")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response generateEvents(MibCompilerGenerateEventsRequest request) throws Exception;
 }

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/MibCompilerRestService.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/MibCompilerRestService.java
@@ -27,7 +27,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.PathParam;
@@ -71,10 +70,10 @@ public interface MibCompilerRestService {
     Response getFileText(@PathParam("location") String location,
                                 @PathParam("fileName") String fileName) throws Exception;
 
-    @PUT
-    @Path("/files/pending/{fileName:.+}/text")
-    @Consumes(MediaType.APPLICATION_JSON)
+    @POST
+    @Path("/files/pending/text")
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @Produces(MediaType.APPLICATION_JSON)
-    Response setFileText(@PathParam("fileName") String fileName,
-                         MibCompilerFileText body) throws Exception;
+    Response setFileText(@QueryParam("fileName") String fileName,
+                         byte[] mibContent) throws Exception;
 }

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerFileService.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerFileService.java
@@ -256,25 +256,20 @@ public class MibCompilerFileService {
         return Files.readString(target, StandardCharsets.UTF_8);
     }
 
-    public boolean writeTextFile(final String location, final String fileName, final String contents) throws java.io.IOException {
-        if (contents == null) {
-            throw new IllegalArgumentException("contents must not be null.");
-        }
-
+    public void writeBinaryFile(final String location, final String fileName, final byte[] contents) throws IOException {
         final File dir = resolveLocationDir(location);
         ensureDirExists(dir);
 
         final Path target = new File(dir, fileName).toPath();
 
         if (!Files.exists(target)) {
-            return false;
+            throw new IllegalArgumentException("File does not exists: " + target);
         }
         if (!Files.isRegularFile(target)) {
-            throw new IllegalStateException("Target is not a regular file: " + fileName);
+            throw new IllegalArgumentException("Target is not a regular file: " + fileName);
         }
 
-        Files.writeString(target, contents, StandardCharsets.UTF_8);
-        return true;
+        Files.write(target, contents);
     }
 
     private static File resolveLocationDir(final String location) {

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerFileService.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerFileService.java
@@ -1,0 +1,410 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.mibcompiler.rest.internal;
+
+import org.opennms.core.utils.ConfigFileConstants;
+import org.opennms.features.mibcompiler.api.MibParser;
+import org.opennms.features.mibcompiler.rest.model.CompileMibResult;
+import org.opennms.features.mibcompiler.rest.model.MibCompilerFileInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class MibCompilerFileService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MibCompilerFileService.class);
+
+    private final MibParser mibParser;
+
+    public static final String DEFAULT_MIB_EXTENSION = ".mib";
+
+    private static final String SHARE_MIBS_DIR = "share" + File.separatorChar + "mibs";
+    private static final String PENDING_DIR = "pending";
+    private static final String COMPILED_DIR = "compiled";
+
+    private static final File MIBS_ROOT_DIR = new File(ConfigFileConstants.getHome(), SHARE_MIBS_DIR);
+
+    /** The Constant MIBS_PENDING_DIR. */
+    private static final File MIBS_PENDING_DIR = new File(MIBS_ROOT_DIR, PENDING_DIR);
+
+    /** The Constant MIBS_COMPILED_DIR. */
+    private static final File MIBS_COMPILED_DIR = new File(MIBS_ROOT_DIR, COMPILED_DIR);
+
+    public MibCompilerFileService(MibParser mibParser) {
+        this.mibParser = mibParser;
+        mibParser.setMibDirectory(MIBS_COMPILED_DIR);
+
+        LOG.debug("Initialized {} with MIB directories: root={}, pending={}, compiled={}",
+                getClass().getSimpleName(),
+                MIBS_ROOT_DIR.getAbsolutePath(),
+                MIBS_PENDING_DIR.getAbsolutePath(),
+                MIBS_COMPILED_DIR.getAbsolutePath());
+    }
+
+    public boolean baseNameExistsInPendingOrCompiled(final String baseName) throws Exception {
+        final boolean existsPending = baseNameExists(MIBS_PENDING_DIR, baseName);
+        final boolean existsCompiled = baseNameExists(MIBS_COMPILED_DIR, baseName);
+        final boolean exists = existsPending || existsCompiled;
+
+        LOG.debug("baseNameExistsInPendingOrCompiled(baseName={}): pending={}, compiled={}, exists={}",
+                baseName, existsPending, existsCompiled, exists);
+
+        return exists;
+    }
+
+    /**
+     * Save a file to pending with a normalized name: {baseName}{extension}
+     * Example: baseName="IF-MIB", extension=".mib" -> IF-MIB.mib
+     */
+    public File saveToPending(final String baseName,
+                              final String extension,
+                              final InputStream content) throws Exception {
+
+        if (baseName == null || baseName.isBlank()) {
+            LOG.warn("saveToPending called with blank baseName");
+            throw new IllegalArgumentException("baseName must not be blank.");
+        }
+        if (content == null) {
+            LOG.warn("saveToPending(baseName={}) called with null content", baseName);
+            throw new IllegalArgumentException("content must not be null.");
+        }
+
+        ensureDirExists(MIBS_PENDING_DIR);
+        final String ext = normalizeExtension(extension, DEFAULT_MIB_EXTENSION);
+        final File target = new File(MIBS_PENDING_DIR, baseName + ext);
+
+        LOG.info("Saving MIB to pending: baseName={}, extension={}, target={}",
+                baseName, ext, target.getAbsolutePath());
+
+        try (FileOutputStream out = new FileOutputStream(target)) {
+            content.transferTo(out);
+        }
+
+        LOG.debug("Saved pending MIB: {}", target.getAbsolutePath());
+        return target;
+    }
+
+    /**
+     * Compile (parse/validate) a file that already exists in the pending directory, then move it
+     * to the compiled directory, forcing a ".mib" extension.
+     */
+    public CompileMibResult compilePendingByBaseName(final String baseName) throws Exception {
+        if (baseName == null || baseName.isBlank()) {
+            LOG.warn("compilePendingByBaseName called with blank baseName");
+            return CompileMibResult.invalidRequest("baseName must not be blank.");
+        }
+
+        ensureDirExists(MIBS_PENDING_DIR);
+        ensureDirExists(MIBS_COMPILED_DIR);
+
+        final String normalizedBaseName = stripPathAndExtension(baseName);
+        if (normalizedBaseName == null || normalizedBaseName.isBlank()) {
+            LOG.warn("compilePendingByBaseName(baseName={}) resulted in blank normalized base name", baseName);
+            return CompileMibResult.invalidRequest("baseName must not be blank.");
+        }
+
+        LOG.info("Compiling pending MIB: requestedBaseName={}, normalizedBaseName={}", baseName, normalizedBaseName);
+
+        final File pendingFile;
+        try {
+            pendingFile = findSingleByBaseName(MIBS_PENDING_DIR, normalizedBaseName);
+        } catch (IllegalStateException e) {
+            LOG.error("Multiple pending files found for baseName={} in dir={}: {}",
+                    normalizedBaseName, MIBS_PENDING_DIR.getAbsolutePath(), e.getMessage(), e);
+            throw e;
+        }
+
+        if (pendingFile == null) {
+            LOG.warn("No pending file found for baseName={} in dir={}", normalizedBaseName, MIBS_PENDING_DIR.getAbsolutePath());
+            return CompileMibResult.notFound("No pending file found with base name '" + normalizedBaseName + "'.");
+        }
+
+        LOG.debug("Found pending file to compile: {}", pendingFile.getAbsolutePath());
+
+        final boolean parsed;
+        try {
+            parsed = mibParser.parseMib(pendingFile);
+        } catch (RuntimeException e) {
+            // If the parser can throw, treat as unexpected
+            LOG.error("Unexpected error while parsing MIB file: {}", pendingFile.getAbsolutePath(), e);
+            throw e;
+        }
+
+        if (!parsed) {
+            final var missingDeps = mibParser.getMissingDependencies();
+            if (missingDeps != null && !missingDeps.isEmpty()) {
+                LOG.warn("MIB compilation failed due to missing dependencies: baseName={}, file={}, missingDependencies={}",
+                        normalizedBaseName, pendingFile.getName(), missingDeps);
+                return CompileMibResult.missingDependencies("Missing dependencies: " + missingDeps, missingDeps);
+            }
+            final String errors = mibParser.getFormattedErrors();
+            LOG.warn("MIB validation failed: baseName={}, file={}, errors={}",
+                    normalizedBaseName, pendingFile.getName(), errors);
+            return CompileMibResult.validationFailed("MIB validation failed.", errors);
+        }
+
+        // Move to compiled and force .mib extension
+        final File destFile = new File(MIBS_COMPILED_DIR, normalizedBaseName + DEFAULT_MIB_EXTENSION);
+        if (destFile.exists()) {
+            LOG.warn("Compilation conflict: destination file already exists: {}", destFile.getAbsolutePath());
+            return CompileMibResult.conflict("Compiled file already exists: " + destFile.getName());
+        }
+
+        LOG.info("Moving compiled MIB from pending to compiled: from={}, to={}",
+                pendingFile.getAbsolutePath(), destFile.getAbsolutePath());
+
+        Files.move(pendingFile.toPath(), destFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
+
+        LOG.info("MIB compiled successfully: baseName={}, compiledFile={}",
+                normalizedBaseName, destFile.getAbsolutePath());
+
+        return CompileMibResult.success(pendingFile, destFile);
+    }
+
+    public List<MibCompilerFileInfo> listPendingAndCompiledFiles() throws IOException {
+        ensureDirExists(MIBS_PENDING_DIR);
+        ensureDirExists(MIBS_COMPILED_DIR);
+
+        final List<MibCompilerFileInfo> results = new ArrayList<>();
+        results.addAll(listFilesInDir(MIBS_PENDING_DIR, MibCompilerFileInfo.Location.PENDING));
+        results.addAll(listFilesInDir(MIBS_COMPILED_DIR, MibCompilerFileInfo.Location.COMPILED));
+
+        results.sort(Comparator
+                .comparing(MibCompilerFileInfo::getLocation)
+                .thenComparing(MibCompilerFileInfo::getFileName));
+
+        LOG.debug("Listed mib compiler files: total={}, pendingDir={}, compiledDir={}",
+                results.size(), MIBS_PENDING_DIR.getAbsolutePath(), MIBS_COMPILED_DIR.getAbsolutePath());
+
+        return results;
+    }
+
+    public boolean deleteFile(final String location, final String fileName) throws IOException {
+        if (location == null || location.isBlank()) {
+            throw new IllegalArgumentException("location must not be blank.");
+        }
+        if (fileName == null || fileName.isBlank()) {
+            throw new IllegalArgumentException("fileName must not be blank.");
+        }
+
+        if (fileName.contains("/") || fileName.contains("\\") || fileName.contains("..")) {
+            throw new IllegalArgumentException("Invalid fileName.");
+        }
+
+        final File dir = resolveLocationDir(location);
+        ensureDirExists(dir);
+
+        final Path target = new File(dir, fileName).toPath();
+
+        if (!Files.exists(target)) {
+            return false; // not found
+        }
+        if (!Files.isRegularFile(target)) {
+            throw new IllegalStateException("Target is not a regular file: " + fileName);
+        }
+
+        Files.delete(target);
+        LOG.info("Deleted MIB file: location={}, fileName={}", location, fileName);
+        return true;
+    }
+
+    public String readTextFile(final String location, final String fileName) throws java.io.IOException {
+        final File dir = resolveLocationDir(location);
+        ensureDirExists(dir);
+
+        final Path target = new File(dir, fileName).toPath();
+
+        if (!Files.exists(target)) {
+            return null;
+        }
+        if (!Files.isRegularFile(target)) {
+            throw new IllegalStateException("Target is not a regular file: " + fileName);
+        }
+
+        return Files.readString(target, StandardCharsets.UTF_8);
+    }
+
+    public boolean writeTextFile(final String location, final String fileName, final String contents) throws java.io.IOException {
+        if (contents == null) {
+            throw new IllegalArgumentException("contents must not be null.");
+        }
+
+        final File dir = resolveLocationDir(location);
+        ensureDirExists(dir);
+
+        final Path target = new File(dir, fileName).toPath();
+
+        if (!Files.exists(target)) {
+            return false;
+        }
+        if (!Files.isRegularFile(target)) {
+            throw new IllegalStateException("Target is not a regular file: " + fileName);
+        }
+
+        Files.writeString(target, contents, StandardCharsets.UTF_8);
+        return true;
+    }
+
+    private static File resolveLocationDir(final String location) {
+        if (location == null || location.isBlank()) {
+            throw new IllegalArgumentException("location must not be blank.");
+        }
+        switch (location.toLowerCase()) {
+            case "pending":
+                return MIBS_PENDING_DIR;
+            case "compiled":
+                return MIBS_COMPILED_DIR;
+            default:
+                throw new IllegalArgumentException("Invalid location: " + location + ". Must be 'pending' or 'compiled'.");
+        }
+    }
+
+    private static List<MibCompilerFileInfo> listFilesInDir(File dir, MibCompilerFileInfo.Location location) throws IOException {
+        if (dir == null || !dir.exists() || !dir.isDirectory()) {
+            return Collections.emptyList();
+        }
+
+        final List<MibCompilerFileInfo> out = new ArrayList<>();
+        try (Stream<Path> stream = Files.list(dir.toPath())) {
+            stream.filter(Files::isRegularFile)
+                    .sorted(Comparator.comparing(p -> p.getFileName().toString()))
+                    .forEach(p -> out.add(new MibCompilerFileInfo(
+                            p.getFileName().toString(),
+                            location
+                    )));
+        }
+        return out;
+    }
+
+    private static File findSingleByBaseName(final File dir, final String baseName) throws Exception {
+        if (dir == null || !dir.exists() || !dir.isDirectory()) {
+            LOG.debug("findSingleByBaseName: directory missing or not a directory: dir={}, baseName={}",
+                    dir == null ? null : dir.getAbsolutePath(), baseName);
+            return null;
+        }
+
+        final List<Path> matches = new ArrayList<>();
+        try (var stream = Files.list(dir.toPath())) {
+            stream.filter(Files::isRegularFile).forEach(p -> {
+                final String bn = stripPathAndExtension(p.getFileName().toString());
+                if (baseName.equals(bn)) {
+                    matches.add(p);
+                }
+            });
+        }
+
+        matches.sort(Comparator.comparing(p -> p.getFileName().toString()));
+
+        if (matches.isEmpty()) {
+            LOG.debug("findSingleByBaseName: no matches: dir={}, baseName={}", dir.getAbsolutePath(), baseName);
+            return null;
+        }
+        if (matches.size() > 1) {
+            LOG.error("findSingleByBaseName: multiple matches: dir={}, baseName={}, matches={}",
+                    dir.getAbsolutePath(), baseName, matches);
+            throw new IllegalStateException("Multiple pending files found with base name '" + baseName + "': " + matches);
+        }
+
+        LOG.debug("findSingleByBaseName: single match found: {}", matches.get(0));
+        return matches.get(0).toFile();
+    }
+
+    private static void ensureDirExists(final File dir) {
+        if (dir.exists()) {
+            if (!dir.isDirectory()) {
+                LOG.error("Path exists but is not a directory: {}", dir.getAbsolutePath());
+                throw new IllegalStateException("Path exists but is not a directory: " + dir.getAbsolutePath());
+            }
+            return;
+        }
+        if (!dir.mkdirs()) {
+            LOG.error("Failed to create directory: {}", dir.getAbsolutePath());
+            throw new IllegalStateException("Failed to create directory: " + dir.getAbsolutePath());
+        }
+        LOG.debug("Created directory: {}", dir.getAbsolutePath());
+    }
+
+    /**
+     * Checks if any file in {@code dir} has the given basename (basename comparison, not full filename).
+     */
+    private static boolean baseNameExists(final File dir, final String baseName) throws Exception {
+        if (dir == null || !dir.exists() || !dir.isDirectory()) {
+            LOG.debug("baseNameExists: dir missing or not a directory: dir={}, baseName={}",
+                    dir == null ? null : dir.getAbsolutePath(), baseName);
+            return false;
+        }
+        try (var stream = Files.list(dir.toPath())) {
+            final boolean found = stream.anyMatch(p -> baseName.equals(stripPathAndExtension(p.getFileName().toString())));
+            LOG.debug("baseNameExists: dir={}, baseName={}, found={}", dir.getAbsolutePath(), baseName, found);
+            return found;
+        }
+    }
+
+    /**
+     * Removes any path segments and strips the extension.
+     */
+    public static String stripPathAndExtension(final String filename) {
+        if (filename == null) return null;
+
+        String justName = filename;
+        int slash = justName.lastIndexOf('/');
+        int backslash = justName.lastIndexOf('\\');
+        int idx = Math.max(slash, backslash);
+        if (idx >= 0 && idx + 1 < justName.length()) {
+            justName = justName.substring(idx + 1);
+        }
+
+        justName = justName.trim();
+        if (justName.isEmpty()) return null;
+
+        int dot = justName.lastIndexOf('.');
+        if (dot > 0) {
+            return justName.substring(0, dot);
+        }
+        return justName;
+    }
+
+    public static String normalizeExtension(final String extension, final String defaultExt) {
+        String ext = extension;
+        if (ext == null || ext.isBlank()) {
+            ext = defaultExt;
+        }
+        ext = ext.trim();
+        if (!ext.startsWith(".")) {
+            ext = "." + ext;
+        }
+        return ext;
+    }
+}

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
@@ -35,10 +35,9 @@ import org.opennms.netmgt.model.events.EventConfSourceMetadataDto;
 import org.opennms.netmgt.xml.eventconf.Events;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionOperations;
 
+import javax.annotation.PreDestroy;
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -227,9 +226,8 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
     public Response deleteFile(String location, String fileName) {
         LOG.debug("REST request: delete mib compiler file: location={}, fileName={}", location, fileName);
 
-        validateFileNameAndLocation(fileName, location);
-
         try {
+            validateLocationAndFileName(location, fileName);
             final boolean deleted = MibCompilerServiceUtil.deleteFile(location, fileName);
 
             if (!deleted) {
@@ -267,7 +265,7 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
     @Override
     public Response getFileText(String location, String fileName) throws Exception {
         try {
-            validateFileNameAndLocation(fileName, location);
+            validateLocationAndFileName(location, fileName);
 
             final String contents = MibCompilerServiceUtil.readTextFile(location, fileName);
             if (contents == null) {
@@ -306,16 +304,17 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
         final String location = "pending";
         LOG.debug("REST request: set mib compiler file text: location={}, fileName={}", location, fileName);
 
-        validateFileNameAndLocation(location, fileName);
-
-        if (mibContent == null) {
-            LOG.warn("Set file text rejected: null mibContent (location={}, fileName={})", location, fileName);
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("mibContent must not be null.")
-                    .build();
-        }
-
         try {
+
+            validateLocationAndFileName(location, fileName);
+
+            if (mibContent == null) {
+                LOG.warn("Set file text rejected: null mibContent (location={}, fileName={})", location, fileName);
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("mibContent must not be null.")
+                        .build();
+            }
+
             MibCompilerServiceUtil.writeBinaryFile(location, fileName, mibContent);
 
             LOG.info("Set file text: updated successfully (location={}, fileName={})", location, fileName);
@@ -346,35 +345,31 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
     }
     @Override
     public Response generateEvents(final MibCompilerGenerateEventsRequest request) {
-        final String location = "compiled";
-        LOG.debug("REST request: generate events: location={}, file={}", location, request != null ? request.getName() : null);
-
         if (request == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Request must not be null.")
                     .build();
         }
-
-        final String fileName = request.getName();
-        if (fileName == null || fileName.trim().isEmpty()) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("mibFileName must not be null/empty.")
-                    .build();
-        }
-
-        final Response validationError = validateFileNameAndLocation(location, fileName);
-        if (validationError != null) {
-            return validationError;
-        }
-
-        final String ueiBase = request.getUeiBase();
-        if (ueiBase == null || ueiBase.trim().isEmpty()) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("ueiBase must not be null/empty.")
-                    .build();
-        }
+        final String location = "compiled";
+        String fileName = request.getName();
+        LOG.debug("REST request: generate events: location={}, file={}", location, request != null ? request.getName() : null);
 
         try {
+
+            if (fileName == null || fileName.trim().isEmpty()) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("mibFileName must not be null/empty.")
+                        .build();
+            }
+
+            validateLocationAndFileName(location, fileName);
+
+            final String ueiBase = request.getUeiBase();
+            if (ueiBase == null || ueiBase.trim().isEmpty()) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("ueiBase must not be null/empty.")
+                        .build();
+            }
             final boolean exists = MibCompilerServiceUtil.exists(location, fileName);
             if (!exists) {
                 LOG.info("Generate events: file not found (location={}, fileName={})", location, fileName);
@@ -416,7 +411,7 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
                     final int maxFileOrder = Optional.ofNullable(eventConfSourceDao.findMaxFileOrder()).orElse(0);
                     final int nextFileOrder = maxFileOrder + 1;
                     final EventConfSourceMetadataDto meta =
-                            buildMetadata(fileName, "", events, nextFileOrder, now);
+                            buildMetadata(fileName, events, nextFileOrder, now);
 
                     final EventConfSource source = EventConfServiceHelper.createOrUpdateSource(eventConfSourceDao, meta);
 
@@ -549,36 +544,24 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
         return f == null ? null : f.getName();
     }
 
-    private static List<String> emptyToNull(List<String> l) {
-        return (l == null || l.isEmpty()) ? null : l;
-    }
-
-    private static Response validateFileNameAndLocation(final String location, final String fileName) {
+    private static void validateLocationAndFileName(final String location, final String fileName) {
         if (location == null || location.isBlank()) {
             LOG.warn("Request rejected: blank location (fileName={})", fileName);
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("location must not be blank.")
-                    .build();
+            throw new IllegalArgumentException("location must not be blank.");
         }
 
         if (fileName == null || fileName.isBlank()) {
             LOG.warn("Request rejected: blank fileName (location={})", location);
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("fileName must not be blank.")
-                    .build();
+            throw new IllegalArgumentException("fileName must not be blank.");
         }
 
         if (fileName.contains("/") || fileName.contains("\\") || fileName.contains("..")) {
             LOG.warn("Request rejected: invalid fileName={} (location={})", fileName, location);
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Invalid fileName.")
-                    .build();
+            throw new IllegalArgumentException("Invalid fileName.");
         }
-
-        return null;
     }
 
-    private EventConfSourceMetadataDto buildMetadata(String fileName, String description, Events events, int fileOrder,
+    private EventConfSourceMetadataDto buildMetadata(String fileName, Events events, int fileOrder,
                                                      Date now) {
 
         final String baseName = StringUtils.substringBeforeLast(fileName, ".");
@@ -593,8 +576,13 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
                 .username("system-generated")
                 .now(now)
                 .vendor(base)
-                .description(description)
+                .description("")
                 .build();
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        eventConfExecutor.shutdown();
     }
 
 }

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
@@ -144,7 +144,6 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
             return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
         }
 
-        // 2) Resolve pending file
         final File pendingFile;
         try {
             pendingFile = MibCompilerServiceUtil.findPendingByBaseName(baseName);
@@ -164,7 +163,6 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
             return Response.status(Response.Status.NOT_FOUND).entity(response).build();
         }
 
-        // 3) Parse/validate using mibParser (now owned by REST)
         final boolean parsed = mibParser.parseMib(pendingFile);
         if (!parsed) {
             final var missingDeps = mibParser.getMissingDependencies();
@@ -186,7 +184,6 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
             return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
         }
 
-        // 4) Parsed OK: move to compiled
         final File compiledFile;
         try {
             compiledFile = MibCompilerServiceUtil.movePendingToCompiled(pendingFile, baseName);
@@ -347,8 +344,6 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
                     .build();
         }
     }
-
-    @Transactional(readOnly = false, propagation = Propagation.REQUIRED)
     @Override
     public Response generateEvents(final MibCompilerGenerateEventsRequest request) {
         final String location = "compiled";

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
@@ -21,36 +21,448 @@
  */
 package org.opennms.features.mibcompiler.rest.internal;
 
-import org.opennms.features.mibcompiler.api.MibParser;
 import org.opennms.features.mibcompiler.rest.MibCompilerRestService;
+import org.opennms.features.mibcompiler.rest.model.CompileMibResult;
+import org.opennms.features.mibcompiler.rest.model.MibCompilerFileText;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.List;
+import java.util.LinkedHashMap;
 
 public class MibCompilerRestServiceImpl implements MibCompilerRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(MibCompilerRestServiceImpl.class);
 
-    private final MibParser mibParser;
+    private static final String UNKNOWN_FILENAME = "unknown";
+    private static final int MAX_FILENAME_LENGTH = 255;
 
-    public MibCompilerRestServiceImpl(MibParser mibParser) {
-        this.mibParser = mibParser;
+    private final MibCompilerFileService mibCompilerFileService;
+
+    public MibCompilerRestServiceImpl(final MibCompilerFileService mibCompilerFileService) {
+        this.mibCompilerFileService = Objects.requireNonNull(mibCompilerFileService, "mibCompilerFileService must not be null");
     }
 
     @Override
-    public Response uploadMib(byte[] mibContent, String filename) {
-        // TODO: implement MIB upload to pending directory
-        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-                .entity("{\"error\": \"Not yet implemented\"}")
-                .build();
+    public Response uploadMib(final byte[] mibContent, final String filename) throws Exception {
+        final List<Map<String, Object>> successList = new ArrayList<>();
+        final List<Map<String, Object>> errorList = new ArrayList<>();
+
+        final String originalFilename = safeFilename(filename);
+        final String baseName = MibCompilerFileService.stripPathAndExtension(originalFilename);
+
+        if (isBlank(baseName)) {
+            LOG.warn("Skipping upload with invalid filename: {}", originalFilename);
+
+            errorList.add(error(originalFilename, baseName,
+                    "Invalid filename; cannot derive base name."));
+
+            return buildResponse(Response.Status.BAD_REQUEST, successList, errorList);
+        }
+
+        if (mibContent == null || mibContent.length == 0) {
+            errorList.add(error(originalFilename, baseName, "Empty MIB content."));
+            return buildResponse(Response.Status.BAD_REQUEST, successList, errorList);
+        }
+
+        if (mibCompilerFileService.baseNameExistsInPendingOrCompiled(baseName)) {
+            errorList.add(error(originalFilename, baseName,
+                    "A MIB with the same base name already exists in pending/ or compiled/."));
+            return buildResponse(Response.Status.CONFLICT, successList, errorList);
+        }
+
+        final String ext = MibCompilerFileService.normalizeExtension(
+                getExtensionOrDefault(originalFilename),
+                MibCompilerFileService.DEFAULT_MIB_EXTENSION
+        );
+
+        try (InputStream in = new ByteArrayInputStream(mibContent)) {
+            final File saved = mibCompilerFileService.saveToPending(baseName, ext, in);
+
+            final Map<String, Object> success = new LinkedHashMap<>();
+            success.put("filename", originalFilename);
+            success.put("savedAs", saved.getName());
+            success.put("success", Boolean.TRUE);
+            successList.add(success);
+
+            return buildResponse(Response.Status.CREATED, successList, errorList);
+
+        } catch (Exception e) {
+            LOG.warn("Failed to save uploaded MIB file '{}' (basename='{}') to pending.", originalFilename, baseName, e);
+
+            errorList.add(errorWithException(originalFilename, baseName, e));
+            return buildResponse(Response.Status.INTERNAL_SERVER_ERROR, successList, errorList);
+        }
     }
 
     @Override
-    public Response compileMib(String name) {
-        // TODO: implement MIB compilation
-        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-                .entity("{\"error\": \"Not yet implemented\"}")
-                .build();
+    public Response compileMib(final String name) throws Exception {
+
+        final CompileMibResult result = mibCompilerFileService.compilePendingByBaseName(name);
+
+        switch (result.getStatus()) {
+
+            case SUCCESS: {
+                Map<String, Object> response = new HashMap<>();
+                response.put("success", true);
+                response.put("message", result.getMessage());
+                response.put("mibName", safeName(name));
+                response.put("compiledFile", fileNameOnly(result.getCompiledFile()));
+
+                return Response.ok(response).build();
+            }
+
+            case NOT_FOUND: {
+                Map<String, Object> response = new HashMap<>();
+                response.put("success", false);
+                response.put("message", result.getMessage());
+                response.put("mibName", safeName(name));
+
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(response)
+                        .build();
+            }
+
+            case INVALID_REQUEST: {
+                Map<String, Object> response = new HashMap<>();
+                response.put("success", false);
+                response.put("message", result.getMessage());
+                response.put("mibName", safeName(name));
+
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(response)
+                        .build();
+            }
+
+            case MISSING_DEPENDENCIES:
+            case CONFLICT: {
+                Map<String, Object> response = new HashMap<>();
+                response.put("success", false);
+                response.put("message", result.getMessage());
+                response.put("mibName", safeName(name));
+                response.put("missingDependencies", emptyToNull(result.getMissingDependencies()));
+
+                return Response.status(Response.Status.CONFLICT)
+                        .entity(response)
+                        .build();
+            }
+
+            case VALIDATION_FAILED: {
+                Map<String, Object> response = new HashMap<>();
+                response.put("success", false);
+                response.put("message", result.getMessage());
+                response.put("mibName", safeName(name));
+                response.put("errors", result.getFormattedErrors());
+
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(response)
+                        .build();
+            }
+
+            default: {
+                Map<String, Object> response = new HashMap<>();
+                response.put("success", false);
+                response.put("message", "Unexpected status: " + result.getStatus());
+                response.put("mibName", safeName(name));
+
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                        .entity(response)
+                        .build();
+            }
+        }
+    }
+
+    @Override
+    public Response listPendingAndCompiledFiles() {
+        LOG.debug("REST request: list mib compiler files");
+
+        try {
+            final var files = mibCompilerFileService.listPendingAndCompiledFiles();
+            return Response.ok(files).build();
+        } catch (java.io.IOException e) {
+            LOG.error("I/O error while listing mib compiler files", e);
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE) // 503
+                    .entity("Unable to read mib directories.")
+                    .build();
+        } catch (Exception e) {
+            LOG.error("Unexpected error while listing mib compiler files", e);
+            return Response.serverError()
+                    .entity("Unexpected error while listing mib compiler files.")
+                    .build();
+        }
+    }
+
+    @Override
+    public Response deleteFile(String location, String fileName) {
+        LOG.debug("REST request: delete mib compiler file: location={}, fileName={}", location, fileName);
+
+        validateFileNameAndLocation(fileName, location);
+
+        try {
+            final boolean deleted = mibCompilerFileService.deleteFile(location, fileName);
+
+            if (!deleted) {
+                LOG.info("Mib compiler file not found for delete: location={}, fileName={}", location, fileName);
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            LOG.info("Mib compiler file deleted: location={}, fileName={}", location, fileName);
+            return Response.noContent().build();
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Delete mib compiler file failed (bad request): location={}, fileName={}, msg={}",
+                    location, fileName, e.getMessage());
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(e.getMessage())
+                    .build();
+        } catch (IllegalStateException e) {
+            LOG.warn("Delete mib compiler file failed (conflict): location={}, fileName={}, msg={}",
+                    location, fileName, e.getMessage(), e);
+            return Response.status(Response.Status.CONFLICT)
+                    .entity(e.getMessage())
+                    .build();
+        } catch (java.io.IOException e) {
+            LOG.error("Delete mib compiler file failed (I/O): location={}, fileName={}", location, fileName, e);
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE) // 503
+                    .entity("Unable to delete file.")
+                    .build();
+        } catch (Exception e) {
+            LOG.error("Delete mib compiler file failed (unexpected): location={}, fileName={}", location, fileName, e);
+            return Response.serverError()
+                    .entity("Unexpected error while deleting file.")
+                    .build();
+        }
+    }
+
+    @Override
+    public Response getFileText(String location, String fileName) throws Exception {
+        try {
+            validateFileNameAndLocation(fileName, location);
+
+            final String contents = mibCompilerFileService.readTextFile(location, fileName);
+            if (contents == null) {
+                LOG.info("Mib compiler file not found for text read: location={}, fileName={}", location, fileName);
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            final var dto = new MibCompilerFileText(fileName, location.toLowerCase(), contents);
+            return Response.ok(dto).build();
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Get file text failed (bad request): location={}, fileName={}, msg={}", location, fileName, e.getMessage());
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(e.getMessage())
+                    .build();
+        } catch (IllegalStateException e) {
+            LOG.warn("Get file text failed (conflict): location={}, fileName={}, msg={}", location, fileName, e.getMessage(), e);
+            return Response.status(Response.Status.CONFLICT)
+                    .entity(e.getMessage())
+                    .build();
+        } catch (java.io.IOException e) {
+            LOG.error("Get file text failed (I/O): location={}, fileName={}", location, fileName, e);
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("Unable to read file.")
+                    .build();
+        } catch (Exception e) {
+            LOG.error("Get file text failed (unexpected): location={}, fileName={}", location, fileName, e);
+            return Response.serverError()
+                    .entity("Unexpected error while reading file.")
+                    .build();
+        }
+    }
+
+    @Override
+    public Response setFileText(final String fileName, final MibCompilerFileText body) {
+        LOG.debug("REST request: set mib compiler file text: location={}, fileName={}", body.getLocation(), fileName);
+
+        validateFileNameAndLocation(body.getLocation(), fileName);
+
+        if (!"pending".equalsIgnoreCase(body.getLocation())) {
+            LOG.warn("Set file text rejected: location must be 'pending' (location={}, fileName={})", body.getLocation(), fileName);
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Setting file contents is only allowed for location 'pending'.")
+                    .build();
+        }
+
+        if (body.getContents() == null) {
+            LOG.warn("Set file text rejected: null contents (location={}, fileName={})", body.getLocation(), fileName);
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("contents must not be null.")
+                    .build();
+        }
+
+        if (body.getName() != null && !fileName.equals(body.getName())) {
+            LOG.warn("Set file text rejected: body.name mismatch (pathFileName={}, bodyName={})", fileName, body.getName());
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Body 'name' must match path fileName.")
+                    .build();
+        }
+
+        try {
+            final boolean updated = mibCompilerFileService.writeTextFile(body.getLocation(), fileName, body.getContents());
+            if (!updated) {
+                LOG.info("Set file text: file not found (location={}, fileName={})", body.getLocation(), fileName);
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            LOG.info("Set file text: updated successfully (location={}, fileName={})", body.getLocation(), fileName);
+
+            final MibCompilerFileText response = new MibCompilerFileText(fileName, "pending", body.getContents());
+            return Response.ok(response).build();
+
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Set file text failed (bad request): location={}, fileName={}, msg={}", body.getLocation(), fileName, e.getMessage());
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(e.getMessage())
+                    .build();
+        } catch (IllegalStateException e) {
+            LOG.warn("Set file text failed (conflict): location={}, fileName={}, msg={}", body.getLocation(), fileName, e.getMessage(), e);
+            return Response.status(Response.Status.CONFLICT)
+                    .entity(e.getMessage())
+                    .build();
+        } catch (java.io.IOException e) {
+            LOG.error("Set file text failed (I/O): location={}, fileName={}", body.getLocation(), fileName, e);
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("Unable to write file.")
+                    .build();
+        } catch (Exception e) {
+            LOG.error("Set file text failed (unexpected): location={}, fileName={}", body.getLocation(), fileName, e);
+            return Response.serverError()
+                    .entity("Unexpected error while writing file.")
+                    .build();
+        }
+    }
+
+    private static Response buildResponse(final Response.Status status,
+                                          final List<Map<String, Object>> successList,
+                                          final List<Map<String, Object>> errorList) {
+        final Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("success", successList);
+        payload.put("errors", errorList);
+        return Response.status(status).entity(payload).build();
+    }
+
+    private static Map<String, Object> error(final String filename, final String basename, final String message) {
+        final Map<String, Object> e = new LinkedHashMap<>();
+        e.put("filename", filename);
+        e.put("basename", basename);
+        e.put("error", message);
+        return e;
+    }
+
+    private static Map<String, Object> errorWithException(final String filename, final String basename, final Exception ex) {
+        final Map<String, Object> e = error(filename, basename, toDetailedErrorMessage(ex));
+        e.put("exception", ex.getClass().getName());
+        return e;
+    }
+
+    private static boolean isBlank(final String s) {
+        if (s == null) return true;
+        for (int i = 0; i < s.length(); i++) {
+            if (!Character.isWhitespace(s.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static String safeFilename(final String filename) {
+        if (filename == null) {
+            return UNKNOWN_FILENAME;
+        }
+
+        String name = filename.trim();
+        if (name.isEmpty()) {
+            return UNKNOWN_FILENAME;
+        }
+
+        name = name.replace('\\', '/');
+        final int lastSlash = name.lastIndexOf('/');
+        if (lastSlash >= 0) {
+            name = name.substring(lastSlash + 1);
+        }
+
+        name = name.trim();
+        if (name.isEmpty() || ".".equals(name) || "..".equals(name)) {
+            return UNKNOWN_FILENAME;
+        }
+
+        name = name.replaceAll("[\\p{Cntrl}\\\\/:*?\"<>|]+", "_");
+
+        name = name.replaceAll("^[\\s.]+", "");
+        name = name.replaceAll("[\\s.]+$", "");
+
+        if (name.isEmpty()) {
+            return UNKNOWN_FILENAME;
+        }
+
+        if (name.length() > MAX_FILENAME_LENGTH) {
+            name = name.substring(0, MAX_FILENAME_LENGTH);
+        }
+
+        return name;
+    }
+
+    private static String getExtensionOrDefault(final String filename) {
+        if (isBlank(filename)) {
+            return MibCompilerFileService.DEFAULT_MIB_EXTENSION;
+        }
+
+        final int dot = filename.lastIndexOf('.');
+        if (dot > 0 && dot < filename.length() - 1) {
+            return filename.substring(dot);
+        }
+        return MibCompilerFileService.DEFAULT_MIB_EXTENSION;
+    }
+
+    private static String toDetailedErrorMessage(final Exception e) {
+        String message = e.getMessage();
+        if (isBlank(message)) {
+            message = "Unexpected error while processing MIB file.";
+        }
+        return e.getClass().getSimpleName() + ": " + message;
+    }
+
+    private static String safeName(String name) {
+        return name == null ? "" : name;
+    }
+
+    private static String fileNameOnly(File f) {
+        return f == null ? null : f.getName();
+    }
+
+    private static List<String> emptyToNull(List<String> l) {
+        return (l == null || l.isEmpty()) ? null : l;
+    }
+
+    private static Response validateFileNameAndLocation(final String location, final String fileName) {
+        if (location == null || location.isBlank()) {
+            LOG.warn("Request rejected: blank location (fileName={})", fileName);
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("location must not be blank.")
+                    .build();
+        }
+
+        if (fileName == null || fileName.isBlank()) {
+            LOG.warn("Request rejected: blank fileName (location={})", location);
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("fileName must not be blank.")
+                    .build();
+        }
+
+        if (fileName.contains("/") || fileName.contains("\\") || fileName.contains("..")) {
+            LOG.warn("Request rejected: invalid fileName={} (location={})", fileName, location);
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Invalid fileName.")
+                    .build();
+        }
+
+        return null;
     }
 }

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
@@ -277,62 +277,45 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
         }
     }
 
+
     @Override
-    public Response setFileText(final String fileName, final MibCompilerFileText body) {
-        LOG.debug("REST request: set mib compiler file text: location={}, fileName={}", body.getLocation(), fileName);
+    public Response setFileText(final String fileName, final byte[] mibContent) {
+        final String location = "pending";
+        LOG.debug("REST request: set mib compiler file text: location={}, fileName={}", location, fileName);
 
-        validateFileNameAndLocation(body.getLocation(), fileName);
+        validateFileNameAndLocation(location, fileName);
 
-        if (!"pending".equalsIgnoreCase(body.getLocation())) {
-            LOG.warn("Set file text rejected: location must be 'pending' (location={}, fileName={})", body.getLocation(), fileName);
+        if (mibContent == null) {
+            LOG.warn("Set file text rejected: null mibContent (location={}, fileName={})", location, fileName);
             return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Setting file contents is only allowed for location 'pending'.")
-                    .build();
-        }
-
-        if (body.getContents() == null) {
-            LOG.warn("Set file text rejected: null contents (location={}, fileName={})", body.getLocation(), fileName);
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("contents must not be null.")
-                    .build();
-        }
-
-        if (body.getName() != null && !fileName.equals(body.getName())) {
-            LOG.warn("Set file text rejected: body.name mismatch (pathFileName={}, bodyName={})", fileName, body.getName());
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Body 'name' must match path fileName.")
+                    .entity("mibContent must not be null.")
                     .build();
         }
 
         try {
-            final boolean updated = mibCompilerFileService.writeTextFile(body.getLocation(), fileName, body.getContents());
-            if (!updated) {
-                LOG.info("Set file text: file not found (location={}, fileName={})", body.getLocation(), fileName);
-                return Response.status(Response.Status.NOT_FOUND).build();
-            }
+            mibCompilerFileService.writeBinaryFile(location, fileName, mibContent);
 
-            LOG.info("Set file text: updated successfully (location={}, fileName={})", body.getLocation(), fileName);
+            LOG.info("Set file text: updated successfully (location={}, fileName={})", location, fileName);
 
-            final MibCompilerFileText response = new MibCompilerFileText(fileName, "pending", body.getContents());
-            return Response.ok(response).build();
+            return Response.ok("Text updated successfully").build();
 
         } catch (IllegalArgumentException e) {
-            LOG.warn("Set file text failed (bad request): location={}, fileName={}, msg={}", body.getLocation(), fileName, e.getMessage());
+            LOG.warn("Set file text failed (bad request): location={}, fileName={}, msg={}", location, fileName, e.getMessage());
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(e.getMessage())
                     .build();
         } catch (IllegalStateException e) {
-            LOG.warn("Set file text failed (conflict): location={}, fileName={}, msg={}", body.getLocation(), fileName, e.getMessage(), e);
+            LOG.warn("Set file text failed (conflict): location={}, fileName={}, msg={}", location, fileName, e.getMessage(), e);
             return Response.status(Response.Status.CONFLICT)
                     .entity(e.getMessage())
                     .build();
         } catch (java.io.IOException e) {
-            LOG.error("Set file text failed (I/O): location={}, fileName={}", body.getLocation(), fileName, e);
+            LOG.error("Set file text failed (I/O): location={}, fileName={}", location, fileName, e);
             return Response.status(Response.Status.SERVICE_UNAVAILABLE)
                     .entity("Unable to write file.")
                     .build();
         } catch (Exception e) {
-            LOG.error("Set file text failed (unexpected): location={}, fileName={}", body.getLocation(), fileName, e);
+            LOG.error("Set file text failed (unexpected): location={}, fileName={}", location, fileName, e);
             return Response.serverError()
                     .entity("Unexpected error while writing file.")
                     .build();

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImpl.java
@@ -21,11 +21,23 @@
  */
 package org.opennms.features.mibcompiler.rest.internal;
 
+import org.apache.commons.lang.StringUtils;
+import org.opennms.features.mibcompiler.api.MibParser;
 import org.opennms.features.mibcompiler.rest.MibCompilerRestService;
-import org.opennms.features.mibcompiler.rest.model.CompileMibResult;
 import org.opennms.features.mibcompiler.rest.model.MibCompilerFileText;
+import org.opennms.features.mibcompiler.rest.model.MibCompilerGenerateEventsRequest;
+import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.dao.api.EventConfEventDao;
+import org.opennms.netmgt.dao.api.EventConfSourceDao;
+import org.opennms.netmgt.dao.support.EventConfServiceHelper;
+import org.opennms.netmgt.model.EventConfSource;
+import org.opennms.netmgt.model.events.EventConfSourceMetadataDto;
+import org.opennms.netmgt.xml.eventconf.Events;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionOperations;
 
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
@@ -37,6 +49,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.List;
 import java.util.LinkedHashMap;
+import java.util.Date;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 public class MibCompilerRestServiceImpl implements MibCompilerRestService {
 
@@ -45,10 +60,24 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
     private static final String UNKNOWN_FILENAME = "unknown";
     private static final int MAX_FILENAME_LENGTH = 255;
 
-    private final MibCompilerFileService mibCompilerFileService;
+    private final MibParser mibParser;
+    private final EventConfSourceDao eventConfSourceDao;
+    private final EventConfEventDao eventConfEventDao;
+    private final EventConfDao eventConfDao;
+    private final TransactionOperations operations;
 
-    public MibCompilerRestServiceImpl(final MibCompilerFileService mibCompilerFileService) {
-        this.mibCompilerFileService = Objects.requireNonNull(mibCompilerFileService, "mibCompilerFileService must not be null");
+    private final ExecutorService eventConfExecutor =
+            EventConfServiceHelper.createEventConfExecutor("load-eventConf-%d");
+
+    public MibCompilerRestServiceImpl(
+            final MibParser mibParser, EventConfSourceDao eventConfSourceDao, EventConfEventDao eventConfEventDao, EventConfDao eventConfDao, TransactionOperations operations) {
+        this.mibParser = Objects.requireNonNull(mibParser, "mibParser must not be null");
+        this.eventConfSourceDao = eventConfSourceDao;
+        this.eventConfEventDao = eventConfEventDao;
+        this.eventConfDao = eventConfDao;
+        this.operations = operations;
+
+        this.mibParser.setMibDirectory(MibCompilerServiceUtil.getCompiledDir());
     }
 
     @Override
@@ -57,7 +86,7 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
         final List<Map<String, Object>> errorList = new ArrayList<>();
 
         final String originalFilename = safeFilename(filename);
-        final String baseName = MibCompilerFileService.stripPathAndExtension(originalFilename);
+        final String baseName = MibCompilerServiceUtil.stripPathAndExtension(originalFilename);
 
         if (isBlank(baseName)) {
             LOG.warn("Skipping upload with invalid filename: {}", originalFilename);
@@ -73,19 +102,19 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
             return buildResponse(Response.Status.BAD_REQUEST, successList, errorList);
         }
 
-        if (mibCompilerFileService.baseNameExistsInPendingOrCompiled(baseName)) {
+        if (MibCompilerServiceUtil.baseNameExistsInPendingOrCompiled(baseName)) {
             errorList.add(error(originalFilename, baseName,
                     "A MIB with the same base name already exists in pending/ or compiled/."));
             return buildResponse(Response.Status.CONFLICT, successList, errorList);
         }
 
-        final String ext = MibCompilerFileService.normalizeExtension(
+        final String ext = MibCompilerServiceUtil.normalizeExtension(
                 getExtensionOrDefault(originalFilename),
-                MibCompilerFileService.DEFAULT_MIB_EXTENSION
+                MibCompilerServiceUtil.DEFAULT_MIB_EXTENSION
         );
 
         try (InputStream in = new ByteArrayInputStream(mibContent)) {
-            final File saved = mibCompilerFileService.saveToPending(baseName, ext, in);
+            final File saved = MibCompilerServiceUtil.saveToPending(baseName, ext, in);
 
             final Map<String, Object> success = new LinkedHashMap<>();
             success.put("filename", originalFilename);
@@ -105,87 +134,84 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
 
     @Override
     public Response compileMib(final String name) throws Exception {
-
-        final CompileMibResult result = mibCompilerFileService.compilePendingByBaseName(name);
-
-        switch (result.getStatus()) {
-
-            case SUCCESS: {
-                Map<String, Object> response = new HashMap<>();
-                response.put("success", true);
-                response.put("message", result.getMessage());
-                response.put("mibName", safeName(name));
-                response.put("compiledFile", fileNameOnly(result.getCompiledFile()));
-
-                return Response.ok(response).build();
-            }
-
-            case NOT_FOUND: {
-                Map<String, Object> response = new HashMap<>();
-                response.put("success", false);
-                response.put("message", result.getMessage());
-                response.put("mibName", safeName(name));
-
-                return Response.status(Response.Status.NOT_FOUND)
-                        .entity(response)
-                        .build();
-            }
-
-            case INVALID_REQUEST: {
-                Map<String, Object> response = new HashMap<>();
-                response.put("success", false);
-                response.put("message", result.getMessage());
-                response.put("mibName", safeName(name));
-
-                return Response.status(Response.Status.BAD_REQUEST)
-                        .entity(response)
-                        .build();
-            }
-
-            case MISSING_DEPENDENCIES:
-            case CONFLICT: {
-                Map<String, Object> response = new HashMap<>();
-                response.put("success", false);
-                response.put("message", result.getMessage());
-                response.put("mibName", safeName(name));
-                response.put("missingDependencies", emptyToNull(result.getMissingDependencies()));
-
-                return Response.status(Response.Status.CONFLICT)
-                        .entity(response)
-                        .build();
-            }
-
-            case VALIDATION_FAILED: {
-                Map<String, Object> response = new HashMap<>();
-                response.put("success", false);
-                response.put("message", result.getMessage());
-                response.put("mibName", safeName(name));
-                response.put("errors", result.getFormattedErrors());
-
-                return Response.status(Response.Status.BAD_REQUEST)
-                        .entity(response)
-                        .build();
-            }
-
-            default: {
-                Map<String, Object> response = new HashMap<>();
-                response.put("success", false);
-                response.put("message", "Unexpected status: " + result.getStatus());
-                response.put("mibName", safeName(name));
-
-                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                        .entity(response)
-                        .build();
-            }
+        // 1) Validate request
+        final String baseName = MibCompilerServiceUtil.stripPathAndExtension(safeName(name));
+        if (isBlank(baseName)) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", false);
+            response.put("message", "baseName must not be blank.");
+            response.put("mibName", safeName(name));
+            return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
         }
-    }
 
+        // 2) Resolve pending file
+        final File pendingFile;
+        try {
+            pendingFile = MibCompilerServiceUtil.findPendingByBaseName(baseName);
+        } catch (IllegalStateException e) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", false);
+            response.put("message", e.getMessage());
+            response.put("mibName", safeName(name));
+            return Response.status(Response.Status.CONFLICT).entity(response).build();
+        }
+
+        if (pendingFile == null) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", false);
+            response.put("message", "No pending file found with base name '" + baseName + "'.");
+            response.put("mibName", safeName(name));
+            return Response.status(Response.Status.NOT_FOUND).entity(response).build();
+        }
+
+        // 3) Parse/validate using mibParser (now owned by REST)
+        final boolean parsed = mibParser.parseMib(pendingFile);
+        if (!parsed) {
+            final var missingDeps = mibParser.getMissingDependencies();
+            if (missingDeps != null && !missingDeps.isEmpty()) {
+                Map<String, Object> response = new HashMap<>();
+                response.put("success", false);
+                response.put("message", "Missing dependencies: " + missingDeps);
+                response.put("mibName", safeName(name));
+                response.put("missingDependencies", missingDeps);
+                return Response.status(Response.Status.CONFLICT).entity(response).build();
+            }
+
+            final String errors = mibParser.getFormattedErrors();
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", false);
+            response.put("message", "MIB validation failed.");
+            response.put("mibName", safeName(name));
+            response.put("errors", errors);
+            return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
+        }
+
+        // 4) Parsed OK: move to compiled
+        final File compiledFile;
+        try {
+            compiledFile = MibCompilerServiceUtil.movePendingToCompiled(pendingFile, baseName);
+        } catch (IllegalStateException e) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", false);
+            response.put("message", e.getMessage());
+            response.put("mibName", safeName(name));
+            return Response.status(Response.Status.CONFLICT).entity(response).build();
+        }
+
+        // 5) Success response
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("message", "MIB compiled successfully.");
+        response.put("mibName", safeName(name));
+        response.put("compiledFile", fileNameOnly(compiledFile));
+        return Response.ok(response).build();
+    }
     @Override
     public Response listPendingAndCompiledFiles() {
         LOG.debug("REST request: list mib compiler files");
 
         try {
-            final var files = mibCompilerFileService.listPendingAndCompiledFiles();
+            final var files = MibCompilerServiceUtil.listPendingAndCompiledFiles();
             return Response.ok(files).build();
         } catch (java.io.IOException e) {
             LOG.error("I/O error while listing mib compiler files", e);
@@ -207,7 +233,7 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
         validateFileNameAndLocation(fileName, location);
 
         try {
-            final boolean deleted = mibCompilerFileService.deleteFile(location, fileName);
+            final boolean deleted = MibCompilerServiceUtil.deleteFile(location, fileName);
 
             if (!deleted) {
                 LOG.info("Mib compiler file not found for delete: location={}, fileName={}", location, fileName);
@@ -246,7 +272,7 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
         try {
             validateFileNameAndLocation(fileName, location);
 
-            final String contents = mibCompilerFileService.readTextFile(location, fileName);
+            final String contents = MibCompilerServiceUtil.readTextFile(location, fileName);
             if (contents == null) {
                 LOG.info("Mib compiler file not found for text read: location={}, fileName={}", location, fileName);
                 return Response.status(Response.Status.NOT_FOUND).build();
@@ -293,7 +319,7 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
         }
 
         try {
-            mibCompilerFileService.writeBinaryFile(location, fileName, mibContent);
+            MibCompilerServiceUtil.writeBinaryFile(location, fileName, mibContent);
 
             LOG.info("Set file text: updated successfully (location={}, fileName={})", location, fileName);
 
@@ -321,6 +347,114 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
                     .build();
         }
     }
+
+    @Transactional(readOnly = false, propagation = Propagation.REQUIRED)
+    @Override
+    public Response generateEvents(final MibCompilerGenerateEventsRequest request) {
+        final String location = "compiled";
+        LOG.debug("REST request: generate events: location={}, file={}", location, request != null ? request.getName() : null);
+
+        if (request == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Request must not be null.")
+                    .build();
+        }
+
+        final String fileName = request.getName();
+        if (fileName == null || fileName.trim().isEmpty()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("mibFileName must not be null/empty.")
+                    .build();
+        }
+
+        final Response validationError = validateFileNameAndLocation(location, fileName);
+        if (validationError != null) {
+            return validationError;
+        }
+
+        final String ueiBase = request.getUeiBase();
+        if (ueiBase == null || ueiBase.trim().isEmpty()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("ueiBase must not be null/empty.")
+                    .build();
+        }
+
+        try {
+            final boolean exists = MibCompilerServiceUtil.exists(location, fileName);
+            if (!exists) {
+                LOG.info("Generate events: file not found (location={}, fileName={})", location, fileName);
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity("MIB file not found in compiled directory: " + fileName)
+                        .build();
+            }
+
+            final File mibFile = MibCompilerServiceUtil.getFile(location, fileName);
+
+            LOG.info("Parsing MIB before generating events (fileName={}, location={})", fileName, location);
+
+            if (!mibParser.parseMib(mibFile)) {
+                final List<String> dependencies = mibParser.getMissingDependencies();
+                if (dependencies != null && !dependencies.isEmpty()) {
+                    LOG.warn("Generate events rejected: missing dependencies (fileName={}, deps={})", fileName, dependencies);
+                    return Response.status(Response.Status.CONFLICT)
+                            .entity("Dependencies required: " + dependencies)
+                            .build();
+                }
+
+                final String formattedErrors = mibParser.getFormattedErrors();
+                LOG.warn("Generate events rejected: MIB parse errors (fileName={}, errors={})", fileName, formattedErrors);
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(formattedErrors != null ? formattedErrors : "Problem found when compiling the MIB.")
+                        .build();
+            }
+
+            final Events events = mibParser.getEvents(ueiBase);
+            if (events == null) {
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                        .entity("MIB parsed successfully but event generation returned null.")
+                        .build();
+            }
+
+            return operations.execute(status -> {
+                try {
+                    final Date now = new Date();
+                    final int maxFileOrder = Optional.ofNullable(eventConfSourceDao.findMaxFileOrder()).orElse(0);
+                    final int nextFileOrder = maxFileOrder + 1;
+                    final EventConfSourceMetadataDto meta =
+                            buildMetadata(fileName, "", events, nextFileOrder, now);
+
+                    final EventConfSource source = EventConfServiceHelper.createOrUpdateSource(eventConfSourceDao, meta);
+
+                    eventConfEventDao.deleteBySourceId(source.getId());
+                    EventConfServiceHelper.saveEvents(eventConfEventDao, source, events, meta.getUsername(), meta.getNow());
+                    EventConfServiceHelper.reloadEventsFromDBAsync(eventConfEventDao, eventConfDao, eventConfExecutor);
+
+                    final Map<String, Object> resp = new LinkedHashMap<>();
+                    resp.put("success", true);
+                    resp.put("message", "Events generated successfully.");
+                    resp.put("mibFile", fileName);
+                    resp.put("sourceId", source.getId());
+                    return Response.ok(resp).build();
+                } catch (Exception e) {
+                    status.setRollbackOnly();
+                    LOG.error("Generate events failed during DB transaction", e);
+                    return Response.serverError()
+                            .entity("Unexpected error while generating events.")
+                            .build();
+                }
+            });
+
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Generate events failed (bad request): location={}, fileName={}, msg={}", location, fileName, e.getMessage());
+            return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+        } catch (Exception e) {
+            LOG.error("Generate events failed (unexpected): location={}, fileName={}", location, fileName, e);
+            return Response.serverError()
+                    .entity("Unexpected error while generating events.")
+                    .build();
+        }
+    }
+
 
     private static Response buildResponse(final Response.Status status,
                                           final List<Map<String, Object>> successList,
@@ -394,14 +528,14 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
 
     private static String getExtensionOrDefault(final String filename) {
         if (isBlank(filename)) {
-            return MibCompilerFileService.DEFAULT_MIB_EXTENSION;
+            return MibCompilerServiceUtil.DEFAULT_MIB_EXTENSION;
         }
 
         final int dot = filename.lastIndexOf('.');
         if (dot > 0 && dot < filename.length() - 1) {
             return filename.substring(dot);
         }
-        return MibCompilerFileService.DEFAULT_MIB_EXTENSION;
+        return MibCompilerServiceUtil.DEFAULT_MIB_EXTENSION;
     }
 
     private static String toDetailedErrorMessage(final Exception e) {
@@ -448,4 +582,24 @@ public class MibCompilerRestServiceImpl implements MibCompilerRestService {
 
         return null;
     }
+
+    private EventConfSourceMetadataDto buildMetadata(String fileName, String description, Events events, int fileOrder,
+                                                     Date now) {
+
+        final String baseName = StringUtils.substringBeforeLast(fileName, ".");
+        final String base = StringUtils.isBlank(baseName) ? fileName : baseName;
+
+        final String eventsFileName = base + ".events";
+
+        return new EventConfSourceMetadataDto.Builder()
+                .filename(eventsFileName)
+                .eventCount(events.getEvents().size())
+                .fileOrder(fileOrder)
+                .username("system-generated")
+                .now(now)
+                .vendor(base)
+                .description(description)
+                .build();
+    }
+
 }

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerServiceUtil.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerServiceUtil.java
@@ -22,8 +22,6 @@
 package org.opennms.features.mibcompiler.rest.internal;
 
 import org.opennms.core.utils.ConfigFileConstants;
-import org.opennms.features.mibcompiler.api.MibParser;
-import org.opennms.features.mibcompiler.rest.model.CompileMibResult;
 import org.opennms.features.mibcompiler.rest.model.MibCompilerFileInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +30,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,11 +41,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class MibCompilerFileService {
+public class MibCompilerServiceUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MibCompilerFileService.class);
-
-    private final MibParser mibParser;
+    private static final Logger LOG = LoggerFactory.getLogger(MibCompilerServiceUtil.class);
 
     public static final String DEFAULT_MIB_EXTENSION = ".mib";
 
@@ -62,18 +59,12 @@ public class MibCompilerFileService {
     /** The Constant MIBS_COMPILED_DIR. */
     private static final File MIBS_COMPILED_DIR = new File(MIBS_ROOT_DIR, COMPILED_DIR);
 
-    public MibCompilerFileService(MibParser mibParser) {
-        this.mibParser = mibParser;
-        mibParser.setMibDirectory(MIBS_COMPILED_DIR);
-
-        LOG.debug("Initialized {} with MIB directories: root={}, pending={}, compiled={}",
-                getClass().getSimpleName(),
-                MIBS_ROOT_DIR.getAbsolutePath(),
-                MIBS_PENDING_DIR.getAbsolutePath(),
-                MIBS_COMPILED_DIR.getAbsolutePath());
+    /** Expose compiled dir for consumers that need to configure parsers, etc. */
+    public static File getCompiledDir() {
+        return MIBS_COMPILED_DIR;
     }
 
-    public boolean baseNameExistsInPendingOrCompiled(final String baseName) throws Exception {
+    public static boolean baseNameExistsInPendingOrCompiled(final String baseName) throws Exception {
         final boolean existsPending = baseNameExists(MIBS_PENDING_DIR, baseName);
         final boolean existsCompiled = baseNameExists(MIBS_COMPILED_DIR, baseName);
         final boolean exists = existsPending || existsCompiled;
@@ -88,11 +79,11 @@ public class MibCompilerFileService {
      * Save a file to pending with a normalized name: {baseName}{extension}
      * Example: baseName="IF-MIB", extension=".mib" -> IF-MIB.mib
      */
-    public File saveToPending(final String baseName,
-                              final String extension,
-                              final InputStream content) throws Exception {
+    public static File saveToPending(final String baseName,
+                                     final String extension,
+                                     final InputStream content) throws Exception {
 
-        if (baseName == null || baseName.isBlank()) {
+        if (isBlank(baseName)) {
             LOG.warn("saveToPending called with blank baseName");
             throw new IllegalArgumentException("baseName must not be blank.");
         }
@@ -109,7 +100,7 @@ public class MibCompilerFileService {
                 baseName, ext, target.getAbsolutePath());
 
         try (FileOutputStream out = new FileOutputStream(target)) {
-            content.transferTo(out);
+            copy(content, out);
         }
 
         LOG.debug("Saved pending MIB: {}", target.getAbsolutePath());
@@ -117,69 +108,48 @@ public class MibCompilerFileService {
     }
 
     /**
-     * Compile (parse/validate) a file that already exists in the pending directory, then move it
-     * to the compiled directory, forcing a ".mib" extension.
+     * Find a single pending file by base name (no parsing/validation here).
+     * @return the pending File or null if not found
+     * @throws IllegalStateException if multiple matches exist
      */
-    public CompileMibResult compilePendingByBaseName(final String baseName) throws Exception {
-        if (baseName == null || baseName.isBlank()) {
-            LOG.warn("compilePendingByBaseName called with blank baseName");
-            return CompileMibResult.invalidRequest("baseName must not be blank.");
+    public static File findPendingByBaseName(final String baseName) throws Exception {
+        if (isBlank(baseName)) {
+            throw new IllegalArgumentException("baseName must not be blank.");
         }
 
         ensureDirExists(MIBS_PENDING_DIR);
+
+        final String normalizedBaseName = stripPathAndExtension(baseName);
+        if (isBlank(normalizedBaseName)) {
+            throw new IllegalArgumentException("baseName must not be blank.");
+        }
+
+        return findSingleByBaseName(MIBS_PENDING_DIR, normalizedBaseName);
+    }
+
+    /**
+     * Move a pending file to compiled directory, forcing ".mib" extension.
+     * This assumes validation/parsing has already happened elsewhere.
+     */
+    public static File movePendingToCompiled(final File pendingFile, final String baseName) throws Exception {
+        if (pendingFile == null) {
+            throw new IllegalArgumentException("pendingFile must not be null.");
+        }
+        if (isBlank(baseName)) {
+            throw new IllegalArgumentException("baseName must not be blank.");
+        }
+
         ensureDirExists(MIBS_COMPILED_DIR);
 
         final String normalizedBaseName = stripPathAndExtension(baseName);
-        if (normalizedBaseName == null || normalizedBaseName.isBlank()) {
-            LOG.warn("compilePendingByBaseName(baseName={}) resulted in blank normalized base name", baseName);
-            return CompileMibResult.invalidRequest("baseName must not be blank.");
+        if (isBlank(normalizedBaseName)) {
+            throw new IllegalArgumentException("baseName must not be blank.");
         }
 
-        LOG.info("Compiling pending MIB: requestedBaseName={}, normalizedBaseName={}", baseName, normalizedBaseName);
-
-        final File pendingFile;
-        try {
-            pendingFile = findSingleByBaseName(MIBS_PENDING_DIR, normalizedBaseName);
-        } catch (IllegalStateException e) {
-            LOG.error("Multiple pending files found for baseName={} in dir={}: {}",
-                    normalizedBaseName, MIBS_PENDING_DIR.getAbsolutePath(), e.getMessage(), e);
-            throw e;
-        }
-
-        if (pendingFile == null) {
-            LOG.warn("No pending file found for baseName={} in dir={}", normalizedBaseName, MIBS_PENDING_DIR.getAbsolutePath());
-            return CompileMibResult.notFound("No pending file found with base name '" + normalizedBaseName + "'.");
-        }
-
-        LOG.debug("Found pending file to compile: {}", pendingFile.getAbsolutePath());
-
-        final boolean parsed;
-        try {
-            parsed = mibParser.parseMib(pendingFile);
-        } catch (RuntimeException e) {
-            // If the parser can throw, treat as unexpected
-            LOG.error("Unexpected error while parsing MIB file: {}", pendingFile.getAbsolutePath(), e);
-            throw e;
-        }
-
-        if (!parsed) {
-            final var missingDeps = mibParser.getMissingDependencies();
-            if (missingDeps != null && !missingDeps.isEmpty()) {
-                LOG.warn("MIB compilation failed due to missing dependencies: baseName={}, file={}, missingDependencies={}",
-                        normalizedBaseName, pendingFile.getName(), missingDeps);
-                return CompileMibResult.missingDependencies("Missing dependencies: " + missingDeps, missingDeps);
-            }
-            final String errors = mibParser.getFormattedErrors();
-            LOG.warn("MIB validation failed: baseName={}, file={}, errors={}",
-                    normalizedBaseName, pendingFile.getName(), errors);
-            return CompileMibResult.validationFailed("MIB validation failed.", errors);
-        }
-
-        // Move to compiled and force .mib extension
         final File destFile = new File(MIBS_COMPILED_DIR, normalizedBaseName + DEFAULT_MIB_EXTENSION);
         if (destFile.exists()) {
             LOG.warn("Compilation conflict: destination file already exists: {}", destFile.getAbsolutePath());
-            return CompileMibResult.conflict("Compiled file already exists: " + destFile.getName());
+            throw new IllegalStateException("Compiled file already exists: " + destFile.getName());
         }
 
         LOG.info("Moving compiled MIB from pending to compiled: from={}, to={}",
@@ -187,17 +157,17 @@ public class MibCompilerFileService {
 
         Files.move(pendingFile.toPath(), destFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
 
-        LOG.info("MIB compiled successfully: baseName={}, compiledFile={}",
+        LOG.info("Moved MIB to compiled: baseName={}, compiledFile={}",
                 normalizedBaseName, destFile.getAbsolutePath());
 
-        return CompileMibResult.success(pendingFile, destFile);
+        return destFile;
     }
 
-    public List<MibCompilerFileInfo> listPendingAndCompiledFiles() throws IOException {
+    public static List<MibCompilerFileInfo> listPendingAndCompiledFiles() throws IOException {
         ensureDirExists(MIBS_PENDING_DIR);
         ensureDirExists(MIBS_COMPILED_DIR);
 
-        final List<MibCompilerFileInfo> results = new ArrayList<>();
+        final List<MibCompilerFileInfo> results = new ArrayList<MibCompilerFileInfo>();
         results.addAll(listFilesInDir(MIBS_PENDING_DIR, MibCompilerFileInfo.Location.PENDING));
         results.addAll(listFilesInDir(MIBS_COMPILED_DIR, MibCompilerFileInfo.Location.COMPILED));
 
@@ -211,11 +181,11 @@ public class MibCompilerFileService {
         return results;
     }
 
-    public boolean deleteFile(final String location, final String fileName) throws IOException {
-        if (location == null || location.isBlank()) {
+    public static boolean deleteFile(final String location, final String fileName) throws IOException {
+        if (isBlank(location)) {
             throw new IllegalArgumentException("location must not be blank.");
         }
-        if (fileName == null || fileName.isBlank()) {
+        if (isBlank(fileName)) {
             throw new IllegalArgumentException("fileName must not be blank.");
         }
 
@@ -240,7 +210,7 @@ public class MibCompilerFileService {
         return true;
     }
 
-    public String readTextFile(final String location, final String fileName) throws java.io.IOException {
+    public static String readTextFile(final String location, final String fileName) throws IOException {
         final File dir = resolveLocationDir(location);
         ensureDirExists(dir);
 
@@ -253,10 +223,11 @@ public class MibCompilerFileService {
             throw new IllegalStateException("Target is not a regular file: " + fileName);
         }
 
-        return Files.readString(target, StandardCharsets.UTF_8);
+        byte[] bytes = Files.readAllBytes(target);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
-    public void writeBinaryFile(final String location, final String fileName, final byte[] contents) throws IOException {
+    public static void writeBinaryFile(final String location, final String fileName, final byte[] contents) throws IOException {
         final File dir = resolveLocationDir(location);
         ensureDirExists(dir);
 
@@ -272,8 +243,22 @@ public class MibCompilerFileService {
         Files.write(target, contents);
     }
 
+    /** Helper for REST: does file exist at location/fileName? */
+    public static boolean exists(final String location, final String fileName) throws IOException {
+        final File dir = resolveLocationDir(location);
+        ensureDirExists(dir);
+        final Path target = new File(dir, fileName).toPath();
+        return Files.exists(target) && Files.isRegularFile(target);
+    }
+
+    /** Helper for REST: get File handle for location/fileName (no existence guarantee). */
+    public static File getFile(final String location, final String fileName) {
+        final File dir = resolveLocationDir(location);
+        return new File(dir, fileName);
+    }
+
     private static File resolveLocationDir(final String location) {
-        if (location == null || location.isBlank()) {
+        if (isBlank(location)) {
             throw new IllegalArgumentException("location must not be blank.");
         }
         switch (location.toLowerCase()) {
@@ -291,7 +276,7 @@ public class MibCompilerFileService {
             return Collections.emptyList();
         }
 
-        final List<MibCompilerFileInfo> out = new ArrayList<>();
+        final List<MibCompilerFileInfo> out = new ArrayList<MibCompilerFileInfo>();
         try (Stream<Path> stream = Files.list(dir.toPath())) {
             stream.filter(Files::isRegularFile)
                     .sorted(Comparator.comparing(p -> p.getFileName().toString()))
@@ -310,8 +295,8 @@ public class MibCompilerFileService {
             return null;
         }
 
-        final List<Path> matches = new ArrayList<>();
-        try (var stream = Files.list(dir.toPath())) {
+        final List<Path> matches = new ArrayList<Path>();
+        try (Stream<Path> stream = Files.list(dir.toPath())) {
             stream.filter(Files::isRegularFile).forEach(p -> {
                 final String bn = stripPathAndExtension(p.getFileName().toString());
                 if (baseName.equals(bn)) {
@@ -351,25 +336,19 @@ public class MibCompilerFileService {
         LOG.debug("Created directory: {}", dir.getAbsolutePath());
     }
 
-    /**
-     * Checks if any file in {@code dir} has the given basename (basename comparison, not full filename).
-     */
     private static boolean baseNameExists(final File dir, final String baseName) throws Exception {
         if (dir == null || !dir.exists() || !dir.isDirectory()) {
             LOG.debug("baseNameExists: dir missing or not a directory: dir={}, baseName={}",
                     dir == null ? null : dir.getAbsolutePath(), baseName);
             return false;
         }
-        try (var stream = Files.list(dir.toPath())) {
+        try (Stream<Path> stream = Files.list(dir.toPath())) {
             final boolean found = stream.anyMatch(p -> baseName.equals(stripPathAndExtension(p.getFileName().toString())));
             LOG.debug("baseNameExists: dir={}, baseName={}, found={}", dir.getAbsolutePath(), baseName, found);
             return found;
         }
     }
 
-    /**
-     * Removes any path segments and strips the extension.
-     */
     public static String stripPathAndExtension(final String filename) {
         if (filename == null) return null;
 
@@ -393,7 +372,7 @@ public class MibCompilerFileService {
 
     public static String normalizeExtension(final String extension, final String defaultExt) {
         String ext = extension;
-        if (ext == null || ext.isBlank()) {
+        if (isBlank(ext)) {
             ext = defaultExt;
         }
         ext = ext.trim();
@@ -401,5 +380,20 @@ public class MibCompilerFileService {
             ext = "." + ext;
         }
         return ext;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+
+    private static long copy(InputStream in, OutputStream out) throws IOException {
+        byte[] buffer = new byte[8192];
+        long total = 0;
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
+            total += read;
+        }
+        return total;
     }
 }

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/model/CompileMibResult.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/model/CompileMibResult.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.mibcompiler.rest.model;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+public class CompileMibResult {
+
+    public enum Status {
+        SUCCESS,
+        NOT_FOUND,
+        INVALID_REQUEST,
+        VALIDATION_FAILED,
+        MISSING_DEPENDENCIES,
+        CONFLICT
+    }
+
+    private final Status status;
+    private final String message;
+    private final File pendingFile;
+    private final File compiledFile;
+    private final List<String> missingDependencies;
+    private final String formattedErrors;
+
+    private CompileMibResult(Status status,
+                             String message,
+                             File pendingFile,
+                             File compiledFile,
+                             List<String> missingDependencies,
+                             String formattedErrors) {
+        this.status = status;
+        this.message = message;
+        this.pendingFile = pendingFile;
+        this.compiledFile = compiledFile;
+        this.missingDependencies = missingDependencies == null ? Collections.<String>emptyList() : missingDependencies;
+        this.formattedErrors = formattedErrors;
+    }
+
+    public static CompileMibResult success(File pendingFile, File compiledFile) {
+        return new CompileMibResult(Status.SUCCESS, "Compiled successfully.", pendingFile, compiledFile,
+                Collections.<String>emptyList(), null);
+    }
+
+    public static CompileMibResult notFound(String message) {
+        return new CompileMibResult(Status.NOT_FOUND, message, null, null,
+                Collections.<String>emptyList(), null);
+    }
+
+    public static CompileMibResult invalidRequest(String message) {
+        return new CompileMibResult(Status.INVALID_REQUEST, message, null, null,
+                Collections.<String>emptyList(), null);
+    }
+
+    public static CompileMibResult validationFailed(String message, String formattedErrors) {
+        return new CompileMibResult(Status.VALIDATION_FAILED, message, null, null,
+                Collections.<String>emptyList(), formattedErrors);
+    }
+
+    public static CompileMibResult missingDependencies(String message, List<String> missingDependencies) {
+        return new CompileMibResult(Status.MISSING_DEPENDENCIES, message, null, null,
+                missingDependencies, null);
+    }
+
+    public static CompileMibResult conflict(String message) {
+        return new CompileMibResult(Status.CONFLICT, message, null, null,
+                Collections.<String>emptyList(), null);
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public File getPendingFile() {
+        return pendingFile;
+    }
+
+    public File getCompiledFile() {
+        return compiledFile;
+    }
+
+    public List<String> getMissingDependencies() {
+        return missingDependencies;
+    }
+
+    public String getFormattedErrors() {
+        return formattedErrors;
+    }
+
+    public boolean isSuccess() {
+        return status == Status.SUCCESS;
+    }
+}

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/model/MibCompilerFileInfo.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/model/MibCompilerFileInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.mibcompiler.rest.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MibCompilerFileInfo {
+    public enum Location {
+        PENDING,
+        COMPILED
+    }
+
+    private final String fileName;
+    private final Location location;
+
+    @JsonCreator
+    public MibCompilerFileInfo(
+            @JsonProperty("fileName") String fileName,
+            @JsonProperty("location") Location location) {
+        this.fileName = fileName;
+        this.location = location;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+}

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/model/MibCompilerFileText.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/model/MibCompilerFileText.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.mibcompiler.rest.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MibCompilerFileText {
+    private final String name;
+    private final String location;
+    private final String contents;
+
+    @JsonCreator
+    public MibCompilerFileText(
+            @JsonProperty("name") String name,
+            @JsonProperty("location") String location,
+            @JsonProperty("contents") String contents) {
+        this.name = name;
+        this.location = location;
+        this.contents = contents;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+}

--- a/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/model/MibCompilerGenerateEventsRequest.java
+++ b/features/mib-compiler/rest/src/main/java/org/opennms/features/mibcompiler/rest/model/MibCompilerGenerateEventsRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.mibcompiler.rest.model;
+
+public class MibCompilerGenerateEventsRequest {
+
+    private String name;
+    private String ueiBase;
+
+    public MibCompilerGenerateEventsRequest() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUeiBase() {
+        return ueiBase;
+    }
+
+    public void setUeiBase(String ueiBase) {
+        this.ueiBase = ueiBase;
+    }
+
+
+
+}

--- a/features/mib-compiler/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/mib-compiler/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -6,13 +6,18 @@
 ">
 
     <reference id="mibParser" interface="org.opennms.features.mibcompiler.api.MibParser" availability="mandatory"/>
+    <reference id="eventConfSourceDao" interface="org.opennms.netmgt.dao.api.EventConfSourceDao" availability="mandatory"/>
+    <reference id="eventConfEventDao" interface="org.opennms.netmgt.dao.api.EventConfEventDao" availability="mandatory"/>
+    <reference id="eventConfDao" interface="org.opennms.netmgt.config.api.EventConfDao" availability="mandatory"/>
+    <reference id="operations" interface="org.springframework.transaction.support.TransactionOperations" availability="mandatory" />
 
-    <bean id="mibCompilerFileService" class="org.opennms.features.mibcompiler.rest.internal.MibCompilerFileService">
-        <argument ref="mibParser"/>
-    </bean>
 
     <bean id="mibCompilerRestService" class="org.opennms.features.mibcompiler.rest.internal.MibCompilerRestServiceImpl">
-        <argument ref="mibCompilerFileService"/>
+        <argument ref="mibParser"/>
+        <argument ref="eventConfSourceDao"/>
+        <argument ref="eventConfEventDao"/>
+        <argument ref="eventConfDao"/>
+        <argument ref="operations"/>
     </bean>
 
     <service interface="org.opennms.features.mibcompiler.rest.MibCompilerRestService" ref="mibCompilerRestService">

--- a/features/mib-compiler/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/mib-compiler/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -7,8 +7,12 @@
 
     <reference id="mibParser" interface="org.opennms.features.mibcompiler.api.MibParser" availability="mandatory"/>
 
-    <bean id="mibCompilerRestService" class="org.opennms.features.mibcompiler.rest.internal.MibCompilerRestServiceImpl">
+    <bean id="mibCompilerFileService" class="org.opennms.features.mibcompiler.rest.internal.MibCompilerFileService">
         <argument ref="mibParser"/>
+    </bean>
+
+    <bean id="mibCompilerRestService" class="org.opennms.features.mibcompiler.rest.internal.MibCompilerRestServiceImpl">
+        <argument ref="mibCompilerFileService"/>
     </bean>
 
     <service interface="org.opennms.features.mibcompiler.rest.MibCompilerRestService" ref="mibCompilerRestService">

--- a/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
+++ b/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
@@ -21,7 +21,12 @@
  */
 package org.opennms.features.mibcompiler.rest.internal;
 
-import org.junit.*;
+import org.junit.Test;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+
 import org.opennms.features.mibcompiler.api.MibParser;
 import org.opennms.features.mibcompiler.rest.model.MibCompilerFileInfo;
 import org.opennms.features.mibcompiler.rest.model.MibCompilerFileText;
@@ -43,7 +48,6 @@ import static org.mockito.Mockito.mock;
 public class MibCompilerRestServiceImplIT {
 
     private File tempHome;
-    private File mibsRoot;
     private File pendingDir;
     private File compiledDir;
     private static File classHome;
@@ -177,42 +181,24 @@ public class MibCompilerRestServiceImplIT {
         Files.writeString(new File(pendingDir, "edit.txt").toPath(),
                 "old", StandardCharsets.UTF_8);
 
-        MibCompilerFileText req = new MibCompilerFileText("edit.txt", "pending", "new\ntext");
+        byte[] content = "new\ntext".getBytes(StandardCharsets.UTF_8);
 
-        Response r = service.setFileText("edit.txt", req);
+        Response r = service.setFileText("edit.txt", content);
 
         assertEquals(200, r.getStatus());
         assertNotNull(r.getEntity());
-        assertTrue(r.getEntity() instanceof MibCompilerFileText);
-
         // Verify content changed on disk
         String updated = Files.readString(new File(pendingDir, "edit.txt").toPath(), StandardCharsets.UTF_8);
         assertEquals("new\ntext", updated);
 
-        // Verify response echoes updated content
-        MibCompilerFileText resp = (MibCompilerFileText) r.getEntity();
-        assertEquals("edit.txt", resp.getName());
-        assertEquals("pending", resp.getLocation());
-        assertEquals("new\ntext", resp.getContents());
     }
 
+
     @Test
-    public void setFileText_shouldReturn400WhenLocationIsCompiled() throws Exception {
-        Files.writeString(new File(compiledDir, "edit.mib").toPath(),
-                "old", StandardCharsets.UTF_8);
-
-        MibCompilerFileText req = new MibCompilerFileText("edit.mib", "compiled", "new");
-
-        Response r = service.setFileText("edit.mib", req);
-
+    public void setFileText_shouldReturn400WhenPendingFileMissing() {
+        byte[] content = "SOME MIB CONTENT".getBytes(StandardCharsets.UTF_8);
+        Response r = service.setFileText("missing.txt", content);
         assertEquals(400, r.getStatus());
-    }
-
-    @Test
-    public void setFileText_shouldReturn404WhenPendingFileMissing() {
-        MibCompilerFileText req = new MibCompilerFileText("missing.txt", "pending", "new");
-        Response r = service.setFileText("missing.txt", req);
-        assertEquals(404, r.getStatus());
     }
 
     @Test

--- a/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
+++ b/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
@@ -184,9 +184,8 @@ public class MibCompilerRestServiceImplIT {
 
     @Test
     public void getFileText_shouldReturn404ForInvalidFileName() throws Exception {
-        // validateFileNameAndLocation(...) returns BAD_REQUEST (400) for "..\\evil.txt"
         Response r = service.getFileText("pending", "..\\evil.txt");
-        assertEquals(404, r.getStatus());
+        assertEquals(400, r.getStatus());
     }
 
     @Test

--- a/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
+++ b/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.mibcompiler.rest.internal;
+
+import org.junit.*;
+import org.opennms.features.mibcompiler.api.MibParser;
+import org.opennms.features.mibcompiler.rest.model.MibCompilerFileInfo;
+import org.opennms.features.mibcompiler.rest.model.MibCompilerFileText;
+
+import javax.ws.rs.core.Response;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.activemq.util.IOHelper.deleteChildren;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+
+public class MibCompilerRestServiceImplIT {
+
+    private File tempHome;
+    private File mibsRoot;
+    private File pendingDir;
+    private File compiledDir;
+    private static File classHome;
+
+    private MibCompilerRestServiceImpl service;
+
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        classHome = Files.createTempDirectory("mibcompiler-rest-it-home-").toFile();
+        System.setProperty("opennms.home", classHome.getAbsolutePath());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("opennms.home");
+        deleteRecursively(classHome);
+    }
+
+
+
+    @Before
+    public void setUp() throws Exception {
+        File mibsRoot = new File(classHome, "share/mibs");
+        pendingDir = new File(mibsRoot, "pending");
+        compiledDir = new File(mibsRoot, "compiled");
+
+        pendingDir.mkdirs();
+        compiledDir.mkdirs();
+
+        deleteChildren(pendingDir);
+        deleteChildren(compiledDir);
+
+        MibParser parser = mock(MibParser.class);
+        MibCompilerFileService fileService = new MibCompilerFileService(parser);
+
+        service = new MibCompilerRestServiceImpl(fileService);
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("opennms.home");
+        deleteRecursively(tempHome);
+    }
+
+    @Test
+    public void listPendingAndCompiledFiles_shouldReturn200AndIncludePendingAndCompiled() throws Exception {
+        Files.writeString(new File(pendingDir, "p1.mib").toPath(), "pending", StandardCharsets.UTF_8);
+        Files.writeString(new File(compiledDir, "c1.mib").toPath(), "compiled", StandardCharsets.UTF_8);
+
+        Response r = service.listPendingAndCompiledFiles();
+
+        assertEquals(200, r.getStatus());
+        assertNotNull(r.getEntity());
+
+        @SuppressWarnings("unchecked")
+        List<MibCompilerFileInfo> list = (List<MibCompilerFileInfo>) r.getEntity();
+
+        assertEquals(2, list.size());
+    }
+
+    @Test
+    public void listPendingAndCompiledFiles_shouldReturn200AndEmptyListWhenNoFiles() {
+        Response r = service.listPendingAndCompiledFiles();
+
+        assertEquals(200, r.getStatus());
+        assertNotNull(r.getEntity());
+
+        @SuppressWarnings("unchecked")
+        List<Object> list = (List<Object>) r.getEntity();
+
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void deleteFile_shouldReturn204WhenPendingFileDeleted() throws Exception {
+        File f = new File(pendingDir, "to-delete.txt");
+        Files.writeString(f.toPath(), "x", StandardCharsets.UTF_8);
+        assertTrue(f.exists());
+
+        Response r = service.deleteFile("pending", "to-delete.txt");
+
+        assertEquals(204, r.getStatus());
+        assertFalse("file should be deleted", f.exists());
+    }
+
+    @Test
+    public void deleteFile_shouldReturn404WhenFileMissing() {
+        Response r = service.deleteFile("pending", "missing.txt");
+        assertEquals(404, r.getStatus());
+    }
+
+    @Test
+    public void deleteFile_shouldReturn400ForInvalidFileNameTraversal() {
+        Response r = service.deleteFile("pending", "../evil.txt");
+        assertEquals(400, r.getStatus());
+    }
+
+    @Test
+    public void getFileText_shouldReturn200AndFileTextForPending() throws Exception {
+        Files.writeString(new File(pendingDir, "file1.txt").toPath(),
+                "opennms\nmibcompiler testing", StandardCharsets.UTF_8);
+
+        Response r = service.getFileText("pending", "file1.txt");
+
+        assertEquals(200, r.getStatus());
+        assertNotNull(r.getEntity());
+        assertTrue(r.getEntity() instanceof MibCompilerFileText);
+
+        MibCompilerFileText body = (MibCompilerFileText) r.getEntity();
+        assertEquals("file1.txt", body.getName());
+        assertEquals("pending", body.getLocation());
+        assertEquals("opennms\nmibcompiler testing", body.getContents());
+    }
+
+    @Test
+    public void getFileText_shouldReturn404WhenMissing() throws Exception {
+        Response r = service.getFileText("compiled", "missing.mib");
+        assertEquals(404, r.getStatus());
+    }
+
+    @Test
+    public void getFileText_shouldReturn404ForInvalidFileName() throws Exception {
+        // This test requires validateFileNameAndLocation(...) result to be returned by getFileText()
+        Response r = service.getFileText("pending", "..\\evil.txt");
+        assertEquals(404, r.getStatus());
+    }
+
+    @Test
+    public void setFileText_shouldReturn200AndOverwritePendingFile() throws Exception {
+        Files.writeString(new File(pendingDir, "edit.txt").toPath(),
+                "old", StandardCharsets.UTF_8);
+
+        MibCompilerFileText req = new MibCompilerFileText("edit.txt", "pending", "new\ntext");
+
+        Response r = service.setFileText("edit.txt", req);
+
+        assertEquals(200, r.getStatus());
+        assertNotNull(r.getEntity());
+        assertTrue(r.getEntity() instanceof MibCompilerFileText);
+
+        // Verify content changed on disk
+        String updated = Files.readString(new File(pendingDir, "edit.txt").toPath(), StandardCharsets.UTF_8);
+        assertEquals("new\ntext", updated);
+
+        // Verify response echoes updated content
+        MibCompilerFileText resp = (MibCompilerFileText) r.getEntity();
+        assertEquals("edit.txt", resp.getName());
+        assertEquals("pending", resp.getLocation());
+        assertEquals("new\ntext", resp.getContents());
+    }
+
+    @Test
+    public void setFileText_shouldReturn400WhenLocationIsCompiled() throws Exception {
+        Files.writeString(new File(compiledDir, "edit.mib").toPath(),
+                "old", StandardCharsets.UTF_8);
+
+        MibCompilerFileText req = new MibCompilerFileText("edit.mib", "compiled", "new");
+
+        Response r = service.setFileText("edit.mib", req);
+
+        assertEquals(400, r.getStatus());
+    }
+
+    @Test
+    public void setFileText_shouldReturn404WhenPendingFileMissing() {
+        MibCompilerFileText req = new MibCompilerFileText("missing.txt", "pending", "new");
+        Response r = service.setFileText("missing.txt", req);
+        assertEquals(404, r.getStatus());
+    }
+
+    @Test
+    public void uploadMib_shouldReturn201AndSaveToPending() throws Exception {
+        byte[] content = "SOME MIB CONTENT".getBytes(StandardCharsets.UTF_8);
+
+        Response r = service.uploadMib(content, "IF-MIB.mib");
+
+        assertEquals(201, r.getStatus());
+        assertNotNull(r.getEntity());
+        assertTrue(r.getEntity() instanceof Map);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = (Map<String, Object>) r.getEntity();
+
+        assertTrue(payload.containsKey("success"));
+        assertTrue(payload.containsKey("errors"));
+
+        File[] pendingFiles = pendingDir.listFiles();
+        assertNotNull(pendingFiles);
+        assertEquals(1, pendingFiles.length);
+        assertEquals("IF-MIB.mib", pendingFiles[0].getName());
+    }
+
+    @Test
+    public void uploadMib_shouldReturn400ForEmptyContent() throws Exception {
+        Response r = service.uploadMib(new byte[0], "IF-MIB.mib");
+        assertEquals(400, r.getStatus());
+    }
+
+    @Test
+    public void uploadMib_shouldReturn409WhenBaseNameAlreadyExistsInPending() throws Exception {
+        // Create a file with same baseName IF-MIB in pending
+        Files.writeString(new File(pendingDir, "IF-MIB.mib").toPath(), "existing", StandardCharsets.UTF_8);
+
+        Response r = service.uploadMib("new".getBytes(StandardCharsets.UTF_8), "IF-MIB.txt");
+
+        assertEquals(409, r.getStatus());
+    }
+
+    private static void deleteRecursively(File f) {
+        if (f == null || !f.exists()) return;
+        File[] kids = f.listFiles();
+        if (kids != null) {
+            for (File k : kids) {
+                deleteRecursively(k);
+            }
+        }
+        f.delete();
+    }
+}

--- a/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
+++ b/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
@@ -30,6 +30,10 @@ import org.junit.AfterClass;
 import org.opennms.features.mibcompiler.api.MibParser;
 import org.opennms.features.mibcompiler.rest.model.MibCompilerFileInfo;
 import org.opennms.features.mibcompiler.rest.model.MibCompilerFileText;
+import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.dao.api.EventConfEventDao;
+import org.opennms.netmgt.dao.api.EventConfSourceDao;
+import org.springframework.transaction.support.TransactionOperations;
 
 import javax.ws.rs.core.Response;
 import java.io.File;
@@ -82,9 +86,13 @@ public class MibCompilerRestServiceImplIT {
         deleteChildren(compiledDir);
 
         MibParser parser = mock(MibParser.class);
-        MibCompilerFileService fileService = new MibCompilerFileService(parser);
+        EventConfSourceDao eventConfSourceDao = mock(EventConfSourceDao.class);
+        EventConfEventDao eventConfEventDao = mock(EventConfEventDao.class);
+        EventConfDao eventConfDao = mock(EventConfDao.class);
+        TransactionOperations operations = mock(TransactionOperations.class);
 
-        service = new MibCompilerRestServiceImpl(fileService);
+
+        service = new MibCompilerRestServiceImpl(parser,eventConfSourceDao,eventConfEventDao,eventConfDao,operations);
     }
 
     @After
@@ -231,11 +239,8 @@ public class MibCompilerRestServiceImplIT {
 
     @Test
     public void uploadMib_shouldReturn409WhenBaseNameAlreadyExistsInPending() throws Exception {
-        // Create a file with same baseName IF-MIB in pending
         Files.writeString(new File(pendingDir, "IF-MIB.mib").toPath(), "existing", StandardCharsets.UTF_8);
-
         Response r = service.uploadMib("new".getBytes(StandardCharsets.UTF_8), "IF-MIB.txt");
-
         assertEquals(409, r.getStatus());
     }
 

--- a/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
+++ b/features/mib-compiler/rest/src/test/java/org/opennms/features/mibcompiler/rest/internal/MibCompilerRestServiceImplIT.java
@@ -21,15 +21,15 @@
  */
 package org.opennms.features.mibcompiler.rest.internal;
 
-import org.junit.Test;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.AfterClass;
-
+import org.junit.Test;
 import org.opennms.features.mibcompiler.api.MibParser;
 import org.opennms.features.mibcompiler.rest.model.MibCompilerFileInfo;
 import org.opennms.features.mibcompiler.rest.model.MibCompilerFileText;
+import org.opennms.features.mibcompiler.rest.model.MibCompilerGenerateEventsRequest;
 import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.dao.api.EventConfEventDao;
 import org.opennms.netmgt.dao.api.EventConfSourceDao;
@@ -44,20 +44,27 @@ import java.util.Map;
 
 import static org.apache.activemq.util.IOHelper.deleteChildren;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MibCompilerRestServiceImplIT {
 
-    private File tempHome;
     private File pendingDir;
     private File compiledDir;
     private static File classHome;
 
-    private MibCompilerRestServiceImpl service;
+    private MibParser parser;
+    private EventConfSourceDao eventConfSourceDao;
+    private EventConfEventDao eventConfEventDao;
+    private EventConfDao eventConfDao;
+    private TransactionOperations operations;
 
+    private MibCompilerRestServiceImpl service;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -71,8 +78,6 @@ public class MibCompilerRestServiceImplIT {
         deleteRecursively(classHome);
     }
 
-
-
     @Before
     public void setUp() throws Exception {
         File mibsRoot = new File(classHome, "share/mibs");
@@ -85,20 +90,20 @@ public class MibCompilerRestServiceImplIT {
         deleteChildren(pendingDir);
         deleteChildren(compiledDir);
 
-        MibParser parser = mock(MibParser.class);
-        EventConfSourceDao eventConfSourceDao = mock(EventConfSourceDao.class);
-        EventConfEventDao eventConfEventDao = mock(EventConfEventDao.class);
-        EventConfDao eventConfDao = mock(EventConfDao.class);
-        TransactionOperations operations = mock(TransactionOperations.class);
+        // Keep references to mocks so tests (especially generateEvents) can stub them.
+        parser = mock(MibParser.class);
+        eventConfSourceDao = mock(EventConfSourceDao.class);
+        eventConfEventDao = mock(EventConfEventDao.class);
+        eventConfDao = mock(EventConfDao.class);
+        operations = mock(TransactionOperations.class);
 
-
-        service = new MibCompilerRestServiceImpl(parser,eventConfSourceDao,eventConfEventDao,eventConfDao,operations);
+        service = new MibCompilerRestServiceImpl(parser, eventConfSourceDao, eventConfEventDao, eventConfDao, operations);
     }
 
     @After
     public void tearDown() {
-        System.clearProperty("opennms.home");
-        deleteRecursively(tempHome);
+        deleteRecursively(pendingDir);
+        deleteRecursively(compiledDir);
     }
 
     @Test
@@ -179,7 +184,7 @@ public class MibCompilerRestServiceImplIT {
 
     @Test
     public void getFileText_shouldReturn404ForInvalidFileName() throws Exception {
-        // This test requires validateFileNameAndLocation(...) result to be returned by getFileText()
+        // validateFileNameAndLocation(...) returns BAD_REQUEST (400) for "..\\evil.txt"
         Response r = service.getFileText("pending", "..\\evil.txt");
         assertEquals(404, r.getStatus());
     }
@@ -195,17 +200,15 @@ public class MibCompilerRestServiceImplIT {
 
         assertEquals(200, r.getStatus());
         assertNotNull(r.getEntity());
+
         // Verify content changed on disk
         String updated = Files.readString(new File(pendingDir, "edit.txt").toPath(), StandardCharsets.UTF_8);
         assertEquals("new\ntext", updated);
-
     }
 
-
     @Test
-    public void setFileText_shouldReturn400WhenPendingFileMissing() {
-        byte[] content = "SOME MIB CONTENT".getBytes(StandardCharsets.UTF_8);
-        Response r = service.setFileText("missing.txt", content);
+    public void setFileText_shouldReturn400WhenMibContentIsNull() {
+        Response r = service.setFileText("edit.txt", null);
         assertEquals(400, r.getStatus());
     }
 
@@ -242,6 +245,54 @@ public class MibCompilerRestServiceImplIT {
         Files.writeString(new File(pendingDir, "IF-MIB.mib").toPath(), "existing", StandardCharsets.UTF_8);
         Response r = service.uploadMib("new".getBytes(StandardCharsets.UTF_8), "IF-MIB.txt");
         assertEquals(409, r.getStatus());
+    }
+
+
+    @Test
+    public void generateEvents_shouldReturn409WhenMissingDependencies() throws Exception {
+        Files.writeString(new File(compiledDir, "D.mib").toPath(), "dummy", StandardCharsets.UTF_8);
+
+        when(parser.parseMib(any(File.class))).thenReturn(false);
+        when(parser.getMissingDependencies()).thenReturn(List.of("SNMPv2-SMI"));
+
+        MibCompilerGenerateEventsRequest req = new MibCompilerGenerateEventsRequest();
+        req.setName("D.mib");
+        req.setUeiBase("uei.opennms.org/test");
+
+        Response r = service.generateEvents(req);
+        assertEquals(409, r.getStatus());
+    }
+
+    @Test
+    public void generateEvents_shouldReturn400WhenParseFailsWithErrors() throws Exception {
+        Files.writeString(new File(compiledDir, "D.mib").toPath(), "dummy", StandardCharsets.UTF_8);
+
+        when(parser.parseMib(any(File.class))).thenReturn(false);
+        when(parser.getMissingDependencies()).thenReturn(List.of());
+        when(parser.getFormattedErrors()).thenReturn("parse error");
+
+        MibCompilerGenerateEventsRequest req = new MibCompilerGenerateEventsRequest();
+        req.setName("D.mib");
+        req.setUeiBase("uei.opennms.org/test");
+
+        Response r = service.generateEvents(req);
+        assertEquals(400, r.getStatus());
+        assertEquals("parse error", r.getEntity());
+    }
+
+    @Test
+    public void generateEvents_shouldReturn500WhenEventsNull() throws Exception {
+        Files.writeString(new File(compiledDir, "D.mib").toPath(), "dummy", StandardCharsets.UTF_8);
+
+        when(parser.parseMib(any(File.class))).thenReturn(true);
+        when(parser.getEvents(anyString())).thenReturn(null);
+
+        MibCompilerGenerateEventsRequest req = new MibCompilerGenerateEventsRequest();
+        req.setName("D.mib");
+        req.setUeiBase("uei.opennms.org/test");
+
+        Response r = service.generateEvents(req);
+        assertEquals(500, r.getStatus());
     }
 
     private static void deleteRecursively(File f) {

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/EventConfServiceHelper.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/EventConfServiceHelper.java
@@ -25,10 +25,13 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.dao.api.EventConfEventDao;
+import org.opennms.netmgt.dao.api.EventConfSourceDao;
 import org.opennms.netmgt.model.EventConfEvent;
 import org.opennms.netmgt.model.EventConfSource;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.events.EventConfSourceMetadataDto;
 import org.opennms.netmgt.xml.eventconf.Event;
+import org.opennms.netmgt.xml.eventconf.Events;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,6 +76,31 @@ public class EventConfServiceHelper {
         eventConfEvent.setLastModified(timestamp);
         eventConfEvent.setModifiedBy(username);
         return eventConfEventDao.save(eventConfEvent);
+    }
+
+
+    public static EventConfSource createOrUpdateSource(EventConfSourceDao eventConfSourceDao,final EventConfSourceMetadataDto eventConfSourceMetadataDto) {
+        EventConfSource source = eventConfSourceDao.findByName(eventConfSourceMetadataDto.getFilename());
+        if (source == null) {
+            source = new EventConfSource();
+            source.setCreatedTime(eventConfSourceMetadataDto.getNow());
+            source.setFileOrder(eventConfSourceMetadataDto.getFileOrder());
+        }
+        source.setName(eventConfSourceMetadataDto.getFilename());
+        source.setEventCount(eventConfSourceMetadataDto.getEventCount());
+        source.setEnabled(true);
+        source.setUploadedBy(eventConfSourceMetadataDto.getUsername());
+        source.setLastModified(eventConfSourceMetadataDto.getNow());
+        source.setVendor(eventConfSourceMetadataDto.getVendor());
+        source.setDescription(eventConfSourceMetadataDto.getDescription());
+        eventConfSourceDao.saveOrUpdate(source);
+        return eventConfSourceDao.get(source.getId());
+    }
+
+    public static  void saveEvents(EventConfEventDao eventConfEventDao,EventConfSource source, Events events, String username, Date now) {
+        List<EventConfEvent> eventEntities = EventConfServiceHelper.createEventConfEventEntities(
+                source, events.getEvents(), username, now);
+        eventConfEventDao.saveAll(eventEntities);
     }
 
     /**

--- a/ui/src/components/MibCompiler/CompiledMibFiles.vue
+++ b/ui/src/components/MibCompiler/CompiledMibFiles.vue
@@ -52,19 +52,19 @@
                   icon="View Details"
                   data-test="view-button"
                 >
-                  <FeatherIcon :icon="Generic"> </FeatherIcon>
+                  <FeatherIcon :icon="Generic" />
                 </FeatherButton>
                 <FeatherButton
                   icon="View Details"
                   data-test="view-button"
                 >
-                  <FeatherIcon :icon="StackedBarChart"> </FeatherIcon>
+                  <FeatherIcon :icon="StackedBarChart" />
                 </FeatherButton>
                 <FeatherButton
                   icon="Download XML"
                   data-test="download-button"
                 >
-                  <FeatherIcon :icon="Delete"> </FeatherIcon>
+                  <FeatherIcon :icon="Delete" />
                 </FeatherButton>
               </div>
             </td>

--- a/ui/src/components/MibCompiler/PendingMibFiles.vue
+++ b/ui/src/components/MibCompiler/PendingMibFiles.vue
@@ -46,7 +46,6 @@
             :key="config.fileName"
           >
             <td>{{ config.fileName }}</td>
-            <td>{{ config.location }}</td>
             <td>
               <div class="action-container">
                 <FeatherButton

--- a/ui/src/components/MibCompiler/UploadMibFiles.vue
+++ b/ui/src/components/MibCompiler/UploadMibFiles.vue
@@ -1,10 +1,401 @@
 <template>
-  <div class="upload-mib-files-container">
-    <h1>Upload MIB Files</h1>
+  <div class="upload-files-tab">
+    <div class="action-bar">
+      <FeatherButton
+        secondary
+        data-test="upload-button"
+        @click="fileInput?.click()"
+      >
+        Upload MIB Files
+      </FeatherButton>
+      <input
+        type="file"
+        :accept="VALID_FILE_EXTENSION"
+        multiple
+        @change="handleUpload"
+        data-test="event-conf-upload-input"
+        ref="fileInput"
+      />
+    </div>
+    <div class="files">
+      <div
+        v-for="(mibFile, index) in mibFiles"
+        :key="index"
+        class="file"
+      >
+        <div class="text">
+          <FeatherIcon :icon="Generic" />
+          <p
+            :title="mibFile.file.name"
+            class="name"
+          >
+            {{ ellipsify(mibFile.file.name, 30) }}
+          </p>
+        </div>
+        <div class="action">
+          <FeatherTooltip
+            v-if="mibFile.isDuplicate"
+            :title="'File is a duplicate of another file that has been already uploaded.'"
+            v-slot="{ attrs, on }"
+          >
+            <FeatherIcon
+              :icon="Warning"
+              v-bind="attrs"
+              v-on="on"
+              class="warning-icon"
+            />
+          </FeatherTooltip>
+          <FeatherTooltip
+            v-if="mibFile.isValid && !mibFile.isDuplicate"
+            :title="'File is valid'"
+            v-slot="{ attrs, on }"
+          >
+            <FeatherIcon
+              :icon="CheckCircle"
+              v-bind="attrs"
+              v-on="on"
+              class="success-icon"
+            />
+          </FeatherTooltip>
+          <FeatherTooltip
+            v-if="!mibFile.isValid"
+            :title="mibFile.errors.map((error: string) => `${error}. `).join('\n')"
+            v-slot="{ attrs, on }"
+          >
+            <FeatherIcon
+              :icon="Error"
+              v-bind="attrs"
+              v-on="on"
+              class="error-icon"
+            />
+          </FeatherTooltip>
+          <FeatherButton
+            text
+            icon="Remove"
+            data-test="remove-file-button"
+            @click="removeFile(index)"
+          >
+            <FeatherIcon :icon="Cancel" />
+          </FeatherButton>
+        </div>
+      </div>
+    </div>
+    <div class="logs-container">
+      <div class="header">
+        <p>MIB Logs</p>
+      </div>
+      <div
+        ref="logsContainerRef"
+        class="logs"
+      >
+        <div
+          v-for="(log, index) in logs"
+          :key="index"
+          :class="['log-entry', log.type]"
+        >
+          <span class="log-timestamp">{{ log.timestamp }}</span>
+          <span class="log-type">{{ log.type.toUpperCase() }}</span>
+          <span class="log-message">{{ log.message }}</span>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import useSnackbar from '@/composables/useSnackbar'
+import { ellipsify } from '@/lib/utils'
+import { uploadMib } from '@/services/mibCompilerService'
+import { useMibCompilerStore } from '@/stores/mibCompilerStore'
+import { UploadMibFileType } from '@/types/mibCompiler'
+import { FeatherButton } from '@featherds/button'
+import { FeatherIcon } from '@featherds/icon'
+import CheckCircle from '@featherds/icon/action/CheckCircle'
+import Generic from '@featherds/icon/file/Generic'
+import Cancel from '@featherds/icon/navigation/Cancel'
+import Warning from '@featherds/icon/notification/Warning'
+import { FeatherTooltip } from '@featherds/tooltip'
+import { mibFilesValidator, VALID_FILE_EXTENSION } from './mibFilesValidator'
 
-<style lang="scss" scoped></style>
+// const isLoading = ref(false)
+const snackbar = useSnackbar()
+const store = useMibCompilerStore()
+const fileInput = ref<HTMLInputElement | null>(null)
+const mibFiles = ref<UploadMibFileType[]>([])
+const logsContainerRef = ref<HTMLElement | null>(null)
+
+interface LogEntry {
+  type: 'info' | 'success' | 'error'
+  timestamp: string
+  message: string
+}
+
+const logs = ref<LogEntry[]>([])
+
+const scrollLogsToBottom = async () => {
+  await nextTick()
+  if (logsContainerRef.value) {
+    logsContainerRef.value.scrollTop = logsContainerRef.value.scrollHeight
+  }
+}
+
+const formatTimestamp = (date: Date): string => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+}
+
+const addLog = (type: 'info' | 'success' | 'error', message: string) => {
+  logs.value.push({
+    type,
+    timestamp: formatTimestamp(new Date()),
+    message
+  })
+
+  void scrollLogsToBottom()
+}
+
+const removeFile = (index: number) => {
+  mibFiles.value.splice(index, 1)
+}
+
+const handleUpload = async (e: Event) => {
+  const input = e.target as HTMLInputElement
+  if (!input.files || input.files.length === 0) {
+    snackbar.showSnackBar({
+      msg: 'No files selected.',
+      error: true
+    })
+    addLog('info', 'No files selected.')
+    return
+  }
+
+  const exts = VALID_FILE_EXTENSION.split(',').map(ext => ext.trim().toLowerCase())
+  const files = Array.from(input.files).filter(f => {
+    const fileExt = f.name.split('.').pop()?.toLowerCase() || ''
+    const isValidExt = exts.includes(`.${fileExt}`)
+    if (!isValidExt) {
+      addLog('error', `${f.name} - Invalid file type`)
+    }
+    return isValidExt
+  })
+  if (files && files.length > 0) {
+    addLog('info', `Processing ${files.length} file(s)...`)
+    for (const file of files) {
+      try {
+        const { isValid, errors } = await mibFilesValidator(file)
+        const fileNames = new Set([
+          ...mibFiles.value.map(mibFile => mibFile.file.name.toLowerCase()),
+          ...store.files.map(source => source.fileName.toLowerCase())
+        ])
+        const isDuplicate = fileNames.has(file.name.toLowerCase())
+        const mibFile: UploadMibFileType = {
+          file,
+          isValid,
+          errors,
+          isDuplicate
+        }
+        mibFiles.value.push(mibFile)
+        
+        if (isDuplicate) {
+          addLog('error', `${file.name} - Duplicate file detected`)
+        } else if (!isValid) {
+          addLog('error', `${file.name} - Validation failed: ${errors.join(', ')}`)
+        } else {
+          addLog('success', `${file.name} - Valid and ready for upload`)
+        }
+
+        addLog('info', `${file.name} - Uploading file...`)
+        await uploadMib(file, file.name)
+        addLog('success', `File uploaded successfully - ${file.name} - ${file.size / 1024} KB`)
+      } catch (error) {
+        addLog('error', `${file.name} - Error processing file`)
+      }
+    }
+    input.value = ''
+    input.files = null
+  } else {
+    addLog('info', 'No valid MIB files selected')
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@use '@featherds/styles/themes/variables';
+@use '@featherds/styles/mixins/typography';
+
+.upload-files-tab {
+  background: var(variables.$surface);
+  width: 100%;
+  padding: 25px;
+  border-radius: 5px;
+  margin-top: 10px;
+
+  .action-bar {
+    display: flex;
+    margin-bottom: 20px;
+
+    input[type="file"] {
+      display: none;
+    }
+  }
+
+  .files {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+
+    .file {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: calc((100% - 24px) / 3);
+      padding: 25px;
+      border: 1px solid var(variables.$border-on-surface);
+      box-shadow:
+        0px 1px 5px 0px rgba(0, 0, 0, 0.12),
+        0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+        0px 3px 1px -2px rgba(0, 0, 0, 0.2);
+
+
+      .text {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+
+        svg {
+          font-size: 24px;
+        }
+
+        p {
+          @include typography.headline3;
+          margin: 0;
+        }
+      }
+
+      .action {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+
+        .success-icon {
+          color: var(variables.$success);
+          cursor: pointer;
+          height: 2em;
+          width: 2em;
+        }
+
+        .error-icon {
+          color: var(variables.$error);
+          cursor: pointer;
+          height: 2em;
+          width: 2em;
+        }
+
+        .warning-icon {
+          color: var(variables.$major);
+          cursor: pointer;
+          height: 2em;
+          width: 2em;
+        }
+      }
+
+      @media (max-width: 768px) {
+        width: calc((100% - 12px) / 2);
+      }
+
+      @media (max-width: 480px) {
+        width: 100%;
+      }
+    }
+  }
+
+  .logs-container {
+    margin-top: 30px;
+
+    .header {
+      p {
+        @include typography.headline2;
+        margin: 0;
+      }
+    }
+
+    .logs {
+      margin-top: 10px;
+      width: 100%;
+      height: 500px;
+      background: var(variables.$background);
+      border-radius: 5px;
+      border: 1px solid var(variables.$border-on-surface);
+      padding: 15px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      .log-entry {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px;
+        border-radius: 4px;
+        font-size: 14px;
+        font-family: monospace;
+
+        .log-type {
+          font-weight: bold;
+          min-width: 60px;
+          text-transform: uppercase;
+        }
+
+        .log-timestamp {
+          min-width: 150px;
+          white-space: nowrap;
+        }
+
+        .log-message {
+          // flex: 1;
+          flex: 1;
+          word-break: break-word;
+        }
+
+        &.info {
+          background-color: rgba(33, 150, 243, 0.1);
+          border-left: 3px solid #2196f3;
+          color: #1565c0;
+
+          .log-type {
+            color: #2196f3;
+          }
+        }
+
+        &.success {
+          background-color: rgba(76, 175, 80, 0.1);
+          border-left: 3px solid #4caf50;
+          color: #2e7d32;
+
+          .log-type {
+            color: #4caf50;
+          }
+        }
+
+        &.error {
+          background-color: rgba(244, 67, 54, 0.1);
+          border-left: 3px solid #f44336;
+          color: #c62828;
+
+          .log-type {
+            color: #f44336;
+          }
+        }
+      }
+    }
+  }
+}
+</style>
 

--- a/ui/src/components/MibCompiler/UploadMibFiles.vue
+++ b/ui/src/components/MibCompiler/UploadMibFiles.vue
@@ -252,6 +252,7 @@ const handleUpload = async (e: Event) => {
               addLog('error', `${errorItem.filename} - ${errorItem.error}`)
             }
           }
+          await store.fetchMibFiles()
         } catch (error: unknown) {
           let errorMsg = 'Unknown error occurred'
           if (error instanceof AxiosError) {

--- a/ui/src/components/MibCompiler/UploadMibFiles.vue
+++ b/ui/src/components/MibCompiler/UploadMibFiles.vue
@@ -5,6 +5,7 @@
         secondary
         data-test="upload-button"
         @click="fileInput?.click()"
+        :disabled="isLoading"
       >
         Upload MIB Files
       </FeatherButton>
@@ -15,6 +16,7 @@
         @change="handleUpload"
         data-test="event-conf-upload-input"
         ref="fileInput"
+        :disabled="isLoading"
       />
     </div>
     <div class="files">
@@ -117,7 +119,7 @@ import Warning from '@featherds/icon/notification/Warning'
 import { FeatherTooltip } from '@featherds/tooltip'
 import { mibFilesValidator, VALID_FILE_EXTENSION } from './mibFilesValidator'
 
-// const isLoading = ref(false)
+const isLoading = ref(false)
 const snackbar = useSnackbar()
 const store = useMibCompilerStore()
 const fileInput = ref<HTMLInputElement | null>(null)
@@ -175,6 +177,7 @@ const handleUpload = async (e: Event) => {
     return
   }
 
+  isLoading.value = true
   const exts = VALID_FILE_EXTENSION.split(',').map(ext => ext.trim().toLowerCase())
   const files = Array.from(input.files).filter(f => {
     const fileExt = f.name.split('.').pop()?.toLowerCase() || ''
@@ -213,14 +216,17 @@ const handleUpload = async (e: Event) => {
         addLog('info', `${file.name} - Uploading file...`)
         await uploadMib(file, file.name)
         addLog('success', `File uploaded successfully - ${file.name} - ${file.size / 1024} KB`)
+        isLoading.value = false
       } catch (error) {
         addLog('error', `${file.name} - Error processing file`)
+        isLoading.value = false
       }
     }
     input.value = ''
     input.files = null
   } else {
     addLog('info', 'No valid MIB files selected')
+    isLoading.value = false
   }
 }
 </script>
@@ -359,7 +365,6 @@ const handleUpload = async (e: Event) => {
         }
 
         .log-message {
-          // flex: 1;
           flex: 1;
           word-break: break-word;
         }

--- a/ui/src/components/MibCompiler/UploadMibFiles.vue
+++ b/ui/src/components/MibCompiler/UploadMibFiles.vue
@@ -121,7 +121,7 @@ import useSnackbar from '@/composables/useSnackbar'
 import { ellipsify } from '@/lib/utils'
 import { uploadMib } from '@/services/mibCompilerService'
 import { useMibCompilerStore } from '@/stores/mibCompilerStore'
-import { UploadMibFileType } from '@/types/mibCompiler'
+import { MibUploadResponse, UploadMibFileType } from '@/types/mibCompiler'
 import { FeatherButton } from '@featherds/button'
 import { FeatherIcon } from '@featherds/icon'
 import CheckCircle from '@featherds/icon/action/CheckCircle'
@@ -129,6 +129,7 @@ import Generic from '@featherds/icon/file/Generic'
 import Cancel from '@featherds/icon/navigation/Cancel'
 import Warning from '@featherds/icon/notification/Warning'
 import { FeatherTooltip } from '@featherds/tooltip'
+import { AxiosError } from 'axios'
 import { mibFilesValidator, VALID_FILE_EXTENSION } from './mibFilesValidator'
 
 const isLoading = ref(false)
@@ -235,11 +236,38 @@ const handleUpload = async (e: Event) => {
         }
 
         addLog('info', `${file.name} - Uploading file...`)
-        await uploadMib(file, file.name)
-        addLog('success', `File uploaded successfully - ${file.name} - ${file.size / 1024} KB`)
+        try {
+          const uploadResponse: MibUploadResponse = await uploadMib(file, file.name)
+          
+          // Handle success cases
+          if (uploadResponse.success && uploadResponse.success.length > 0) {
+            for (const successItem of uploadResponse.success) {
+              addLog('success', `${successItem.filename} - Uploaded successfully as ${successItem.savedAs} (${(file.size / 1024).toFixed(2)} KB)`)
+            }
+          }
+          
+          // Handle error cases
+          if (uploadResponse.errors && uploadResponse.errors.length > 0) {
+            for (const errorItem of uploadResponse.errors) {
+              addLog('error', `${errorItem.filename} - ${errorItem.error}`)
+            }
+          }
+        } catch (error: unknown) {
+          let errorMsg = 'Unknown error occurred'
+          if (error instanceof AxiosError) {
+            errorMsg = error.response?.data?.message || error.message || 'Server error'
+          } else if (error instanceof Error) {
+            errorMsg = error.message
+          }
+          addLog('error', `${file.name} - Upload failed: ${errorMsg}`)
+        }
         isLoading.value = false
-      } catch (error) {
-        addLog('error', `${file.name} - Error processing file`)
+      } catch (error: unknown) {
+        let errorMsg = 'Unknown error occurred'
+        if (error instanceof Error) {
+          errorMsg = error.message
+        }
+        addLog('error', `${file.name} - Error processing file: ${errorMsg}`)
         isLoading.value = false
       }
     }

--- a/ui/src/components/MibCompiler/UploadMibFiles.vue
+++ b/ui/src/components/MibCompiler/UploadMibFiles.vue
@@ -1,23 +1,35 @@
 <template>
   <div class="upload-files-tab">
     <div class="action-bar">
-      <FeatherButton
-        secondary
-        data-test="upload-button"
-        @click="fileInput?.click()"
-        :disabled="isLoading"
-      >
-        Upload MIB Files
-      </FeatherButton>
-      <input
-        type="file"
-        :accept="VALID_FILE_EXTENSION"
-        multiple
-        @change="handleUpload"
-        data-test="event-conf-upload-input"
-        ref="fileInput"
-        :disabled="isLoading"
-      />
+      <div>
+        <FeatherButton
+          secondary
+          data-test="upload-button"
+          @click="fileInput?.click()"
+          :disabled="isLoading"
+        >
+          Upload MIB Files
+        </FeatherButton>
+        <input
+          type="file"
+          :accept="VALID_FILE_EXTENSION"
+          multiple
+          @change="handleUpload"
+          data-test="event-conf-upload-input"
+          ref="fileInput"
+          :disabled="isLoading"
+        />
+      </div>
+      <div>
+        <FeatherButton
+          text
+          data-test="clear-logs-button"
+          @click="clear"
+          :disabled="isLoading|| mibFiles.length === 0 || logs.length === 0"
+        >
+          Clear Logs
+        </FeatherButton>
+      </div>
     </div>
     <div class="files">
       <div
@@ -166,6 +178,15 @@ const removeFile = (index: number) => {
   mibFiles.value.splice(index, 1)
 }
 
+const clear = () => {
+  if (fileInput.value) {
+    fileInput.value.value = ''
+    fileInput.value.files = null
+  }
+  mibFiles.value = []
+  logs.value = []
+}
+
 const handleUpload = async (e: Event) => {
   const input = e.target as HTMLInputElement
   if (!input.files || input.files.length === 0) {
@@ -204,7 +225,7 @@ const handleUpload = async (e: Event) => {
           isDuplicate
         }
         mibFiles.value.push(mibFile)
-        
+
         if (isDuplicate) {
           addLog('error', `${file.name} - Duplicate file detected`)
         } else if (!isValid) {
@@ -244,6 +265,8 @@ const handleUpload = async (e: Event) => {
 
   .action-bar {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
     margin-bottom: 20px;
 
     input[type="file"] {

--- a/ui/src/components/MibCompiler/mibFilesValidator.ts
+++ b/ui/src/components/MibCompiler/mibFilesValidator.ts
@@ -1,0 +1,22 @@
+import { UploadMibFileType } from '@/types/mibCompiler'
+
+export const mibFilesValidator = async (file: File): Promise<{ isValid: boolean; errors: string[] }> => {
+  const errors: string[] = []
+  if (!file.name.toLowerCase().endsWith('.txt')) {
+    errors.push('Invalid file type. Only .txt files are allowed.')
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    errors.push(`File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)}MB.`)
+  }
+  return {
+    isValid: errors.length === 0,
+    errors
+  }
+}
+
+export const isDuplicateFile = (fileName: string, existingFiles: UploadMibFileType[]): boolean => {
+  return existingFiles.some((file) => file.file.name === fileName)
+}
+
+export const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+export const VALID_FILE_EXTENSION = '.txt,.mib'

--- a/ui/src/services/mibCompilerService.ts
+++ b/ui/src/services/mibCompilerService.ts
@@ -1,18 +1,20 @@
 import {
   MibCompilerFileLocation,
   MibCompilerGenerateEventsRequest,
-  MibFileListResponse
+  MibFileListResponse,
+  MibUploadResponse
 } from '@/types/mibCompiler'
 import { rest } from './axiosInstances'
 
 const endpoint = '/mib-compiler'
 
-export const uploadMib = async (file: File, filename: string): Promise<void> => {
+export const uploadMib = async (file: File, filename: string): Promise<MibUploadResponse> => {
   const buffer = await file.arrayBuffer()
-  await rest.post(`${endpoint}/upload`, buffer, {
+  const response = await rest.post<MibUploadResponse>(`${endpoint}/upload`, buffer, {
     params: { filename },
     headers: { 'Content-Type': 'application/octet-stream' }
   })
+  return response.data
 }
 
 export const compileMib = async (name: string): Promise<void> => {

--- a/ui/src/types/mibCompiler.d.ts
+++ b/ui/src/types/mibCompiler.d.ts
@@ -46,3 +46,17 @@ export type UploadMibFileType = {
   isDuplicate: boolean
 }
 
+export interface MibUploadResponse {
+  success: Array<{
+    filename: string
+    savedAs: string
+    success: boolean
+  }>
+  errors: Array<{
+    filename: string
+    basename: string
+    error: string
+    exception?: string
+  }>
+}
+

--- a/ui/src/types/mibCompiler.d.ts
+++ b/ui/src/types/mibCompiler.d.ts
@@ -39,3 +39,10 @@ export interface MibCompilerStoreState {
   }
 }
 
+export type UploadMibFileType = {
+  file: File
+  isValid: boolean
+  errors: string[]
+  isDuplicate: boolean
+}
+


### PR DESCRIPTION

Implement a UI for uploading MIB files via Rest API, see: https://opennms.atlassian.net/browse/NMS-19166 

Can be similar to the Event Config upload files functionality.

Files can be uploaded to either Compiled or Pending. Perhaps the easiest way to implement is to have 2 upload sections, one for each of those. But then all files the user selected, whether compiled or pending, can be uploaded at once, in one Rest API call.

The Rest API call will return a list of files and either success or an error message for each, similar to the Event Config upload response.

Files can have either a .txt or .mib extension and some basic checks for reasonable file names.

The files probably do not need any further client side validation, they are text files. Perhaps some reasonable file length limit like 5 MB. The server will parse them to ensure they are valid MIB files.

Can also do client side validation that filenames do not exist in either compiled or pending.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19171

