### PR TITLE
NMS-19171: MIB Compiler UI for uploading files

### DIFF
--- a/ui/src/components/MibCompiler/CompiledMibFiles.vue
+++ b/ui/src/components/MibCompiler/CompiledMibFiles.vue
@@ -52,19 +52,19 @@
                   icon="View Details"
                   data-test="view-button"
                 >
-                  <FeatherIcon :icon="Generic"> </FeatherIcon>
+                  <FeatherIcon :icon="Generic" />
                 </FeatherButton>
                 <FeatherButton
                   icon="View Details"
                   data-test="view-button"
                 >
-                  <FeatherIcon :icon="StackedBarChart"> </FeatherIcon>
+                  <FeatherIcon :icon="StackedBarChart" />
                 </FeatherButton>
                 <FeatherButton
                   icon="Download XML"
                   data-test="download-button"
                 >
-                  <FeatherIcon :icon="Delete"> </FeatherIcon>
+                  <FeatherIcon :icon="Delete" />
                 </FeatherButton>
               </div>
             </td>

--- a/ui/src/components/MibCompiler/PendingMibFiles.vue
+++ b/ui/src/components/MibCompiler/PendingMibFiles.vue
@@ -46,7 +46,6 @@
             :key="config.fileName"
           >
             <td>{{ config.fileName }}</td>
-            <td>{{ config.location }}</td>
             <td>
               <div class="action-container">
                 <FeatherButton

--- a/ui/src/components/MibCompiler/UploadMibFiles.vue
+++ b/ui/src/components/MibCompiler/UploadMibFiles.vue
@@ -12,7 +12,7 @@
         </FeatherButton>
         <input
           type="file"
-          :accept="VALID_FILE_EXTENSION"
+          :accept="VALID_FILE_EXTENSION.join(',')"
           multiple
           @change="handleUpload"
           data-test="event-conf-upload-input"
@@ -25,7 +25,7 @@
           text
           data-test="clear-logs-button"
           @click="clear"
-          :disabled="isLoading|| mibFiles.length === 0 || logs.length === 0"
+          :disabled="isLoading || mibFiles.length === 0 || logs.length === 0"
         >
           Clear Logs
         </FeatherButton>
@@ -130,7 +130,9 @@ import Cancel from '@featherds/icon/navigation/Cancel'
 import Warning from '@featherds/icon/notification/Warning'
 import { FeatherTooltip } from '@featherds/tooltip'
 import { AxiosError } from 'axios'
-import { mibFilesValidator, VALID_FILE_EXTENSION } from './mibFilesValidator'
+import { format as fnsFormat } from 'date-fns'
+import { isValidMibExtension, mibFilesValidator, VALID_FILE_EXTENSION } from './mibFilesValidator'
+
 
 const isLoading = ref(false)
 const snackbar = useSnackbar()
@@ -154,21 +156,10 @@ const scrollLogsToBottom = async () => {
   }
 }
 
-const formatTimestamp = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  const hours = String(date.getHours()).padStart(2, '0')
-  const minutes = String(date.getMinutes()).padStart(2, '0')
-  const seconds = String(date.getSeconds()).padStart(2, '0')
-
-  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
-}
-
 const addLog = (type: 'info' | 'success' | 'error', message: string) => {
   logs.value.push({
     type,
-    timestamp: formatTimestamp(new Date()),
+    timestamp: fnsFormat(new Date(), 'yyyy-MM-dd HH:mm:ss'),
     message
   })
 
@@ -200,10 +191,8 @@ const handleUpload = async (e: Event) => {
   }
 
   isLoading.value = true
-  const exts = VALID_FILE_EXTENSION.split(',').map(ext => ext.trim().toLowerCase())
   const files = Array.from(input.files).filter(f => {
-    const fileExt = f.name.split('.').pop()?.toLowerCase() || ''
-    const isValidExt = exts.includes(`.${fileExt}`)
+    const isValidExt = isValidMibExtension(f.name)
     if (!isValidExt) {
       addLog('error', `${f.name} - Invalid file type`)
     }
@@ -238,14 +227,14 @@ const handleUpload = async (e: Event) => {
         addLog('info', `${file.name} - Uploading file...`)
         try {
           const uploadResponse: MibUploadResponse = await uploadMib(file, file.name)
-          
+
           // Handle success cases
           if (uploadResponse.success && uploadResponse.success.length > 0) {
             for (const successItem of uploadResponse.success) {
               addLog('success', `${successItem.filename} - Uploaded successfully as ${successItem.savedAs} (${(file.size / 1024).toFixed(2)} KB)`)
             }
           }
-          
+
           // Handle error cases
           if (uploadResponse.errors && uploadResponse.errors.length > 0) {
             for (const errorItem of uploadResponse.errors) {

--- a/ui/src/components/MibCompiler/UploadMibFiles.vue
+++ b/ui/src/components/MibCompiler/UploadMibFiles.vue
@@ -1,10 +1,458 @@
 <template>
-  <div class="upload-mib-files-container">
-    <h1>Upload MIB Files</h1>
+  <div class="upload-files-tab">
+    <div class="action-bar">
+      <div>
+        <FeatherButton
+          secondary
+          data-test="upload-button"
+          @click="fileInput?.click()"
+          :disabled="isLoading"
+        >
+          Upload MIB Files
+        </FeatherButton>
+        <input
+          type="file"
+          :accept="VALID_FILE_EXTENSION"
+          multiple
+          @change="handleUpload"
+          data-test="event-conf-upload-input"
+          ref="fileInput"
+          :disabled="isLoading"
+        />
+      </div>
+      <div>
+        <FeatherButton
+          text
+          data-test="clear-logs-button"
+          @click="clear"
+          :disabled="isLoading|| mibFiles.length === 0 || logs.length === 0"
+        >
+          Clear Logs
+        </FeatherButton>
+      </div>
+    </div>
+    <div class="files">
+      <div
+        v-for="(mibFile, index) in mibFiles"
+        :key="index"
+        class="file"
+      >
+        <div class="text">
+          <FeatherIcon :icon="Generic" />
+          <p
+            :title="mibFile.file.name"
+            class="name"
+          >
+            {{ ellipsify(mibFile.file.name, 30) }}
+          </p>
+        </div>
+        <div class="action">
+          <FeatherTooltip
+            v-if="mibFile.isDuplicate"
+            :title="'File is a duplicate of another file that has been already uploaded.'"
+            v-slot="{ attrs, on }"
+          >
+            <FeatherIcon
+              :icon="Warning"
+              v-bind="attrs"
+              v-on="on"
+              class="warning-icon"
+            />
+          </FeatherTooltip>
+          <FeatherTooltip
+            v-if="mibFile.isValid && !mibFile.isDuplicate"
+            :title="'File is valid'"
+            v-slot="{ attrs, on }"
+          >
+            <FeatherIcon
+              :icon="CheckCircle"
+              v-bind="attrs"
+              v-on="on"
+              class="success-icon"
+            />
+          </FeatherTooltip>
+          <FeatherTooltip
+            v-if="!mibFile.isValid"
+            :title="mibFile.errors.map((error: string) => `${error}. `).join('\n')"
+            v-slot="{ attrs, on }"
+          >
+            <FeatherIcon
+              :icon="Error"
+              v-bind="attrs"
+              v-on="on"
+              class="error-icon"
+            />
+          </FeatherTooltip>
+          <FeatherButton
+            text
+            icon="Remove"
+            data-test="remove-file-button"
+            @click="removeFile(index)"
+          >
+            <FeatherIcon :icon="Cancel" />
+          </FeatherButton>
+        </div>
+      </div>
+    </div>
+    <div class="logs-container">
+      <div class="header">
+        <p>MIB Logs</p>
+      </div>
+      <div
+        ref="logsContainerRef"
+        class="logs"
+      >
+        <div
+          v-for="(log, index) in logs"
+          :key="index"
+          :class="['log-entry', log.type]"
+        >
+          <span class="log-timestamp">{{ log.timestamp }}</span>
+          <span class="log-type">{{ log.type.toUpperCase() }}</span>
+          <span class="log-message">{{ log.message }}</span>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import useSnackbar from '@/composables/useSnackbar'
+import { ellipsify } from '@/lib/utils'
+import { uploadMib } from '@/services/mibCompilerService'
+import { useMibCompilerStore } from '@/stores/mibCompilerStore'
+import { MibUploadResponse, UploadMibFileType } from '@/types/mibCompiler'
+import { FeatherButton } from '@featherds/button'
+import { FeatherIcon } from '@featherds/icon'
+import CheckCircle from '@featherds/icon/action/CheckCircle'
+import Generic from '@featherds/icon/file/Generic'
+import Cancel from '@featherds/icon/navigation/Cancel'
+import Warning from '@featherds/icon/notification/Warning'
+import { FeatherTooltip } from '@featherds/tooltip'
+import { AxiosError } from 'axios'
+import { mibFilesValidator, VALID_FILE_EXTENSION } from './mibFilesValidator'
 
-<style lang="scss" scoped></style>
+const isLoading = ref(false)
+const snackbar = useSnackbar()
+const store = useMibCompilerStore()
+const fileInput = ref<HTMLInputElement | null>(null)
+const mibFiles = ref<UploadMibFileType[]>([])
+const logsContainerRef = ref<HTMLElement | null>(null)
+
+interface LogEntry {
+  type: 'info' | 'success' | 'error'
+  timestamp: string
+  message: string
+}
+
+const logs = ref<LogEntry[]>([])
+
+const scrollLogsToBottom = async () => {
+  await nextTick()
+  if (logsContainerRef.value) {
+    logsContainerRef.value.scrollTop = logsContainerRef.value.scrollHeight
+  }
+}
+
+const formatTimestamp = (date: Date): string => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+}
+
+const addLog = (type: 'info' | 'success' | 'error', message: string) => {
+  logs.value.push({
+    type,
+    timestamp: formatTimestamp(new Date()),
+    message
+  })
+
+  void scrollLogsToBottom()
+}
+
+const removeFile = (index: number) => {
+  mibFiles.value.splice(index, 1)
+}
+
+const clear = () => {
+  if (fileInput.value) {
+    fileInput.value.value = ''
+    fileInput.value.files = null
+  }
+  mibFiles.value = []
+  logs.value = []
+}
+
+const handleUpload = async (e: Event) => {
+  const input = e.target as HTMLInputElement
+  if (!input.files || input.files.length === 0) {
+    snackbar.showSnackBar({
+      msg: 'No files selected.',
+      error: true
+    })
+    addLog('info', 'No files selected.')
+    return
+  }
+
+  isLoading.value = true
+  const exts = VALID_FILE_EXTENSION.split(',').map(ext => ext.trim().toLowerCase())
+  const files = Array.from(input.files).filter(f => {
+    const fileExt = f.name.split('.').pop()?.toLowerCase() || ''
+    const isValidExt = exts.includes(`.${fileExt}`)
+    if (!isValidExt) {
+      addLog('error', `${f.name} - Invalid file type`)
+    }
+    return isValidExt
+  })
+  if (files && files.length > 0) {
+    addLog('info', `Processing ${files.length} file(s)...`)
+    for (const file of files) {
+      try {
+        const { isValid, errors } = await mibFilesValidator(file)
+        const fileNames = new Set([
+          ...mibFiles.value.map(mibFile => mibFile.file.name.toLowerCase()),
+          ...store.files.map(source => source.fileName.toLowerCase())
+        ])
+        const isDuplicate = fileNames.has(file.name.toLowerCase())
+        const mibFile: UploadMibFileType = {
+          file,
+          isValid,
+          errors,
+          isDuplicate
+        }
+        mibFiles.value.push(mibFile)
+
+        if (isDuplicate) {
+          addLog('error', `${file.name} - Duplicate file detected`)
+        } else if (!isValid) {
+          addLog('error', `${file.name} - Validation failed: ${errors.join(', ')}`)
+        } else {
+          addLog('success', `${file.name} - Valid and ready for upload`)
+        }
+
+        addLog('info', `${file.name} - Uploading file...`)
+        try {
+          const uploadResponse: MibUploadResponse = await uploadMib(file, file.name)
+          
+          // Handle success cases
+          if (uploadResponse.success && uploadResponse.success.length > 0) {
+            for (const successItem of uploadResponse.success) {
+              addLog('success', `${successItem.filename} - Uploaded successfully as ${successItem.savedAs} (${(file.size / 1024).toFixed(2)} KB)`)
+            }
+          }
+          
+          // Handle error cases
+          if (uploadResponse.errors && uploadResponse.errors.length > 0) {
+            for (const errorItem of uploadResponse.errors) {
+              addLog('error', `${errorItem.filename} - ${errorItem.error}`)
+            }
+          }
+          await store.fetchMibFiles()
+        } catch (error: unknown) {
+          let errorMsg = 'Unknown error occurred'
+          if (error instanceof AxiosError) {
+            errorMsg = error.response?.data?.message || error.message || 'Server error'
+          } else if (error instanceof Error) {
+            errorMsg = error.message
+          }
+          addLog('error', `${file.name} - Upload failed: ${errorMsg}`)
+        }
+        isLoading.value = false
+      } catch (error: unknown) {
+        let errorMsg = 'Unknown error occurred'
+        if (error instanceof Error) {
+          errorMsg = error.message
+        }
+        addLog('error', `${file.name} - Error processing file: ${errorMsg}`)
+        isLoading.value = false
+      }
+    }
+    input.value = ''
+    input.files = null
+  } else {
+    addLog('info', 'No valid MIB files selected')
+    isLoading.value = false
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@use '@featherds/styles/themes/variables';
+@use '@featherds/styles/mixins/typography';
+
+.upload-files-tab {
+  background: var(variables.$surface);
+  width: 100%;
+  padding: 25px;
+  border-radius: 5px;
+  margin-top: 10px;
+
+  .action-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+
+    input[type="file"] {
+      display: none;
+    }
+  }
+
+  .files {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+
+    .file {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: calc((100% - 24px) / 3);
+      padding: 25px;
+      border: 1px solid var(variables.$border-on-surface);
+      box-shadow:
+        0px 1px 5px 0px rgba(0, 0, 0, 0.12),
+        0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+        0px 3px 1px -2px rgba(0, 0, 0, 0.2);
+
+
+      .text {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+
+        svg {
+          font-size: 24px;
+        }
+
+        p {
+          @include typography.headline3;
+          margin: 0;
+        }
+      }
+
+      .action {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+
+        .success-icon {
+          color: var(variables.$success);
+          cursor: pointer;
+          height: 2em;
+          width: 2em;
+        }
+
+        .error-icon {
+          color: var(variables.$error);
+          cursor: pointer;
+          height: 2em;
+          width: 2em;
+        }
+
+        .warning-icon {
+          color: var(variables.$major);
+          cursor: pointer;
+          height: 2em;
+          width: 2em;
+        }
+      }
+
+      @media (max-width: 768px) {
+        width: calc((100% - 12px) / 2);
+      }
+
+      @media (max-width: 480px) {
+        width: 100%;
+      }
+    }
+  }
+
+  .logs-container {
+    margin-top: 30px;
+
+    .header {
+      p {
+        @include typography.headline2;
+        margin: 0;
+      }
+    }
+
+    .logs {
+      margin-top: 10px;
+      width: 100%;
+      height: 500px;
+      background: var(variables.$background);
+      border-radius: 5px;
+      border: 1px solid var(variables.$border-on-surface);
+      padding: 15px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      .log-entry {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px;
+        border-radius: 4px;
+        font-size: 14px;
+        font-family: monospace;
+
+        .log-type {
+          font-weight: bold;
+          min-width: 60px;
+          text-transform: uppercase;
+        }
+
+        .log-timestamp {
+          min-width: 150px;
+          white-space: nowrap;
+        }
+
+        .log-message {
+          flex: 1;
+          word-break: break-word;
+        }
+
+        &.info {
+          background-color: rgba(33, 150, 243, 0.1);
+          border-left: 3px solid #2196f3;
+          color: #1565c0;
+
+          .log-type {
+            color: #2196f3;
+          }
+        }
+
+        &.success {
+          background-color: rgba(76, 175, 80, 0.1);
+          border-left: 3px solid #4caf50;
+          color: #2e7d32;
+
+          .log-type {
+            color: #4caf50;
+          }
+        }
+
+        &.error {
+          background-color: rgba(244, 67, 54, 0.1);
+          border-left: 3px solid #f44336;
+          color: #c62828;
+
+          .log-type {
+            color: #f44336;
+          }
+        }
+      }
+    }
+  }
+}
+</style>
 

--- a/ui/src/components/MibCompiler/mibFilesValidator.ts
+++ b/ui/src/components/MibCompiler/mibFilesValidator.ts
@@ -1,9 +1,13 @@
 import { UploadMibFileType } from '@/types/mibCompiler'
 
+export const isValidMibExtension = (fileName: string): boolean => {
+  return VALID_FILE_EXTENSION.some(ext => fileName.toLowerCase().endsWith(ext))
+}
+
 export const mibFilesValidator = async (file: File): Promise<{ isValid: boolean; errors: string[] }> => {
   const errors: string[] = []
-  if (!file.name.toLowerCase().endsWith('.txt')) {
-    errors.push('Invalid file type. Only .txt files are allowed.')
+  if (!isValidMibExtension(file.name)) {
+    errors.push(`Invalid file type. Only ${VALID_FILE_EXTENSION.join(', ')} files are allowed.`)
   }
   if (file.size > MAX_FILE_SIZE) {
     errors.push(`File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)}MB.`)
@@ -19,5 +23,5 @@ export const isDuplicateFile = (fileName: string, existingFiles: UploadMibFileTy
 }
 
 export const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
-export const VALID_FILE_EXTENSION = '.txt,.mib'
+export const VALID_FILE_EXTENSION = ['.txt', '.mib']
 

--- a/ui/src/components/MibCompiler/mibFilesValidator.ts
+++ b/ui/src/components/MibCompiler/mibFilesValidator.ts
@@ -1,0 +1,23 @@
+import { UploadMibFileType } from '@/types/mibCompiler'
+
+export const mibFilesValidator = async (file: File): Promise<{ isValid: boolean; errors: string[] }> => {
+  const errors: string[] = []
+  if (!file.name.toLowerCase().endsWith('.txt')) {
+    errors.push('Invalid file type. Only .txt files are allowed.')
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    errors.push(`File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)}MB.`)
+  }
+  return {
+    isValid: errors.length === 0,
+    errors
+  }
+}
+
+export const isDuplicateFile = (fileName: string, existingFiles: UploadMibFileType[]): boolean => {
+  return existingFiles.some((file) => file.file.name === fileName)
+}
+
+export const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+export const VALID_FILE_EXTENSION = '.txt,.mib'
+

--- a/ui/src/services/mibCompilerService.ts
+++ b/ui/src/services/mibCompilerService.ts
@@ -1,18 +1,20 @@
 import {
   MibCompilerFileLocation,
   MibCompilerGenerateEventsRequest,
-  MibFileListResponse
+  MibFileListResponse,
+  MibUploadResponse
 } from '@/types/mibCompiler'
 import { rest } from './axiosInstances'
 
 const endpoint = '/mib-compiler'
 
-export const uploadMib = async (file: File, filename: string): Promise<void> => {
+export const uploadMib = async (file: File, filename: string): Promise<MibUploadResponse> => {
   const buffer = await file.arrayBuffer()
-  await rest.post(`${endpoint}/upload`, buffer, {
+  const response = await rest.post<MibUploadResponse>(`${endpoint}/upload`, buffer, {
     params: { filename },
     headers: { 'Content-Type': 'application/octet-stream' }
   })
+  return response.data
 }
 
 export const compileMib = async (name: string): Promise<void> => {

--- a/ui/src/types/mibCompiler.d.ts
+++ b/ui/src/types/mibCompiler.d.ts
@@ -39,3 +39,24 @@ export interface MibCompilerStoreState {
   }
 }
 
+export type UploadMibFileType = {
+  file: File
+  isValid: boolean
+  errors: string[]
+  isDuplicate: boolean
+}
+
+export interface MibUploadResponse {
+  success: Array<{
+    filename: string
+    savedAs: string
+    success: boolean
+  }>
+  errors: Array<{
+    filename: string
+    basename: string
+    error: string
+    exception?: string
+  }>
+}
+


### PR DESCRIPTION

### Description

Implement a UI for uploading MIB files via Rest API, see: https://opennms.atlassian.net/browse/NMS-19166 

Can be similar to the Event Config upload files functionality.

Files can be uploaded to either Compiled or Pending. Perhaps the easiest way to implement is to have 2 upload sections, one for each of those. But then all files the user selected, whether compiled or pending, can be uploaded at once, in one Rest API call.

The Rest API call will return a list of files and either success or an error message for each, similar to the Event Config upload response.

Files can have either a .txt or .mib extension and some basic checks for reasonable file names.

The files probably do not need any further client side validation, they are text files. Perhaps some reasonable file length limit like 5 MB. The server will parse them to ensure they are valid MIB files.

Can also do client side validation that filenames do not exist in either compiled or pending.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19171

