### PR TITLE
NMS-19544: Fix donut graph top alignment

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/status-box/index.js
+++ b/core/web-assets/src/main/assets/js/apps/status-box/index.js
@@ -28,190 +28,227 @@ d3.document = window.document;
 
 // the color palette to map each severity to
 const colorPalette = {
-	Normal: '#336600',
-	Warning: '#ffcc00',
-	Minor: '#ff9900',
-	Major: '#ff3300',
-	Critical: '#cc0000'
+  Normal: '#336600',
+  Warning: '#ffcc00',
+  Minor: '#ff9900',
+  Major: '#ff3300',
+  Critical: '#cc0000'
 };
 
 // the size of each donut
 const donutSize = {
-	// Don't set size to allow resizing automatically based on space available
-	width: 0,
-	height: 0
+  // Don't set size to allow resizing automatically based on space available
+  width: 0,
+  height: 0
+};
+
+const normalizeDonutTops = function() {
+  const arcs = document.querySelectorAll('#chart-content .c3-chart-arcs');
+  if (arcs.length < 2) {
+    return;
+  }
+
+  let minY = Infinity;
+  arcs.forEach(function(arc) {
+    const transform = arc.getAttribute('transform');
+    const match = transform && transform.match(/translate\(\s*[^,]+,\s*([^)]+)\)/);
+    if (match) {
+      minY = Math.min(minY, parseFloat(match[1]));
+    }
+  });
+
+  if (!isFinite(minY)) {
+    return;
+  }
+
+  arcs.forEach(function(arc) {
+    const transform = arc.getAttribute('transform');
+    const match = transform && transform.match(/translate\(\s*([^,]+),\s*[^)]+\)/);
+    if (match) {
+      arc.setAttribute('transform', 'translate(' + match[1] + ',' + minY + ')');
+    }
+  });
 };
 
 const loadChartData = function(graph) {
-	$.ajax({
-		method: 'GET',
-		url: graph.url,
-		headers: {
-			'X-Requested-With': 'XMLHttpRequest'
-		},
-		dataType: 'json',
-		success: function(data) {
-		const columns = [];
+  return new Promise(function(resolve) {
+    $.ajax({
+      method: 'GET',
+      url: graph.url,
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      dataType: 'json',
+      success: function(data) {
+      const columns = [];
 
-		// Only include values > 0
-		for (let i = 0; i < data.length; i++) {
-			if (data[i].length >= 2) {
-				if (data[i][1] > 0) {
-					columns.push(data[i]);
-				}
-			}
-		}
+      // Only include values > 0
+      for (let i = 0; i < data.length; i++) {
+        if (data[i].length >= 2) {
+          if (data[i][1] > 0) {
+            columns.push(data[i]);
+          }
+        }
+      }
 
-		// Decide to show or hide the graph
-		let sum = 0;
-		for (let i = 0; i < data.length; i++) {
-			sum += data[i][1];
-		}
-		if (sum > 0) {
-			// The first chart with data shows the box
-			$('#status-overview-box').show();
-			$('#' + graph.id).parent().show();
+      // Decide to show or hide the graph
+      let sum = 0;
+      for (let i = 0; i < data.length; i++) {
+        sum += data[i][1];
+      }
+      if (sum > 0) {
+        // The first chart with data shows the box
+        $('#status-overview-box').show();
+        $('#' + graph.id).parent().show();
 
-			// Generate graph
-			const chart = c3.generate({
-				bindto: '#' + graph.id,
-				size: donutSize,
-				data: {
-					order: null,
-					columns: [],
-					colors: colorPalette,
-					type: 'donut',
-					onclick: graph.onclick
-				},
-				donut: {
-					title: graph.title,
-					label: {
-						format: function(value, id, ratio) {
-							return value;
-						}
-					}
-				}
-			});
-			chart.load({
-				columns: columns
-			});
+        // Generate graph
+        const chart = c3.generate({
+          bindto: '#' + graph.id,
+          size: donutSize,
+          data: {
+            order: null,
+            columns: [],
+            colors: colorPalette,
+            type: 'donut',
+            onclick: graph.onclick
+          },
+          donut: {
+            title: graph.title,
+            label: {
+              format: function(value, id, ratio) {
+                return value;
+              }
+            }
+          },
+          onrendered: normalizeDonutTops
+        });
+        chart.load({
+          columns: columns,
+          done: resolve
+        });
 
-			// Add graph tooltip
-			const description = graph.description || graph.title || '';
-			if (description !== '') {
-				d3.select('#' + graph.id)
-					.select('.c3-chart')
-					.append('svg:title')
-					.text(description);
-			}
-		}
-		}
-	});
+        // Add graph tooltip
+        const description = graph.description || graph.title || '';
+        if (description !== '') {
+          d3.select('#' + graph.id)
+            .select('.c3-chart')
+            .append('svg:title')
+            .text(description);
+        }
+      } else {
+        resolve();
+      }
+      },
+      error: resolve
+    });
+  });
 };
 
 const render = function(options) {
-	const graphs = options.graphs;
-	if (graphs === undefined || graphs === null || graphs.length === 0) {
-		return;
-	}
-	if (options.parentContainer === undefined || graphs.parentContainer === null) {
-		return;
-	}
-	if ($(options.parentContainer) === undefined) {
-		return;
-	}
+  const graphs = options.graphs;
+  if (graphs === undefined || graphs === null || graphs.length === 0) {
+    return;
+  }
+  if (options.parentContainer === undefined || graphs.parentContainer === null) {
+    return;
+  }
+  if ($(options.parentContainer) === undefined) {
+    return;
+  }
 
-	for (let i = 0; i < graphs.length; i++) {
-		// Gather options to draw graph
-		const graph = graphs[i];
+  const promises = [];
+  for (let i = 0; i < graphs.length; i++) {
+    // Gather options to draw graph
+    const graph = graphs[i];
 
-		// Skip the entry when any of the required fields are missing
-		if (graph.id === undefined || graph.id === null || graph.id === '') {
-			return;
-		}
-		if (graph.url === undefined || graph.url === null || graph.url === '') {
-			return;
-		}
+    // Skip the entry when any of the required fields are missing
+    if (graph.id === undefined || graph.id === null || graph.id === '') {
+      return;
+    }
+    if (graph.url === undefined || graph.url === null || graph.url === '') {
+      return;
+    }
 
-		// create container for graph if it does not exist yet
-		if ($('#' + graph.id).length === 0) {
-			const graphContainer = $('<div/>', {
-				class: 'mx-auto col-xs-12 col-sm-6 col-md-6 col-lg-4'
-			});
-			graphContainer.append($('<div></div>', {
-				id: graph.id
-			}));
-			graphContainer.hide();
-			$(options.parentContainer).append(graphContainer);
-		}
+    // create container for graph if it does not exist yet
+    if ($('#' + graph.id).length === 0) {
+      const graphContainer = $('<div/>', {
+        class: 'mx-auto col-xs-12 col-sm-6 col-md-6 col-lg-4'
+      });
+      graphContainer.append($('<div></div>', {
+        id: graph.id
+      }));
+      graphContainer.hide();
+      $(options.parentContainer).append(graphContainer);
+    }
 
-		// load data and populate graph
-		loadChartData(graph);
-	}
+    // load data and populate graph
+    promises.push(loadChartData(graph));
+  }
+  Promise.all(promises).then(normalizeDonutTops);
 };
 
 // all supported graphs
 const graphDefinitions = {
-	'business-services': {
-		id: 'businessServiceProblemChart',
-		title: 'Business Services',
-		description: 'Business Services Status Overview',
-		url: 'api/v2/status/summary/business-services',
-		onclick: function(e) {
-			window.location = 'status/index.jsp?title=Business Service List&type=business-services&severityFilter=' + e.id;
-		}
-	},
+  'business-services': {
+    id: 'businessServiceProblemChart',
+    title: 'Business Services',
+    description: 'Business Services Status Overview',
+    url: 'api/v2/status/summary/business-services',
+    onclick: function(e) {
+      window.location = 'status/index.jsp?title=Business Service List&type=business-services&severityFilter=' + e.id;
+    }
+  },
 
-	applications: {
-		id: 'applicationProblemChart',
-		title: 'Applications',
-		description: 'Applications Status Overview',
-		url: 'api/v2/status/summary/applications',
-		onclick: function(e) {
-			window.location = 'status/index.jsp?title=Application List&type=applications&severityFilter=' + e.id;
-		}
-	},
+  applications: {
+    id: 'applicationProblemChart',
+    title: 'Applications',
+    description: 'Applications Status Overview',
+    url: 'api/v2/status/summary/applications',
+    onclick: function(e) {
+      window.location = 'status/index.jsp?title=Application List&type=applications&severityFilter=' + e.id;
+    }
+  },
 
-	'nodes-by-alarms': {
-		id: 'nodeProblemChartsByAlarms',
-		title: 'Alarms',
-		description: 'Nodes grouped by unacknowledged Alarms',
-		url: 'api/v2/status/summary/nodes/alarms',
-		onclick: function(e) {
-			window.location = 'status/index.jsp?title=Node List&type=nodes&strategy=alarms&severityFilter=' + e.id;
-		}
-	},
-	'nodes-by-outages': {
-		id: 'nodeProblemChartByOutages',
-		title: 'Outages',
-		description: 'Nodes grouped by current Outages',
-		url: 'api/v2/status/summary/nodes/outages',
-		onclick: function(e) {
-			window.location = 'status/index.jsp?title=Node List&type=nodes&strategy=outages&severityFilter=' + e.id;
-		}
-	}
+  'nodes-by-alarms': {
+    id: 'nodeProblemChartsByAlarms',
+    title: 'Alarms',
+    description: 'Nodes grouped by unacknowledged Alarms',
+    url: 'api/v2/status/summary/nodes/alarms',
+    onclick: function(e) {
+      window.location = 'status/index.jsp?title=Node List&type=nodes&strategy=alarms&severityFilter=' + e.id;
+    }
+  },
+  'nodes-by-outages': {
+    id: 'nodeProblemChartByOutages',
+    title: 'Outages',
+    description: 'Nodes grouped by current Outages',
+    url: 'api/v2/status/summary/nodes/outages',
+    onclick: function(e) {
+      window.location = 'status/index.jsp?title=Node List&type=nodes&strategy=outages&severityFilter=' + e.id;
+    }
+  }
 };
 
 const doRender = function(graphKeys) {
-	//console.log('doRender:',graphKeys);
-	const graphs = [];
-	for (let i = 0; i < graphKeys.length; i++) {
-		const graphKey = graphKeys[i];
-		if (graphKey !== undefined && graphKey in graphDefinitions) {
-			graphs.push(graphDefinitions[graphKey]);
-		}
-	}
+  //console.log('doRender:',graphKeys);
+  const graphs = [];
+  for (let i = 0; i < graphKeys.length; i++) {
+    const graphKey = graphKeys[i];
+    if (graphKey !== undefined && graphKey in graphDefinitions) {
+      graphs.push(graphDefinitions[graphKey]);
+    }
+  }
 
-	// only render if something is configured to show
-	if (graphs.length !== 0) {
-		//console.log('rendering ' + graphs.length + ' graphs');
-		render({
-			parentContainer: '#chart-content',
-			graphs: graphs
-		})
-	} else {
-		//console.log('no graphs found');
-	}
+  // only render if something is configured to show
+  if (graphs.length !== 0) {
+    //console.log('rendering ' + graphs.length + ' graphs');
+    render({
+      parentContainer: '#chart-content',
+      graphs: graphs
+    })
+  } else {
+    //console.log('no graphs found');
+  }
 };
 
 window.renderStatusGraphs = doRender;


### PR DESCRIPTION
Fix the "donut" chart top/vertical alignment on the main page. We use the `c3` library to draw these charts.

When there are multiple categories / legend items, they may take up more than one line in the legend below the donut charts. This causes the chart with more items to be "pushed up" and now the 3 charts are misaligned.

Fix is to:

- load and render all charts, which also includes Rest API calls to get the data. We don't know the number of legend items in advance, so have to check after they are all done. Collect in a `Promise.all()`, then call `normalizeDonutTops`
- `normalizeDonutTops` can now via `#chart-content .c3-chart-arcs` to find the `y` transform that was applied and normalize them for all charts
- hook into `c3.onresized` to call `normalizeDonutTops` any time the browser window is resized

Also linted the file.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19544
