### PR TITLE
NMS-19617: Enable light/dark mode for Vue UI

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/nodeList.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/nodeList.jsp
@@ -110,7 +110,7 @@
         }
       %>
     </select>
-    <div class="btn-toolbar" role="toolbar">
+    <div class="btn-toolbar mt-2" role="toolbar">
       <span>Nodes</span>
       <span class="btn-group mr-2 ml-4"><a href="javascript:toggleClassDisplay('NLdbid', '', 'inline');"><i class="fas fa-database fa-lg" title="Toggle database IDs"></i></a>&nbsp;&nbsp;<a href="javascript:toggleClassDisplay('NLfs', '', 'inline');"><i class="fas fa-rectangle-list fa-lg" title="Toggle requisition names"></i></a>&nbsp;&nbsp;<a href="javascript:toggleClassDisplay('NLfid', '', 'inline');"><i class="fas fa-qrcode fa-lg" title="Toggle foreign IDs"></i></a>&nbsp;&nbsp;<a href="javascript:toggleClassDisplay('NLloc', '', 'inline');"><i class="fas fa-location-dot fa-lg" title="Toggle locations"></i></a> <c:if test="${anyFlows}">&nbsp;<a href="javascript:toggleClassDisplay('NLflows', '', 'inline');"><i class="fas fa-right-left fa-lg" title="Toggle flow data"></i></a></span></c:if>
     </div>

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -94,7 +94,7 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         // Inventory Menu
         // Note, some items are below under Vue UI checks
         clickMenuItem("inventoryMenu", "Nodes");
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='btn-toolbar']/span[text()='Nodes' or text()='Availability']")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'btn-toolbar')]/span[text()='Nodes' or text()='Availability']")));
 
         clickMenuItem("inventoryMenu", "Assets");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='content']//div[@class='card-header']/span[text()='Search Asset Information']")));

--- a/smoke-test/src/test/java/org/opennms/smoketest/NodeListPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/NodeListPageIT.java
@@ -108,7 +108,7 @@ public class NodeListPageIT extends OpenNMSSeleniumIT {
 
     @Test
     public void testAllTextIsPresent() throws Exception {
-        findElementByXpath("//div[@class='btn-toolbar']/span[text()='Nodes']");
+        findElementByXpath("//div[contains(@class, 'btn-toolbar')]/span[text()='Nodes']");
         findElementByXpath("//ol[@class=\"breadcrumb\"]//li[text()='Node List']");
     }
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/SearchPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/SearchPageIT.java
@@ -76,7 +76,7 @@ public class SearchPageIT extends OpenNMSSeleniumIT {
     @Test
     public void testAllLinks() throws InterruptedException {
         findElementByLink("All nodes").click();
-        findElementByXpath("//div[@class='btn-toolbar']/span[text()='Nodes']");
+        findElementByXpath("//div[contains(@class, 'btn-toolbar')]/span[text()='Nodes']");
 
         searchPage();
         findElementByLink("All nodes and their interfaces").click();
@@ -94,6 +94,6 @@ public class SearchPageIT extends OpenNMSSeleniumIT {
         maclike.sendKeys(Keys.ENTER);
 
         findElementByXpath("//div[@id='content']/nav/ol/li[text()='Node List']");
-        findElementByXpath("//div[@class='card-header']//div[@class='btn-toolbar']/span[text()='Nodes']");
+        findElementByXpath("//div[@class='card-header']//div[contains(@class, 'btn-toolbar')]/span[text()='Nodes']");
     }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -135,7 +135,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
       "@antfu/utils": "^0.7.3",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -775,36 +775,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -909,66 +915,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}

--- a/ui/src/components/EventConfigEventCreate/BasicInformation.vue
+++ b/ui/src/components/EventConfigEventCreate/BasicInformation.vue
@@ -770,7 +770,7 @@ onMounted(async () => {
   margin: 30px;
 
   border-radius: 8px;
-  background-color: #ffffff;
+  background: var(variables.$surface);
 
   .title {
     display: flex;
@@ -813,11 +813,9 @@ onMounted(async () => {
     justify-content: flex-end;
     gap: 10px;
   }
-
 }
 
 .modal-body-form {
   width: 50rem;
 }
 </style>
-

--- a/ui/src/components/Layout/BreadCrumbs.vue
+++ b/ui/src/components/Layout/BreadCrumbs.vue
@@ -30,16 +30,17 @@ defineProps({
   width: 100%;
   display: flex;
   margin-bottom: 15px;
-  background: #e9ecef;
+  background-color: var(--feather-surface);
+  color: var(--feather-secondary-text-on-surface);
 
   .link {
-    color: #265A87;
+    color: var(--feather-clickable-normal);
     a {
       font-weight:400;
-      color: #265A87;
+      color: var(--feather-clickable-normal);
     }
     a:visited {
-      color: #265A87;
+      color: var(--feather-clickable-normal);
     }
 
     padding:8px 0;

--- a/ui/src/components/Map/LeafletMap.vue
+++ b/ui/src/components/Map/LeafletMap.vue
@@ -403,6 +403,11 @@ defineExpose({ invalidateSizeFn })
   }
 }
 
+.leaflet-popup-content-wrapper {
+  background: var($surface);
+  color: var(--feather-secondary-text-on-surface);
+}
+
 .leaflet-popup-content {
   min-width: 440px;
 }

--- a/ui/src/components/Menu/Menubar.vue
+++ b/ui/src/components/Menu/Menubar.vue
@@ -24,6 +24,18 @@
         <div class="date-formatted-time">{{ formattedTime }}</div>
         <div class="date-formatted-date">{{ formattedDate }}</div>
       </div>
+
+       <span title="Toggle Light/Dark Mode">
+        <FeatherIcon
+            :icon="LightDarkMode"
+            title="Toggle Light/Dark Mode"
+            class="light-dark"
+            role="button"
+            tabindex="0"
+            @click="appStore.toggleTheme()"
+            @keydown.enter.space.prevent="appStore.toggleTheme()"
+          />
+        </span>
       <template v-if="mainMenu.username">
         <UserNotificationsMenuItem
           :expanded="currentDropdownMenu === DropdownMenuType.UserNotifications"
@@ -37,9 +49,6 @@
           @menuHide="() => onMenuHide(DropdownMenuType.SelfService)"
         />
       </template>
-
-      <!-- <FeatherIcon :icon="LightDarkMode" title="Toggle Light/Dark Mode" class="pointer light-dark"
-        @click="toggleDarkLightMode(null)" /> -->
     </template>
   </FeatherAppBar>
 </template>
@@ -48,6 +57,8 @@
 import { useOutsideClick } from '@featherds/composables/events/OutsideClick'
 import { FeatherAppBar, FeatherAppBarLink } from '@featherds/app-bar'
 import { FeatherButton } from '@featherds/button'
+import { FeatherIcon } from '@featherds/icon'
+import LightDarkMode from '@featherds/icon/action/LightDarkMode'
 
 // see vite.config.ts, resolve.alias for the actual logo file that is imported
 import IconLogo from './src/assets/ProductLogo.vue'
@@ -61,10 +72,7 @@ import UserSelfServiceMenuItem from './UserSelfServiceMenuItem.vue'
 
 const appStore = useAppStore()
 const menuStore = useMenuStore()
-const theme = ref('')
 const lastShift = reactive({ lastKey: '', timeSinceLastKey: 0 })
-const light = 'open-light'
-const dark = 'open-dark'
 const outsideClick = ref()
 const currentDropdownMenu = ref<DropdownMenuType>(DropdownMenuType.None)
 
@@ -95,30 +103,6 @@ const onMenuHide = (val: DropdownMenuType) => {
 const onAddNode = () => {
   const url = computeLink(mainMenu.value.provisionMenu?.url || '')
   window.location.assign(url)
-}
-
-const toggleDarkLightMode = (savedTheme: string | null) => {
-  const el = document.body
-  const newTheme = theme.value === light ? dark : light
-
-  if (savedTheme && (savedTheme === light || savedTheme === dark)) {
-    theme.value = savedTheme
-    el.classList.add(savedTheme)
-    return
-  }
-
-  // set the new theme on the body
-  el.classList.add(newTheme)
-
-  // remove the current theme
-  if (theme.value) {
-    el.classList.remove(theme.value)
-  }
-
-  // save the new theme in data and localStorage
-  theme.value = newTheme
-  localStorage.setItem('theme', theme.value)
-  appStore.setTheme(theme.value)
 }
 
 const computeLink = (url: string) => {
@@ -160,7 +144,7 @@ const shiftCheck = (e: KeyboardEvent) => {
       if (Date.now() - lastShift.timeSinceLastKey < shiftDelay) {
         clearShiftCheck()
 
-        const elem: HTMLInputElement | null = document.querySelector('#opennms-sidemenu-container .onms-search-input-wrapper input.search-input')
+        const elem: HTMLInputElement | null = document.querySelector('.onms-search-input-wrapper input.search-input')
 
         if (elem) {
           elem.focus()
@@ -177,12 +161,12 @@ const shiftCheck = (e: KeyboardEvent) => {
   }
 }
 
-onMounted(async () => {
-  const savedTheme = localStorage.getItem('theme')
-  console.log('Got theme: ', savedTheme)
-
-  toggleDarkLightMode(savedTheme)
+onMounted(() => {
   window.addEventListener('keyup', shiftCheck)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keyup', shiftCheck)
 })
 </script>
 
@@ -193,19 +177,30 @@ onMounted(async () => {
 @import "@featherds/styles/mixins/typography";
 @import "@featherds/styles/themes/variables";
 
-.alarm-error {
-  background-color: var($error);
+// Notification-status colors stay on their light-theme Feather values so
+// the indicator meaning doesn't change with the active theme. We re-declare
+// the Feather CSS variables locally with their light-mode values and keep
+// the consuming rules pointing at the Feather variable names.
+.alarm-error,
+.alarm-ok,
+.alarm-unknown {
+  --feather-primary-text-on-color: rgba(255, 255, 255, 1);
   color: var($primary-text-on-color) !important;
+}
+
+.alarm-error {
+  --feather-error: #a5021f;
+  background-color: var($error);
 }
 
 .alarm-ok {
+  --feather-success: #0b720c;
   background-color: var($success);
-  color: var($primary-text-on-color) !important;
 }
 
 .alarm-unknown {
+  --feather-indeterminate: #0092c7;
   background-color: var($indeterminate);
-  color: var($primary-text-on-color) !important;
 }
 
 .search-left-margin {
@@ -259,24 +254,23 @@ onMounted(async () => {
 </style>
 
 <style lang="scss">
-@import "@featherds/styles/themes/open-mixins";
-@import "@featherds/styles/themes/variables";
-
-body {
-  background: var($background);
-}
-
-.open-light {
-  @include open-light;
-}
-
-.open-dark {
-  @include open-dark;
-}
-
 .light-dark {
   font-size: 24px;
   margin-top: 2px;
+  margin-right: 0.5rem;
+  color: var(--feather-state-text-color-on-surface-dark);
+  cursor: pointer;
+  outline: none;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--feather-primary);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
 }
 
 .header .header-content {

--- a/ui/src/components/Menu/Search.vue
+++ b/ui/src/components/Menu/Search.vue
@@ -22,6 +22,17 @@
       class="search-results-dropdown"
       @mousedown.prevent
     >
+      <div class="search-results-toolbar">
+        <FeatherIcon
+          :icon="CancelIcon"
+          class="search-results-close"
+          role="button"
+          tabindex="0"
+          title="Close"
+          @click="closeResults"
+          @keydown.enter.space.prevent="closeResults"
+        />
+      </div>
       <template
         v-for="(searchResultByContext, searchResultByContextKey) in filteredResults"
         :key="searchResultByContextKey"
@@ -62,6 +73,7 @@
 import { ref, computed, watch, nextTick } from 'vue'
 import { FeatherIcon } from '@featherds/icon'
 import SearchIcon from '@featherds/icon/action/Search'
+import CancelIcon from '@featherds/icon/navigation/Cancel'
 import SearchHeader from './SearchHeader.vue'
 import SearchResult from './SearchResult.vue'
 import { useMenuStore } from '@/stores/menuStore'
@@ -217,6 +229,11 @@ const selectCurrentItem = () => {
   }
 }
 
+const closeResults = () => {
+  showResults.value = false
+  selectedIndex.value = -1
+}
+
 const onKeyDown = async (event: KeyboardEvent) => {
   if (!showResults.value || !hasResults.value) {
     return
@@ -252,8 +269,7 @@ const onKeyDown = async (event: KeyboardEvent) => {
         break
         
       case 'Escape':
-        showResults.value = false
-        selectedIndex.value = -1
+        closeResults()
         break
     }
   }
@@ -275,7 +291,8 @@ const onKeyDown = async (event: KeyboardEvent) => {
   top: 100%;
   left: 0;
   width: 100%;
-  background: var($surface);
+  background: var($background);
+  color: var(--feather-secondary-text-on-surface);
   border: 1px solid var($secondary);
   border-radius: 4px;
   max-height: 400px;
@@ -284,24 +301,48 @@ const onKeyDown = async (event: KeyboardEvent) => {
   z-index: 1000;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 
+  .search-results-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0.25em 0.5em;
+    border-bottom: 1px solid var($border-on-surface);
+
+    .search-results-close {
+      cursor: pointer;
+      color: var($secondary-text-on-surface);
+      font-size: 1.25rem;
+
+      &:hover {
+        color: var($primary-text-on-surface);
+      }
+
+      &:focus-visible {
+        outline: 2px solid var($primary);
+        outline-offset: 2px;
+        border-radius: 2px;
+      }
+    }
+  }
+
   .search-category {
-    background-color: #f8f9fa;
+    background-color: var(--feather-background);
     padding: 0.5em 0.75em;
-    border-bottom: 1px solid #dee2e6;
-    font-weight: 500;
+    border-bottom: 1px solid var(--feather-surface);
+    font-weight: 800;
   }
 
   .search-result-item {
-    border-bottom: 1px solid #f1f3f4;
+    border-bottom: 1px solid var(--feather-surface);
     transition: background-color 0.15s ease;
     padding-left: 0.5em;
+    color: var(--feather-secondary-text-on-surface);
 
     &:hover {
-      background-color: #f8f9fa;
+      background-color: var(--feather-surface);
     }
 
     &.keyboard-selected {
-      background-color: #e9ecef;
+      background-color: var(--feather-surface);
     }
 
     &:last-child {
@@ -315,18 +356,18 @@ const onKeyDown = async (event: KeyboardEvent) => {
   position: relative;
   align-items: center;
   width: 100%;
-  background-color: #f8f9fa;
-  border: 1px solid #dee2e6;
+  background-color: var($surface);
+  border: 1px solid var($border-on-surface);
   border-radius: 4px;
-  
+
   .search-icon {
     position: absolute;
     left: 8px;
     z-index: 1;
-    color: #6c757d;
+    color: var($secondary-text-on-surface);
     pointer-events: none;
   }
-  
+
   .search-input {
     width: 100%;
     padding: 8px 12px 8px 36px;
@@ -334,10 +375,10 @@ const onKeyDown = async (event: KeyboardEvent) => {
     background: transparent;
     outline: none;
     font-size: 14px;
-    color: black;
+    color: var($primary-text-on-surface);
 
     &::placeholder {
-      color: #0c0d0e;
+      color: var($secondary-text-on-surface);
     }
     
     &:focus {

--- a/ui/src/components/Menu/SearchResult.vue
+++ b/ui/src/components/Menu/SearchResult.vue
@@ -73,9 +73,7 @@ const onItemOut = () => {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    background-color: '#e9ecef';
-    color: '#495057';
-    font-weight: 500;
+    font-weight: 550;
     white-space: break-spaces;
     padding: 0 3px;
 
@@ -89,6 +87,7 @@ const onItemOut = () => {
     }
 
     span {
+        margin-right: 1em;
         opacity: 0;
     }
 
@@ -106,26 +105,26 @@ const onItemOut = () => {
  */
 .search-result-button {
     background: transparent;
-    border:none;
+    border: none;
     appearance: none;
-    block-size:24px;
+    block-size: 24px;
     caret-color: rgb(10,12,27,0.7);
-    color: rgba(10, 12, 27, 0.7);
+    color: var(--feather-secondary-text-on-surface);
     column-rule-color: rgba(10, 12, 27, 0.7);
     cursor: pointer;
-    display:block;
+    display: block;
     font-family: OpenSans, Helvetica, Arial, sans-serif;
-    font-size:14px;
-    height:24px;
-    inline-size:266px;
-    letter-spacing:0.25px;
-    line-height:24px;
+    font-size: 14px;
+    height: 24px;
+    inline-size: 266px;
+    letter-spacing: 0.25px;
+    line-height: 24px;
     /* width for text in search result labels, so text does not get cut off */
     min-width: 30em;
-    outline-color:rgba(10, 12, 27, 0.7);
-    padding:0;
+    outline-color: rgba(10, 12, 27, 0.7);
+    padding: 0;
     perspective-origin: 133px 12px;
-    text-align:left;
+    text-align: left;
     text-decoration-color: rgba(10, 12, 27, 0.7);
     text-emphasis-color: rgba(10, 12, 27, 0.7);
     transform-origin: 133px 12px;
@@ -136,7 +135,7 @@ const onItemOut = () => {
 .search-item-details {
   margin-left: 1em;
   z-index: 1100;
-  color: black;
+  color: var(--feather-secondary-text-on-surface);
   padding: 0.25em;
 }
 </style>

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -73,10 +73,15 @@ const topPanels = computed<MenuListEntry[]>(() => {
 
   #opennms-sidebar-control {
     --feather-dock-header-offset: 3.75rem;
-  
+
     // tighten spacing between toggle button and top of menu items
     --feather-dock-content-padding-top: 3em;
     --feather-dock-toggle-top: 2em;
+
+    // Pin the side menu to dark regardless of active theme so that the
+    // side menu and top menubar stay visually consistent with one another.
+    --feather-dock-background-color: var(--feather-surface-dark);
+    --feather-dock-color: var(--feather-state-text-color-on-surface-dark);
   }
 
   // fix Sidenav toggle button placement

--- a/ui/src/components/Menu/UserNotificationsMenuItem.vue
+++ b/ui/src/components/Menu/UserNotificationsMenuItem.vue
@@ -342,19 +342,30 @@ div.user-notification-badge-wrapper {
   padding: 10px;
 }
 
-.alarm-error {
-  background-color: var($error);
+// Notification-status colors stay on their light-theme Feather values so
+// the indicator meaning doesn't change with the active theme. We re-declare
+// the Feather CSS variables locally with their light-mode values and keep
+// the consuming rules pointing at the Feather variable names.
+.alarm-error,
+.alarm-ok,
+.alarm-unknown {
+  --feather-primary-text-on-color: rgba(255, 255, 255, 1);
   color: var($primary-text-on-color) !important;
+}
+
+.alarm-error {
+  --feather-error: #a5021f;
+  background-color: var($error);
 }
 
 .alarm-ok {
+  --feather-success: #0b720c;
   background-color: var($success);
-  color: var($primary-text-on-color) !important;
 }
 
 .alarm-unknown {
+  --feather-indeterminate: #0092c7;
   background-color: var($indeterminate);
-  color: var($primary-text-on-color) !important;
 }
 
 .notice-status-display {

--- a/ui/src/components/Nodes/ColumnSelectionDrawer.vue
+++ b/ui/src/components/Nodes/ColumnSelectionDrawer.vue
@@ -2,9 +2,9 @@
   <FeatherDrawer
     id="column-selection-drawer"
     data-test="column-selection-drawer"
+    @hidden="nodeStructureStore.columnsDrawerState.visible = false"
     v-model="nodeStructureStore.columnsDrawerState.visible"
     :labels="{ close: 'close', title: 'Customize Columns' }"
-    hide-close
     width="55em"
   >
     <div class="feather-drawer-custom-padding">
@@ -40,7 +40,13 @@
         </template>
       </Draggable>
       <div class="spacer-medium"></div>
-      <div class="button-column">
+      <div class="button-row">
+        <FeatherButton
+          primary
+          @click="customizeTable"
+        >
+          Save
+        </FeatherButton>
         <FeatherButton
           secondary
           :disabled="selectedColumns.length >= 10"
@@ -55,10 +61,10 @@
           Reset Columns
         </FeatherButton>
         <FeatherButton
-          primary
-          @click="customizeTable"
+          secondary
+          @click="nodeStructureStore.columnsDrawerState.visible = false"
         >
-          Customize Table
+          Close
         </FeatherButton>
       </div>
     </div>
@@ -196,15 +202,14 @@ button.primary {
     display: none;
 }
 
-.button-column{
+.button-row {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 1rem;
-  align-items:flex-start;
+  align-items: flex-start;
 
  :deep(.btn + .btn) {
     margin-left: 0 !important;
   }
 }
 </style>
-

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -273,6 +273,7 @@
     <FeatherPagination
       v-if="nodeStore.totalCount > 0"
       v-model="pageNumber"
+      :pageSize="pageSize"
       :pageSizes="[10, 20, 50, 100, 200]"
       :total="nodeStore.totalCount"
       @update:modelValue="updatePageNumber"
@@ -400,9 +401,10 @@ const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 
 const dialogVisible = ref(false)
 const dialogNode = ref<Node>()
-const tableCssClasses = computed<string[]>(() => getTableCssClasses(nodeStructureStore.columns))
+const tableCssClasses = computed<string[]>(() => [...getTableCssClasses(nodeStructureStore.columns), 'condensed'])
 const queryParameters = ref<QueryParameters>(nodeStore.nodeQueryParameters)
 const pageNumber = ref(1)
+const pageSize = ref(nodeStore.nodeQueryParameters.limit || 50)
 
 const isSelectedColumn = (column: NodeColumnSelectionItem, id: string) => {
   return column.selected && column.id === id
@@ -418,7 +420,9 @@ const updatePageNumber = (page: number) => {
 }
 
 const updatePageSize = (size: number) => {
-  queryParameters.value = { ...queryParameters.value, limit: size }
+  pageSize.value = size
+  pageNumber.value = 1
+  queryParameters.value = { ...queryParameters.value, limit: size, offset: 0 }
   nodeStore.setNodeQueryParameters(queryParameters.value)
 
   updateQuery()
@@ -548,10 +552,10 @@ watch([() => nodeStructureStore.queryFilter], () => {
 </script>
 
 <style lang="scss" scoped>
-@import "@featherds/table/scss/table";
-@import "@featherds/styles/mixins/elevation";
-@import "@featherds/styles/mixins/typography";
-@import "@featherds/styles/themes/variables";
+@use "@featherds/table/scss/table" as table;
+@use "@featherds/styles/mixins/elevation" as elevation;
+@use "@featherds/styles/mixins/typography" as typography;
+@use "@featherds/styles/themes/variables" as variables;
 
 .node-table {
   margin-top: 1rem;
@@ -563,16 +567,16 @@ watch([() => nodeStructureStore.queryFilter], () => {
 }
 
 .card {
-  @include elevation(2);
-  background: var($surface);
+  @include elevation.elevation(2);
+  background: var(variables.$surface);
   padding: 30px;
 }
 
 table {
-  @include table;
-  @include table-condensed;
-  @include row-select();
-  @include row-hover();
+  @include table.table;
+  @include table.table-condensed;
+  @include table.row-select();
+  @include table.row-hover();
 
   tbody {
     tr {
@@ -584,7 +588,7 @@ table {
 }
 
 .title {
-  @include headline1;
+  @include typography.headline1;
   display: block;
 }
 
@@ -608,7 +612,7 @@ table {
   }
 
   .btn.btn-icon{
-    border: 2px solid var($border-on-surface);
+    border: 2px solid var(variables.$border-on-surface);
     border-radius: 3px;
     padding: 0 0.5rem;
     height: 3rem;
@@ -668,4 +672,3 @@ table {
   }
 }
 </style>
-

--- a/ui/src/components/Resources/TimeControls.vue
+++ b/ui/src/components/Resources/TimeControls.vue
@@ -172,6 +172,8 @@ const applyCustomTime = () => {
 .graph-controls {
   .menu {
     max-width: 550px;
+    position: relative;
+    min-width: 40em;
   }
   .menu-name {
     display: none !important;

--- a/ui/src/containers/EventConfigurationDetail.vue
+++ b/ui/src/containers/EventConfigurationDetail.vue
@@ -173,7 +173,7 @@ onMounted(async () => {
     border: 1px solid var($primary);
     border-radius: 4px;
     padding: 20px;
-    background: white;
+    background: var($surface);
     margin-bottom: 30px;
 
     .config-row {
@@ -189,12 +189,12 @@ onMounted(async () => {
         .field-label {
           font-weight: bold;
           margin-right: 10px;
-          color: #555;
+          color: var(--feather-secondary-text-on-surface);
           min-width: 80px;
         }
 
         .field-value {
-          color: #333;
+          color: var(--feather-secondary-text-on-surface);
         }
       }
 

--- a/ui/src/main/main.ts
+++ b/ui/src/main/main.ts
@@ -35,13 +35,14 @@ import * as Pinia from 'pinia'
 import * as VueRouter from 'vue-router'
 
 import '@featherds/styles'
-import '@featherds/styles/themes/open-light.css'
+import '@/styles/themes.scss'
 
 import 'vue-diff/dist/index.css'
 
 import dateFormatDirective from '../directives/v-date'
 import { externalComponent, getJSPath } from '../components/Plugin/utils'
 import { setupPrimeVue } from '../theme/primevue-setup'
+import { useAppStore } from '@/stores/appStore'
 
 // let plugins use state mngmnt / router
 (window as any).Vue = Vue;
@@ -100,4 +101,7 @@ app
   .use(router)
   .use(createPinia())
   .directive('date', dateFormatDirective)
-  .mount('#app')
+
+useAppStore().initTheme()
+
+app.mount('#app')

--- a/ui/src/services/themeService.ts
+++ b/ui/src/services/themeService.ts
@@ -20,37 +20,28 @@
 /// License.
 ///
 
-import { defineStore } from 'pinia'
-import {
-  applyThemeClass,
-  DARK_THEME,
-  LIGHT_THEME,
-  loadTheme,
-  saveTheme,
-  Theme
-} from '@/services/themeService'
+export type Theme = 'open-light' | 'open-dark'
 
-export const useAppStore = defineStore('appStore', () => {
-  const theme = ref<Theme>(loadTheme())
+export const LIGHT_THEME: Theme = 'open-light'
+export const DARK_THEME: Theme = 'open-dark'
+export const DEFAULT_THEME: Theme = LIGHT_THEME
 
-  const setTheme = (newTheme: Theme) => {
-    theme.value = newTheme
-    saveTheme(newTheme)
-    applyThemeClass(newTheme)
-  }
+const THEME_STORAGE_KEY = 'theme'
 
-  const initTheme = () => {
-    applyThemeClass(theme.value)
-  }
+const isTheme = (value: unknown): value is Theme =>
+  value === LIGHT_THEME || value === DARK_THEME
 
-  const toggleTheme = () => {
-    setTheme(theme.value === LIGHT_THEME ? DARK_THEME : LIGHT_THEME)
-  }
+export const loadTheme = (): Theme => {
+  const value = localStorage.getItem(THEME_STORAGE_KEY)
+  return isTheme(value) ? value : DEFAULT_THEME
+}
 
-  return {
-    theme,
-    setTheme,
-    initTheme,
-    toggleTheme
-  }
-})
+export const saveTheme = (theme: Theme): void => {
+  localStorage.setItem(THEME_STORAGE_KEY, theme)
+}
+
+export const applyThemeClass = (theme: Theme): void => {
+  const body = document.body
+  body.classList.remove(LIGHT_THEME, DARK_THEME)
+  body.classList.add(theme)
+}

--- a/ui/src/stores/nodeStore.ts
+++ b/ui/src/stores/nodeStore.ts
@@ -36,7 +36,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
   const availability = ref({} as NodeAvailability)
   const outages = ref([] as Outage[])
   const outagesTotalCount = ref(0)
-  const nodeQueryParameters = ref({ limit: 20, offset: 0, orderBy: 'label' } as QueryParameters)
+  const nodeQueryParameters = ref({ limit: 50, offset: 0, orderBy: 'label' } as QueryParameters)
 
   // map of nodeId to IpInterfaces associated with that node
   const nodeToIpInterfaceMap = ref<Map<string, IpInterface[]>>(new Map<string, IpInterface[]>())

--- a/ui/src/styles/themes.scss
+++ b/ui/src/styles/themes.scss
@@ -20,37 +20,17 @@
 /// License.
 ///
 
-import { defineStore } from 'pinia'
-import {
-  applyThemeClass,
-  DARK_THEME,
-  LIGHT_THEME,
-  loadTheme,
-  saveTheme,
-  Theme
-} from '@/services/themeService'
+@import "@featherds/styles/themes/open-mixins";
+@import "@featherds/styles/themes/variables";
 
-export const useAppStore = defineStore('appStore', () => {
-  const theme = ref<Theme>(loadTheme())
+.open-light {
+  @include open-light;
+}
 
-  const setTheme = (newTheme: Theme) => {
-    theme.value = newTheme
-    saveTheme(newTheme)
-    applyThemeClass(newTheme)
-  }
+.open-dark {
+  @include open-dark;
+}
 
-  const initTheme = () => {
-    applyThemeClass(theme.value)
-  }
-
-  const toggleTheme = () => {
-    setTheme(theme.value === LIGHT_THEME ? DARK_THEME : LIGHT_THEME)
-  }
-
-  return {
-    theme,
-    setTheme,
-    initTheme,
-    toggleTheme
-  }
-})
+body {
+  background: var($background);
+}


### PR DESCRIPTION
Enable toggling light/dark mode for the Vue UI pages. Not yet enabled for legacy JSP etc. pages.

The top and side menu backgrounds remain dark regardless of mode, but individual items in it toggle light/dark mode, including the Search box and results, Notifications and User dropdowns.

These changes also work with PrimeVue.

In addition, fixed a few other issues:

- Structured Node Page pagination and Customize Columns drawer close button
- Double-shift to focus Search now works on both JSP and Vue SPA pages and the `keyup` handler is cleaned up
- `X` added to top of Search box results to close. It was confusing how to close it before.
- Some other styling fixes to Search box, and it now respects light/dark mode
- Resource graph Time popup dialog is now placed correctly (to the right of the side menu)

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19617
