### PR TITLE
NMS-19727: remove process.env in /ui

### DIFF
--- a/ui/vite.config.menu.ts
+++ b/ui/vite.config.menu.ts
@@ -58,9 +58,6 @@ export default defineConfig({
       }
     })
   ],
-  define: {
-    'process.env': process.env
-  },
   root: './src/menu',
   // make sure we get environment variables from .env files in the main ui directory
   // path is relative to 'root' defined just above

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -65,9 +65,6 @@ export default defineConfig({
       }
     })
   ],
-  define: {
-    'process.env': process.env
-  },
   test: {
     dir: './tests',
     globals: true,


### PR DESCRIPTION
We get the following warning when building the `/ui`:

```
The `define` option contains an object with "PATH" for "process.env" key.
It looks like you may have passed the entire `process.env` object to `define`, which can unintentionally expose all environment variables. This poses a security risk and is discouraged.
```

We don’t actually even use `process.env` (the source code uses `import.meta.env` everywhere), so we can remove to remove any security risk.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19727

