### PR TITLE
NMS-19728: SNMP Config Lookup UI help

### DIFF
--- a/ui/src/components/Common/MessageDialog.vue
+++ b/ui/src/components/Common/MessageDialog.vue
@@ -6,7 +6,7 @@
       hide-close
       @hidden="onClose"
     >
-      <div class="modal-body">
+      <div class="modal-body" :style="{ maxWidth: props.maxWidth, maxHeight: props.maxHeight }">
         <slot name="content"></slot>
       </div>
       <template v-slot:footer>
@@ -25,6 +25,8 @@ import { FeatherButton } from '@featherds/button'
 import { FeatherDialog } from '@featherds/dialog'
 
 const props = defineProps({
+  maxHeight: { type: String, default: '20em' },
+  maxWidth: { type: String, default: '50em' },
   title: { required: false, type: String },
   visible: { required: true, type: Boolean }
 })
@@ -50,4 +52,8 @@ watch ([() => props.visible], ([newVal]) => {
 </script>
 
 <style scoped lang="scss">
+  .modal-body {
+    overflow: auto;
+    word-break: break-word;
+  }
 </style>

--- a/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionBasicInformation.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionBasicInformation.vue
@@ -14,6 +14,12 @@
           {{ isCreate ? 'Create New SNMP Definition' : 'Edit SNMP Definition Details' }}
         </h3>
       </div>
+      <FeatherIcon
+        :icon="InfoIcon"
+        class="info-icon"
+        @click="isMessageDialogVisible = true"
+        data-test="snmp-config-lookup-info-icon"
+      />
     </div>
     <div class="spacer"></div>
     <div class="basic-info">
@@ -63,6 +69,40 @@
         />
       </div>
     </div>
+    <MessageDialog
+      :visible="isMessageDialogVisible"
+      maxHeight="22em"
+      maxWidth="50em"
+      title="SNMP Definition Details"
+      @close="isMessageDialogVisible = false"
+    >
+      <template #content>
+        <div class="snmp-definition-message-dialog-help-body">
+          <p>The SNMP Configuration UI allows you to manage SNMP definitions. SNMP definitions are used to specify the SNMP settings that should be applied to nodes based on their IP address or other criteria.</p>
+
+          <p>The top section, <strong>Configuration applies to these IP Ranges</strong>, shows badges with each specific IP, IP range or IPLIKE expression that is being viewed or edited.</p>
+
+          <p><strong>NOTE:</strong> The same detail view is used whether you arrived via <strong>Lookup by IP</strong> or via <strong>Manage Definitions</strong>.</p>
+
+          <p>In the case of a lookup, there will be only one badge for the specific IP address that was looked up. In the case of editing, either on this screen or the <strong>Manage Definitions</strong> screen, there may be multiple badges for the various IP addresses, IP ranges or IPLIKE expressions that are being edited.</p>
+
+          <p>In the input fields below, you can add a single IP address, specify a first and last IP address of a range, or specify an IPLIKE expression. Then click <strong>Add</strong>, and a new badge will appear in the top section.</p>
+
+          <p>Click the <strong>X</strong> on a badge to remove that item from the configuration being edited.</p>
+
+          <p>You may then edit all the other parameters as needed, and click <strong>Save</strong> to save the configuration, which will now apply to all the IP addresses, ranges or IPLIKE expressions specified in the badges.</p>
+
+          <p><strong>NOTE:</strong> OpenNMS will optimize the application of these configurations to the specified IP addresses, ranges, or IPLIKE expressions, for 
+          example by consolidating overlapping ranges.</p>
+
+          <h4>Secure Credentials Vault (SCV) Support</h4>
+
+          <p>For secure parameters such as read/write community strings or SNMP v3 authentication and privacy credentials, you can choose to store these in the OpenNMS Secure Credentials Vault. This allows you to keep sensitive information secure while still allowing OpenNMS to access it when needed.</p>
+
+          <p>Click on the SCV icon next to those fields to open the SCV drawer which allows you to select a credential from the vault. This will enter a reference to that credential in the field, which OpenNMS will resolve to the actual credential value when it needs to use it. A typical expression looks like <code>${scv:snmp-read-community}</code>, where <code>snmp-read-community</code> is the name of the credential stored in the vault. Note, you can also enter the reference expression directly into the field without using the SCV drawer, as long as you use the correct syntax.</p>
+        </div>
+      </template>
+    </MessageDialog>
   </div>
 </template>
 
@@ -70,7 +110,9 @@
 import { FeatherBackButton } from '@featherds/back-button'
 import { FeatherChip, FeatherChipList } from '@featherds/chips'
 import { FeatherIcon } from '@featherds/icon'
+import InfoIcon from '@featherds/icon/action/Info'
 import IconCancel from '@featherds/icon/navigation/Cancel'
+import MessageDialog from '../Common/MessageDialog.vue'
 import { DEFAULT_MONITORING_LOCATION } from '@/lib/constants'
 import { convertSnmpVersionToString } from '@/services/snmpConfigService'
 import { getDefaultSnmpDefinition } from '@/stores/snmpConfigStore'
@@ -96,6 +138,7 @@ interface DefinitionBadgeItem {
   ipMatch?: string
 }
 
+const isMessageDialogVisible = ref(false)
 const isValid = ref(false)
 const errors = ref<SnmpConfigFormErrors>({})
 const currentDefinition = ref<SnmpDefinition>(getDefaultSnmpDefinition())
@@ -379,6 +422,24 @@ onMounted(() => {
 @use '@featherds/styles/mixins/typography';
 @use "@featherds/table/scss/table";
 
+
+.snmp-definition-message-dialog-help-body {
+  p {
+    margin: 0.5em 0;
+  }
+
+  h4 {
+    margin-top: 1em;
+  }
+
+  code {
+    background-color: var(variables.$background);
+    padding: 0.2em 0.4em;
+    border-radius: 4px;
+    font-family: monospace;
+  }
+}
+
 .main-content {
   padding: 0.2em;
   margin: 0.2em;
@@ -389,6 +450,17 @@ onMounted(() => {
     display: flex;
     align-items: center;
     gap: 20px;
+  }
+
+  .info-icon {
+    cursor: pointer;
+    font-size: 1.5em;
+    margin-left: 0.5em;
+    color: var(variables.$primary);
+
+    &:hover {
+      opacity: 0.8;
+    }
   }
 
   .basic-info {

--- a/ui/src/components/SnmpConfiguration/SnmpConfigLookupPanel.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigLookupPanel.vue
@@ -3,8 +3,15 @@
     <div class="title-container">
       <h3>Lookup by IP</h3>
     </div>
-    <div>
-      <p>Find the SNMP configuration that exists for a particular IP address.</p>
+    
+    <div class="info-section">
+      <span>Find the SNMP configuration that exists for a particular IP address.</span>
+      <FeatherIcon
+        :icon="InfoIcon"
+        class="info-icon"
+        @click="isMessageDialogVisible = true"
+        data-test="snmp-config-lookup-info-icon"
+      />
     </div>
     <div class="large-spacer"></div>
 
@@ -55,13 +62,32 @@
         </div>
       </div>
     </div>
+    <MessageDialog
+      :visible="isMessageDialogVisible"
+      maxHeight="22em"
+      maxWidth="50em"
+      title="SNMP Lookup"
+      @close="isMessageDialogVisible = false"
+    >
+      <template #content>
+        <div>
+          <p>The SNMP Configuration Lookup feature allows you to quickly find the SNMP configuration for a specific IP address.</p>
+          <p>Enter an IP address in the lookup field and choose a Monitoring Location, then click the *Lookup* button.
+          If you are not using Minions, then the Monitoring Location is always `Default`. If you are using Minions, then the Monitoring Location is determined by the Minion that is responsible for monitoring the IP address.</p>
+          <p>The SNMP configuration that applies to that IP address will then be displayed.</p>
+        </div>
+      </template>
+    </MessageDialog>
   </div>
 </template>
 
 <script setup lang="ts">
 import { FeatherButton } from '@featherds/button'
+import { FeatherIcon } from '@featherds/icon'
+import InfoIcon from '@featherds/icon/action/Info'
 import { FeatherInput } from '@featherds/input'
 import { FeatherSelect, ISelectItemType } from '@featherds/select'
+import MessageDialog from '../Common/MessageDialog.vue'
 import useSnackbar from '@/composables/useSnackbar'
 import { SnmpLookupEditMode, useSnmpConfigStore } from '@/stores/snmpConfigStore'
 import { SnmpAgentConfig } from '@/types/snmpConfig'
@@ -78,6 +104,7 @@ const lookupIpAddress = ref('')
 const lookupConfig = ref<SnmpAgentConfig>()
 const lookupMonitoringLocation = ref<ISelectItemType>({ _text: DEFAULT_MONITORING_LOCATION, _value: DEFAULT_MONITORING_LOCATION })
 const isLoading = ref(false)
+const isMessageDialogVisible = ref(false)
 
 // lookup config response individual parameters to edit
 const ipAddress = ref('')
@@ -194,6 +221,25 @@ watch(() => props.autoLookupIpAddress, (ip) => {
 
     .title {
       @include typography.headline3;
+    }
+  }
+
+  .info-section {
+    margin-bottom: 1em;
+
+    .label {
+      color: var(variables.$primary-text-on-surface);
+    }
+
+    .info-icon {
+      cursor: pointer;
+      font-size: 1.5em;
+      margin-left: 0.5em;
+      color: var(variables.$primary);
+
+      &:hover {
+        opacity: 0.8;
+      }
     }
   }
 

--- a/ui/src/components/SnmpConfiguration/SnmpConfigUploadDownloadTab.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigUploadDownloadTab.vue
@@ -4,7 +4,8 @@
         <h3>SNMP Configuration Upload/Download</h3>
         <div class="feather-row">
           <div class="feather-col-12">
-            <span class="label">You can both download and upload the entire SNMP configuration in both XML and Json formats.</span>
+            <span class="label">You can both download and upload the entire SNMP configuration in both XML and Json formats.
+              <strong>Use caution</strong> when uploading SNMP configuration files, as this will overwrite the existing configuration and may impact device monitoring if the uploaded configuration is not correct.</span>
           </div>
         </div>
         <div class="feather-row">


### PR DESCRIPTION
Instead of adding a lot of documentation to the docs about SNMP Config UI, which may become a burden to maintain, this PR instead adds some more help in the UI itself.

The various SNMP Config pages have Info icons that open dialogs with more help. The updates here should be enough to guide the user through the process.

Also updated the `MessageDialog` to have configurable `maxHeight` and `maxWidth`.

We can then close the [other PR](https://github.com/OpenNMS/opennms/pull/8443) and [ticket NMS-19154](https://opennms.atlassian.net/browse/NMS-19154).

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19728
