### PR TITLE
NMS-19712: Strafeping Update

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-graph/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-graph/index.js
@@ -130,9 +130,12 @@ const drawBackshiftGraph = (el, def, dim) => {
     });
     const graphModel = rrdGraphConverter.model;
 
-    // OpenNMS-specific marker (not real rrdtool syntax) to opt into
-    // backshift's step-line rendering for this graph.
-    const stepMode = /(^|\s)--step-mode(\s|$)/.test(graphDef.command || '');
+    // Graph commands can include --slope-mode to opt into backshift's
+    // step-line rendering. The flag name is borrowed from rrdtool so the
+    // command stays rrdtool-compatible on the PNG render path, but note
+    // rrdtool's own interpretation of --slope-mode is the opposite (it
+    // enables sloped lines in PNG output).
+    const stepMode = /(^|\s)--slope-mode(\s|$)/.test(graphDef.command || '');
 
     // Build the data-source
     const ds = new Backshift.DataSource.OpenNMS({

--- a/core/web-assets/src/main/assets/js/apps/onms-graph/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-graph/index.js
@@ -130,6 +130,10 @@ const drawBackshiftGraph = (el, def, dim) => {
     });
     const graphModel = rrdGraphConverter.model;
 
+    // OpenNMS-specific marker (not real rrdtool syntax) to opt into
+    // backshift's step-line rendering for this graph.
+    const stepMode = /(^|\s)--step-mode(\s|$)/.test(graphDef.command || '');
+
     // Build the data-source
     const ds = new Backshift.DataSource.OpenNMS({
       url: window.onmsGraphContainers.baseHref + 'rest/measurements',
@@ -147,7 +151,8 @@ const drawBackshiftGraph = (el, def, dim) => {
       model: graphModel,
       printStatements: graphModel.printStatements,
       title: graphModel.title,
-      verticalLabel: graphModel.verticalLabel
+      verticalLabel: graphModel.verticalLabel,
+      step: stepMode
     });
     graph.render();
   }).fail((jqXHR, textStatus) => {

--- a/opennms-base-assembly/src/main/filtered/etc/response-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/response-graph.properties
@@ -322,7 +322,7 @@ report.strafeping.command=--title="StrafePing Response Time" \
  --alt-autoscale-max \
  --alt-y-grid \
  --lower-limit 0 \
- --vertical-label Seconds \
+ --vertical-label "Seconds" \
  DEF:ping1Micro={rrd1}:ping1:AVERAGE \
  CDEF:ping1=ping1Micro,1000000,/ \
  DEF:ping2Micro={rrd1}:ping2:AVERAGE \
@@ -363,94 +363,121 @@ report.strafeping.command=--title="StrafePing Response Time" \
  CDEF:ping19=ping19Micro,1000000,/ \
  DEF:ping20Micro={rrd1}:ping20:AVERAGE \
  CDEF:ping20=ping20Micro,1000000,/ \
- CDEF:cp1=ping1,0,0.14290626,LIMIT \
- CDEF:cp2=ping2,0,0.14290626,LIMIT \
- CDEF:cp3=ping3,0,0.14290626,LIMIT \
- CDEF:cp4=ping4,0,0.14290626,LIMIT \
- CDEF:cp5=ping5,0,0.14290626,LIMIT \
- CDEF:cp6=ping6,0,0.14290626,LIMIT \
- CDEF:cp7=ping7,0,0.14290626,LIMIT \
- CDEF:cp8=ping8,0,0.14290626,LIMIT \
- CDEF:cp9=ping9,0,0.14290626,LIMIT \
- CDEF:cp10=ping10,0,0.14290626,LIMIT \
- CDEF:cp11=ping11,0,0.14290626,LIMIT \
- CDEF:cp12=ping12,0,0.14290626,LIMIT \
- CDEF:cp13=ping13,0,0.14290626,LIMIT \
- CDEF:cp14=ping14,0,0.14290626,LIMIT \
- CDEF:cp15=ping15,0,0.14290626,LIMIT \
- CDEF:cp16=ping16,0,0.14290626,LIMIT \
- CDEF:cp17=ping17,0,0.14290626,LIMIT \
- CDEF:cp18=ping18,0,0.14290626,LIMIT \
- CDEF:cp19=ping19,0,0.14290626,LIMIT \
- CDEF:cp20=ping20,0,0.14290626,LIMIT \
- DEF:loss={rrd1}:loss:AVERAGE \
- DEF:maxLoss={rrd1}:loss:MAX \
- AREA:cp20#f0f0f0 \
- AREA:cp19#dddddd \
- AREA:cp18#cacaca \
- AREA:cp17#b7b7b7 \
- AREA:cp16#a4a4a4 \
- AREA:cp15#919191 \
- AREA:cp14#7e7e7e \
- AREA:cp13#6b6b6b \
- AREA:cp12#585858 \
- AREA:cp11#454545 \
- AREA:cp10#535353 \
- AREA:cp9#666666 \
- AREA:cp8#797979 \
- AREA:cp7#8c8c8c \
- AREA:cp6#9f9f9f \
- AREA:cp5#b2b2b2 \
- AREA:cp4#c5c5c5 \
- AREA:cp3#d8d8d8 \
- AREA:cp2#ebebeb \
- AREA:cp1#fefefe \
  DEF:medianMicro={rrd1}:median:AVERAGE \
  CDEF:median=medianMicro,1000000,/ \
+ DEF:minMedianMicro={rrd1}:median:MIN \
+ CDEF:minMedian=minMedianMicro,1000000,/ \
+ DEF:maxMedianMicro={rrd1}:median:MAX \
+ CDEF:maxMedian=maxMedianMicro,1000000,/ \
+ CDEF:barH=maxMedian,100,/ \
+ DEF:loss={rrd1}:loss:AVERAGE \
+ DEF:maxLoss={rrd1}:loss:MAX \
  CDEF:ploss=loss,20,/,100,* \
  CDEF:maxPloss=maxLoss,20,/,100,* \
- GPRINT:median:AVERAGE:"Median RTT (%.1lf %ss avg)" \
+ CDEF:p20=ping20 \
+ CDEF:p19=ping19,UN,p20,ping19,IF \
+ CDEF:p18=ping18,UN,p19,ping18,IF \
+ CDEF:p17=ping17,UN,p18,ping17,IF \
+ CDEF:p16=ping16,UN,p17,ping16,IF \
+ CDEF:p15=ping15,UN,p16,ping15,IF \
+ CDEF:p14=ping14,UN,p15,ping14,IF \
+ CDEF:p13=ping13,UN,p14,ping13,IF \
+ CDEF:p12=ping12,UN,p13,ping12,IF \
+ CDEF:p11=ping11,UN,p12,ping11,IF \
+ CDEF:p10=ping10,UN,p11,ping10,IF \
+ CDEF:p9=ping9,UN,p10,ping9,IF \
+ CDEF:p8=ping8,UN,p9,ping8,IF \
+ CDEF:p7=ping7,UN,p8,ping7,IF \
+ CDEF:p6=ping6,UN,p7,ping6,IF \
+ CDEF:p5=ping5,UN,p6,ping5,IF \
+ CDEF:p4=ping4,UN,p5,ping4,IF \
+ CDEF:p3=ping3,UN,p4,ping3,IF \
+ CDEF:p2=ping2,UN,p3,ping2,IF \
+ CDEF:p1=ping1,UN,p2,ping1,IF \
+ CDEF:d1=p2,p1,- \
+ CDEF:d2=p3,p2,- \
+ CDEF:d3=p4,p3,- \
+ CDEF:d4=p5,p4,- \
+ CDEF:d5=p6,p5,- \
+ CDEF:d6=p7,p6,- \
+ CDEF:d7=p8,p7,- \
+ CDEF:d8=p9,p8,- \
+ CDEF:d9=p10,p9,- \
+ CDEF:d10=p11,p10,- \
+ CDEF:d11=p12,p11,- \
+ CDEF:d12=p13,p12,- \
+ CDEF:d13=p14,p13,- \
+ CDEF:d14=p15,p14,- \
+ CDEF:d15=p16,p15,- \
+ CDEF:d16=p17,p16,- \
+ CDEF:d17=p18,p17,- \
+ CDEF:d18=p19,p18,- \
+ CDEF:d19=p20,p19,- \
+ AREA:p1#00000000 \
+ STACK:d1#e8e8e8 \
+ STACK:d2#d4d4d4 \
+ STACK:d3#c0c0c0 \
+ STACK:d4#acacac \
+ STACK:d5#989898 \
+ STACK:d6#848484 \
+ STACK:d7#707070 \
+ STACK:d8#5c5c5c \
+ STACK:d9#484848 \
+ STACK:d10#484848 \
+ STACK:d11#5c5c5c \
+ STACK:d12#707070 \
+ STACK:d13#848484 \
+ STACK:d14#989898 \
+ STACK:d15#acacac \
+ STACK:d16#c0c0c0 \
+ STACK:d17#d4d4d4 \
+ STACK:d18#e8e8e8 \
+ STACK:d19#f4f4f4 \
  LINE1:median#202020 \
  CDEF:me0=loss,-1,GT,loss,0,LE,*,1,UNKN,IF,median,* \
- CDEF:meL0=me0,0.0007145313,- \
- CDEF:meH0=me0,0,*,0.0007145313,2,*,+ \
- AREA:meL0 \
- STACK:meH0#26ff00:0 \
+ CDEF:meL0=me0,barH,- \
+ CDEF:meH0=me0,0,*,barH,2,*,+ \
+ AREA:meL0#00000000 \
+ STACK:meH0#26ff00:"0       " \
  CDEF:me1=loss,0,GT,loss,1,LE,*,1,UNKN,IF,median,* \
- CDEF:meL1=me1,0.0007145313,- \
- CDEF:meH1=me1,0,*,0.0007145313,2,*,+ \
- AREA:meL1 \
- STACK:meH1#00b8ff:1/20 \
+ CDEF:meL1=me1,barH,- \
+ CDEF:meH1=me1,0,*,barH,2,*,+ \
+ AREA:meL1#00000000 \
+ STACK:meH1#00b8ff:"1/20    " \
  CDEF:me2=loss,1,GT,loss,2,LE,*,1,UNKN,IF,median,* \
- CDEF:meL2=me2,0.0007145313,- \
- CDEF:meH2=me2,0,*,0.0007145313,2,*,+ \
- AREA:meL2 \
- STACK:meH2#0059ff:2/20 \
+ CDEF:meL2=me2,barH,- \
+ CDEF:meH2=me2,0,*,barH,2,*,+ \
+ AREA:meL2#00000000 \
+ STACK:meH2#0059ff:"2/20    " \
  CDEF:me3=loss,2,GT,loss,3,LE,*,1,UNKN,IF,median,* \
- CDEF:meL3=me3,0.0007145313,- \
- CDEF:meH3=me3,0,*,0.0007145313,2,*,+ \
- AREA:meL3 \
- STACK:meH3#5e00ff:3/20 \
+ CDEF:meL3=me3,barH,- \
+ CDEF:meH3=me3,0,*,barH,2,*,+ \
+ AREA:meL3#00000000 \
+ STACK:meH3#5e00ff:"3/20    " \
  CDEF:me4=loss,3,GT,loss,4,LE,*,1,UNKN,IF,median,* \
- CDEF:meL4=me4,0.0007145313,- \
- CDEF:meH4=me4,0,*,0.0007145313,2,*,+ \
- AREA:meL4 \
- STACK:meH4#7e00ff:4/20 \
+ CDEF:meL4=me4,barH,- \
+ CDEF:meH4=me4,0,*,barH,2,*,+ \
+ AREA:meL4#00000000 \
+ STACK:meH4#7e00ff:"4/20    " \
  CDEF:me10=loss,4,GT,loss,10,LE,*,1,UNKN,IF,median,* \
- CDEF:meL10=me10,0.0007145313,- \
- CDEF:meH10=me10,0,*,0.0007145313,2,*,+ \
- AREA:meL10 \
- STACK:meH10#dd00ff:10/20 \
+ CDEF:meL10=me10,barH,- \
+ CDEF:meH10=me10,0,*,barH,2,*,+ \
+ AREA:meL10#00000000 \
+ STACK:meH10#dd00ff:"10/20   " \
  CDEF:me19=loss,10,GT,loss,19,LE,*,1,UNKN,IF,median,* \
- CDEF:meL19=me19,0.0007145313,- \
- CDEF:meH19=me19,0,*,0.0007145313,2,*,+ \
- AREA:meL19 \
- STACK:meH19#ff0000:19/20 \
- COMMENT:"\\l" \
- GPRINT:ploss:AVERAGE:"\Packet Loss\\: %.2lf %% average"\ \
- GPRINT:maxPloss:MAX:"%.2lf %% maximum" \
- GPRINT:ploss:LAST:"%.2lf %% current\\l" \
- COMMENT:"\\s"
+ CDEF:meL19=me19,barH,- \
+ CDEF:meH19=me19,0,*,barH,2,*,+ \
+ AREA:meL19#00000000 \
+ STACK:meH19#ff0000:"19/20\\l" \
+ COMMENT:"median rtt\\:" \
+ GPRINT:median:AVERAGE:"%5.1lf %ss avg" \
+ GPRINT:maxMedian:MAX:"%5.1lf %ss max" \
+ GPRINT:minMedian:MIN:"%5.1lf %ss min" \
+ GPRINT:median:LAST:"%5.1lf %ss now\\l" \
+ COMMENT:"packet loss\\:" \
+ GPRINT:ploss:AVERAGE:"%5.2lf %% avg" \
+ GPRINT:maxPloss:MAX:"%5.2lf %% max" \
+ GPRINT:ploss:LAST:"%5.2lf %% now\\l"
 
 
 ########################################################################


### PR DESCRIPTION
This addresses items 1,2, and 3 from NMS-19712.  Couple things in here that are all related:

1. The new StrafePing graph definition.

- Adaptive bar height: barH = maxMedian/100 (was hard-coded 0.0007145313).
- Loss-color bars now scale with observed max median RTT instead of assuming a 143 ms y-axis.
- New percentile stacking: old cp1..cp20/LIMIT + gray AREAs replaced with p1..p20 (UN-fallback chain so gaps propagate instead of becoming zero) and d1..d19 deltas rendered as STACK layers
- Transparent base + stacks: AREA:meL*#00000000 (was colorless AREA:meL*), enabling backshift v1.3.4's 8-digit-hex transparency.
- GPRINTs rewritten: explicit median avg/max/min/now and ploss avg/max/now lines replacing the single packet-loss line.

2. Removing the filters for StrafePing, I'm fairly certain these were there as examples at some point and they aren't needed and just clutter up the poller config and make using StrafePing harder.  It's not auto added to nodes via discovery anyway.
3. I've added the option for "--slope-mode" to work (as inverted from what rrdtool does with it) for rendering steps.  I've left it out of the graph definition but it was vaguely hinted at by the customer so I might need it for them when this gets in.

Some before and after images of the new graphs (with the backshift fixes in now):

Before:
<img width="2581" height="1083" alt="image" src="https://github.com/user-attachments/assets/c72a4f33-74cf-4221-9473-fdc1cf42c8e9" />

After:
<img width="2581" height="1083" alt="image" src="https://github.com/user-attachments/assets/44a862cd-0d65-4cd0-8f72-a48c1154a616" />

Before:
<img width="2581" height="1083" alt="image" src="https://github.com/user-attachments/assets/f107ad70-06f0-46c2-b206-b565dcdf194b" />

After:
<img width="2581" height="1083" alt="image" src="https://github.com/user-attachments/assets/849b01a5-7422-4f39-9f5c-6d9d5e1e860e" />

Bonus screenshot of steps in action:
<img width="2581" height="1083" alt="image" src="https://github.com/user-attachments/assets/0fe2ef51-6245-4e3d-9e2c-41b22ed04144" />

Assisted-by: Claude Code:Opus 4.6 & 4.7