### PR TITLE
NMS-19730: Keep Alarm Advanced Search dialog in sync with applied filters

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/AlarmQueryServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/AlarmQueryServlet.java
@@ -338,9 +338,9 @@ public class AlarmQueryServlet extends HttpServlet {
             throw new MissingParameterException(prefix + "ampm", this.getRequiredDateFields(prefix));
         }
 
-        if (amPmString.equalsIgnoreCase("am")) {
+        if (amPmString.equalsIgnoreCase("am") || amPmString.equalsIgnoreCase("midnight")) {
             cal.set(Calendar.AM_PM, Calendar.AM);
-        } else if (amPmString.equalsIgnoreCase("pm")) {
+        } else if (amPmString.equalsIgnoreCase("pm") || amPmString.equalsIgnoreCase("noon")) {
             cal.set(Calendar.AM_PM, Calendar.PM);
         } else {
             throw new IllegalArgumentException("Illegal AM/PM value: " + amPmString);

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/AlarmTextFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/AlarmTextFilter.java
@@ -43,6 +43,10 @@ public class AlarmTextFilter extends OrFilter {
         return ("<AlarmTextFilter: " + this.getDescription() + ">");
     }
 
+    public String getValue() {
+        return value;
+    }
+
     @Override
     public String getDescription() {
         return TYPE + "=" + value;

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmFilterController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmFilterController.java
@@ -95,7 +95,7 @@ public class AlarmFilterController extends MultiActionController implements Init
     private ModelAndView list(HttpServletRequest request, OnmsFilterFavorite favorite) {
         AcknowledgeType ackType = getAcknowledgeType(request);
         ModelAndView modelAndView = createListModelAndView(request,
-                getFilterCallback().parse(request.getQueryString() == null ? "" : request.getQueryString()), ackType);
+                getFilterCallback().parse(FilterUtil.parse(request.getQueryString() == null ? "" : request.getQueryString())), ackType);
         modelAndView.addObject("favorite", favorite);
         modelAndView.setViewName("alarm/list");
         return modelAndView;

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmFilterController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmFilterController.java
@@ -95,7 +95,7 @@ public class AlarmFilterController extends MultiActionController implements Init
     private ModelAndView list(HttpServletRequest request, OnmsFilterFavorite favorite) {
         AcknowledgeType ackType = getAcknowledgeType(request);
         ModelAndView modelAndView = createListModelAndView(request,
-                getFilterCallback().parse(FilterUtil.parse(request.getQueryString() == null ? "" : request.getQueryString())), ackType);
+                getFilterCallback().parse(request.getQueryString() == null ? "" : request.getQueryString()), ackType);
         modelAndView.addObject("favorite", favorite);
         modelAndView.setViewName("alarm/list");
         return modelAndView;

--- a/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
@@ -303,9 +303,9 @@ public class EventQueryServlet extends HttpServlet {
             throw new MissingParameterException(prefix + "ampm", this.getRequiredDateFields(prefix));
         }
 
-        if (amPmString.equalsIgnoreCase("am")) {
+        if (amPmString.equalsIgnoreCase("am") || amPmString.equalsIgnoreCase("midnight")) {
             cal.set(Calendar.AM_PM, Calendar.AM);
-        } else if (amPmString.equalsIgnoreCase("pm")) {
+        } else if (amPmString.equalsIgnoreCase("pm") || amPmString.equalsIgnoreCase("noon")) {
             cal.set(Calendar.AM_PM, Calendar.PM);
         } else {
             throw new IllegalArgumentException("Illegal AM/PM value: " + amPmString);

--- a/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
@@ -29,6 +29,7 @@ import org.opennms.web.filter.QueryParameters;
 
 import javax.servlet.ServletContext;
 import java.net.URLDecoder;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.opennms.web.filter.FilterUtil.getFilterParameters;
@@ -67,12 +68,15 @@ public abstract class AbstractFilterCallback implements FilterCallback {
     @Override
     public List<Filter> parse(String filterString) {
         String[] filterParameter = getFilterParameters(filterString);
-        for (int i=0; i< filterParameter.length; i++) {
+
+        for (int i = 0; i < filterParameter.length; i++) {
             if (filterParameter[i].startsWith("filter=")) {
                 filterParameter[i] = filterParameter[i].replaceFirst("filter=", "");
                 filterParameter[i] = URLDecoder.decode(filterParameter[i]);
             }
         }
+
+        // Note, filters are deduped in the following call to 'parse()'
         return parse(filterParameter);
     }
 
@@ -87,10 +91,11 @@ public abstract class AbstractFilterCallback implements FilterCallback {
             }
         }
         */
-        return getIndividualFilterList(filters, servletContext);
+
+        String[] dedupedFilters = Arrays.stream(filters).distinct().toArray(String[]::new);
+
+        return getIndividualFilterList(dedupedFilters, servletContext);
     }
-
-
 
     @Override
     public String createLink(String urlBase, QueryParameters parameters, OnmsFilterFavorite favorite) {

--- a/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
@@ -21,7 +21,6 @@
  */
 package org.opennms.web.tags.filters;
 
-
 import org.opennms.netmgt.model.OnmsFilterFavorite;
 import org.opennms.web.filter.Filter;
 import org.opennms.web.filter.FilterUtil;
@@ -29,6 +28,7 @@ import org.opennms.web.filter.QueryParameters;
 
 import javax.servlet.ServletContext;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -51,9 +51,9 @@ public abstract class AbstractFilterCallback implements FilterCallback {
 
     @Override
     public String toFilterString(List<Filter> filters) {
-        if( filters != null ) {
+        if (filters != null ) {
             String[] filterStrings = new String[filters.size()];
-            for (int i=0; i<filterStrings.length; i++) {
+            for (int i = 0; i < filterStrings.length; i++) {
                 filterStrings[i] = getIndividualFilterString(filters.get(i));
             }
             return toFilterString(filterStrings);
@@ -72,7 +72,7 @@ public abstract class AbstractFilterCallback implements FilterCallback {
         for (int i = 0; i < filterParameter.length; i++) {
             if (filterParameter[i].startsWith("filter=")) {
                 filterParameter[i] = filterParameter[i].replaceFirst("filter=", "");
-                filterParameter[i] = URLDecoder.decode(filterParameter[i]);
+                filterParameter[i] = URLDecoder.decode(filterParameter[i], StandardCharsets.UTF_8);
             }
         }
 
@@ -111,7 +111,7 @@ public abstract class AbstractFilterCallback implements FilterCallback {
             buffer.append("&amp;display=").append(parameters.getDisplay());
         }
         String filters = toFilterString(parameters.getFilters());
-        if (filters != null && filters.length() > 0) {
+        if (filters != null && !filters.isEmpty()) {
             buffer.append("&amp;").append(filters);
         }
         if (favorite != null) {
@@ -123,5 +123,4 @@ public abstract class AbstractFilterCallback implements FilterCallback {
     protected abstract String getIndividualFilterString(Filter filter);
 
     protected abstract List<Filter> getIndividualFilterList(String[] filters, ServletContext servletContext);
-
 }

--- a/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
@@ -291,10 +291,6 @@
         if (_svcJs.length() > 0) _svcJs.append(",");
         _svcJs.append(_id);
     }
-    String afterFirstAmPmJs = (afterFirstAmPm.equals("AM") || afterFirstAmPm.equals("Midnight")) ? "am" : "pm";
-    String beforeFirstAmPmJs = (beforeFirstAmPm.equals("AM") || beforeFirstAmPm.equals("Midnight")) ? "am" : "pm";
-    String afterLastAmPmJs = (afterLastAmPm.equals("AM") || afterLastAmPm.equals("Midnight")) ? "am" : "pm";
-    String beforeLastAmPmJs = (beforeLastAmPm.equals("AM") || beforeLastAmPm.equals("Midnight")) ? "am" : "pm";
 %>
 <script type="text/javascript">
 (function() {
@@ -312,28 +308,28 @@
         useAfterFirst: <%= useAfterFirstEventTime %>,
         afterFirstHour: '<%= afterFirstHour %>',
         afterFirstMinute: '<%= afterFirstMinute %>',
-        afterFirstAmPm: '<%= afterFirstAmPmJs %>',
+        afterFirstAmPm: '<%= Encode.forJavaScript(afterFirstAmPm) %>',
         afterFirstMonthIdx: '<%= afterFirstMonthCount - 1 %>',
         afterFirstDay: '<%= afterFirstDay %>',
         afterFirstYear: '<%= afterFirstYear %>',
         useBeforeFirst: <%= useBeforeFirstEventTime %>,
         beforeFirstHour: '<%= beforeFirstHour %>',
         beforeFirstMinute: '<%= beforeFirstMinute %>',
-        beforeFirstAmPm: '<%= beforeFirstAmPmJs %>',
+        beforeFirstAmPm: '<%= Encode.forJavaScript(beforeFirstAmPm) %>',
         beforeFirstMonthIdx: '<%= beforeFirstMonthCount - 1 %>',
         beforeFirstDay: '<%= beforeFirstDay %>',
         beforeFirstYear: '<%= beforeFirstYear %>',
         useAfterLast: <%= useAfterLastEventTime %>,
         afterLastHour: '<%= afterLastHour %>',
         afterLastMinute: '<%= afterLastMinute %>',
-        afterLastAmPm: '<%= afterLastAmPmJs %>',
+        afterLastAmPm: '<%= Encode.forJavaScript(afterLastAmPm) %>',
         afterLastMonthIdx: '<%= afterLastMonthCount - 1 %>',
         afterLastDay: '<%= afterLastDay %>',
         afterLastYear: '<%= afterLastYear %>',
         useBeforeLast: <%= useBeforeLastEventTime %>,
         beforeLastHour: '<%= beforeLastHour %>',
         beforeLastMinute: '<%= beforeLastMinute %>',
-        beforeLastAmPm: '<%= beforeLastAmPmJs %>',
+        beforeLastAmPm: '<%= Encode.forJavaScript(beforeLastAmPm) %>',
         beforeLastMonthIdx: '<%= beforeLastMonthCount - 1 %>',
         beforeLastDay: '<%= beforeLastDay %>',
         beforeLastYear: '<%= beforeLastYear %>'
@@ -388,7 +384,7 @@
 
     var _nowHour = '${nowHour}';
     var _nowMin = '${formattedNowMinute}';
-    var _nowAmpm = '${nowAmPm}' === 'AM' ? 'am' : 'pm';
+    var _nowAmpm = '${amPmText}';
     var _nowMonthIdx = parseInt('${nowMonth}', 10) - 1;
     var _nowDay = '${nowDate}';
     var _nowYear = '${nowYear}';
@@ -535,7 +531,7 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterfirsteventtimeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==afterFirstAmPm}">${dayTime}</form:option>
+						<form:option value="${dayTime}" selected="${dayTime==afterFirstAmPm}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>
@@ -578,7 +574,7 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforefirsteventtimeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==beforeFirstAmPm}">${dayTime}</form:option>
+						<form:option value="${dayTime}" selected="${dayTime==beforeFirstAmPm}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>
@@ -621,7 +617,7 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterlasteventtimeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==afterLastAmPm}">${dayTime}</form:option>
+						<form:option value="${dayTime}" selected="${dayTime==afterLastAmPm}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>
@@ -664,7 +660,7 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforelasteventtimeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==beforeLastAmPm}">${dayTime}</form:option>
+						<form:option value="${dayTime}" selected="${dayTime==beforeLastAmPm}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>

--- a/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
@@ -354,10 +354,10 @@
         if (ncat) ncat.checked = s.nestedCategoryNot;
 
         form.querySelectorAll('[name^="severity-"]').forEach(function(cb) {
-            cb.checked = s.severities.indexOf(parseInt(cb.name.split('-')[1])) >= 0;
+            cb.checked = s.severities.indexOf(parseInt(cb.name.split('-')[1], 10)) >= 0;
         });
         form.querySelectorAll('[name^="service-"]').forEach(function(cb) {
-            cb.checked = s.services.indexOf(parseInt(cb.name.split('-')[1])) >= 0;
+            cb.checked = s.services.indexOf(parseInt(cb.name.split('-')[1], 10)) >= 0;
         });
 
         function applyTime(prefix, collapseId, useTime, hour, minute, ampm, monthIdx, day, year) {
@@ -389,7 +389,7 @@
     var _nowHour = '${nowHour}';
     var _nowMin = '${formattedNowMinute}';
     var _nowAmpm = '${nowAmPm}' === 'AM' ? 'am' : 'pm';
-    var _nowMonthIdx = parseInt('${nowMonth}') - 1;
+    var _nowMonthIdx = parseInt('${nowMonth}', 10) - 1;
     var _nowDay = '${nowDate}';
     var _nowYear = '${nowYear}';
 

--- a/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
@@ -31,6 +31,24 @@
 		org.opennms.netmgt.model.OnmsSeverity
 		"
 %>
+<%@ page import="org.opennms.web.filter.NormalizedQueryParameters" %>
+<%@ page import="org.opennms.web.filter.Filter" %>
+<%@ page import="org.opennms.web.alarm.filter.SeverityOrFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.SeverityFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.ServiceOrFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.ServiceFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.NodeNameLikeFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.AlarmTextFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.LogMessageSubstringFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.IPAddrLikeFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.SituationFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.CategoryFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.NegativeCategoryFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.AfterFirstEventTimeFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.BeforeFirstEventTimeFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.AfterLastEventTimeFilter" %>
+<%@ page import="org.opennms.web.alarm.filter.BeforeLastEventTimeFilter" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
@@ -61,22 +79,363 @@
   </c:choose>
 </c:set>
 
+<%
+    // Build pre-population state from current filters in parms
+    NormalizedQueryParameters advParms = (NormalizedQueryParameters) request.getAttribute("parms");
+
+    Set<Integer> checkedSeverities = new HashSet<>();
+    Set<Integer> checkedServices = new HashSet<>();
+    String prefillAlarmText = "";
+    String prefillIpLike = "";
+    String prefillNodeName = "";
+    String prefillSituation = "any";
+    String prefillCategory = "";
+    boolean prefillNestedCategoryNot = false;
+
+    String prefillSortStyle = "id";
+    int prefillLimit = 20;
+
+    // Initialize all date/time defaults from JSTL-computed "now" values
+    int nowHourInt = Integer.parseInt((String) pageContext.getAttribute("nowHour"));
+    String nowFormattedMin = (String) pageContext.getAttribute("formattedNowMinute");
+    int nowMonthCount = Integer.parseInt((String) pageContext.getAttribute("nowMonth"));
+    int nowDayVal = Integer.parseInt((String) pageContext.getAttribute("nowDate"));
+    int nowYearVal = Integer.parseInt((String) pageContext.getAttribute("nowYear"));
+    String rawAmPm = (String) pageContext.getAttribute("amPmText");
+    String nowAmPmStr = rawAmPm != null ? rawAmPm.trim() : "AM";
+
+    // After First Event Time
+    boolean useAfterFirstEventTime = false;
+    int afterFirstHour = nowHourInt;
+    String afterFirstMinute = nowFormattedMin;
+    int afterFirstMonthCount = nowMonthCount;
+    int afterFirstDay = nowDayVal;
+    int afterFirstYear = nowYearVal;
+    String afterFirstAmPm = nowAmPmStr;
+
+    // Before First Event Time
+    boolean useBeforeFirstEventTime = false;
+    int beforeFirstHour = nowHourInt;
+    String beforeFirstMinute = nowFormattedMin;
+    int beforeFirstMonthCount = nowMonthCount;
+    int beforeFirstDay = nowDayVal;
+    int beforeFirstYear = nowYearVal;
+    String beforeFirstAmPm = nowAmPmStr;
+
+    // After Last Event Time
+    boolean useAfterLastEventTime = false;
+    int afterLastHour = nowHourInt;
+    String afterLastMinute = nowFormattedMin;
+    int afterLastMonthCount = nowMonthCount;
+    int afterLastDay = nowDayVal;
+    int afterLastYear = nowYearVal;
+    String afterLastAmPm = nowAmPmStr;
+
+    // Before Last Event Time
+    boolean useBeforeLastEventTime = false;
+    int beforeLastHour = nowHourInt;
+    String beforeLastMinute = nowFormattedMin;
+    int beforeLastMonthCount = nowMonthCount;
+    int beforeLastDay = nowDayVal;
+    int beforeLastYear = nowYearVal;
+    String beforeLastAmPm = nowAmPmStr;
+
+    if (advParms != null) {
+        String sortStyle = advParms.getSortStyleShortName();
+        if (sortStyle != null && !sortStyle.isEmpty()) {
+            prefillSortStyle = sortStyle;
+        }
+        int limitVal = advParms.getLimit();
+        if (limitVal != 0) {
+            prefillLimit = limitVal;
+        }
+
+        for (Filter filter : advParms.getFilters()) {
+            if (filter instanceof SeverityOrFilter) {
+                for (Filter sf : ((SeverityOrFilter) filter).getFilters()) {
+                    checkedSeverities.add(((SeverityFilter) sf).getSeverity());
+                }
+            } else if (filter instanceof SeverityFilter) {
+                checkedSeverities.add(((SeverityFilter) filter).getSeverity());
+            } else if (filter instanceof ServiceOrFilter) {
+                for (Filter sf : ((ServiceOrFilter) filter).getFilters()) {
+                    checkedServices.add(((ServiceFilter) sf).getServiceId());
+                }
+            } else if (filter instanceof ServiceFilter) {
+                checkedServices.add(((ServiceFilter) filter).getServiceId());
+            } else if (filter instanceof AlarmTextFilter) {
+                for (Filter sf : ((AlarmTextFilter) filter).getFilters()) {
+                    if (sf instanceof LogMessageSubstringFilter) {
+                        prefillAlarmText = ((LogMessageSubstringFilter) sf).getValue();
+                        break;
+                    }
+                }
+            } else if (filter instanceof NodeNameLikeFilter) {
+                prefillNodeName = ((NodeNameLikeFilter) filter).getValue();
+            } else if (filter instanceof IPAddrLikeFilter) {
+                prefillIpLike = ((IPAddrLikeFilter) filter).getValue();
+            } else if (filter instanceof SituationFilter) {
+                String d = filter.getDescription();
+                prefillSituation = d.substring(d.indexOf('=') + 1);
+            } else if (filter instanceof NegativeCategoryFilter) {
+                prefillCategory = ((NegativeCategoryFilter) filter).getValue();
+                prefillNestedCategoryNot = true;
+            } else if (filter instanceof CategoryFilter) {
+                prefillCategory = ((CategoryFilter) filter).getValue();
+                prefillNestedCategoryNot = false;
+            } else if (filter instanceof AfterFirstEventTimeFilter) {
+                useAfterFirstEventTime = true;
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(((AfterFirstEventTimeFilter) filter).getDate());
+                int calHour = cal.get(Calendar.HOUR);
+                afterFirstHour = (calHour == 0) ? 12 : calHour;
+                afterFirstMinute = String.format("%02d", cal.get(Calendar.MINUTE));
+                afterFirstMonthCount = cal.get(Calendar.MONTH) + 1;
+                afterFirstDay = cal.get(Calendar.DATE);
+                afterFirstYear = cal.get(Calendar.YEAR);
+                boolean isAm = cal.get(Calendar.AM_PM) == Calendar.AM;
+                if (isAm && afterFirstHour == 12) afterFirstAmPm = "Midnight";
+                else if (isAm) afterFirstAmPm = "AM";
+                else if (!isAm && afterFirstHour == 12) afterFirstAmPm = "Noon";
+                else afterFirstAmPm = "PM";
+            } else if (filter instanceof BeforeFirstEventTimeFilter) {
+                useBeforeFirstEventTime = true;
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(((BeforeFirstEventTimeFilter) filter).getDate());
+                int calHour = cal.get(Calendar.HOUR);
+                beforeFirstHour = (calHour == 0) ? 12 : calHour;
+                beforeFirstMinute = String.format("%02d", cal.get(Calendar.MINUTE));
+                beforeFirstMonthCount = cal.get(Calendar.MONTH) + 1;
+                beforeFirstDay = cal.get(Calendar.DATE);
+                beforeFirstYear = cal.get(Calendar.YEAR);
+                boolean isAm = cal.get(Calendar.AM_PM) == Calendar.AM;
+                if (isAm && beforeFirstHour == 12) beforeFirstAmPm = "Midnight";
+                else if (isAm) beforeFirstAmPm = "AM";
+                else if (!isAm && beforeFirstHour == 12) beforeFirstAmPm = "Noon";
+                else beforeFirstAmPm = "PM";
+            } else if (filter instanceof AfterLastEventTimeFilter) {
+                useAfterLastEventTime = true;
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(((AfterLastEventTimeFilter) filter).getDate());
+                int calHour = cal.get(Calendar.HOUR);
+                afterLastHour = (calHour == 0) ? 12 : calHour;
+                afterLastMinute = String.format("%02d", cal.get(Calendar.MINUTE));
+                afterLastMonthCount = cal.get(Calendar.MONTH) + 1;
+                afterLastDay = cal.get(Calendar.DATE);
+                afterLastYear = cal.get(Calendar.YEAR);
+                boolean isAm = cal.get(Calendar.AM_PM) == Calendar.AM;
+                if (isAm && afterLastHour == 12) afterLastAmPm = "Midnight";
+                else if (isAm) afterLastAmPm = "AM";
+                else if (!isAm && afterLastHour == 12) afterLastAmPm = "Noon";
+                else afterLastAmPm = "PM";
+            } else if (filter instanceof BeforeLastEventTimeFilter) {
+                useBeforeLastEventTime = true;
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(((BeforeLastEventTimeFilter) filter).getDate());
+                int calHour = cal.get(Calendar.HOUR);
+                beforeLastHour = (calHour == 0) ? 12 : calHour;
+                beforeLastMinute = String.format("%02d", cal.get(Calendar.MINUTE));
+                beforeLastMonthCount = cal.get(Calendar.MONTH) + 1;
+                beforeLastDay = cal.get(Calendar.DATE);
+                beforeLastYear = cal.get(Calendar.YEAR);
+                boolean isAm = cal.get(Calendar.AM_PM) == Calendar.AM;
+                if (isAm && beforeLastHour == 12) beforeLastAmPm = "Midnight";
+                else if (isAm) beforeLastAmPm = "AM";
+                else if (!isAm && beforeLastHour == 12) beforeLastAmPm = "Noon";
+                else beforeLastAmPm = "PM";
+            }
+        }
+    }
+
+    // Expose date/time values to EL for use in selects
+    pageContext.setAttribute("prefillSortStyle", prefillSortStyle);
+    pageContext.setAttribute("prefillLimit", prefillLimit);
+
+    pageContext.setAttribute("afterFirstHour", afterFirstHour);
+    pageContext.setAttribute("afterFirstMinute", afterFirstMinute);
+    pageContext.setAttribute("afterFirstMonthCount", afterFirstMonthCount);
+    pageContext.setAttribute("afterFirstDay", afterFirstDay);
+    pageContext.setAttribute("afterFirstYear", afterFirstYear);
+    pageContext.setAttribute("afterFirstAmPm", afterFirstAmPm);
+
+    pageContext.setAttribute("beforeFirstHour", beforeFirstHour);
+    pageContext.setAttribute("beforeFirstMinute", beforeFirstMinute);
+    pageContext.setAttribute("beforeFirstMonthCount", beforeFirstMonthCount);
+    pageContext.setAttribute("beforeFirstDay", beforeFirstDay);
+    pageContext.setAttribute("beforeFirstYear", beforeFirstYear);
+    pageContext.setAttribute("beforeFirstAmPm", beforeFirstAmPm);
+
+    pageContext.setAttribute("afterLastHour", afterLastHour);
+    pageContext.setAttribute("afterLastMinute", afterLastMinute);
+    pageContext.setAttribute("afterLastMonthCount", afterLastMonthCount);
+    pageContext.setAttribute("afterLastDay", afterLastDay);
+    pageContext.setAttribute("afterLastYear", afterLastYear);
+    pageContext.setAttribute("afterLastAmPm", afterLastAmPm);
+
+    pageContext.setAttribute("beforeLastHour", beforeLastHour);
+    pageContext.setAttribute("beforeLastMinute", beforeLastMinute);
+    pageContext.setAttribute("beforeLastMonthCount", beforeLastMonthCount);
+    pageContext.setAttribute("beforeLastDay", beforeLastDay);
+    pageContext.setAttribute("beforeLastYear", beforeLastYear);
+    pageContext.setAttribute("beforeLastAmPm", beforeLastAmPm);
+%>
+
+<%
+    StringBuilder _sevJs = new StringBuilder();
+    for (Integer _id : checkedSeverities) {
+        if (_sevJs.length() > 0) _sevJs.append(",");
+        _sevJs.append(_id);
+    }
+    StringBuilder _svcJs = new StringBuilder();
+    for (Integer _id : checkedServices) {
+        if (_svcJs.length() > 0) _svcJs.append(",");
+        _svcJs.append(_id);
+    }
+    String afterFirstAmPmJs = (afterFirstAmPm.equals("AM") || afterFirstAmPm.equals("Midnight")) ? "am" : "pm";
+    String beforeFirstAmPmJs = (beforeFirstAmPm.equals("AM") || beforeFirstAmPm.equals("Midnight")) ? "am" : "pm";
+    String afterLastAmPmJs = (afterLastAmPm.equals("AM") || afterLastAmPm.equals("Midnight")) ? "am" : "pm";
+    String beforeLastAmPmJs = (beforeLastAmPm.equals("AM") || beforeLastAmPm.equals("Midnight")) ? "am" : "pm";
+%>
+<script type="text/javascript">
+(function() {
+    var _state = {
+        alarmtext: '<%= Encode.forJavaScript(prefillAlarmText) %>',
+        iplike: '<%= Encode.forJavaScript(prefillIpLike) %>',
+        nodenamelike: '<%= Encode.forJavaScript(prefillNodeName) %>',
+        sortby: '<%= Encode.forJavaScript(prefillSortStyle) %>',
+        limit: '<%= prefillLimit %>',
+        situation: '<%= Encode.forJavaScript(prefillSituation) %>',
+        category: '<%= Encode.forJavaScript(prefillCategory) %>',
+        nestedCategoryNot: <%= prefillNestedCategoryNot %>,
+        severities: [<%= _sevJs %>],
+        services: [<%= _svcJs %>],
+        useAfterFirst: <%= useAfterFirstEventTime %>,
+        afterFirstHour: '<%= afterFirstHour %>',
+        afterFirstMinute: '<%= afterFirstMinute %>',
+        afterFirstAmPm: '<%= afterFirstAmPmJs %>',
+        afterFirstMonthIdx: '<%= afterFirstMonthCount - 1 %>',
+        afterFirstDay: '<%= afterFirstDay %>',
+        afterFirstYear: '<%= afterFirstYear %>',
+        useBeforeFirst: <%= useBeforeFirstEventTime %>,
+        beforeFirstHour: '<%= beforeFirstHour %>',
+        beforeFirstMinute: '<%= beforeFirstMinute %>',
+        beforeFirstAmPm: '<%= beforeFirstAmPmJs %>',
+        beforeFirstMonthIdx: '<%= beforeFirstMonthCount - 1 %>',
+        beforeFirstDay: '<%= beforeFirstDay %>',
+        beforeFirstYear: '<%= beforeFirstYear %>',
+        useAfterLast: <%= useAfterLastEventTime %>,
+        afterLastHour: '<%= afterLastHour %>',
+        afterLastMinute: '<%= afterLastMinute %>',
+        afterLastAmPm: '<%= afterLastAmPmJs %>',
+        afterLastMonthIdx: '<%= afterLastMonthCount - 1 %>',
+        afterLastDay: '<%= afterLastDay %>',
+        afterLastYear: '<%= afterLastYear %>',
+        useBeforeLast: <%= useBeforeLastEventTime %>,
+        beforeLastHour: '<%= beforeLastHour %>',
+        beforeLastMinute: '<%= beforeLastMinute %>',
+        beforeLastAmPm: '<%= beforeLastAmPmJs %>',
+        beforeLastMonthIdx: '<%= beforeLastMonthCount - 1 %>',
+        beforeLastDay: '<%= beforeLastDay %>',
+        beforeLastYear: '<%= beforeLastYear %>'
+    };
+
+    function applyState(s) {
+        var form = document.querySelector('#advancedSearchModal form');
+
+        form.querySelector('[name="alarmtext"]').value = s.alarmtext;
+        form.querySelector('[name="iplike"]').value = s.iplike;
+        form.querySelector('[name="nodenamelike"]').value = s.nodenamelike;
+        form.querySelector('[name="sortby"]').value = s.sortby;
+        form.querySelector('[name="limit"]').value = s.limit;
+        form.querySelector('[name="situation"]').value = s.situation;
+        form.querySelector('[name="category"]').value = s.category;
+
+        var ncat = form.querySelector('[name="nestedCategoryNot"]');
+        if (ncat) ncat.checked = s.nestedCategoryNot;
+
+        form.querySelectorAll('[name^="severity-"]').forEach(function(cb) {
+            cb.checked = s.severities.indexOf(parseInt(cb.name.split('-')[1])) >= 0;
+        });
+        form.querySelectorAll('[name^="service-"]').forEach(function(cb) {
+            cb.checked = s.services.indexOf(parseInt(cb.name.split('-')[1])) >= 0;
+        });
+
+        function applyTime(prefix, collapseId, useTime, hour, minute, ampm, monthIdx, day, year) {
+            var cb = form.querySelector('[name="use' + prefix + '"]');
+            if (cb) cb.checked = useTime;
+            var colEl = document.getElementById(collapseId);
+            if (colEl) {
+                if (useTime) { colEl.classList.add('show'); }
+                else { colEl.classList.remove('show'); }
+            }
+            form.querySelector('[name="' + prefix + 'hour"]').value = hour;
+            form.querySelector('[name="' + prefix + 'minute"]').value = minute;
+            form.querySelector('[name="' + prefix + 'ampm"]').value = ampm;
+            form.querySelector('[name="' + prefix + 'month"]').value = monthIdx;
+            form.querySelector('[name="' + prefix + 'date"]').value = day;
+            form.querySelector('[name="' + prefix + 'year"]').value = year;
+        }
+
+        applyTime('afterfirsteventtime', 'collapseAlarmsFirstAfter', s.useAfterFirst,
+            s.afterFirstHour, s.afterFirstMinute, s.afterFirstAmPm, s.afterFirstMonthIdx, s.afterFirstDay, s.afterFirstYear);
+        applyTime('beforefirsteventtime', 'collapseAlarmsFirstBefore', s.useBeforeFirst,
+            s.beforeFirstHour, s.beforeFirstMinute, s.beforeFirstAmPm, s.beforeFirstMonthIdx, s.beforeFirstDay, s.beforeFirstYear);
+        applyTime('afterlasteventtime', 'collapseAlarmsLastAfter', s.useAfterLast,
+            s.afterLastHour, s.afterLastMinute, s.afterLastAmPm, s.afterLastMonthIdx, s.afterLastDay, s.afterLastYear);
+        applyTime('beforelasteventtime', 'collapseAlarmsLastBefore', s.useBeforeLast,
+            s.beforeLastHour, s.beforeLastMinute, s.beforeLastAmPm, s.beforeLastMonthIdx, s.beforeLastDay, s.beforeLastYear);
+    }
+
+    var _nowHour = '${nowHour}';
+    var _nowMin = '${formattedNowMinute}';
+    var _nowAmpm = '${nowAmPm}' === 'AM' ? 'am' : 'pm';
+    var _nowMonthIdx = parseInt('${nowMonth}') - 1;
+    var _nowDay = '${nowDate}';
+    var _nowYear = '${nowYear}';
+
+    window.resetAdvancedSearch = function() {
+        applyState({
+            alarmtext: '', iplike: '', nodenamelike: '',
+            sortby: 'id', limit: '20', situation: 'any', category: '',
+            nestedCategoryNot: false,
+            severities: [], services: [],
+            useAfterFirst: false,
+            afterFirstHour: _nowHour, afterFirstMinute: _nowMin, afterFirstAmPm: _nowAmpm,
+            afterFirstMonthIdx: _nowMonthIdx, afterFirstDay: _nowDay, afterFirstYear: _nowYear,
+            useBeforeFirst: false,
+            beforeFirstHour: _nowHour, beforeFirstMinute: _nowMin, beforeFirstAmPm: _nowAmpm,
+            beforeFirstMonthIdx: _nowMonthIdx, beforeFirstDay: _nowDay, beforeFirstYear: _nowYear,
+            useAfterLast: false,
+            afterLastHour: _nowHour, afterLastMinute: _nowMin, afterLastAmPm: _nowAmpm,
+            afterLastMonthIdx: _nowMonthIdx, afterLastDay: _nowDay, afterLastYear: _nowYear,
+            useBeforeLast: false,
+            beforeLastHour: _nowHour, beforeLastMinute: _nowMin, beforeLastAmPm: _nowAmpm,
+            beforeLastMonthIdx: _nowMonthIdx, beforeLastDay: _nowDay, beforeLastYear: _nowYear
+        });
+    };
+
+    $('#advancedSearchModal').on('show.bs.modal', function() {
+        applyState(_state);
+    });
+})();
+</script>
+
 <form action="alarm/query" method="post">
 	<input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
 	<div class="form-group col-sm-6">
 		<label for="alarmtext">Alarm Text Contains</label>
-		<input class="form-control" type="text" name="alarmtext" />
+		<input class="form-control" type="text" name="alarmtext" value="<%= prefillAlarmText %>" />
 	</div>
 
 	<div class="form-group col-sm-6">
 		<label for="iplike">TCP/IP Address Like</label>
-		<input class="form-control" type="text" name="iplike" value="" />
+		<input class="form-control" type="text" name="iplike" value="<%= prefillIpLike %>" />
 	</div>
 
 	<div class="form-group col-sm-6">
 		<label for="nodenamelike">Node Label Contains</label>
-		<input class="form-control" type="text" name="nodenamelike" />
+		<input class="form-control" type="text" name="nodenamelike" value="<%= prefillNodeName %>" />
 	</div>
 
     <div class="form-group col-sm-6">
@@ -84,7 +443,8 @@
         <% for (OnmsSeverity severity : OnmsSeverity.values()) { %>
             <div>
                 <label>
-                    <input type="checkbox" name="severity-<%=severity.getId()%>" value="1" /> <%=severity.getLabel()%>
+                    <input type="checkbox" name="severity-<%=severity.getId()%>" value="1"
+                           <%=checkedSeverities.contains(severity.getId()) ? "checked" : ""%> /> <%=severity.getLabel()%>
                 </label>
             </div>
         <% } %>
@@ -96,7 +456,8 @@
         <% for (String name : serviceNameSet) { %>
             <div>
                 <label>
-                    <input type="checkbox" name="service-<%=serviceNameMap.get(name)%>" value="1" /> <%=name%>
+                    <input type="checkbox" name="service-<%=serviceNameMap.get(name)%>" value="1"
+                           <%=checkedServices.contains(serviceNameMap.get(name)) ? "checked" : ""%> /> <%=name%>
                 </label>
             </div>
         <% } %>
@@ -105,80 +466,76 @@
 	<div class="form-group col-sm-6">
 		<label for="sortby">Sort By</label>
 		<select class="form-control custom-select" name="sortby">
-			<option value="id">Alarm ID (Descending)</option>
-			<option value="rev_id">Alarm ID (Ascending)</option>
-			<option value="severity">Severity (Descending)</option>
-			<option value="rev_severity">Severity (Ascending)</option>
-			<option value="lasteventtime">Time (Descending)</option>
-			<option value="rev_lasteventtime">Time (Ascending)</option>
-			<option value="node">Node (Ascending)</option>
-			<option value="rev_node">Node (Descending)</option>
-			<option value="interface">Interface (Ascending)</option>
-			<option value="rev_interface">Interface (Descending)</option>
-			<option value="service">Service (Ascending)</option>
-			<option value="rev_service">Service (Descending)</option>
+			<option value="id" ${prefillSortStyle == 'id' ? 'selected' : ''}>Alarm ID (Descending)</option>
+			<option value="rev_id" ${prefillSortStyle == 'rev_id' ? 'selected' : ''}>Alarm ID (Ascending)</option>
+			<option value="severity" ${prefillSortStyle == 'severity' ? 'selected' : ''}>Severity (Descending)</option>
+			<option value="rev_severity" ${prefillSortStyle == 'rev_severity' ? 'selected' : ''}>Severity (Ascending)</option>
+			<option value="lasteventtime" ${prefillSortStyle == 'lasteventtime' ? 'selected' : ''}>Time (Descending)</option>
+			<option value="rev_lasteventtime" ${prefillSortStyle == 'rev_lasteventtime' ? 'selected' : ''}>Time (Ascending)</option>
+			<option value="node" ${prefillSortStyle == 'node' ? 'selected' : ''}>Node (Ascending)</option>
+			<option value="rev_node" ${prefillSortStyle == 'rev_node' ? 'selected' : ''}>Node (Descending)</option>
+			<option value="interface" ${prefillSortStyle == 'interface' ? 'selected' : ''}>Interface (Ascending)</option>
+			<option value="rev_interface" ${prefillSortStyle == 'rev_interface' ? 'selected' : ''}>Interface (Descending)</option>
+			<option value="service" ${prefillSortStyle == 'service' ? 'selected' : ''}>Service (Ascending)</option>
+			<option value="rev_service" ${prefillSortStyle == 'rev_service' ? 'selected' : ''}>Service (Descending)</option>
 		</select>
 	</div>
 
 	<div class="form-group col-sm-6">
 		<label for="limit">Number of Alarms Per Page</label>
 		<select class="form-control custom-select" name="limit">
-			<option value="10">10 alarms</option>
-			<option value="20">20 alarms</option>
-			<option value="30">30 alarms</option>
-			<option value="50">50 alarms</option>
-			<option value="100">100 alarms</option>
-			<option value="-1">All alarms</option>
+			<option value="10" ${prefillLimit == 10 ? 'selected' : ''}>10 alarms</option>
+			<option value="20" ${prefillLimit == 20 ? 'selected' : ''}>20 alarms</option>
+			<option value="30" ${prefillLimit == 30 ? 'selected' : ''}>30 alarms</option>
+			<option value="50" ${prefillLimit == 50 ? 'selected' : ''}>50 alarms</option>
+			<option value="100" ${prefillLimit == 100 ? 'selected' : ''}>100 alarms</option>
+			<option value="-1" ${prefillLimit == -1 ? 'selected' : ''}>All alarms</option>
 		</select>
 	</div>
 
 	<div class="form-group col-sm-6">
 		<label for="situation">Alarm type</label>
 		<select class="form-control custom-select" name="situation">
-			<option value="any">All Alarms and Situations</option>
-			<option value="false">Only Alarms</option>
-			<option value="true">Only Situations</option>
+			<option value="any" <%= "any".equals(prefillSituation) ? "selected" : "" %>>All Alarms and Situations</option>
+			<option value="false" <%= "false".equals(prefillSituation) ? "selected" : "" %>>Only Alarms</option>
+			<option value="true" <%= "true".equals(prefillSituation) ? "selected" : "" %>>Only Situations</option>
 		</select>
 	</div>
 
 	<div class="form-group col-sm-6">
 		<label for="category">Category</label>
 		<select class="form-control custom-select" name="category">
-			<option value="">Do not filter by category</option>
+			<option value="" <%= prefillCategory.isEmpty() ? "selected" : "" %>>Do not filter by category</option>
 			<% for (final String category: categories) { %>
-			<option value="<%=category%>"><%=category%></option>
+			<option value="<%=category%>" <%= category.equals(prefillCategory) ? "selected" : "" %>><%=category%></option>
 			<% } %>
 		</select>
 
         <label for="nestedCategoryNot">Exclude:</label>
-        <input type="checkbox" name="nestedCategoryNot" />
+        <input type="checkbox" name="nestedCategoryNot" <%= prefillNestedCategoryNot ? "checked" : "" %>/>
 	</div>
 
 	<div class="col-sm-6 my-2">
-		<label data-toggle="collapse" data-target="#collapseAlarmsFirstAfter" aria-expanded="false" aria-controls="collapseAlarmsFirstAfter">
-			<input type="checkbox" name="useafterfirsteventtime" value="1" /> Filter for Alarms after First Event:
+		<label data-toggle="collapse" data-target="#collapseAlarmsFirstAfter" aria-expanded="<%= useAfterFirstEventTime ? "true" : "false" %>" aria-controls="collapseAlarmsFirstAfter">
+			<input type="checkbox" name="useafterfirsteventtime" value="1" <%= useAfterFirstEventTime ? "checked" : "" %> /> Filter for Alarms after First Event:
 		</label>
-		<!--
-		<input type="date" name="beforedate"/>
-		<input type="time" name="beforetime"/>
-		-->
 		<br />
-		<div id="collapseAlarmsFirstAfter" class="collapse">
+		<div id="collapseAlarmsFirstAfter" class="collapse <%= useAfterFirstEventTime ? "show" : "" %>">
 		<div class="row">
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterfirsteventtimehour">
 					<c:forEach var="i" begin="1" end="12">
-						<form:option value="${i}" selected="${nowHour==i}">${i}</form:option>
+						<form:option value="${i}" selected="${afterFirstHour==i}">${i}</form:option>
 					</c:forEach>
 				</select>
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="afterfirsteventtimeminute" maxlength="2" value="${formattedNowMinute}" />
+				<input class="form-control" type="text" name="afterfirsteventtimeminute" maxlength="2" value="${afterFirstMinute}" />
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterfirsteventtimeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==amPmText}">${dayTime}</form:option>
+						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==afterFirstAmPm}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>
@@ -187,45 +544,41 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterfirsteventtimemonth">
 					<c:forEach var="month" items="${months}" varStatus="status">
-						<form:option value="${status.index}" selected="${status.count == nowMonth}">${month}</form:option>
+						<form:option value="${status.index}" selected="${status.count == afterFirstMonthCount}">${month}</form:option>
 					</c:forEach>
 				</select>
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="afterfirsteventtimedate" maxlength="2" value="${nowDate}" />
+				<input class="form-control" type="text" name="afterfirsteventtimedate" maxlength="2" value="${afterFirstDay}" />
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="afterfirsteventtimeyear" maxlength="4" value="${nowYear}" />
+				<input class="form-control" type="text" name="afterfirsteventtimeyear" maxlength="4" value="${afterFirstYear}" />
 			</div>
 		</div>
 		</div>
 	</div>
 
 	<div class="col-sm-6 my-2">
-		<label data-toggle="collapse" data-target="#collapseAlarmsFirstBefore" aria-expanded="false" aria-controls="collapseAlarmsFirstBefore">
-			<input type="checkbox" name="usebeforefirsteventtime" value="1" /> Filter for Alarms before First Event:
+		<label data-toggle="collapse" data-target="#collapseAlarmsFirstBefore" aria-expanded="<%= useBeforeFirstEventTime ? "true" : "false" %>" aria-controls="collapseAlarmsFirstBefore">
+			<input type="checkbox" name="usebeforefirsteventtime" value="1" <%= useBeforeFirstEventTime ? "checked" : "" %> /> Filter for Alarms before First Event:
 		</label>
-		<!--
-		<input type="date" name="beforedate"/>
-		<input type="time" name="beforetime"/>
-		-->
 		<br />
-		<div id="collapseAlarmsFirstBefore" class="collapse">
+		<div id="collapseAlarmsFirstBefore" class="collapse <%= useBeforeFirstEventTime ? "show" : "" %>">
 		<div class="row">
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforefirsteventtimehour">
 					<c:forEach var="i" begin="1" end="12">
-						<form:option value="${i}" selected="${nowHour==i}">${i}</form:option>
+						<form:option value="${i}" selected="${beforeFirstHour==i}">${i}</form:option>
 					</c:forEach>
 				</select>
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="beforefirsteventtimeminute" maxlength="2" value="${formattedNowMinute}" />
+				<input class="form-control" type="text" name="beforefirsteventtimeminute" maxlength="2" value="${beforeFirstMinute}" />
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforefirsteventtimeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==amPmText}">${dayTime}</form:option>
+						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==beforeFirstAmPm}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>
@@ -234,45 +587,41 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforefirsteventtimemonth">
 					<c:forEach var="month" items="${months}" varStatus="status">
-						<form:option value="${status.index}" selected="${status.count == nowMonth}">${month}</form:option>
+						<form:option value="${status.index}" selected="${status.count == beforeFirstMonthCount}">${month}</form:option>
 					</c:forEach>
 				</select>
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="beforefirsteventtimedate" maxlength="2" value="${nowDate}" />
+				<input class="form-control" type="text" name="beforefirsteventtimedate" maxlength="2" value="${beforeFirstDay}" />
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="beforefirsteventtimeyear" maxlength="4" value="${nowYear}" />
+				<input class="form-control" type="text" name="beforefirsteventtimeyear" maxlength="4" value="${beforeFirstYear}" />
 			</div>
 		</div>
 		</div>
 	</div>
 
 	<div class="col-sm-6 my-2">
-		<label data-toggle="collapse" data-target="#collapseAlarmsLastAfter" aria-expanded="false" aria-controls="collapseAlarmsLastAfter">
-			<input type="checkbox" name="useafterlasteventtime"	value="1" /> Filter for Alarms after Last Event:
+		<label data-toggle="collapse" data-target="#collapseAlarmsLastAfter" aria-expanded="<%= useAfterLastEventTime ? "true" : "false" %>" aria-controls="collapseAlarmsLastAfter">
+			<input type="checkbox" name="useafterlasteventtime" value="1" <%= useAfterLastEventTime ? "checked" : "" %> /> Filter for Alarms after Last Event:
 		</label>
-		<!--
-		<input type="date" name="beforedate"/>
-		<input type="time" name="beforetime"/>
-		-->
 		<br />
-		<div id="collapseAlarmsLastAfter" class="collapse">
-		<div class="row " aria-expanded="false">
+		<div id="collapseAlarmsLastAfter" class="collapse <%= useAfterLastEventTime ? "show" : "" %>">
+		<div class="row">
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterlasteventtimehour">
 					<c:forEach var="i" begin="1" end="12">
-						<form:option value="${i}" selected="${nowHour==i}">${i}</form:option>
+						<form:option value="${i}" selected="${afterLastHour==i}">${i}</form:option>
 					</c:forEach>
 				</select>
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="afterlasteventtimeminute" maxlength="2" value="${formattedNowMinute}" />
+				<input class="form-control" type="text" name="afterlasteventtimeminute" maxlength="2" value="${afterLastMinute}" />
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterlasteventtimeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==amPmText}">${dayTime}</form:option>
+						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==afterLastAmPm}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>
@@ -281,45 +630,41 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterlasteventtimemonth">
 					<c:forEach var="month" items="${months}" varStatus="status">
-						<form:option value="${status.index}" selected="${status.count == nowMonth}">${month}</form:option>
+						<form:option value="${status.index}" selected="${status.count == afterLastMonthCount}">${month}</form:option>
 					</c:forEach>
 				</select>
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="afterlasteventtimedate" maxlength="2" value="${nowDate}" />
+				<input class="form-control" type="text" name="afterlasteventtimedate" maxlength="2" value="${afterLastDay}" />
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="afterlasteventtimeyear" maxlength="4" value="${nowYear}" />
+				<input class="form-control" type="text" name="afterlasteventtimeyear" maxlength="4" value="${afterLastYear}" />
 			</div>
 		</div>
 		</div>
 	</div>
 
 	<div class="col-sm-6 my-2">
-		<label data-toggle="collapse" data-target="#collapseAlarmsLasttBefore" aria-expanded="false" aria-controls="collapseAlarmsLasttBefore">
-			<input type="checkbox" name="usebeforelasteventtime" value="1" /> Filter for Alarms before Last Event:
+		<label data-toggle="collapse" data-target="#collapseAlarmsLastBefore" aria-expanded="<%= useBeforeLastEventTime ? "true" : "false" %>" aria-controls="collapseAlarmsLastBefore">
+			<input type="checkbox" name="usebeforelasteventtime" value="1" <%= useBeforeLastEventTime ? "checked" : "" %> /> Filter for Alarms before Last Event:
 		</label>
-		<!-- 
-		<input type="date" name="beforedate"/>
-		<input type="time" name="beforetime"/>
-		-->
 		<br />
-		<div id="collapseAlarmsLasttBefore" class="collapse">
+		<div id="collapseAlarmsLastBefore" class="collapse <%= useBeforeLastEventTime ? "show" : "" %>">
 		<div class="row">
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforelasteventtimehour">
 					<c:forEach var="i" begin="1" end="12">
-						<form:option value="${i}" selected="${nowHour==i}">${i}</form:option>
+						<form:option value="${i}" selected="${beforeLastHour==i}">${i}</form:option>
 					</c:forEach>
 				</select>
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="beforelasteventtimeminute" maxlength="2" value="${formattedNowMinute}" />
+				<input class="form-control" type="text" name="beforelasteventtimeminute" maxlength="2" value="${beforeLastMinute}" />
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforelasteventtimeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==amPmText}">${dayTime}</form:option>
+						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==beforeLastAmPm}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>
@@ -328,21 +673,22 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforelasteventtimemonth">
 					<c:forEach var="month" items="${months}" varStatus="status">
-						<form:option value="${status.index}" selected="${status.count == nowMonth}">${month}</form:option>
+						<form:option value="${status.index}" selected="${status.count == beforeLastMonthCount}">${month}</form:option>
 					</c:forEach>
 				</select>
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="beforelasteventtimedate" maxlength="2" value="${nowDate}" />
+				<input class="form-control" type="text" name="beforelasteventtimedate" maxlength="2" value="${beforeLastDay}" />
 			</div>
 			<div class="col-xs-4 col-sm-4 col-md-3">
-				<input class="form-control" type="text" name="beforelasteventtimeyear" maxlength="4" value="${nowYear}" />
+				<input class="form-control" type="text" name="beforelasteventtimeyear" maxlength="4" value="${beforeLastYear}" />
 			</div>
 		</div>
 		</div>
 	</div>
 
-	<div class="form-group col-sm-12">
+	<div class="col-sm-12 my-2">
 		<button class="btn btn-secondary" type="submit"><i class="fa fa-search"></i> Search</button>
+		<button class="btn btn-secondary" type="button" onclick="resetAdvancedSearch()">Reset</button>
 	</div>
 </form>

--- a/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
@@ -425,17 +425,17 @@
 
 	<div class="form-group col-sm-6">
 		<label for="alarmtext">Alarm Text Contains</label>
-		<input class="form-control" type="text" name="alarmtext" value="<%= prefillAlarmText %>" />
+		<input class="form-control" type="text" name="alarmtext" value="<%= Encode.forHtmlAttribute(prefillAlarmText) %>" />
 	</div>
 
 	<div class="form-group col-sm-6">
 		<label for="iplike">TCP/IP Address Like</label>
-		<input class="form-control" type="text" name="iplike" value="<%= prefillIpLike %>" />
+		<input class="form-control" type="text" name="iplike" value="<%= Encode.forHtmlAttribute(prefillIpLike) %>" />
 	</div>
 
 	<div class="form-group col-sm-6">
 		<label for="nodenamelike">Node Label Contains</label>
-		<input class="form-control" type="text" name="nodenamelike" value="<%= prefillNodeName %>" />
+		<input class="form-control" type="text" name="nodenamelike" value="<%= Encode.forHtmlAttribute(prefillNodeName) %>" />
 	</div>
 
     <div class="form-group col-sm-6">
@@ -444,7 +444,7 @@
             <div>
                 <label>
                     <input type="checkbox" name="severity-<%=severity.getId()%>" value="1"
-                           <%=checkedSeverities.contains(severity.getId()) ? "checked" : ""%> /> <%=severity.getLabel()%>
+                           <%=checkedSeverities.contains(severity.getId()) ? "checked" : ""%> /> <%= Encode.forHtml(severity.getLabel()) %>
                 </label>
             </div>
         <% } %>
@@ -457,7 +457,7 @@
             <div>
                 <label>
                     <input type="checkbox" name="service-<%=serviceNameMap.get(name)%>" value="1"
-                           <%=checkedServices.contains(serviceNameMap.get(name)) ? "checked" : ""%> /> <%=name%>
+                           <%=checkedServices.contains(serviceNameMap.get(name)) ? "checked" : ""%> /> <%= Encode.forHtml(name) %>
                 </label>
             </div>
         <% } %>
@@ -507,7 +507,7 @@
 		<select class="form-control custom-select" name="category">
 			<option value="" <%= prefillCategory.isEmpty() ? "selected" : "" %>>Do not filter by category</option>
 			<% for (final String category: categories) { %>
-			<option value="<%=category%>" <%= category.equals(prefillCategory) ? "selected" : "" %>><%=category%></option>
+			<option value="<%= Encode.forHtmlAttribute(category) %>" <%= category.equals(prefillCategory) ? "selected" : "" %>><%= Encode.forHtml(category) %></option>
 			<% } %>
 		</select>
 

--- a/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/alarm-advquerypanel.jsp
@@ -356,14 +356,27 @@
             cb.checked = s.services.indexOf(parseInt(cb.name.split('-')[1], 10)) >= 0;
         });
 
+        function setCollapseExpanded(collapseId, expanded) {
+            var colEl = document.getElementById(collapseId);
+            if (!colEl) return;
+
+            if (expanded) { colEl.classList.add('show'); }
+            else { colEl.classList.remove('show'); }
+
+            var targetSelector = '#' + collapseId;
+            document.querySelectorAll(
+                '[href="' + targetSelector + '"], ' +
+                '[data-target="' + targetSelector + '"], ' +
+                '[data-bs-target="' + targetSelector + '"]'
+            ).forEach(function(toggleEl) {
+                toggleEl.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            });
+        }
+
         function applyTime(prefix, collapseId, useTime, hour, minute, ampm, monthIdx, day, year) {
             var cb = form.querySelector('[name="use' + prefix + '"]');
             if (cb) cb.checked = useTime;
-            var colEl = document.getElementById(collapseId);
-            if (colEl) {
-                if (useTime) { colEl.classList.add('show'); }
-                else { colEl.classList.remove('show'); }
-            }
+            setCollapseExpanded(collapseId, useTime);
             form.querySelector('[name="' + prefix + 'hour"]').value = hour;
             form.querySelector('[name="' + prefix + 'minute"]').value = minute;
             form.querySelector('[name="' + prefix + 'ampm"]').value = ampm;

--- a/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
@@ -318,19 +318,19 @@
 	</div>
 	<div class="form-group col-sm-6">
 		<label for="nodenamelike">Node Label Contains</label>
-		<input class="form-control" type="text" name="nodenamelike" value="<%= prefillNodeName %>" />
+		<input class="form-control" type="text" name="nodenamelike" value="<%= Encode.forHtmlAttribute(prefillNodeName) %>" />
 	</div>
 	</div>
 
 	<div class="row">
 	<div class="form-group col-sm-6">
 		<label for="eventtext">Event Text Contains</label>
-		<input class="form-control" type="text" name="eventtext" value="<%= prefillEventText %>" />
+		<input class="form-control" type="text" name="eventtext" value="<%= Encode.forHtmlAttribute(prefillEventText) %>" />
 	</div>
 
 	<div class="form-group col-sm-6">
 		<label for="iplike">TCP/IP Address Like</label>
-		<input class="form-control" type="text" name="iplike" value="<%= prefillIpLike %>" />
+		<input class="form-control" type="text" name="iplike" value="<%= Encode.forHtmlAttribute(prefillIpLike) %>" />
 	</div>
 	</div>
 
@@ -340,9 +340,9 @@
 			<select class="form-control custom-select" name="nodelocation">
 				<option <%= prefillNodeLocation.isEmpty() ? "selected=\"selected\"" : "" %>>Any</option>
 				<% for (OnmsMonitoringLocation onmsMonitoringLocation : monitoringLocations ) { %>
-				<option value="<%= onmsMonitoringLocation.getLocationName() %>"
+				<option value="<%= Encode.forHtmlAttribute(onmsMonitoringLocation.getLocationName()) %>"
 				        <%= onmsMonitoringLocation.getLocationName().equals(prefillNodeLocation) ? "selected=\"selected\"" : "" %>>
-					<%= onmsMonitoringLocation.getLocationName() %>
+					<%= Encode.forHtml(onmsMonitoringLocation.getLocationName()) %>
 				</option>
 				<% } %>
 			</select>
@@ -353,9 +353,9 @@
 			<select class="form-control custom-select" name="systemId">
 				<option <%= prefillSystemId.isEmpty() ? "selected" : "" %>>Any</option>
 				<% for (OnmsMonitoringSystem onmsMonitoringSystem : monitoringSystems ) { %>
-				<option value="<%= onmsMonitoringSystem.getId() %>"
+				<option value="<%= Encode.forHtmlAttribute(onmsMonitoringSystem.getId()) %>"
 				        <%= onmsMonitoringSystem.getId().equals(prefillSystemId) ? "selected" : "" %>>
-					<%= onmsMonitoringSystem.getId() %>
+					<%= Encode.forHtml(onmsMonitoringSystem.getId()) %>
 				</option>
 				<% } %>
 			</select>
@@ -369,7 +369,7 @@
                 <div>
                     <label>
                         <input type="checkbox" name="severity-<%=severity.getId()%>" value="1"
-                               <%=checkedSeverities.contains(severity.getId()) ? "checked" : ""%> /> <%=severity.getLabel()%>
+                               <%=checkedSeverities.contains(severity.getId()) ? "checked" : ""%> /> <%= Encode.forHtml(severity.getLabel()) %>
                     </label>
                 </div>
             <% } %>
@@ -381,7 +381,7 @@
                 <div>
                     <label>
                         <input type="checkbox" name="service-<%=serviceNameMap.get(name)%>" value="1"
-                               <%=checkedServices.contains(serviceNameMap.get(name)) ? "checked" : ""%> /> <%=name%>
+                               <%=checkedServices.contains(serviceNameMap.get(name)) ? "checked" : ""%> /> <%= Encode.forHtml(name) %>
                     </label>
                 </div>
             <% } %>
@@ -391,7 +391,7 @@
 	<div class="row">
 	<div class="form-group col-sm-12">
 		<label for="exactuei">Exact Event UEI</label>
-		<input class="form-control" type="text" name="exactuei" size="64" maxsize="128" value="<%= prefillExactUei %>" />
+		<input class="form-control" type="text" name="exactuei" size="64" maxsize="128" value="<%= Encode.forHtmlAttribute(prefillExactUei) %>" />
 	</div>
 	</div>
 

--- a/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
@@ -257,10 +257,10 @@
         form.querySelector('[name="limit"]').value = s.limit;
 
         form.querySelectorAll('[name^="severity-"]').forEach(function(cb) {
-            cb.checked = s.severities.indexOf(parseInt(cb.name.split('-')[1])) >= 0;
+            cb.checked = s.severities.indexOf(parseInt(cb.name.split('-')[1], 10)) >= 0;
         });
         form.querySelectorAll('[name^="service-"]').forEach(function(cb) {
-            cb.checked = s.services.indexOf(parseInt(cb.name.split('-')[1])) >= 0;
+            cb.checked = s.services.indexOf(parseInt(cb.name.split('-')[1], 10)) >= 0;
         });
 
         form.querySelector('[name="useaftertime"]').checked = s.useAfterTime;
@@ -283,7 +283,7 @@
     var _nowHour = '${nowHour}';
     var _nowMin = '${formattedNowMinute}';
     var _nowAmpm = '${nowAmPm}' === 'AM' ? 'am' : 'pm';
-    var _nowMonthIdx = parseInt('${nowMonth}') - 1;
+    var _nowMonthIdx = parseInt('${nowMonth}', 10) - 1;
     var _nowDay = '${nowDate}';
     var _nowYear = '${nowYear}';
 

--- a/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
@@ -204,8 +204,6 @@
         if (_evtSvcJs.length() > 0) _evtSvcJs.append(",");
         _evtSvcJs.append(_id);
     }
-    String afterAmPmJs = (afterAmPmText.equals("AM") || afterAmPmText.equals("Midnight")) ? "am" : "pm";
-    String beforeAmPmJs = (beforeAmPmText.equals("AM") || beforeAmPmText.equals("Midnight")) ? "am" : "pm";
 %>
 <script type="text/javascript">
 (function() {
@@ -224,14 +222,14 @@
         useAfterTime: <%= useAfterTime %>,
         afterHour: '<%= afterHourVal %>',
         afterMinute: '<%= afterFormattedMinute %>',
-        afterAmPm: '<%= afterAmPmJs %>',
+        afterAmPm: '<%= Encode.forJavaScript(afterAmPmText) %>',
         afterMonthIdx: '<%= afterMonthCount - 1 %>',
         afterDay: '<%= afterDayVal %>',
         afterYear: '<%= afterYearVal %>',
         useBeforeTime: <%= useBeforeTime %>,
         beforeHour: '<%= beforeHourVal %>',
         beforeMinute: '<%= beforeFormattedMinute %>',
-        beforeAmPm: '<%= beforeAmPmJs %>',
+        beforeAmPm: '<%= Encode.forJavaScript(beforeAmPmText) %>',
         beforeMonthIdx: '<%= beforeMonthCount - 1 %>',
         beforeDay: '<%= beforeDayVal %>',
         beforeYear: '<%= beforeYearVal %>'
@@ -282,7 +280,7 @@
 
     var _nowHour = '${nowHour}';
     var _nowMin = '${formattedNowMinute}';
-    var _nowAmpm = '${nowAmPm}' === 'AM' ? 'am' : 'pm';
+    var _nowAmpm = '${amPmText}';
     var _nowMonthIdx = parseInt('${nowMonth}', 10) - 1;
     var _nowDay = '${nowDate}';
     var _nowYear = '${nowYear}';
@@ -464,7 +462,7 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="afterampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==afterAmPmText}">${dayTime}</form:option>
+						<form:option value="${dayTime}" selected="${dayTime==afterAmPmText}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>
@@ -509,7 +507,7 @@
 			<div class="col-xs-4 col-sm-4 col-md-3">
 				<select class="form-control custom-select" name="beforeampm">
 					<c:forEach var="dayTime" items="AM,Noon,PM,Midnight">
-						<form:option value="${dayTime == 'AM' || dayTime == 'Midnight' ? 'am' : 'pm'}" selected="${dayTime==beforeAmPmText}">${dayTime}</form:option>
+						<form:option value="${dayTime}" selected="${dayTime==beforeAmPmText}">${dayTime}</form:option>
 					</c:forEach>
 				</select>
 			</div>

--- a/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
@@ -44,6 +44,7 @@
 <%@ page import="org.opennms.web.event.filter.SystemIdFilter" %>
 <%@ page import="org.opennms.web.event.filter.AfterDateFilter" %>
 <%@ page import="org.opennms.web.event.filter.BeforeDateFilter" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib tagdir="/WEB-INF/tags/form" prefix="form" %>
@@ -192,50 +193,119 @@
     pageContext.setAttribute("beforeAmPmText", beforeAmPmText);
 %>
 
+<%
+    StringBuilder _evtSevJs = new StringBuilder();
+    for (Integer _id : checkedSeverities) {
+        if (_evtSevJs.length() > 0) _evtSevJs.append(",");
+        _evtSevJs.append(_id);
+    }
+    StringBuilder _evtSvcJs = new StringBuilder();
+    for (Integer _id : checkedServices) {
+        if (_evtSvcJs.length() > 0) _evtSvcJs.append(",");
+        _evtSvcJs.append(_id);
+    }
+    String afterAmPmJs = (afterAmPmText.equals("AM") || afterAmPmText.equals("Midnight")) ? "am" : "pm";
+    String beforeAmPmJs = (beforeAmPmText.equals("AM") || beforeAmPmText.equals("Midnight")) ? "am" : "pm";
+%>
 <script type="text/javascript">
-function resetAdvancedSearch() {
-    var form = document.querySelector('#advancedSearchModal form');
+(function() {
+    var _state = {
+        eventid: '<%= Encode.forJavaScript(prefillEventId) %>',
+        nodenamelike: '<%= Encode.forJavaScript(prefillNodeName) %>',
+        eventtext: '<%= Encode.forJavaScript(prefillEventText) %>',
+        iplike: '<%= Encode.forJavaScript(prefillIpLike) %>',
+        exactuei: '<%= Encode.forJavaScript(prefillExactUei) %>',
+        nodelocation: '<%= Encode.forJavaScript(prefillNodeLocation) %>',
+        systemId: '<%= Encode.forJavaScript(prefillSystemId) %>',
+        sortby: '<%= Encode.forJavaScript(prefillSortStyle) %>',
+        limit: '<%= prefillLimit %>',
+        severities: [<%= _evtSevJs %>],
+        services: [<%= _evtSvcJs %>],
+        useAfterTime: <%= useAfterTime %>,
+        afterHour: '<%= afterHourVal %>',
+        afterMinute: '<%= afterFormattedMinute %>',
+        afterAmPm: '<%= afterAmPmJs %>',
+        afterMonthIdx: '<%= afterMonthCount - 1 %>',
+        afterDay: '<%= afterDayVal %>',
+        afterYear: '<%= afterYearVal %>',
+        useBeforeTime: <%= useBeforeTime %>,
+        beforeHour: '<%= beforeHourVal %>',
+        beforeMinute: '<%= beforeFormattedMinute %>',
+        beforeAmPm: '<%= beforeAmPmJs %>',
+        beforeMonthIdx: '<%= beforeMonthCount - 1 %>',
+        beforeDay: '<%= beforeDayVal %>',
+        beforeYear: '<%= beforeYearVal %>'
+    };
 
-    // Clear text inputs
-    ['eventid', 'nodenamelike', 'eventtext', 'iplike', 'exactuei'].forEach(function(name) {
-        form.querySelector('[name="' + name + '"]').value = '';
+    function applyState(s) {
+        var form = document.querySelector('#advancedSearchModal form');
+
+        ['eventid', 'nodenamelike', 'eventtext', 'iplike', 'exactuei'].forEach(function(name) {
+            form.querySelector('[name="' + name + '"]').value = s[name];
+        });
+
+        var nlSel = form.querySelector('[name="nodelocation"]');
+        if (s.nodelocation) { nlSel.value = s.nodelocation; }
+        else { nlSel.selectedIndex = 0; }
+
+        var sysSel = form.querySelector('[name="systemId"]');
+        if (s.systemId) { sysSel.value = s.systemId; }
+        else { sysSel.selectedIndex = 0; }
+
+        form.querySelector('[name="relativetime"]').value = '0';
+        form.querySelector('[name="sortby"]').value = s.sortby;
+        form.querySelector('[name="limit"]').value = s.limit;
+
+        form.querySelectorAll('[name^="severity-"]').forEach(function(cb) {
+            cb.checked = s.severities.indexOf(parseInt(cb.name.split('-')[1])) >= 0;
+        });
+        form.querySelectorAll('[name^="service-"]').forEach(function(cb) {
+            cb.checked = s.services.indexOf(parseInt(cb.name.split('-')[1])) >= 0;
+        });
+
+        form.querySelector('[name="useaftertime"]').checked = s.useAfterTime;
+        form.querySelector('[name="afterhour"]').value = s.afterHour;
+        form.querySelector('[name="afterminute"]').value = s.afterMinute;
+        form.querySelector('[name="afterampm"]').value = s.afterAmPm;
+        form.querySelector('[name="aftermonth"]').value = s.afterMonthIdx;
+        form.querySelector('[name="afterdate"]').value = s.afterDay;
+        form.querySelector('[name="afteryear"]').value = s.afterYear;
+
+        form.querySelector('[name="usebeforetime"]').checked = s.useBeforeTime;
+        form.querySelector('[name="beforehour"]').value = s.beforeHour;
+        form.querySelector('[name="beforeminute"]').value = s.beforeMinute;
+        form.querySelector('[name="beforeampm"]').value = s.beforeAmPm;
+        form.querySelector('[name="beforemonth"]').value = s.beforeMonthIdx;
+        form.querySelector('[name="beforedate"]').value = s.beforeDay;
+        form.querySelector('[name="beforeyear"]').value = s.beforeYear;
+    }
+
+    var _nowHour = '${nowHour}';
+    var _nowMin = '${formattedNowMinute}';
+    var _nowAmpm = '${nowAmPm}' === 'AM' ? 'am' : 'pm';
+    var _nowMonthIdx = parseInt('${nowMonth}') - 1;
+    var _nowDay = '${nowDate}';
+    var _nowYear = '${nowYear}';
+
+    window.resetAdvancedSearch = function() {
+        applyState({
+            eventid: '', nodenamelike: '', eventtext: '', iplike: '', exactuei: '',
+            nodelocation: '', systemId: '',
+            sortby: 'id', limit: '20',
+            severities: [], services: [],
+            useAfterTime: false,
+            afterHour: _nowHour, afterMinute: _nowMin, afterAmPm: _nowAmpm,
+            afterMonthIdx: _nowMonthIdx, afterDay: _nowDay, afterYear: _nowYear,
+            useBeforeTime: false,
+            beforeHour: _nowHour, beforeMinute: _nowMin, beforeAmPm: _nowAmpm,
+            beforeMonthIdx: _nowMonthIdx, beforeDay: _nowDay, beforeYear: _nowYear
+        });
+    };
+
+    $('#advancedSearchModal').on('show.bs.modal', function() {
+        applyState(_state);
     });
-
-    // Uncheck all severity and service checkboxes
-    form.querySelectorAll('[name^="severity-"], [name^="service-"]').forEach(function(cb) {
-        cb.checked = false;
-    });
-
-    // Reset location/system dropdowns to "Any"
-    form.querySelector('[name="nodelocation"]').selectedIndex = 0;
-    form.querySelector('[name="systemId"]').selectedIndex = 0;
-
-    // Reset other dropdowns to defaults
-    form.querySelector('[name="relativetime"]').value = '0';
-    form.querySelector('[name="sortby"]').value = 'id';
-    form.querySelector('[name="limit"]').value = '20';
-
-    // Uncheck time filter checkboxes
-    form.querySelector('[name="useaftertime"]').checked = false;
-    form.querySelector('[name="usebeforetime"]').checked = false;
-
-    // Reset date/time fields to current server time
-    var nowHour = '${nowHour}';
-    var nowMin = '${formattedNowMinute}';
-    var nowAmpm = '${nowAmPm}' === 'AM' ? 'am' : 'pm';
-    var nowMonthIdx = parseInt('${nowMonth}') - 1;
-    var nowDay = '${nowDate}';
-    var nowYear = '${nowYear}';
-
-    ['after', 'before'].forEach(function(prefix) {
-        form.querySelector('[name="' + prefix + 'hour"]').value = nowHour;
-        form.querySelector('[name="' + prefix + 'minute"]').value = nowMin;
-        form.querySelector('[name="' + prefix + 'ampm"]').value = nowAmpm;
-        form.querySelector('[name="' + prefix + 'month"]').value = nowMonthIdx;
-        form.querySelector('[name="' + prefix + 'date"]').value = nowDay;
-        form.querySelector('[name="' + prefix + 'year"]').value = nowYear;
-    });
-}
+})();
 </script>
 
 <form action="event/query" method="post">
@@ -464,7 +534,7 @@ function resetAdvancedSearch() {
 
 	<br/>
 
-	<button class="btn btn-secondary" type="submit">Search</button>
+	<button class="btn btn-secondary" type="submit"><i class="fa fa-search"></i> Search</button>
 	<button class="btn btn-secondary" type="button" onclick="resetAdvancedSearch()">Reset</button>
 
 </form>

--- a/opennms-webapp/src/test/java/org/opennms/web/controller/alarm/AlarmFilterControllerTest.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/controller/alarm/AlarmFilterControllerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
@@ -72,6 +73,7 @@ public class AlarmFilterControllerTest {
 
         when(alarmRepository.getMatchingAlarms(any())).thenReturn(new OnmsAlarm[0]);
         when(alarmRepository.countMatchingAlarms(any())).thenReturn(0);
+        when(favoriteService.getFavorites(any(), any())).thenReturn(new ArrayList<>());
     }
 
     // -------------------------------------------------------------------------
@@ -271,7 +273,6 @@ public class AlarmFilterControllerTest {
 
         assertEquals(1, filters.size());
         assertTrue(filters.get(0) instanceof AlarmTextFilter);
-        // Will fail: AlarmTextFilter#getValue() returns "ping " instead of "ping & dns"
         assertEquals("ping & dns", ((AlarmTextFilter) filters.get(0)).getValue());
     }
 }

--- a/opennms-webapp/src/test/java/org/opennms/web/controller/alarm/AlarmFilterControllerTest.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/controller/alarm/AlarmFilterControllerTest.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.controller.alarm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.netmgt.dao.hibernate.AlarmRepositoryHibernate;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.web.alarm.filter.AlarmTextFilter;
+import org.opennms.web.alarm.filter.NodeNameLikeFilter;
+import org.opennms.web.alarm.filter.SeverityOrFilter;
+import org.opennms.web.alarm.filter.SituationFilter;
+import org.opennms.web.filter.Filter;
+import org.opennms.web.filter.FilterUtil;
+import org.opennms.web.services.FilterFavoriteService;
+import org.opennms.web.tags.filters.AlarmFilterCallback;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * Tests for {@link AlarmFilterController} query string handling, focused on
+ * verifying that {@link FilterUtil#parse(String)} correctly extracts filter
+ * parameters and ignores non-filter parameters (limit, sortby, acktype, etc.).
+ */
+public class AlarmFilterControllerTest {
+
+    private AlarmFilterController controller;
+    private AlarmRepositoryHibernate alarmRepository;
+    private FilterFavoriteService favoriteService;
+    private AlarmFilterCallback filterCallback;
+
+    @Before
+    public void setUp() {
+        alarmRepository = mock(AlarmRepositoryHibernate.class);
+        favoriteService = mock(FilterFavoriteService.class);
+
+        controller = new AlarmFilterController();
+        controller.setServletContext(new MockServletContext("file:src/main/webapp"));
+        controller.setWebAlarmRepository(alarmRepository);
+        controller.setFavoriteService(favoriteService);
+        controller.afterPropertiesSet();
+
+        filterCallback = new AlarmFilterCallback(new MockServletContext("file:src/main/webapp"));
+
+        when(alarmRepository.getMatchingAlarms(any())).thenReturn(new OnmsAlarm[0]);
+        when(alarmRepository.countMatchingAlarms(any())).thenReturn(0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Controller-level tests: verify list() handles query strings without error
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testList_nullQueryString() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setQueryString(null);
+
+        ModelAndView mv = controller.list(request, new MockHttpServletResponse());
+
+        assertEquals("alarm/list", mv.getViewName());
+    }
+
+    @Test
+    public void testList_emptyQueryString() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setQueryString("");
+
+        ModelAndView mv = controller.list(request, new MockHttpServletResponse());
+
+        assertEquals("alarm/list", mv.getViewName());
+    }
+
+    @Test
+    public void testList_filterParamsOnly() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setQueryString("filter=alarmtext%3Dtest&filter=severity%3D3");
+
+        ModelAndView mv = controller.list(request, new MockHttpServletResponse());
+
+        assertEquals("alarm/list", mv.getViewName());
+    }
+
+    @Test
+    public void testList_nonFilterParamsOnly() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setQueryString("limit=10&sortby=id&acktype=unacknowledged&display=short&multiple=0");
+
+        ModelAndView mv = controller.list(request, new MockHttpServletResponse());
+
+        assertEquals("alarm/list", mv.getViewName());
+    }
+
+    @Test
+    public void testList_mixedFilterAndNonFilterParams() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setQueryString("limit=10&sortby=id&acktype=unacknowledged&filter=alarmtext%3Dtest&filter=severity%3D3");
+
+        ModelAndView mv = controller.list(request, new MockHttpServletResponse());
+
+        assertEquals("alarm/list", mv.getViewName());
+    }
+
+    @Test
+    public void testList_ampEntityEncodedSeparator() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setQueryString("limit=10&amp;sortby=id&amp;filter=alarmtext%3Dtest&amp;filter=severity%3D3");
+
+        ModelAndView mv = controller.list(request, new MockHttpServletResponse());
+
+        assertEquals("alarm/list", mv.getViewName());
+    }
+
+    // -------------------------------------------------------------------------
+    // Filter parsing tests: verify FilterUtil.parse() + AlarmFilterCallback
+    // correctly extracts filters and ignores non-filter query parameters.
+    // This is the exact expression used at AlarmFilterController line 98.
+    // -------------------------------------------------------------------------
+
+    private List<Filter> parseFiltersFromQueryString(String queryString) {
+        return filterCallback.parse(FilterUtil.parse(queryString == null ? "" : queryString));
+    }
+
+    @Test
+    public void testFilterParsing_nullQueryString_producesEmptyList() {
+        List<Filter> filters = parseFiltersFromQueryString(null);
+        assertTrue("Expected no filters for null query string", filters.isEmpty());
+    }
+
+    @Test
+    public void testFilterParsing_emptyQueryString_producesEmptyList() {
+        List<Filter> filters = parseFiltersFromQueryString("");
+        assertTrue("Expected no filters for empty query string", filters.isEmpty());
+    }
+
+    @Test
+    public void testFilterParsing_singleAlarmTextFilter() {
+        List<Filter> filters = parseFiltersFromQueryString("filter=alarmtext%3Dtest");
+
+        assertEquals(1, filters.size());
+        assertTrue(filters.get(0) instanceof AlarmTextFilter);
+    }
+
+    @Test
+    public void testFilterParsing_singleSeverityFilter() {
+        List<Filter> filters = parseFiltersFromQueryString("filter=severity%3D3");
+
+        assertEquals(1, filters.size());
+        assertTrue(filters.get(0) instanceof SeverityOrFilter);
+    }
+
+    @Test
+    public void testFilterParsing_multipleFilters() {
+        List<Filter> filters = parseFiltersFromQueryString(
+                "filter=alarmtext%3Dtest&filter=severity%3D3&filter=nodenamelike%3DMyNode");
+
+        assertEquals(3, filters.size());
+        assertEquals(1, filters.stream().filter(f -> f instanceof AlarmTextFilter).count());
+        assertEquals(1, filters.stream().filter(f -> f instanceof SeverityOrFilter).count());
+        assertEquals(1, filters.stream().filter(f -> f instanceof NodeNameLikeFilter).count());
+    }
+
+    @Test
+    public void testFilterParsing_urlEncodedEqualsInValue() {
+        // filter=alarmtext=my test (space encoded as +)
+        List<Filter> filters = parseFiltersFromQueryString("filter=alarmtext%3Dmy+test");
+
+        assertEquals(1, filters.size());
+        assertTrue(filters.get(0) instanceof AlarmTextFilter);
+    }
+
+    @Test
+    public void testFilterParsing_ampEntitySeparator_sameAsAmpersand() {
+        List<Filter> filtersAmp = parseFiltersFromQueryString(
+                "filter=alarmtext%3Dtest&filter=severity%3D3");
+        List<Filter> filtersAmpEntity = parseFiltersFromQueryString(
+                "filter=alarmtext%3Dtest&amp;filter=severity%3D3");
+
+        assertEquals(filtersAmp.size(), filtersAmpEntity.size());
+    }
+
+    @Test
+    public void testFilterParsing_duplicateFiltersAreDeduped() {
+        // FilterUtil.parse() applies .distinct(), so duplicate filter values yield one filter
+        List<Filter> filters = parseFiltersFromQueryString(
+                "filter=alarmtext%3Dtest&filter=alarmtext%3Dtest");
+
+        assertEquals("Duplicate filter params should be de-duplicated", 1, filters.size());
+    }
+
+    @Test
+    public void testFilterParsing_commonNonFilterParams_areIgnored() {
+        // limit, sortby, acktype, display, multiple, favoriteId have no matching filter TYPE
+        // and must not produce any Filter objects.
+        List<Filter> filters = parseFiltersFromQueryString(
+                "limit=10&sortby=id&acktype=unacknowledged&display=short&multiple=0&favoriteId=123");
+
+        assertTrue("Non-filter query params must not produce filters", filters.isEmpty());
+    }
+
+    @Test
+    public void testFilterParsing_mixedParams_onlyFilterParamsProduceFilters() {
+        // The full query string from the advanced search form includes many non-filter params.
+        String queryString = "limit=10&sortby=id&acktype=unacknowledged&display=short&multiple=0"
+                + "&filter=alarmtext%3Dtest&filter=severity%3D3&filter=nodenamelike%3DMyNode";
+
+        List<Filter> filters = parseFiltersFromQueryString(queryString);
+
+        assertEquals("Only filter= params should produce Filter objects", 3, filters.size());
+    }
+
+    @Test
+    public void testFilterParsing_mixedParams_ampEntitySeparated_onlyFilterParamsProduceFilters() {
+        // Same as above but using &amp; separators, which is what the alarm advanced search JSP sends.
+        String queryString = "limit=10&amp;sortby=id&amp;acktype=unacknowledged"
+                + "&amp;filter=alarmtext%3Dtest&amp;filter=severity%3D3&amp;filter=nodenamelike%3DMyNode";
+
+        List<Filter> filters = parseFiltersFromQueryString(queryString);
+
+        assertEquals("Only filter= params should produce Filter objects", 3, filters.size());
+    }
+
+    /**
+     * Documents a known pre-existing behavior: the query param {@code situation=any} (sent by
+     * the advanced search form when "Any" situation is selected) has the same key as
+     * {@link SituationFilter#TYPE}, so it is parsed as {@code SituationFilter(false)}.
+     *
+     * <p>This behavior existed before the introduction of {@link FilterUtil#parse(String)} in
+     * the controller. It is noted here so that any future fix to suppress spurious
+     * situation/nodelocation filters can be verified by updating this test.</p>
+     */
+    @Test
+    public void testFilterParsing_situationAnyParam_producesSpuriousSituationFilter_knownBehavior() {
+        // "situation=any" is a non-filter control param meaning "no situation filter",
+        // but its key collides with SituationFilter.TYPE = "situation".
+        List<Filter> filters = parseFiltersFromQueryString("situation=any");
+
+        assertEquals("situation=any currently creates a SituationFilter(false) due to key collision", 1, filters.size());
+        assertTrue(filters.get(0) instanceof SituationFilter);
+    }
+}

--- a/opennms-webapp/src/test/java/org/opennms/web/controller/alarm/AlarmFilterControllerTest.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/controller/alarm/AlarmFilterControllerTest.java
@@ -38,7 +38,6 @@ import org.opennms.web.alarm.filter.NodeNameLikeFilter;
 import org.opennms.web.alarm.filter.SeverityOrFilter;
 import org.opennms.web.alarm.filter.SituationFilter;
 import org.opennms.web.filter.Filter;
-import org.opennms.web.filter.FilterUtil;
 import org.opennms.web.services.FilterFavoriteService;
 import org.opennms.web.tags.filters.AlarmFilterCallback;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -48,7 +47,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Tests for {@link AlarmFilterController} query string handling, focused on
- * verifying that {@link FilterUtil#parse(String)} correctly extracts filter
+ * verifying that {@link AlarmFilterController#parse(String)} correctly extracts filter
  * parameters and ignores non-filter parameters (limit, sortby, acktype, etc.).
  */
 public class AlarmFilterControllerTest {
@@ -140,13 +139,13 @@ public class AlarmFilterControllerTest {
     }
 
     // -------------------------------------------------------------------------
-    // Filter parsing tests: verify FilterUtil.parse() + AlarmFilterCallback
+    // Filter parsing tests: verify AlarmFilterCallback.parse
     // correctly extracts filters and ignores non-filter query parameters.
-    // This is the exact expression used at AlarmFilterController line 98.
+    // This is the exact expression used at AlarmFilterController.list(), line 98.
     // -------------------------------------------------------------------------
 
     private List<Filter> parseFiltersFromQueryString(String queryString) {
-        return filterCallback.parse(FilterUtil.parse(queryString == null ? "" : queryString));
+        return filterCallback.parse(queryString == null ? "" : queryString);
     }
 
     @Test
@@ -209,7 +208,6 @@ public class AlarmFilterControllerTest {
 
     @Test
     public void testFilterParsing_duplicateFiltersAreDeduped() {
-        // FilterUtil.parse() applies .distinct(), so duplicate filter values yield one filter
         List<Filter> filters = parseFiltersFromQueryString(
                 "filter=alarmtext%3Dtest&filter=alarmtext%3Dtest");
 
@@ -253,8 +251,7 @@ public class AlarmFilterControllerTest {
      * the advanced search form when "Any" situation is selected) has the same key as
      * {@link SituationFilter#TYPE}, so it is parsed as {@code SituationFilter(false)}.
      *
-     * <p>This behavior existed before the introduction of {@link FilterUtil#parse(String)} in
-     * the controller. It is noted here so that any future fix to suppress spurious
+     * <p>It is noted here so that any future fix to suppress spurious
      * situation/nodelocation filters can be verified by updating this test.</p>
      */
     @Test
@@ -265,5 +262,16 @@ public class AlarmFilterControllerTest {
 
         assertEquals("situation=any currently creates a SituationFilter(false) due to key collision", 1, filters.size());
         assertTrue(filters.get(0) instanceof SituationFilter);
+    }
+
+    @Test
+    public void testFilterParsing_alarmTextWithAmpersand_isNotTruncated() {
+        // alarmtext = "ping & dns" → filter=alarmtext%3Dping+%26+dns
+        List<Filter> filters = parseFiltersFromQueryString("filter=alarmtext%3Dping+%26+dns");
+
+        assertEquals(1, filters.size());
+        assertTrue(filters.get(0) instanceof AlarmTextFilter);
+        // Will fail: AlarmTextFilter#getValue() returns "ping " instead of "ping & dns"
+        assertEquals("ping & dns", ((AlarmTextFilter) filters.get(0)).getValue());
     }
 }


### PR DESCRIPTION
Keep Alarm Advanced Search dialog in sync with applied filters, fix Alarm and Event Reset buttons.

When user clicks Reset on Alarm or Event dialog Advanced Search dialog, values are reset just for the form. If there user closes the form without clicking `Search`, then no filters are changed. When user clicks "Advanced Search" again, the currently-applied filters are prepopulated in the panel (previously there was a bug where they would still be cleared).

This also implements a cleaner way of doing the above.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19730
