### PR TITLE
NMS-19712: remove default filters for strafeping

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
@@ -314,8 +314,6 @@
    -->
    <package name="strafer">
       <filter>IPADDR != '0.0.0.0'</filter>
-      <include-range begin="10.1.1.1" end="10.1.1.10" />
-      <!-- <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" /> -->
       <rrd step="300">
          <rra>RRA:AVERAGE:0.5:1:2016</rra>
          <rra>RRA:AVERAGE:0.5:12:1488</rra>


### PR DESCRIPTION
I'm lumping this in with NMS-19712 but applying to develop based on feedback.  Strafeping is not part of the detectors so there isn't a risk of it being auto discovered and added to nodes.  This should make it easier to use.