### PR TITLE
NMS-19731: Fix SNMP Config set default overrides

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
@@ -233,13 +233,17 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
         }
     }
 
+    /**
+     * Update and save the config, replacing any existing config.
+     * Also gets the config from the store afterward, ensuring that the in-memory config is in sync with the store.
+     */
     @Override
     public void setAndSaveConfig(SnmpConfig snmpConfig) throws IOException {
         getWriteLock().lock();
 
         try {
             encryptSnmpConfig(snmpConfig);
-            getSnmpConfigDao().updateConfig(snmpConfig);
+            getSnmpConfigDao().updateConfig(snmpConfig, true);
 
             // repopulate m_config from the DAO to make sure it is in sync with what is saved
             this.m_config = getSnmpConfigDao().getConfig();
@@ -753,11 +757,8 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
             SnmpConfig clonedConfig = SnmpPeerFactory.cloneConfig(getSnmpConfig());
             setConfigurationParams(clonedConfig, config);
 
-            // call these directly since we are already in a write lock
-
             try {
-                getSnmpConfigDao().updateConfig(clonedConfig);
-                m_config = clonedConfig;
+                setAndSaveConfig(clonedConfig);
             } catch (Exception e) {
                 LOG.error("Failed to save default overrides to config, failed schema validation.", e);
                 // m_config remains untouched

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
@@ -760,7 +760,7 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
             try {
                 setAndSaveConfig(clonedConfig);
             } catch (Exception e) {
-                LOG.error("Failed to save default overrides to config, failed schema validation.", e);
+                LOG.error("Failed to save default overrides to config.", e);
                 // m_config remains untouched
             }
         } finally {

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpPeerFactoryTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpPeerFactoryTest.java
@@ -1527,16 +1527,20 @@ public class SnmpPeerFactoryTest extends TestCase {
 
     public void testSaveDefaultOverrides_UsesReplaceFlag() {
         SnmpPeerFactory.setResource(new ByteArrayResource(getSnmpConfig().getBytes()));
-        SnmpPeerFactory.snmpConfigDao = Mockito.spy(SnmpPeerFactory.snmpConfigDao);
+        final SnmpConfigDao originalSnmpConfigDao = SnmpPeerFactory.snmpConfigDao;
+        SnmpPeerFactory.snmpConfigDao = Mockito.spy(originalSnmpConfigDao);
+        try {
+            Configuration config = new Configuration(
+                161, 3, 3000, "public", "private",
+                null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
+            );
+            SnmpPeerFactory.getInstance().saveDefaultOverrides(config);
 
-        Configuration config = new Configuration(
-            161, 3, 3000, "public", "private",
-            null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
-        );
-        SnmpPeerFactory.getInstance().saveDefaultOverrides(config);
-
-        Mockito.verify(SnmpPeerFactory.snmpConfigDao).updateConfig(
-            Mockito.any(SnmpConfig.class), Mockito.eq(true)
-        );
+            Mockito.verify(SnmpPeerFactory.snmpConfigDao).updateConfig(
+                Mockito.any(SnmpConfig.class), Mockito.eq(true)
+            );
+        } finally {
+            SnmpPeerFactory.snmpConfigDao = originalSnmpConfigDao;
+        }
     }
 }

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpPeerFactoryTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpPeerFactoryTest.java
@@ -49,6 +49,7 @@ import org.opennms.netmgt.config.snmp.Definition;
 import org.opennms.netmgt.config.snmp.Range;
 import org.opennms.netmgt.config.snmp.SnmpConfig;
 import org.opennms.netmgt.config.snmp.SnmpProfile;
+import org.opennms.netmgt.dao.api.SnmpConfigDao;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.mockito.Mockito;
 import org.springframework.core.io.ByteArrayResource;
@@ -1527,20 +1528,20 @@ public class SnmpPeerFactoryTest extends TestCase {
 
     public void testSaveDefaultOverrides_UsesReplaceFlag() {
         SnmpPeerFactory.setResource(new ByteArrayResource(getSnmpConfig().getBytes()));
-        final SnmpConfigDao originalSnmpConfigDao = SnmpPeerFactory.snmpConfigDao;
-        SnmpPeerFactory.snmpConfigDao = Mockito.spy(originalSnmpConfigDao);
-        try {
-            Configuration config = new Configuration(
-                161, 3, 3000, "public", "private",
-                null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
-            );
-            SnmpPeerFactory.getInstance().saveDefaultOverrides(config);
+        SnmpConfig currentConfig = SnmpPeerFactory.snmpConfigDao.getConfig();
 
-            Mockito.verify(SnmpPeerFactory.snmpConfigDao).updateConfig(
-                Mockito.any(SnmpConfig.class), Mockito.eq(true)
-            );
-        } finally {
-            SnmpPeerFactory.snmpConfigDao = originalSnmpConfigDao;
-        }
+        SnmpConfigDao mockDao = Mockito.mock(SnmpConfigDao.class);
+        Mockito.when(mockDao.getConfig()).thenReturn(currentConfig);
+        SnmpPeerFactory.snmpConfigDao = mockDao;
+
+        Configuration config = new Configuration(
+            161, 3, 3000, "public", "private",
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
+        );
+        SnmpPeerFactory.getInstance().saveDefaultOverrides(config);
+
+        Mockito.verify(mockDao).updateConfig(
+            Mockito.any(SnmpConfig.class), Mockito.eq(true)
+        );
     }
 }

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpPeerFactoryTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpPeerFactoryTest.java
@@ -50,6 +50,7 @@ import org.opennms.netmgt.config.snmp.Range;
 import org.opennms.netmgt.config.snmp.SnmpConfig;
 import org.opennms.netmgt.config.snmp.SnmpProfile;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.mockito.Mockito;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.InputStreamResource;
 
@@ -1524,9 +1525,18 @@ public class SnmpPeerFactoryTest extends TestCase {
         assertEquals(originalConfig, updatedConfig1); // config should not have changed
     }
 
-    // NOTE: There is no test for saveDefaultOverrides when it receives a configuration that does not pass
-    // schema validation because it is overly complex to mock SnmpPeerFactory.snmpConfigDao just for testing,
-    // since we would have to add additional logic to SnmpPeerFactory.setResource() to allow injecting a mock dao that
-    // throws a fake ValidationException.
-    // However, this functionality *is* covered by the SnmpPeerFactoryTest.testSaveDefaultOverrides_InvalidConfig test.
+    public void testSaveDefaultOverrides_UsesReplaceFlag() {
+        SnmpPeerFactory.setResource(new ByteArrayResource(getSnmpConfig().getBytes()));
+        SnmpPeerFactory.snmpConfigDao = Mockito.spy(SnmpPeerFactory.snmpConfigDao);
+
+        Configuration config = new Configuration(
+            161, 3, 3000, "public", "private",
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
+        );
+        SnmpPeerFactory.getInstance().saveDefaultOverrides(config);
+
+        Mockito.verify(SnmpPeerFactory.snmpConfigDao).updateConfig(
+            Mockito.any(SnmpConfig.class), Mockito.eq(true)
+        );
+    }
 }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpConfigDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpConfigDao.java
@@ -31,7 +31,12 @@ public interface SnmpConfigDao {
 
     /**
      * Update and save the configuration to the backing store. This should also refresh the cache.
-     * When isReplace is true, null values in config clear existing values rather than being ignored.
+     * <p>
+     * The default implementation ignores {@code isReplace} and delegates to
+     * {@link #updateConfig(SnmpConfig)}.
+     * Implementations must override this method to support replace semantics where
+     * {@code isReplace} being {@code true} causes null values in {@code config} to
+     * clear existing values instead of being ignored.
      */
     default void updateConfig(SnmpConfig config, boolean isReplace) {
         updateConfig(config);

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpConfigDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpConfigDao.java
@@ -28,4 +28,12 @@ public interface SnmpConfigDao {
     SnmpConfig getConfig();
     /** Update and save the configuration to the backing store. This should also refresh the cache. */
     void updateConfig(SnmpConfig config);
+
+    /**
+     * Update and save the configuration to the backing store. This should also refresh the cache.
+     * When isReplace is true, null values in config clear existing values rather than being ignored.
+     */
+    default void updateConfig(SnmpConfig config, boolean isReplace) {
+        updateConfig(config);
+    }
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/jaxb/DefaultSnmpConfigDao.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/jaxb/DefaultSnmpConfigDao.java
@@ -23,6 +23,7 @@ package org.opennms.netmgt.dao.jaxb;
 
 import org.opennms.features.config.service.api.ConfigUpdateInfo;
 import org.opennms.features.config.service.impl.AbstractCmJaxbConfigDao;
+import org.opennms.features.config.service.util.ConfigConvertUtil;
 import org.opennms.netmgt.config.snmp.SnmpConfig;
 import org.opennms.netmgt.dao.api.SnmpConfigDao;
 import org.opennms.netmgt.dao.jaxb.callback.ConfigurationReloadEventCallback;
@@ -62,4 +63,11 @@ public class DefaultSnmpConfigDao extends AbstractCmJaxbConfigDao<SnmpConfig> im
         return new SnmpConfigConfigurationValidationCallback();
     }
 
+    /**
+     * Override to allow use of isReplace flag.
+     */
+    @Override
+    public void updateConfig(SnmpConfig config, boolean isReplace) {
+        this.updateConfig(this.getDefaultConfigId(), ConfigConvertUtil.objectToJson(config), isReplace);
+    }
 }


### PR DESCRIPTION
There was an issue with saving SNMP Config default overrides. If user cleared out values in order to set them back to the system default (i.e. in the UI, but also in Rest API), the null values would not actually replace the values in the backing store, but instead were treated as "not changed".

This PR exposes the `AbstractCmJaxbConfigDao` `updateConfig` method which takes a `boolean isReplace` to completely replace the config in the backing store. The Rest API now uses this when saving default overrides, ensuring the default override value is reset to `null` and thus the system falls back to the hard-coded default value.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19731
