### PR TITLE
NMS-19750: Forecast feature fix and doc addition

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/forecast/buildFilter.js
+++ b/core/web-assets/src/main/assets/js/apps/forecast/buildFilter.js
@@ -1,0 +1,39 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+'use strict';
+
+// The /rest/measurements endpoint expects filter parameters as string values.
+// Passing a raw number (which Angular's number inputs produce) can fail
+// downstream deserialization or jQuery attribute handling in opaque ways.
+// Centralising the String() coercion here makes it impossible to forget.
+function buildFilter(name, params) {
+    var parameter = Object.keys(params).map(function(key) {
+        return { key: key, value: String(params[key]) };
+    });
+    return {
+        type: 'filter',
+        name: name,
+        parameter: parameter
+    };
+}
+
+module.exports = buildFilter;

--- a/core/web-assets/src/main/assets/js/apps/forecast/checkForecastWarning.js
+++ b/core/web-assets/src/main/assets/js/apps/forecast/checkForecastWarning.js
@@ -1,0 +1,62 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+'use strict';
+
+// Inspect a /rest/measurements response to detect forecast failure modes the
+// user should be told about. Returns a human-readable warning string when one
+// of the conditions below applies, or null when the forecast looks healthy.
+function checkForecastWarning(results) {
+    if (!results || !results.columnNameToIndex) {
+        return null;
+    }
+    var idx = results.columnNameToIndex;
+    if (!('HWFit' in idx)) {
+        return 'Forecast could not be produced. The most common cause is that the selected training window does not have enough historical data.';
+    }
+    var fit = results.columns[idx.HWFit];
+    var hasValidFit = false;
+    if (fit) {
+        for (var k = 0; k < fit.length; k++) {
+            if (!isNaN(fit[k])) { hasValidFit = true; break; }
+        }
+    }
+    if (!hasValidFit) {
+        return 'Forecast produced no valid values. This typically means gaps or outliers in the training window left too few usable samples after filtering.';
+    }
+    if ('HWLwr' in idx && 'HWUpr' in idx) {
+        var lwr = results.columns[idx.HWLwr];
+        var upr = results.columns[idx.HWUpr];
+        var boundsVisible = false;
+        for (var i = 0; i < lwr.length; i++) {
+            if (!isNaN(lwr[i]) && !isNaN(upr[i]) && Math.abs(upr[i] - lwr[i]) > 1e-12) {
+                boundsVisible = true;
+                break;
+            }
+        }
+        if (!boundsVisible) {
+            return 'Confidence bounds have zero width (training residuals had no variance); upper and lower bounds coincide with the fit line.';
+        }
+    }
+    return null;
+}
+
+module.exports = checkForecastWarning;

--- a/core/web-assets/src/main/assets/js/apps/forecast/index.js
+++ b/core/web-assets/src/main/assets/js/apps/forecast/index.js
@@ -25,6 +25,8 @@ require('lib/onms-http');
 const Backshift = require('vendor/backshift-js');
 const $ = require('vendor/jquery-js');
 const _ = require('vendor/underscore-js');
+const buildFilter = require('./buildFilter');
+const checkForecastWarning = require('./checkForecastWarning');
 require('apps/onms-default-apps');
 
 const INTEGER_REGEXP = /^-?\d+$/;
@@ -209,6 +211,7 @@ app.controller('forecastCtrl', /* @ngInject */ function($scope) {
 
     $scope.reset = function() {
         clearUserInput();
+        $scope.forecastWarning = null;
         // Re-render the original graph model
         var rrdGraphConverter = new Backshift.Utilities.RrdGraphConverter({
             graphDef: $scope.graphDef,
@@ -241,7 +244,7 @@ app.controller('forecastCtrl', /* @ngInject */ function($scope) {
             'name': 'HW Fit',
             'metric': 'HWFit',
             'type': 'line',
-            'color': '#0000ff'
+            'color': '#9d4edd'
         });
         graphModel.series.push({
             'name': 'HW Lwr',
@@ -262,77 +265,48 @@ app.controller('forecastCtrl', /* @ngInject */ function($scope) {
         var graphStartInMillis = now - ($scope.forecastingOptions.graphStart * numberOfSecondsInADay * 1000);
         var graphEndInMillis = now;
 
-        // Add metric filters to prepare, trend and forecast the target metric
-        graphModel.metrics.push({
-            'type': 'filter',
-            'name': 'Chomp',
-            'parameter': [{
-                'key': 'stripNaNs',
-                'value': 'true'
-            }]
-        });
-        graphModel.metrics.push({
-            'type': 'filter',
-            'name': 'Outlier',
-            'parameter': [{
-                'key': 'inputColumn',
-                'value': $scope.metricToForecast.metric
-            }, {
-                'key': 'quantile',
-                'value': String($scope.forecastingOptions.outlierThreshold)
-            }]
-        });
-        graphModel.metrics.push({
-            'type': 'filter',
-            'name': 'HoltWinters',
-            'parameter': [{
-                'key': 'inputColumn',
-                'value': $scope.metricToForecast.metric
-            }, {
-                'key': 'outputPrefix',
-                'value': 'HW'
-            }, {
-                'key': 'numPeriodsToForecast',
-                'value': String($scope.forecastingOptions.forecasts)
-            }, {
-                'key': 'periodInSeconds',
-                'value': String($scope.forecastingOptions.season * numberOfSecondsInADay)
-            }, {
-                'key': 'confidenceLevel',
-                'value': String($scope.forecastingOptions.confidenceLevel)
-            }]
-        });
-        graphModel.metrics.push({
-            'type': 'filter',
-            'name': 'Trend',
-            'parameter': [{
-                'key': 'inputColumn',
-                'value': $scope.metricToForecast.metric
-            }, {
-                'key': 'outputColumn',
-                'value': 'Trend'
-            }, {
-                'key': 'secondsAhead',
-                'value': String($scope.forecastingOptions.forecasts * $scope.forecastingOptions.season * numberOfSecondsInADay)
-            }, {
-                'key': 'polynomialOrder',
-                'value': $scope.forecastingOptions.trendOrder
-            }]
-        });
+        // Add metric filters to prepare, trend and forecast the target metric.
+        // buildFilter() wraps every value in String() so numeric Angular inputs
+        // don't leak raw numbers into the REST payload.
+        graphModel.metrics.push(buildFilter('Chomp', {
+            stripNaNs: true
+        }));
+        graphModel.metrics.push(buildFilter('Outlier', {
+            inputColumn: $scope.metricToForecast.metric,
+            quantile: $scope.forecastingOptions.outlierThreshold
+        }));
+        graphModel.metrics.push(buildFilter('HoltWinters', {
+            inputColumn: $scope.metricToForecast.metric,
+            outputPrefix: 'HW',
+            numPeriodsToForecast: $scope.forecastingOptions.forecasts,
+            periodInSeconds: $scope.forecastingOptions.season * numberOfSecondsInADay,
+            confidenceLevel: $scope.forecastingOptions.confidenceLevel
+        }));
+        graphModel.metrics.push(buildFilter('Trend', {
+            inputColumn: $scope.metricToForecast.metric,
+            outputColumn: 'Trend',
+            secondsAhead: $scope.forecastingOptions.forecasts * $scope.forecastingOptions.season * numberOfSecondsInADay,
+            polynomialOrder: $scope.forecastingOptions.trendOrder
+        }));
 
-        // Add another filter to trim all of the records in the training period
-        graphModel.metrics.push({
-            'type': 'filter',
-            'name': 'Chomp',
-            'parameter': [{
-                'key': 'stripNaNs',
-                'value': 'false'
-            }, {
-                'key': 'cutoffDate',
-                'value': String(graphStartInMillis)
-            }]
-        });
+        // Trim all of the records in the training period
+        graphModel.metrics.push(buildFilter('Chomp', {
+            stripNaNs: false,
+            cutoffDate: graphStartInMillis
+        }));
         renderGraph(graphModel, trainingStartInMillis, graphEndInMillis);
+
+        // Wrap drawChart to surface forecast failures in the UI. The REST
+        // response arrives asynchronously; we inspect its columns to detect
+        // (a) a completely bailed forecast (no HWFit column) or (b) bounds
+        // that coincide with the fit due to zero residual variance.
+        var origDrawChart = $scope.graph.drawChart.bind($scope.graph);
+        $scope.graph.drawChart = function(results) {
+            $scope.$apply(function() {
+                $scope.forecastWarning = checkForecastWarning(results);
+            });
+            return origDrawChart(results);
+        };
     };
 
     if (window.forecastError) {

--- a/core/web-assets/src/test/javascript/forecast/buildFilter.test.js
+++ b/core/web-assets/src/test/javascript/forecast/buildFilter.test.js
@@ -1,0 +1,61 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+const buildFilter = require('forecast/buildFilter');
+
+test('returns a filter descriptor with the given name', () => {
+    const result = buildFilter('HoltWinters', { inputColumn: 'rt' });
+    expect(result.type).toBe('filter');
+    expect(result.name).toBe('HoltWinters');
+});
+
+test('coerces numeric values to strings', () => {
+    const result = buildFilter('Trend', {
+        polynomialOrder: 3,
+        secondsAhead: 86400,
+        outlierThreshold: 0.975
+    });
+    const byKey = {};
+    result.parameter.forEach(p => { byKey[p.key] = p; });
+    expect(byKey.polynomialOrder.value).toBe('3');
+    expect(byKey.secondsAhead.value).toBe('86400');
+    expect(byKey.outlierThreshold.value).toBe('0.975');
+    result.parameter.forEach(p => {
+        expect(typeof p.value).toBe('string');
+    });
+});
+
+test('coerces boolean values to strings', () => {
+    const result = buildFilter('Chomp', { stripNaNs: true });
+    expect(result.parameter[0]).toEqual({ key: 'stripNaNs', value: 'true' });
+});
+
+test('passes through string values unchanged', () => {
+    const result = buildFilter('Outlier', {
+        inputColumn: 'response_time'
+    });
+    expect(result.parameter[0]).toEqual({ key: 'inputColumn', value: 'response_time' });
+});
+
+test('preserves key order', () => {
+    const result = buildFilter('Foo', { a: 1, b: 2, c: 3 });
+    expect(result.parameter.map(p => p.key)).toEqual(['a', 'b', 'c']);
+});

--- a/core/web-assets/src/test/javascript/forecast/checkForecastWarning.test.js
+++ b/core/web-assets/src/test/javascript/forecast/checkForecastWarning.test.js
@@ -1,0 +1,105 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+const checkForecastWarning = require('forecast/checkForecastWarning');
+
+// Build a measurement response in the same shape Backshift hands to drawChart.
+// columns is a map of name -> values array; the helper builds the numeric
+// columnNameToIndex and columns-by-index that the function inspects.
+function buildResults(columnsByName) {
+    const names = Object.keys(columnsByName);
+    const columnNameToIndex = {};
+    const columns = [];
+    names.forEach((name, idx) => {
+        columnNameToIndex[name] = idx;
+        columns.push(columnsByName[name]);
+    });
+    return { columnNameToIndex, columns };
+}
+
+test('returns null when results are null or undefined', () => {
+    expect(checkForecastWarning(null)).toBeNull();
+    expect(checkForecastWarning(undefined)).toBeNull();
+    expect(checkForecastWarning({})).toBeNull();
+});
+
+test('warns when the HWFit column is missing entirely', () => {
+    const results = buildResults({
+        timestamp: [1, 2, 3],
+        Trend: [10, 11, 12]
+        // no HWFit
+    });
+    expect(checkForecastWarning(results)).toMatch(/could not be produced/i);
+});
+
+test('warns when HWFit is present but every sample is NaN', () => {
+    const results = buildResults({
+        HWFit: [NaN, NaN, NaN, NaN],
+        HWLwr: [NaN, NaN, NaN, NaN],
+        HWUpr: [NaN, NaN, NaN, NaN]
+    });
+    expect(checkForecastWarning(results)).toMatch(/no valid values/i);
+});
+
+test('warns when HWLwr and HWUpr coincide with HWFit (zero-width bounds)', () => {
+    const results = buildResults({
+        HWFit: [10, 11, 12, 13],
+        HWLwr: [10, 11, 12, 13],
+        HWUpr: [10, 11, 12, 13]
+    });
+    expect(checkForecastWarning(results)).toMatch(/zero width/i);
+});
+
+test('warns on zero-width bounds even when some values are NaN', () => {
+    const results = buildResults({
+        HWFit: [10, 11, NaN, 13],
+        HWLwr: [10, 11, NaN, 13],
+        HWUpr: [10, 11, NaN, 13]
+    });
+    expect(checkForecastWarning(results)).toMatch(/zero width/i);
+});
+
+test('returns null on a healthy forecast with non-zero bounds', () => {
+    const results = buildResults({
+        HWFit: [10, 11, 12, 13],
+        HWLwr: [9.5, 10.2, 11.1, 12.0],
+        HWUpr: [10.5, 11.8, 12.9, 14.0]
+    });
+    expect(checkForecastWarning(results)).toBeNull();
+});
+
+test('returns null when HWFit has values but HWLwr/HWUpr are absent', () => {
+    // confidenceLevel=0 path: server emits HWFit but no bounds. Should not warn.
+    const results = buildResults({
+        HWFit: [10, 11, 12]
+    });
+    expect(checkForecastWarning(results)).toBeNull();
+});
+
+test('returns null when only the first sample is non-NaN', () => {
+    // Even one valid value qualifies as a usable forecast.
+    const results = buildResults({
+        HWFit: [10, NaN, NaN, NaN],
+        HWLwr: [9.5, NaN, NaN, NaN],
+        HWUpr: [10.5, NaN, NaN, NaN]
+    });
+    expect(checkForecastWarning(results)).toBeNull();
+});

--- a/docs/modules/operation/nav.adoc
+++ b/docs/modules/operation/nav.adoc
@@ -72,6 +72,7 @@
 **** xref:deep-dive/performance-data-collection/snmp-index.adoc[]
 *** xref:deep-dive/performance-data-collection/collectors.adoc[]
 *** xref:deep-dive/performance-data-collection/graphs.adoc[]
+*** xref:deep-dive/performance-data-collection/forecasting.adoc[]
 *** xref:deep-dive/performance-data-collection/snmp-property-extenders/property-extenders.adoc[]
 **** xref:deep-dive/performance-data-collection/snmp-property-extenders/cisco-cbqos.adoc[]
 **** xref:deep-dive/performance-data-collection/snmp-property-extenders/enum-lookup.adoc[]

--- a/docs/modules/operation/pages/deep-dive/performance-data-collection/forecasting.adoc
+++ b/docs/modules/operation/pages/deep-dive/performance-data-collection/forecasting.adoc
@@ -1,0 +1,167 @@
+
+[[forecasting]]
+= Forecasting
+:description: How to use the Holt-Winters forecasting feature in {page-component-title} to project a metric forward in time.
+
+For any graph rendered through the Resource Graphs UI, {page-component-title} can fit a Holt-Winters model to the historical samples and project the metric forward by a configurable horizon.
+The forecast view overlays a fit line, a polynomial trend, and a Gaussian confidence envelope on top of the original graph so you can see where the metric is likely to trend.
+
+== Accessing forecasting
+
+. From the Web UI, navigate to a node and open *Resource Graphs*.
+. Each graph has a small toolbar above it.
+The forecast button is the line-chart icon labeled "Forecast" on hover.
+. Clicking the icon opens the forecast page in a new tab, pre-loaded with the same graph.
+
+The forecast page renders the original graph and a configuration form.
+Pick a metric from the dropdown (only the named series in the graph are eligible). Then choose a forecasting template, optionally tune the parameters, and click *Forecast*.
+
+== Forecasting templates
+
+Three preset templates cover the common cases, plus a *Custom* option for full control:
+
+[cols="1,1,1,1,3"]
+|===
+| Template | Training Start | Graph Start | Forecasts | Description
+
+| 1 day forecast
+| 14 days
+| 7 days
+| 1
+| Uses two weeks of history to project one day ahead.
+
+| 7 day forecast
+| 60 days
+| 30 days
+| 7
+| Uses two months of history to project a week out.
+
+| 31 day forecast
+| 365 days
+| 90 days
+| 4 (each 7 days)
+| Uses a year of history to project four weekly periods.
+
+| Custom
+| n/a
+| n/a
+| n/a
+| Lets you set every parameter individually.
+|===
+
+The *Training Start* parameter sets how far back the model reads samples (in days) when estimating its level, trend, and seasonal components.
+The *Graph Start* parameter sets what's actually visible on screen.
+*Forecasts* is the number of seasonal periods projected forward.
+
+== What gets drawn
+
+The forecast page adds three overlays on top of the original graph:
+
+[cols="1,1,3"]
+|===
+| Series | Color | Meaning
+
+| HW Fit
+| purple (`#9d4edd`)
+| The Holt-Winters point forecast. This is the model's best estimate of the metric at each future time step.
+
+| HW Lwr / HW Upr
+| red (`#ff0000`)
+| The lower and upper confidence bounds of the forecast.
+The interval between them is where the model expects the actual value to fall, given the configured confidence level (default 95%).
+
+| Trend
+| cyan (`#00ffff`)
+| A polynomial trend line fit to the same history window.
+Independent of the Holt-Winters model. Useful as a sanity check on the long-run direction of the metric.
+|===
+
+A static legend below the graph maps each color to its label.
+
+== Holt-Winters in brief
+
+Holt-Winters (also called triple exponential smoothing) is a classic forecasting algorithm for time-series data that exhibits a level, a trend, and seasonality.
+The model maintains three internal state variables:
+
+* *Level* - the current baseline value of the series.
+* *Trend* - the rate at which the level is changing over time.
+* *Seasonal* - a periodic component capturing repeating patterns within each season (for example, daily or weekly cycles).
+
+Each new observation updates all three with exponentially weighted averages, controlled by smoothing parameters that the model estimates by walking the historical samples once.
+A multiplicative seasonality model is used, which works well for metrics whose seasonal swings scale with the overall level (for example, traffic that doubles during business hours scales with monthly growth).
+
+To produce a forecast, {page-component-title} feeds the model the historical samples in the history window, lets it adapt its state, and then iterates the level + trend + seasonal forward by the configured number of steps.
+
+For deeper background, see the link:https://otexts.com/fpp2/holt-winters.html[Holt-Winters chapter] in _Forecasting: Principles and Practice_ by Hyndman & Athanasopoulos.
+
+== Confidence bounds
+
+The bounds (`HW Lwr` and `HW Upr`) are an empirical Gaussian approximation rather than the canonical Holt-Winters prediction interval.
+They are derived from the model's in-sample residuals, the differences between what the model predicted and what actually happened over the history window.
+The standard deviation of those residuals (sigma) becomes the per-step uncertainty.
+
+For a chosen confidence level, a critical value `z` is taken from the standard normal distribution (z &asymp; 1.96 for 95%).
+At a forecast horizon of `h` steps ahead, the half-width of the interval is:
+
+----
+delta = z * sigma * sqrt(min(h, period))
+----
+
+The bounds widen with the square root of the horizon, capped at one full seasonal period.
+The cap reflects the fact that monitoring data is usually mean-reverting rather than a pure random walk. Without it, bounds would fan open quickly and overstate uncertainty.
+
+[NOTE]
+====
+The canonical Holt-Winters prediction interval depends on the model's fitted smoothing parameters (alpha, beta, gamma) and generally grows faster than the simple `sqrt(h)` law used here, particularly for series with real trend or seasonal contributions.
+The residual-based approximation we use trades that fidelity for simplicity and tends to produce bounds that are tighter than the canonical interval would be.
+
+The Gaussian-residual approximation also assumes the model's errors are roughly normally distributed and stationary.
+Highly bursty metrics can violate that assumption and produce bounds that are too tight in calm periods or too loose during spikes.
+====
+
+If the in-sample residuals are all zero (typical for a perfectly flat metric) sigma is zero, the bounds collapse onto the fit line, and a banner is shown explaining this.
+
+== Limitations and warnings
+
+The forecast page surfaces a yellow banner above the graph when one of the following conditions is detected:
+
+[cols="1,3"]
+|===
+| Condition | What it means
+
+| Forecast could not be produced
+| The selected history window has fewer than two usable samples.
+This commonly happens when the graph is new, has gaps, or the window extends before collection started.
+
+| Forecast produced no valid values
+| {page-component-title} ran the filter pipeline but every output sample is `NaN`.
+Typical cause: the upstream `Chomp` and `Outlier` filters removed too many points.
+
+| Confidence bounds have zero width
+| The in-sample residuals had no variance, so the upper and lower bounds coincide with the fit line.
+The forecast is still rendered; the bounds simply aren't visually distinguishable.
+|===
+
+== Behind the scenes
+
+You don't interact with these directly, but it's useful to know what's happening when you click *Forecast*.
+The Web UI doesn't simply hand the raw samples to the Holt-Winters algorithm; instead it builds a fixed chain of server-side measurement filters that prepare the data, run the model, and trim the result to the visible window:
+
+. *Chomp (strip NaNs)* - removes leading and trailing NaN samples from the input column so the model isn't fed gaps at either end.
+. *Outlier* - caps extreme values at the *Outlier Threshold* quantile (default `0.975`) so a single spike doesn't dominate the fit.
+. *HoltWinters* - runs the Holt-Winters algorithm using the configured *Season*, *Forecasts*, and *Confidence Level*, and emits the `HWFit`, `HWLwr`, and `HWUpr` columns.
+. *Trend* - fits a polynomial of order *Trend Order* to the same column and emits a `Trend` column.
+. *Chomp (cutoff)* - trims any rows before *Graph Start* so that only the visible window is returned to the browser.
+
+[cols="1,2"]
+|===
+| Parameter | Affects
+
+| Outlier Threshold | the *Outlier* filter's quantile cap
+| Season | the *HoltWinters* filter's seasonal period (in days)
+| Forecasts | the *HoltWinters* filter's number of seasons projected forward, and the *Trend* filter's `secondsAhead` extent
+| Confidence Level | the *HoltWinters* filter's bound width
+| Trend Order | the *Trend* filter's polynomial order
+| Training Start | how far back the input column is read before the pipeline runs
+| Graph Start | the *Chomp (cutoff)* filter's cutoff date
+|===

--- a/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/filters/impl/HWForecast.java
+++ b/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/filters/impl/HWForecast.java
@@ -24,6 +24,8 @@ package org.opennms.netmgt.measurements.filters.impl;
 import java.util.Date;
 
 
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.opennms.netmgt.measurements.api.Filter;
 import org.opennms.netmgt.measurements.api.FilterInfo;
 import org.opennms.netmgt.measurements.api.FilterParam;
@@ -60,14 +62,24 @@ public class HWForecast implements Filter {
     @FilterParam(key="periodInSeconds", required=true, displayName="Period", description="Size of a period in seconds.")
     private long m_periodInSeconds;
 
+    @FilterParam(key="confidenceLevel", value="0.95", displayName="Level", description="Probability used for confidence bounds. Set this to 0 in order to disable the bounds.")
+    private double m_confidenceLevel;
+
     protected HWForecast() {}
 
     public HWForecast(String outputPrefix, String inputColumn,
             int numPeriodsToForecast, long periodInSeconds) {
+        this(outputPrefix, inputColumn, numPeriodsToForecast, periodInSeconds, 0.95);
+    }
+
+    public HWForecast(String outputPrefix, String inputColumn,
+            int numPeriodsToForecast, long periodInSeconds,
+            double confidenceLevel) {
         m_outputPrefix = outputPrefix;
         m_inputColumn = inputColumn;
         m_numPeriodsToForecast = numPeriodsToForecast;
         m_periodInSeconds = periodInSeconds;
+        m_confidenceLevel = confidenceLevel;
     }
 
     @Override
@@ -107,19 +119,50 @@ public class HWForecast implements Filter {
                 .setInitTrainingMethod(HoltWintersTrainingMethod.SIMPLE);
 
         var subject = new HoltWintersPointForecaster(params);
-        long firstIndexForTraining = Math.max(limits.firstRowWithValues, (limits.lastRowWithValues - (numSamplesPerPeriod * 2L)));
+        // Use all available history. The SIMPLE training method consumes the first
+        // 2 * frequency observations; anything beyond that feeds the online algorithm,
+        // which is what produces meaningful forecasts (and therefore meaningful
+        // residuals for the confidence-bound calculation below).
+        long firstIndexForTraining = limits.firstRowWithValues;
 
+        // Collect one-step-ahead residuals during training to derive a Gaussian prediction
+        // interval. PointForecast.getValue() returns the forecast made BEFORE observing the
+        // new sample, so actual - forecast is the prediction error for the current sample.
+        // Warmup samples are skipped because the model hasn't learned the seasonal state yet.
+        DescriptiveStatistics residuals = new DescriptiveStatistics();
         double lastValue = Double.NaN;
         for (long i = firstIndexForTraining; i < limits.lastRowWithValues; i++) {
             lastValue = table.get(i, m_inputColumn);
-            subject.forecast(lastValue);
+            PointForecast fc = subject.forecast(lastValue);
+            if (!fc.isWarmup()) {
+                residuals.addValue(lastValue - fc.getValue());
+            }
         }
+
+        double sigma = residuals.getN() > 1 ? residuals.getStandardDeviation() : 0.0;
+        double z = 0.0;
+        if (m_confidenceLevel > 0.0 && m_confidenceLevel < 1.0) {
+            z = new NormalDistribution().inverseCumulativeProbability(1.0 - (1.0 - m_confidenceLevel) / 2.0);
+        }
+        boolean emitBounds = z > 0.0;
 
         for (long i = limits.lastRowWithValues + 1; i <= (limits.lastRowWithValues + numForecasts); i++) {
             PointForecast forecast = subject.forecast(lastValue);
             long idxForecast = i - limits.lastRowWithValues;
-            table.put(i, m_outputPrefix + "Fit", forecast.getValue());
+            double fitValue = forecast.getValue();
+            table.put(i, m_outputPrefix + "Fit", fitValue);
             table.put(i, TIMESTAMP_COLUMN_NAME, (double)new Date(lastTimestamp.getTime() + stepInMs * idxForecast).getTime());
+
+            if (emitBounds) {
+                // Variance grows with forecast horizon, but σ·√h on a pure-random-walk
+                // assumption wildly overstates uncertainty for the near-stationary data
+                // typical of monitoring. Cap the horizon at one period so bounds widen
+                // briefly and then plateau rather than fanning open without bound.
+                double horizon = Math.min((double) idxForecast, (double) numSamplesPerPeriod);
+                double delta = z * sigma * Math.sqrt(horizon);
+                table.put(i, m_outputPrefix + "Lwr", fitValue - delta);
+                table.put(i, m_outputPrefix + "Upr", fitValue + delta);
+            }
 
             // Save value for next iteration
             lastValue = forecast.getValue();

--- a/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/filters/impl/HWForecastIT.java
+++ b/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/filters/impl/HWForecastIT.java
@@ -68,5 +68,121 @@ public class HWForecastIT extends AnalyticsFilterTest {
         for (long i = 100; i < 112; i++) {
             Assert.assertEquals(1.0d, table.get(i, "HWFit"), 0.0001);
         }
+
+        // Constant input yields zero residuals post-warmup, so the bounds should
+        // coincide with the fit.
+        for (long i = 100; i < 112; i++) {
+            Assert.assertEquals(1.0d, table.get(i, "HWLwr"), 0.0001);
+            Assert.assertEquals(1.0d, table.get(i, "HWUpr"), 0.0001);
+        }
+    }
+
+    @Test
+    public void boundsWidenOnNoisyInput() throws Exception {
+        FilterDef filterDef = new FilterDef("HoltWinters",
+                "outputPrefix", "HW",
+                "inputColumn", "X",
+                "numPeriodsToForecast", "2",
+                "periodInSeconds", "10",
+                "confidenceLevel", "0.95");
+
+        // Deterministic Gaussian noise around a constant mean. numSamplesPerPeriod = 10
+        // gives 20 training samples (10 warmup + 10 scored residuals), enough for a
+        // meaningful standard deviation.
+        java.util.Random rng = new java.util.Random(42);
+        RowSortedTable<Long, String, Double> table = TreeBasedTable.create();
+        for (long i = 0; i < 200; i++) {
+            table.put(i, Filter.TIMESTAMP_COLUMN_NAME, (double)(i * 1000));
+            table.put(i, "X", 10.0d + rng.nextGaussian());
+        }
+
+        getFilterEngine().filter(filterDef, table);
+
+        // numForecasts = numSamplesPerPeriod * numPeriodsToForecast = 10 * 2 = 20.
+        // idxForecast runs 1..20 over rows 200..219; the horizon is capped at
+        // numSamplesPerPeriod=10, so rows 200..209 should grow and rows 210..219
+        // should be flat at the capped width.
+        double prevWidth = 0.0;
+        for (long i = 200; i < 210; i++) {
+            double fit = table.get(i, "HWFit");
+            double lwr = table.get(i, "HWLwr");
+            double upr = table.get(i, "HWUpr");
+
+            Assert.assertTrue("lwr should be <= fit at i=" + i, lwr <= fit);
+            Assert.assertTrue("upr should be >= fit at i=" + i, upr >= fit);
+
+            double width = upr - lwr;
+            Assert.assertTrue("interval width should grow with horizon at i=" + i,
+                    width >= prevWidth);
+            prevWidth = width;
+        }
+
+        Assert.assertTrue("interval should have non-zero width with noisy input",
+                prevWidth > 0.0);
+
+        // Past the cap, widths are constant.
+        double cappedWidth = prevWidth;
+        for (long i = 210; i < 220; i++) {
+            double width = table.get(i, "HWUpr") - table.get(i, "HWLwr");
+            Assert.assertEquals("width should be capped past one period at i=" + i,
+                    cappedWidth, width, 1e-9);
+        }
+    }
+
+    @Test
+    public void confidenceLevelZeroSuppressesBounds() throws Exception {
+        FilterDef filterDef = new FilterDef("HoltWinters",
+                "outputPrefix", "HW",
+                "inputColumn", "X",
+                "numPeriodsToForecast", "2",
+                "periodInSeconds", "10",
+                "confidenceLevel", "0");
+
+        java.util.Random rng = new java.util.Random(42);
+        RowSortedTable<Long, String, Double> table = TreeBasedTable.create();
+        for (long i = 0; i < 200; i++) {
+            table.put(i, Filter.TIMESTAMP_COLUMN_NAME, (double)(i * 1000));
+            table.put(i, "X", 10.0d + rng.nextGaussian());
+        }
+
+        getFilterEngine().filter(filterDef, table);
+
+        // Fit must still be produced.
+        Assert.assertTrue("HWFit should still be produced when confidenceLevel=0",
+                table.containsColumn("HWFit"));
+
+        // Bounds must not be emitted (or at least never carry a value distinct from the fit).
+        for (long i = 200; i < 220; i++) {
+            Double lwr = table.get(i, "HWLwr");
+            Double upr = table.get(i, "HWUpr");
+            // Either the columns weren't emitted at all, or the bound rows are absent.
+            Assert.assertNull("HWLwr should not be emitted with confidenceLevel=0 at i=" + i, lwr);
+            Assert.assertNull("HWUpr should not be emitted with confidenceLevel=0 at i=" + i, upr);
+        }
+    }
+
+    @Test
+    public void insufficientSamplesEmitsNoFit() throws Exception {
+        FilterDef filterDef = new FilterDef("HoltWinters",
+                "outputPrefix", "HW",
+                "inputColumn", "X",
+                "numPeriodsToForecast", "2",
+                "periodInSeconds", "10",
+                "confidenceLevel", "0.95");
+
+        // Only one row with a value; the filter should bail early because there
+        // aren't enough samples to fit anything.
+        RowSortedTable<Long, String, Double> table = TreeBasedTable.create();
+        table.put(0L, Filter.TIMESTAMP_COLUMN_NAME, 0.0d);
+        table.put(0L, "X", 1.0d);
+
+        getFilterEngine().filter(filterDef, table);
+
+        Assert.assertFalse("HWFit must not be emitted when there is no usable history",
+                table.containsColumn("HWFit"));
+        Assert.assertFalse("HWLwr must not be emitted when there is no usable history",
+                table.containsColumn("HWLwr"));
+        Assert.assertFalse("HWUpr must not be emitted when there is no usable history",
+                table.containsColumn("HWUpr"));
     }
 }

--- a/opennms-webapp/src/main/webapp/graph/forecast.jsp
+++ b/opennms-webapp/src/main/webapp/graph/forecast.jsp
@@ -96,9 +96,20 @@ window.forecastError = "One or more dependencies required for forecasting "
           <span>Forecasting <c:out value="${report}"/> on <c:out value="${resourceId}"/> </span>
       </div> <!-- card-header -->
       <div class="card-body">
+		<div ng-cloak class="alert alert-warning" role="alert" ng-show="forecastWarning">
+			<span class="fa fa-exclamation-triangle" aria-hidden="true"></span>
+			{{forecastWarning}}
+		</div>
 		<div class="row-fluid">
 			<div class="col-md-7">
 		        <div data-graph-report="<c:out value="${report}"/>" data-graph-resource="<c:out value="${resourceId}"/>"></div>
+		        <div class="forecast-legend mt-2 small" ng-show="graph">
+		            <span style="display:inline-block;width:12px;height:12px;background-color:#9d4edd;vertical-align:middle;margin-right:4px"></span>HW Fit
+		            &nbsp;&nbsp;
+		            <span style="display:inline-block;width:12px;height:12px;background-color:#ff0000;vertical-align:middle;margin-right:4px"></span>HW Bounds (low/high)
+		            &nbsp;&nbsp;
+		            <span style="display:inline-block;width:12px;height:12px;background-color:#00ffff;vertical-align:middle;margin-right:4px"></span>Trend
+		        </div>
 		    </div>
 		    <div class="col-md-4" ng-show="series.length < 1">
 		        <p>The graph does not contain any series that can be forecasted.</p>


### PR DESCRIPTION
Per NMS-19750, this PR has updates to the forecasting feature to make it function again (now completely removing the last R dependencies).  I also included a legend of the graph page and a slight tweak to the color of the forecast line to make it obvious and doc updates to explain the feature.  I also included test cases for this feature to ensure it gets tested.

Screenshot of the functioning feature in action:
<img width="1920" height="1702" alt="image" src="https://github.com/user-attachments/assets/f4f8ecab-30b6-4430-b4be-d70254ab280d" />

@cgorantla - I think this would be a good one to test out the code review stuff on.

Assisted-by: Claude Code:Opus 4.7