### PR TITLE
NMS-16237: add support for RFC2348 "TFTP blksize" to the tftp implementation

### DIFF
--- a/features/device-config/tftp/src/main/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImpl.java
+++ b/features/device-config/tftp/src/main/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImpl.java
@@ -172,23 +172,34 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                             if (timeoutCount >= maxTimeoutRetries_) {
                                 throw e;
                             }
-                            // It didn't get our ack. Resend it.
-                            LOG.debug("Resending missed ack to '{}'", twrp.getAddress());
-                            transferTftp_.bufferedSend(lastSentAck);
+                            // Maybe the client didn't get our ack. If there is no blksize option, resend the last ack
+                            if (! twrpOptions.containsKey("blksize")) {
+                                LOG.debug("Resending missed ack to '{}'", twrp.getAddress());
+                                transferTftp_.bufferedSend(lastSentAck);
+                                }
+                            if (lastSentAck.getBlockNumber() == 0 && twrpOptions.containsKey("blksize")) {
+                                // if we haven't received any data block yet, we should resend the OACK
+                                LOG.debug("Resending missed OACK to '{}'", twrp.getAddress());
+                                DatagramPacket oackPacket = createBlksizeOAckPacket(negotiatedBlksize, twrp.getAddress(), twrp.getPort());
+                                sendOAckPacket(transferTftp_, oackPacket);
+                            }
                             timeoutCount++;
                             continue;
                         }
                     }
 
                     if (dataPacket instanceof TFTPWriteRequestPacket) {
-                        // It must have missed our initial response. Resend the
-                        // same packet we sent before so option negotiation state
-                        // is preserved (for example, OACK vs ACK(0)).
-                        LOG.debug("Resending WRQ response to '{}'", twrp.getAddress());
-                        if (lastSentAck == null) {
+                        // Client must have missed our initial ack. If this is a WRQ and
+                        // contains a blksize option, we need to resend the OACK.
+                        if (((TFTPWriteRequestPacket)dataPacket).getOptions().containsKey("blksize")) {
+                            DatagramPacket oackPacket = createBlksizeOAckPacket(negotiatedBlksize, twrp.getAddress(), twrp.getPort());
+                            LOG.debug("Resending WRQ OACK to '{}'", twrp.getAddress());
+                            sendOAckPacket(transferTftp_, oackPacket);
+                        } else {
                             lastSentAck = new TFTPAckPacket(twrp.getAddress(), twrp.getPort(), 0);
+                            LOG.debug("Resending WRQ ack to '{}'", twrp.getAddress());
+                            transferTftp_.bufferedSend(lastSentAck);
                         }
-                        transferTftp_.bufferedSend(lastSentAck);
                     } else if (dataPacket == null || !(dataPacket instanceof TFTPDataPacket)) {
                         if (!shutdownTransfer) {
                             statistics.incErrors();
@@ -210,7 +221,7 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                             statistics.incBytesReceived(dataLength);
                             if (bytesReceived > maximumReceiveSize) {
                                 statistics.incErrors();
-                                LOG.error("Maximum receive size exceeded - address: {}, fileName: {}; max: {}; received: ", twrp.getAddress(), twrp.getFilename(), maximumReceiveSize, bytesReceived);
+                                LOG.error("Maximum receive size exceeded - address: '{}', fileName: '{}'; max: '{}'; received: '{}'", twrp.getAddress(), twrp.getFilename(), maximumReceiveSize, bytesReceived);
                                 // make sure it was from the right client...
                                 transferTftp_
                                         .bufferedSend(new TFTPErrorPacket(dataPacket

--- a/features/device-config/tftp/src/main/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImpl.java
+++ b/features/device-config/tftp/src/main/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImpl.java
@@ -22,18 +22,21 @@
 package org.opennms.features.deviceconfig.tftp.impl;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.net.io.FromNetASCIIOutputStream;
@@ -60,6 +63,7 @@ import org.slf4j.LoggerFactory;
 // - received files are not stored on disk but in memory and are handed off to registered listeners
 // - the maximum file size to receive can be configured
 // - requesting files is not supported
+// - added support for RFC2348 blksize
 
 public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
 
@@ -92,6 +96,8 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
             try {
                 int lastBlock = 0;
                 final String fileName = twrp.getFilename();
+                int negotiatedBlksize = TFTPDataPacket.MAX_DATA_LENGTH;
+                Map<String,String> twrpOptions = twrp.getOptions();
 
                 try {
                     if (twrp.getMode() == TFTP.NETASCII_MODE) {
@@ -104,9 +110,37 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                             .getPort(), TFTPErrorPacket.UNDEFINED, e.getMessage()));
                     return;
                 }
-
                 TFTPAckPacket lastSentAck = new TFTPAckPacket(twrp.getAddress(), twrp.getPort(), 0);
-                sendData(transferTftp_, lastSentAck); // send the data
+
+                // Handle RFC2348 TFTP blksize
+                if (twrpOptions.containsKey("blksize")) {
+                    LOG.debug("Received blksize option from client '{}', attempting negotiation", twrp.getAddress());
+                    try {
+                        negotiatedBlksize = Integer.parseInt(twrpOptions.get("blksize"));
+                        if (negotiatedBlksize < 8 || negotiatedBlksize > 65464) {
+                            LOG.error("Received invalid blksize '{}' option from client {}", negotiatedBlksize, twrp.getAddress());
+                            transferTftp_.bufferedSend(new TFTPErrorPacket(twrp.getAddress(),
+                                    twrp.getPort(), TFTPErrorPacket.INVALID_OPTIONS_VALUE,
+                                    "Invalid blksize"));
+                            return;
+                        } else {
+                            LOG.debug("Negotiating tftp blksize '{}' with client '{}'", negotiatedBlksize, twrp.getAddress());
+                            // Create an OAck response packet - commons doesn't provide a method for this yet.
+                            DatagramPacket oackPacket = createBlksizeOAckPacket(negotiatedBlksize, twrp.getAddress(), twrp.getPort());
+                            sendOAckPacket(transferTftp_, oackPacket);
+                            transferTftp_.resetBuffersToSize(negotiatedBlksize);
+                            LOG.debug("Successfully negotiated blksize '{}' with client '{}'", negotiatedBlksize, twrp.getAddress());
+                        }
+                    } catch (final Exception e) {
+                        LOG.error("Received invalid blksize '{}' option from client {}:", negotiatedBlksize, twrp.getAddress(), e);
+                        transferTftp_.bufferedSend(new TFTPErrorPacket(twrp.getAddress(),
+                                twrp.getPort(), TFTPErrorPacket.INVALID_OPTIONS_VALUE,
+                                "Invalid blksize"));
+                        return;
+                    }
+                } else {
+                    sendData(transferTftp_, lastSentAck); // send the ack
+                }
 
                 while (true) {
                     // get the response - ensure it is from the right place.
@@ -134,11 +168,12 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                             dataPacket = transferTftp_.bufferedReceive();
                         } catch (final SocketTimeoutException e) {
                             statistics.incErrors();
-                            LOG.error("did not receive data packet", e);
+                            LOG.error("did not receive data packet from client '{}': ", twrp.getAddress(), e);
                             if (timeoutCount >= maxTimeoutRetries_) {
                                 throw e;
                             }
                             // It didn't get our ack. Resend it.
+                            LOG.debug("Resending missed ack to '{}'", twrp.getAddress());
                             transferTftp_.bufferedSend(lastSentAck);
                             timeoutCount++;
                             continue;
@@ -147,6 +182,7 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
 
                     if (dataPacket instanceof TFTPWriteRequestPacket) {
                         // it must have missed our initial ack. Send another.
+                        LOG.debug("Resending WRQ ack to '{}'", twrp.getAddress());
                         lastSentAck = new TFTPAckPacket(twrp.getAddress(), twrp.getPort(), 0);
                         transferTftp_.bufferedSend(lastSentAck);
                     } else if (dataPacket == null || !(dataPacket instanceof TFTPDataPacket)) {
@@ -161,6 +197,7 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                         final byte[] data = ((TFTPDataPacket) dataPacket).getData();
                         final int dataLength = ((TFTPDataPacket) dataPacket).getDataLength();
                         final int dataOffset = ((TFTPDataPacket) dataPacket).getDataOffset();
+                        LOG.debug("Processing block {} from client '{}'", block, twrp.getAddress());
 
                         if (block > lastBlock || lastBlock == 65535 && block == 0) {
                             // it might resend a data block if it missed our ack
@@ -184,8 +221,9 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                         }
 
                         lastSentAck = new TFTPAckPacket(twrp.getAddress(), twrp.getPort(), block);
+                        LOG.debug("Sending Ack for block {} from client '{}'", block, twrp.getAddress());
                         sendData(transferTftp_, lastSentAck); // send the data
-                        if (dataLength < TFTPDataPacket.MAX_DATA_LENGTH) {
+                        if (dataLength < negotiatedBlksize) {
                             // end of stream signal - The transfer is complete.
                             bos.close();
 
@@ -195,7 +233,7 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
 
                             List<TftpFileReceiver> rs;
                             synchronized (receivers) {
-                                rs = new ArrayList(receivers);
+                                rs = new ArrayList<>(receivers);
                             }
                             rs.forEach(r -> {
                                 r.onFileReceived(twrp.getAddress(), fileName, content);
@@ -209,6 +247,7 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                                 } catch (final SocketTimeoutException e) {
                                     // this is the expected route - the client
                                     // shouldn't be sending any more packets.
+                                    LOG.debug("tftp transfer from client '{}' complete.", twrp.getAddress());
                                     break;
                                 }
 
@@ -236,6 +275,7 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                             }
 
                             // all done.
+                            LOG.debug("Timing out transfer from client '{}'", twrp.getAddress());
                             break;
                         }
                     }
@@ -266,6 +306,7 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                             .getPort(), TFTPErrorPacket.ILLEGAL_OPERATION,
                             "Read not allowed by server."));
                 } else if (tftpPacket_ instanceof TFTPWriteRequestPacket) {
+                    LOG.debug("Received write request from client '{}'", tftpPacket_.getAddress());
                     handleWrite((TFTPWriteRequestPacket) tftpPacket_);
                 } else {
                     statistics.incWarnings();
@@ -598,5 +639,39 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
     @Override
     public TftpStatistics getAndResetStatistics() {
         return statistics.cloneAndReset();
+    }
+
+    private DatagramPacket createBlksizeOAckPacket(int size, InetAddress addr, int port) throws IOException {
+        // build the oack packet - commons doesn't provide a method for this yet...
+        ByteArrayOutputStream oack = new ByteArrayOutputStream();
+        oack.write(0);
+        oack.write(TFTPPacket.OACK);
+        oack.write("blksize".getBytes(StandardCharsets.US_ASCII));
+        oack.write(0);
+        oack.write(String.valueOf(size).getBytes(StandardCharsets.US_ASCII));
+        oack.write(0);
+        //make it a byte array
+        byte[] oackData = oack.toByteArray();
+
+        return new DatagramPacket(oackData, oackData.length, addr, port);
+    }
+
+    //Helper method to send a DatagramPacket through transferTftp_'s underlying socket using reflection
+    private void sendOAckPacket(TFTP tftp, DatagramPacket oackPacket) throws IOException {
+        try {
+            // TFTP class extends DatagramSocketClient, which has a protected field "_socket_"
+            // that holds the underlying DatagramSocket.
+            java.lang.reflect.Field socketField =
+                    org.apache.commons.net.DatagramSocketClient.class.getDeclaredField("_socket_");
+            socketField.setAccessible(true);
+
+            DatagramSocket socket = (DatagramSocket) socketField.get(tftp);
+            if (socket == null || socket.isClosed()) {
+                throw new IOException("TFTP socket is not open");
+            }
+            socket.send(oackPacket);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IOException("Failed to access TFTP socket via reflection", e);
+        }
     }
 }

--- a/features/device-config/tftp/src/main/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImpl.java
+++ b/features/device-config/tftp/src/main/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImpl.java
@@ -181,9 +181,13 @@ public class TftpServerImpl implements TftpServer, Runnable, AutoCloseable {
                     }
 
                     if (dataPacket instanceof TFTPWriteRequestPacket) {
-                        // it must have missed our initial ack. Send another.
-                        LOG.debug("Resending WRQ ack to '{}'", twrp.getAddress());
-                        lastSentAck = new TFTPAckPacket(twrp.getAddress(), twrp.getPort(), 0);
+                        // It must have missed our initial response. Resend the
+                        // same packet we sent before so option negotiation state
+                        // is preserved (for example, OACK vs ACK(0)).
+                        LOG.debug("Resending WRQ response to '{}'", twrp.getAddress());
+                        if (lastSentAck == null) {
+                            lastSentAck = new TFTPAckPacket(twrp.getAddress(), twrp.getPort(), 0);
+                        }
                         transferTftp_.bufferedSend(lastSentAck);
                     } else if (dataPacket == null || !(dataPacket instanceof TFTPDataPacket)) {
                         if (!shutdownTransfer) {

--- a/features/device-config/tftp/src/test/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImplTest.java
+++ b/features/device-config/tftp/src/test/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImplTest.java
@@ -113,9 +113,34 @@ public class TftpServerImplTest {
                 var resp = new DatagramPacket(new byte[512], 512);
                 socket.receive(resp);
                 var respData = resp.getData();
+                var respLength = resp.getLength();
                 // opcode 6 = OACK
                 assertThat((int) respData[0] << 8 | (respData[1] & 0xFF), is(TFTPPacket.OACK));
 
+                var oackBlksize = null;
+                var idx = 2;
+                while (idx < respLength) {
+                    var optionStart = idx;
+                    while (idx < respLength && respData[idx] != 0) {
+                        idx++;
+                    }
+                    var option = new String(respData, optionStart, idx - optionStart, StandardCharsets.US_ASCII);
+                    idx++;
+
+                    var valueStart = idx;
+                    while (idx < respLength && respData[idx] != 0) {
+                        idx++;
+                    }
+                    var value = new String(respData, valueStart, idx - valueStart, StandardCharsets.US_ASCII);
+                    idx++;
+
+                    if ("blksize".equalsIgnoreCase(option)) {
+                        oackBlksize = value;
+                        break;
+                    }
+                }
+                assertThat(oackBlksize != null, is(true));
+                assertThat(oackBlksize, is(String.valueOf(blksize)));
                 // The server's transfer thread replies from its own port - use that for the rest
                 var srvAddr = resp.getAddress();
                 var srvPort = resp.getPort();

--- a/features/device-config/tftp/src/test/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImplTest.java
+++ b/features/device-config/tftp/src/test/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImplTest.java
@@ -117,7 +117,7 @@ public class TftpServerImplTest {
                 // opcode 6 = OACK
                 assertThat((int) respData[0] << 8 | (respData[1] & 0xFF), is(TFTPPacket.OACK));
 
-                var oackBlksize = 0;
+                var oackBlksize = "";
                 var idx = 2;
                 while (idx < respLength) {
                     var optionStart = idx;
@@ -139,7 +139,7 @@ public class TftpServerImplTest {
                         break;
                     }
                 }
-                assertThat(oackBlksize > 0, is(true));
+                assertThat(oackBlksize != "", is(true));
                 assertThat(oackBlksize, is(String.valueOf(blksize)));
                 // The server's transfer thread replies from its own port - use that for the rest
                 var srvAddr = resp.getAddress();

--- a/features/device-config/tftp/src/test/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImplTest.java
+++ b/features/device-config/tftp/src/test/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImplTest.java
@@ -117,7 +117,7 @@ public class TftpServerImplTest {
                 // opcode 6 = OACK
                 assertThat((int) respData[0] << 8 | (respData[1] & 0xFF), is(TFTPPacket.OACK));
 
-                var oackBlksize = null;
+                var oackBlksize = 0;
                 var idx = 2;
                 while (idx < respLength) {
                     var optionStart = idx;
@@ -139,7 +139,7 @@ public class TftpServerImplTest {
                         break;
                     }
                 }
-                assertThat(oackBlksize != null, is(true));
+                assertThat(oackBlksize > 0, is(true));
                 assertThat(oackBlksize, is(String.valueOf(blksize)));
                 // The server's transfer thread replies from its own port - use that for the rest
                 var srvAddr = resp.getAddress();

--- a/features/device-config/tftp/src/test/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImplTest.java
+++ b/features/device-config/tftp/src/test/java/org/opennms/features/deviceconfig/tftp/impl/TftpServerImplTest.java
@@ -28,7 +28,11 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -36,6 +40,7 @@ import java.util.Random;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.net.tftp.TFTP;
 import org.apache.commons.net.tftp.TFTPClient;
+import org.apache.commons.net.tftp.TFTPPacket;
 import org.junit.Test;
 import org.opennms.features.deviceconfig.tftp.TftpFileReceiver;
 
@@ -51,7 +56,7 @@ public class TftpServerImplTest {
     }
     
     @Test
-    public void test() throws Exception {
+    public void testTftpServerImpl() throws Exception {
         try(var server = new TftpServerImpl()) {
             var port = 6903;
             server.setPort(port);
@@ -79,6 +84,115 @@ public class TftpServerImplTest {
             assertThat(statistics.errors(), is(0));
         }
 
+    }
+
+    @Test
+    public void testBlksizeNegotiation() throws Exception {
+        try (var server = new TftpServerImpl()) {
+            var port = 6904;
+            server.setPort(port);
+            server.launch();
+
+            var receiver = new Receiver();
+            server.register(receiver);
+
+            var bytes = new byte[2500];
+            new Random().nextBytes(bytes);
+            var fileName = "test-blksize";
+            var blksize = 1024;
+
+            try (var socket = new DatagramSocket()) {
+                socket.setSoTimeout(5000);
+                var localhost = InetAddress.getByName("localhost");
+
+                // Send WRQ with blksize option
+                var wrq = buildWrqWithBlksize(fileName, "octet", blksize, localhost, port);
+                socket.send(wrq);
+
+                // Expect OACK echoing our blksize
+                var resp = new DatagramPacket(new byte[512], 512);
+                socket.receive(resp);
+                var respData = resp.getData();
+                // opcode 6 = OACK
+                assertThat((int) respData[0] << 8 | (respData[1] & 0xFF), is(TFTPPacket.OACK));
+
+                // The server's transfer thread replies from its own port - use that for the rest
+                var srvAddr = resp.getAddress();
+                var srvPort = resp.getPort();
+
+                // Send data blocks at the negotiated blksize
+                var offset = 0;
+                var block = 1;
+                while (offset < bytes.length) {
+                    var chunkSize = Math.min(blksize, bytes.length - offset);
+                    var chunk = new byte[chunkSize];
+                    System.arraycopy(bytes, offset, chunk, 0, chunkSize);
+                    offset += chunkSize;
+
+                    socket.send(buildDataPacket(block, chunk, srvAddr, srvPort));
+
+                    var ack = new DatagramPacket(new byte[64], 64);
+                    socket.receive(ack);
+                    // opcode 4 = ACK, then 2-byte block number
+                    assertThat((int) ack.getData()[1] & 0xFF, is(TFTPPacket.ACKNOWLEDGEMENT));
+                    assertThat((ack.getData()[2] & 0xFF) << 8 | (ack.getData()[3] & 0xFF), is(block));
+
+                    block++;
+                }
+
+                // If the last chunk was exactly blksize, send a zero-length terminator
+                if (bytes.length % blksize == 0) {
+                    socket.send(buildDataPacket(block, new byte[0], srvAddr, srvPort));
+                    var ack = new DatagramPacket(new byte[64], 64);
+                    socket.receive(ack);
+                }
+            }
+
+            await().untilAsserted(() -> assertThat(receiver.received, hasSize(1)));
+            assertThat(receiver.received.get(0).getKey(), equalTo(fileName));
+            assertThat(receiver.received.get(0).getValue(), is(bytes));
+        }
+    }
+    // -- Packet builder helpers ------------------------------------------------
+
+    /**
+     * Build a TFTP WRQ (opcode 2) with an RFC2348 blksize option.
+     *
+     *  2 bytes   string  1 byte  string  1 byte  string   1 byte  string  1 byte
+     *  | 0x02 | filename | 0x00 | mode  | 0x00 | blksize  | 0x00 | value | 0x00 |
+     */
+    private static DatagramPacket buildWrqWithBlksize(String file, String mode, int blksize,
+                                                      InetAddress addr, int port) throws Exception {
+        var bos = new ByteArrayOutputStream();
+        bos.write(0);
+        bos.write(TFTPPacket.WRITE_REQUEST);
+        bos.write(file.getBytes(StandardCharsets.US_ASCII));
+        bos.write(0);
+        bos.write(mode.getBytes(StandardCharsets.US_ASCII));
+        bos.write(0);
+        bos.write("blksize".getBytes(StandardCharsets.US_ASCII));
+        bos.write(0);
+        bos.write(String.valueOf(blksize).getBytes(StandardCharsets.US_ASCII));
+        bos.write(0);
+        var data = bos.toByteArray();
+        return new DatagramPacket(data, data.length, addr, port);
+    }
+
+    /**
+     * Build a TFTP DATA packet (opcode 3).
+     *
+     *  2 bytes  2 bytes   n bytes
+     *  | 0x03 | block# |  data  |
+     */
+    private static DatagramPacket buildDataPacket(int block, byte[] payload,
+                                                  InetAddress addr, int port) {
+        var pkt = new byte[4 + payload.length];
+        pkt[0] = 0;
+        pkt[1] = TFTPPacket.DATA;
+        pkt[2] = (byte) ((block >> 8) & 0xFF);
+        pkt[3] = (byte) (block & 0xFF);
+        System.arraycopy(payload, 0, pkt, 4, payload.length);
+        return new DatagramPacket(pkt, pkt.length, addr, port);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1773,7 +1773,7 @@
     <commonsLangVersion>2.6</commonsLangVersion>
     <commonsLang3Version>3.16.0</commonsLang3Version>
     <commonsMath3Version>3.6.1</commonsMath3Version>
-    <commonsNetVersion>3.10.0</commonsNetVersion>
+    <commonsNetVersion>3.12.0</commonsNetVersion>
     <commonsPoolVersion>1.6</commonsPoolVersion>
     <commonsPool2Version>2.4.3</commonsPool2Version>
     <commonsTextVersion>1.11.0</commonsTextVersion>


### PR DESCRIPTION

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16237
* previous PR: https://github.com/OpenNMS/opennms/pull/8184
* reverted changes in `RetrieverImpl.java` that simplified `{fileNameSuffix}` usage by request.

