### PR TITLE
NMS-19754: DCB: Add inline SSH configuration capture

### DIFF
--- a/docs/modules/operation/pages/deep-dive/device-config-backup/ssh.adoc
+++ b/docs/modules/operation/pages/deep-dive/device-config-backup/ssh.adoc
@@ -15,10 +15,15 @@ You will reference these scripts when you xref:deep-dive/device-config-backup/dc
 
 == SSH scripting engine
 
-The scripting engine supports two commands:
+The scripting engine supports the following commands:
 
 * `send: ...`: Sends the given string to the device.
 * `await: ...`: Waits for a response from the device that matches the given string.
+* `capture:`: Marks the current position in the device's output as the start of the configuration to capture.
+  When an `await:` command matches after a `capture:`, the matched line is automatically excluded from the captured output.
+  No TFTP server or file transfer is involved; the captured bytes are stored directly.
+* `capture: <string>`: Same as `capture:`, but first waits for `<string>` to appear in the output before setting the capture start point.
+  Use this form to skip the device's echo of the preceding `send:` command.
 
 Scripts can reference the following variables by using `$\{varname}` notation:
 
@@ -64,6 +69,28 @@ send: put juniper.conf.gz juniper.conf.gz${filenameSuffix}
 await: tftp>
 send: exit
 ----
+
+=== Inline capture example
+
+Some devices support retrieving configuration output directly from the SSH session without a separate file transfer.
+The following example retrieves the running configuration from a Cisco IOS device using inline capture.
+
+[source, script]
+----
+await: #
+send: terminal length 0
+await: #
+send: show running-config
+capture: show running-config
+await: #
+----
+
+`terminal length 0` disables paging so the full configuration is returned in a single output block.
+`capture: show running-config` waits for the device to echo the command back, then starts recording the output.
+The final `await: #` waits for the prompt that signals the end of the output; the prompt line is excluded from the stored configuration.
+
+NOTE: The `filenameSuffix`, `tftpServerIp`, and `tftpServerPort` variables are not used in capture-based scripts.
+The `configType` variable is still used to identify the configuration type that is stored.
 
 == Vendor TFTP support
 

--- a/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
+++ b/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.opennms.core.concurrent.FutureUtils;
 import org.opennms.features.deviceconfig.retrieval.api.Retriever;
@@ -103,6 +104,37 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
         // set the ip address and port of the tftp server
         vs.put(SCRIPT_VAR_TFTP_SERVER_PORT, String.valueOf(tftpServer.getPort()));
         vs.put(SCRIPT_VAR_CONFIG_TYPE, configType);
+
+        // If the script contains a 'capture:' statement, capture device output inline.
+        // No file transfer (TFTP/SCP/FTP) is used — the captured bytes come back in scriptResult.capturedConfig.
+        if (scriptContainsCapture(script)) {
+            return CompletableFuture.supplyAsync(() -> {
+                SshScriptingService.Result scriptResult;
+                try {
+                    scriptResult = sshScriptingService.execute(
+                            script, user, password, authKey, target, hostKeyFingerprint, shell, vs, timeout);
+                } catch (Exception e) {
+                    var msg = scriptingFailureMsg(target, e.getMessage());
+                    LOG.error(msg, e);
+                    return Either.<Failure, Success>left(new Failure(msg));
+                }
+
+                if (scriptResult.isFailed()) {
+                    return Either.<Failure, Success>left(new Failure(
+                            scriptingFailureMsg(target, scriptResult.message),
+                            scriptResult.stdout, scriptResult.stderr, scriptResult.scriptOutput));
+                }
+
+                if (scriptResult.capturedConfig.isEmpty()) {
+                    return Either.<Failure, Success>left(new Failure(
+                            "no config captured - script must include a 'capture:' statement - target: " + target,
+                            scriptResult.stdout, scriptResult.stderr, scriptResult.scriptOutput));
+                }
+
+                return Either.<Failure, Success>right(
+                        new Success(scriptResult.capturedConfig.get(), configType, scriptResult.scriptOutput));
+            }, executor);
+        }
 
         if (protocol == Protocol.TFTP) {
             // Keep timeout common between TFTP server and scripting service
@@ -228,6 +260,12 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
                 }
             }
         }
+    }
+
+    static boolean scriptContainsCapture(String script) {
+        return Stream.of(script.split("\\\\n|\\n"))
+                .map(String::trim)
+                .anyMatch(line -> line.equals("capture:") || line.startsWith("capture:"));
     }
 
     static String scriptingFailureMsg(final SocketAddress target, String msg) {

--- a/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
+++ b/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
@@ -125,9 +125,9 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
                             scriptResult.stdout, scriptResult.stderr, scriptResult.scriptOutput));
                 }
 
-                if (scriptResult.capturedConfig.isEmpty()) {
+                if (scriptResult.capturedConfig.isEmpty() || !hasPrintableContent(scriptResult.capturedConfig.get())) {
                     return Either.<Failure, Success>left(new Failure(
-                            "Script 'capture: ' statement parsed but captured no output - target: " + target,
+                            "Script 'capture:' statement parsed but captured no output or no printable characters - target: " + target,
                             scriptResult.stdout, scriptResult.stderr, scriptResult.scriptOutput));
                 }
 
@@ -260,6 +260,15 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
                 }
             }
         }
+    }
+
+    static boolean hasPrintableContent(byte[] bytes) {
+        for (byte b : bytes) {
+            if (b >= 0x21 && b <= 0x7E) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static boolean scriptContainsCapture(String script) {

--- a/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
+++ b/features/device-config/retrieval/src/main/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImpl.java
@@ -127,7 +127,7 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
 
                 if (scriptResult.capturedConfig.isEmpty()) {
                     return Either.<Failure, Success>left(new Failure(
-                            "no config captured - script must include a 'capture:' statement - target: " + target,
+                            "Script 'capture: ' statement parsed but captured no output - target: " + target,
                             scriptResult.stdout, scriptResult.stderr, scriptResult.scriptOutput));
                 }
 
@@ -265,7 +265,7 @@ public class RetrieverImpl implements Retriever, AutoCloseable {
     static boolean scriptContainsCapture(String script) {
         return Stream.of(script.split("\\\\n|\\n"))
                 .map(String::trim)
-                .anyMatch(line -> line.equals("capture:") || line.startsWith("capture:"));
+                .anyMatch(line -> line.startsWith("capture:"));
     }
 
     static String scriptingFailureMsg(final SocketAddress target, String msg) {

--- a/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
+++ b/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
@@ -28,8 +28,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +41,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -234,6 +237,127 @@ public class RetrieverImplTest {
 
         verify(tftpServer, times(1)).unregister(receiver);
     }
+
+    // =========================================================================
+    // SSH capture tests
+    // =========================================================================
+
+    @Test
+    public void shouldRetrieveConfigViaSshCapture() throws Exception {
+        var sshScriptingService = mock(SshScriptingService.class);
+        var tftpServer = mock(TftpServer.class);
+
+        var capturedBytes = "hostname router\ninterface eth0\n".getBytes();
+        var configType = "running.cfg";
+        // Script contains 'capture:' — inline capture path is taken regardless of protocol
+        var script = "send: show running-config\ncapture:\nawait: #";
+
+        when(sshScriptingService.execute(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(SshScriptingService.Result.success("Success", "", "", "ssh-debug-output", Optional.of(capturedBytes)));
+
+        var retriever = new RetrieverImpl(sshScriptingService, tftpServer);
+
+        var future = retriever.retrieveConfig(
+                Retriever.Protocol.TFTP, script, "", "", null,
+                new InetSocketAddress("host", 22), null, null, configType,
+                Collections.emptyMap(), Duration.ofSeconds(30)
+        ).toCompletableFuture();
+
+        await().until(future::isDone);
+
+        var either = future.get();
+        assertTrue(either.isRight());
+
+        var success = either.get();
+        assertThat(success.config, is(capturedBytes));
+        assertThat(success.filename, is(configType));
+        assertThat(success.scriptOutput, is("ssh-debug-output"));
+
+        // TFTP server must not be touched when script contains capture:
+        verify(tftpServer, never()).register(any());
+        verify(tftpServer, never()).unregister(any());
+    }
+
+    @Test
+    public void shouldFailWhenCapturedConfigIsEmpty() throws Exception {
+        var sshScriptingService = mock(SshScriptingService.class);
+        var tftpServer = mock(TftpServer.class);
+
+        // Script contains capture: but SshScriptingService returns empty capturedConfig
+        var script = "capture:";
+        when(sshScriptingService.execute(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(SshScriptingService.Result.success("Success", "", "", "debug-output", Optional.empty()));
+
+        var retriever = new RetrieverImpl(sshScriptingService, tftpServer);
+
+        var future = retriever.retrieveConfig(
+                Retriever.Protocol.TFTP, script, "", "", null,
+                new InetSocketAddress("host", 22), null, null, "running.cfg",
+                Collections.emptyMap(), Duration.ofSeconds(30)
+        ).toCompletableFuture();
+
+        await().until(future::isDone);
+
+        var either = future.get();
+        assertTrue(either.isLeft());
+        assertThat(either.getLeft().message, containsString("capture:"));
+    }
+
+    @Test
+    public void shouldHandleSshScriptFailure() throws Exception {
+        var sshScriptingService = mock(SshScriptingService.class);
+        var tftpServer = mock(TftpServer.class);
+
+        var failureMessage = "auth failed";
+        var script = "capture:";
+        when(sshScriptingService.execute(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(SshScriptingService.Result.failure(failureMessage));
+
+        var retriever = new RetrieverImpl(sshScriptingService, tftpServer);
+
+        var future = retriever.retrieveConfig(
+                Retriever.Protocol.TFTP, script, "", "", null,
+                new InetSocketAddress("host", 22), null, null, "running.cfg",
+                Collections.emptyMap(), Duration.ofSeconds(30)
+        ).toCompletableFuture();
+
+        await().until(future::isDone);
+
+        var either = future.get();
+        assertTrue(either.isLeft());
+        assertThat(either.getLeft().message,
+                containsString(RetrieverImpl.scriptingFailureMsg(new InetSocketAddress("host", 22), failureMessage)));
+    }
+
+    @Test
+    public void shouldHandleSshScriptException() throws Exception {
+        var sshScriptingService = mock(SshScriptingService.class);
+        var tftpServer = mock(TftpServer.class);
+
+        var scriptingException = new RuntimeException("connection reset");
+        var script = "capture:";
+        when(sshScriptingService.execute(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenThrow(scriptingException);
+
+        var retriever = new RetrieverImpl(sshScriptingService, tftpServer);
+
+        var future = retriever.retrieveConfig(
+                Retriever.Protocol.TFTP, script, "", "", null,
+                new InetSocketAddress("host", 22), null, null, "running.cfg",
+                Collections.emptyMap(), Duration.ofSeconds(30)
+        ).toCompletableFuture();
+
+        await().until(future::isDone);
+
+        var either = future.get();
+        assertTrue(either.isLeft());
+        assertThat(either.getLeft().message,
+                containsString(RetrieverImpl.scriptingFailureMsg(new InetSocketAddress("host", 22), "connection reset")));
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
 
     private <T> T waitFor(ArgumentCaptor<T> captor) {
         return await().until(() -> captor.getValue(), t -> true);

--- a/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
+++ b/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
+++ b/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
@@ -329,6 +329,66 @@ public class RetrieverImplTest {
     }
 
     @Test
+    public void shouldFailWhenCapturedConfigHasNoPrintableContent() throws Exception {
+        var sshScriptingService = mock(SshScriptingService.class);
+        var tftpServer = mock(TftpServer.class);
+
+        var script = "capture:";
+        // Only whitespace / control characters — no printable ASCII content
+        var whitespaceOnly = new byte[]{'\n', '\r', ' ', '\t'};
+        when(sshScriptingService.execute(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(SshScriptingService.Result.success("Success", "", "", "debug-output", Optional.of(whitespaceOnly)));
+
+        var retriever = new RetrieverImpl(sshScriptingService, tftpServer);
+
+        var future = retriever.retrieveConfig(
+                Retriever.Protocol.TFTP, script, "", "", null,
+                new InetSocketAddress("host", 22), null, null, "running.cfg",
+                Collections.emptyMap(), Duration.ofSeconds(30)
+        ).toCompletableFuture();
+
+        await().until(future::isDone);
+
+        var either = future.get();
+        assertTrue(either.isLeft());
+        assertThat(either.getLeft().message, containsString("whitespace or control characters"));
+    }
+
+    // =========================================================================
+    // hasPrintableContent unit tests
+    // =========================================================================
+
+    @Test
+    public void hasPrintableContentReturnsFalseForEmptyArray() {
+        assertThat(RetrieverImpl.hasPrintableContent(new byte[]{}), is(false));
+    }
+
+    @Test
+    public void hasPrintableContentReturnsFalseForWhitespaceOnly() {
+        assertThat(RetrieverImpl.hasPrintableContent(new byte[]{' ', '\t', '\n', '\r'}), is(false));
+    }
+
+    @Test
+    public void hasPrintableContentReturnsFalseForControlsOnly() {
+        // 0x00–0x1F are control characters; 0x7F is DEL
+        assertThat(RetrieverImpl.hasPrintableContent(new byte[]{0x00, 0x01, 0x1F, 0x7F}), is(false));
+    }
+
+    @Test
+    public void hasPrintableContentReturnsTrueWhenPrintablePresent() {
+        // 'a' (0x61) is printable ASCII
+        assertThat(RetrieverImpl.hasPrintableContent(new byte[]{'\n', 'a', '\n'}), is(true));
+    }
+
+    @Test
+    public void hasPrintableContentTreatsSpaceAsNonPrintable() {
+        // 0x20 is space — whitespace, not printable by our definition
+        assertThat(RetrieverImpl.hasPrintableContent(new byte[]{0x20}), is(false));
+        // 0x21 is '!' — first printable character
+        assertThat(RetrieverImpl.hasPrintableContent(new byte[]{0x21}), is(true));
+    }
+
+    @Test
     public void shouldHandleSshScriptException() throws Exception {
         var sshScriptingService = mock(SshScriptingService.class);
         var tftpServer = mock(TftpServer.class);

--- a/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
+++ b/features/device-config/retrieval/src/test/java/org/opennms/features/deviceconfig/retrieval/impl/RetrieverImplTest.java
@@ -351,7 +351,7 @@ public class RetrieverImplTest {
 
         var either = future.get();
         assertTrue(either.isLeft());
-        assertThat(either.getLeft().message, containsString("whitespace or control characters"));
+        assertThat(either.getLeft().message, containsString("captured no output or no printable characters"));
     }
 
     // =========================================================================

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/SshScriptingService.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/SshScriptingService.java
@@ -64,36 +64,48 @@ public interface SshScriptingService {
 
         public final String scriptOutput;
 
-        private Result(final boolean success, final String message, final Optional<String> stdout, final Optional<String> stderr, String scriptOutput) {
+        /**
+         * Config bytes captured via a {@code capture:} statement in the script.
+         * Present only when the script contained a {@code capture:} statement and
+         * the script executed successfully.
+         */
+        public final Optional<byte[]> capturedConfig;
+
+        private Result(final boolean success, final String message, final Optional<String> stdout, final Optional<String> stderr, String scriptOutput, Optional<byte[]> capturedConfig) {
             this.success = success;
             this.message = message;
             this.stdout = stdout;
             this.stderr = stderr;
             this.scriptOutput = scriptOutput;
+            this.capturedConfig = capturedConfig;
+        }
+
+        public static Result success(final String message, final String stdout, final String stderr, String scriptOutput, Optional<byte[]> capturedConfig) {
+            return new Result(true, message, Optional.of(stdout), Optional.of(stderr), scriptOutput, capturedConfig);
         }
 
         public static Result success(final String message, final String stdout, final String stderr, String scriptOutput) {
-            return new Result(true, message, Optional.of(stdout), Optional.of(stderr), scriptOutput);
+            return new Result(true, message, Optional.of(stdout), Optional.of(stderr), scriptOutput, Optional.empty());
         }
 
         public static Result success(final String message, final String stdout, final String stderr) {
-            return new Result(true, message, Optional.of(stdout), Optional.of(stderr), "");
+            return new Result(true, message, Optional.of(stdout), Optional.of(stderr), "", Optional.empty());
         }
 
         public static Result success(final String message) {
-            return new Result(true, message, Optional.empty(), Optional.empty(), "");
+            return new Result(true, message, Optional.empty(), Optional.empty(), "", Optional.empty());
         }
 
         public static Result failure(final String message, final String stdout, final String stderr, String scriptOutput) {
-            return new Result(false, message, Optional.of(stdout), Optional.of(stderr), scriptOutput);
+            return new Result(false, message, Optional.of(stdout), Optional.of(stderr), scriptOutput, Optional.empty());
         }
 
         public static Result failure(final String message, final String stdout, final String stderr) {
-            return new Result(false, message, Optional.of(stdout), Optional.of(stderr), "");
+            return new Result(false, message, Optional.of(stdout), Optional.of(stderr), "", Optional.empty());
         }
 
         public static Result failure(final String message) {
-            return new Result(false, message, Optional.empty(), Optional.empty(), "");
+            return new Result(false, message, Optional.empty(), Optional.empty(), "", Optional.empty());
         }
 
         public boolean isSuccess() {

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshInteraction.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshInteraction.java
@@ -27,6 +27,23 @@ public interface SshInteraction {
 
     void await(String string) throws Exception;
 
+    /**
+     * Marks the current position in the SSH session's stdout stream as the start of the
+     * device configuration capture.  All output received after this point (up to the end
+     * of the script) is returned in {@link org.opennms.features.deviceconfig.sshscripting.SshScriptingService.Result#capturedConfig}.
+     */
+    void startCapture() throws Exception;
+
+    /**
+     * Awaits the given string in the session output, then atomically marks the position
+     * immediately after the match as the capture start point.  Unlike calling
+     * {@link #await(String)} followed by {@link #startCapture()}, this method sets the
+     * capture position while still holding the internal lock on the await buffer, so bytes
+     * that arrive between the match and the capture-point record cannot push the start past
+     * the actual config output.
+     */
+    void awaitAndCapture(String string) throws Exception;
+
     String replaceVars(String string);
 
 }

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
@@ -425,16 +425,7 @@ public class SshScriptingServiceImpl implements SshScriptingService {
             if (captureStart < 0) {
                 return Optional.empty();
             }
-            var allBytes = stdout.toByteArray();
-            int end = (captureEnd >= captureStart) ? captureEnd : allBytes.length;
-            // Trim backwards to the preceding newline so the prompt line that triggered
-            // captureEnd is fully excluded, not just the matched substring within it.
-            // e.g. await: # on "router#" leaves captureEnd before '#'; trimming removes
-            // "router" too, ending the capture at the '\n' before the prompt line.
-            while (end > captureStart && allBytes[end - 1] != (byte) 0x0A) { // 0x0A == \n
-                end--;
-            }
-            return Optional.of(Arrays.copyOfRange(allBytes, captureStart, end));
+            return Optional.of(SshScriptingServiceImpl.extractCapturedBytes(stdout.toByteArray(), captureStart, captureEnd));
         }
 
         String getDebugOutput() {
@@ -445,6 +436,23 @@ public class SshScriptingServiceImpl implements SshScriptingService {
                 return debugOutput.toString(StandardCharsets.UTF_8);
             }
         }
+    }
+
+    /**
+     * Extracts the captured bytes from a stdout snapshot.
+     * <p>
+     * When {@code captureEnd >= captureStart} it marks the position in stdout just before the
+     * last awaited string (e.g. a device prompt); the method scans backwards from that point to
+     * the preceding {@code 0x0A} so the entire prompt line is excluded, not only the matched
+     * substring.  When {@code captureEnd < captureStart} (still -1 because no await fired after
+     * capture) the full tail of the buffer from {@code captureStart} is returned.
+     */
+    static byte[] extractCapturedBytes(byte[] allBytes, int captureStart, int captureEnd) {
+        int end = (captureEnd >= captureStart) ? captureEnd : allBytes.length;
+        while (end > captureStart && allBytes[end - 1] != (byte) 0x0A) {
+            end--;
+        }
+        return Arrays.copyOfRange(allBytes, captureStart, end);
     }
 
     static boolean matchAndConsume(ByteArrayOutputStream awaitStdout, byte[] search) {

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImpl.java
@@ -35,8 +35,10 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.output.TeeOutputStream;
@@ -127,7 +129,12 @@ public class SshScriptingServiceImpl implements SshScriptingService {
                                 scriptDebugOutput = sshInteraction.getDebugOutput();
                                 prevStatement = statement;
                             }
-                            return Result.success("Script execution succeeded",  sshInteraction.stdout.toString(StandardCharsets.UTF_8),  sshInteraction.stderr.toString(StandardCharsets.UTF_8), sshInteraction.getDebugOutput());
+                            var capturedConfig = sshInteraction.getCapturedConfig();
+                            return Result.success("Script execution succeeded",
+                                    sshInteraction.stdout.toString(StandardCharsets.UTF_8),
+                                    sshInteraction.stderr.toString(StandardCharsets.UTF_8),
+                                    sshInteraction.getDebugOutput(),
+                                    capturedConfig);
                         }
                     } catch (Exception e) {
                         LOG.error("error with ssh interactions", e);
@@ -187,6 +194,16 @@ public class SshScriptingServiceImpl implements SshScriptingService {
         private final Instant timeoutInstant;
 
         private final boolean disableIOCollection;
+
+        /** Byte offset into {@code stdout} at which capture was started; -1 means not capturing. */
+        private int captureStart = -1;
+        /**
+         * Byte offset into {@code stdout} just before the last awaited string that ran while capture
+         * was active. -1 means use the full end of stdout. Updated by every {@link #await} call that
+         * fires after {@link #startCapture} or {@link #awaitAndCapture}, so the terminal prompt that
+         * the script waits on is automatically excluded from the captured config bytes.
+         */
+        private int captureEnd = -1;
 
         private SshInteractionImpl(
                 String user,
@@ -340,6 +357,42 @@ public class SshScriptingServiceImpl implements SshScriptingService {
             while (Instant.now().isBefore(timeoutInstant)) {
                 synchronized (awaitStdout) {
                     if (matchAndConsume(awaitStdout, search)) {
+                        if (captureStart >= 0) {
+                            // The awaited string (e.g. a prompt) marks the end of the interesting
+                            // output. Record the position just before it so the prompt is excluded
+                            // from the captured config bytes. Updated on every await while capture
+                            // is active, so the last awaited prompt wins.
+                            captureEnd = stdout.size() - awaitStdout.size() - search.length;
+                        }
+                        if (!disableIOCollection) {
+                            debugOutput.write(debugStderr.toString().getBytes(StandardCharsets.UTF_8));
+                            debugOutput.write(debugStdout.toString().getBytes(StandardCharsets.UTF_8));
+                        }
+                        debugStdout.reset();
+                        debugStderr.reset();
+                        return;
+                    }
+                }
+                Thread.sleep(1000);
+            }
+            if (!disableIOCollection) {
+                debugOutput.write(debugStderr.toString().getBytes(StandardCharsets.UTF_8));
+                debugOutput.write(debugStdout.toString().getBytes(StandardCharsets.UTF_8));
+            }
+            throw new Exception("awaited output missing - expected: " + string);
+        }
+
+        @Override
+        public void awaitAndCapture(String string) throws Exception {
+            var search = string.getBytes(StandardCharsets.UTF_8);
+            while (Instant.now().isBefore(timeoutInstant)) {
+                synchronized (awaitStdout) {
+                    if (matchAndConsume(awaitStdout, search)) {
+                        // Set the capture point while still holding the lock so no incoming
+                        // bytes can widen the gap between the match position and captureStart.
+                        // stdout.size() - awaitStdout.size() is the position in stdout right
+                        // after the consumed match string.
+                        captureStart = stdout.size() - awaitStdout.size();
                         if (!disableIOCollection) {
                             debugOutput.write(debugStderr.toString().getBytes(StandardCharsets.UTF_8));
                             debugOutput.write(debugStdout.toString().getBytes(StandardCharsets.UTF_8));
@@ -361,6 +414,27 @@ public class SshScriptingServiceImpl implements SshScriptingService {
         @Override
         public String replaceVars(String string) {
             return StrSubstitutor.replace(string, vars);
+        }
+
+        @Override
+        public void startCapture() {
+            captureStart = stdout.size();
+        }
+
+        Optional<byte[]> getCapturedConfig() {
+            if (captureStart < 0) {
+                return Optional.empty();
+            }
+            var allBytes = stdout.toByteArray();
+            int end = (captureEnd >= captureStart) ? captureEnd : allBytes.length;
+            // Trim backwards to the preceding newline so the prompt line that triggered
+            // captureEnd is fully excluded, not just the matched substring within it.
+            // e.g. await: # on "router#" leaves captureEnd before '#'; trimming removes
+            // "router" too, ending the capture at the '\n' before the prompt line.
+            while (end > captureStart && allBytes[end - 1] != (byte) 0x0A) { // 0x0A == \n
+                end--;
+            }
+            return Optional.of(Arrays.copyOfRange(allBytes, captureStart, end));
         }
 
         String getDebugOutput() {

--- a/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/Statement.java
+++ b/features/device-config/ssh-scripting/src/main/java/org/opennms/features/deviceconfig/sshscripting/impl/Statement.java
@@ -89,6 +89,34 @@ class Statement {
             public void execute(SshInteraction interaction, String string) throws Exception {
                 interaction.await(string);
             }
+        }, capture {
+            /**
+             * {@code capture:} may optionally take a string argument.
+             * With no argument ({@code capture:}), capture starts immediately at the current stdout position.
+             * With an argument ({@code capture: show running-config}), the argument is first awaited
+             * (consuming the device's echo of the preceding send: command), then capture starts —
+             * so the echoed command line is excluded from the captured bytes.
+             */
+            @Override
+            public Statement parse(String line) {
+                if (line.equals(name() + ":")) {
+                    return new Statement(this, "");
+                }
+                if (line.startsWith(name() + ":")) {
+                    var arg = line.substring(name().length() + 1).trim();
+                    return new Statement(this, arg);
+                }
+                return null;
+            }
+
+            @Override
+            public void execute(SshInteraction interaction, String string) throws Exception {
+                if (!string.isEmpty()) {
+                    interaction.awaitAndCapture(string);
+                } else {
+                    interaction.startCapture();
+                }
+            }
         };
 
         public Statement parse(String line) {

--- a/features/device-config/ssh-scripting/src/test/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImplIT.java
+++ b/features/device-config/ssh-scripting/src/test/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImplIT.java
@@ -22,7 +22,9 @@
 package org.opennms.features.deviceconfig.sshscripting.impl;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -206,6 +208,55 @@ public class SshScriptingServiceImplIT {
                                                                                       List.of(AuthorizedKeyEntry.parseAuthorizedKeyEntry(AUTH_KEY_PUB), AuthorizedKeyEntry.parseAuthorizedKeyEntry(AUTH_KEY_PUB_ED25519)),
                                                                                       null));
         sshd.start();
+    }
+
+    /**
+     * {@code capture:} (bare form): capture starts at the current stdout position, after the
+     * command echo has already been consumed by an explicit {@code await:}.  The captured output
+     * should contain the config lines sent after the capture marker and must not include the
+     * command echo or the trailing prompt.
+     */
+    @Test
+    public void capturesBareForm() {
+        var result = execute(
+                "send: show running-config",
+                "await: show running-config",
+                "capture:",
+                "send: interface eth0",
+                "send: router#",
+                "await: router#"
+        );
+        assertThat(result.isSuccess(), is(true));
+        assertThat(result.capturedConfig.isPresent(), is(true));
+        var captured = new String(result.capturedConfig.get(), StandardCharsets.UTF_8);
+        assertThat(captured, is("interface eth0\n"));
+        assertThat(captured, not(containsString("show running-config")));
+        assertThat(captured, not(containsString("router#")));
+    }
+
+    /**
+     * {@code capture: <string>} form: the argument is awaited via {@link
+     * org.opennms.features.deviceconfig.sshscripting.impl.SshInteraction#awaitAndCapture} which
+     * sets the capture start atomically inside the await lock.  This means the command echo is
+     * excluded from the captured output even if the full config arrives before the next polling
+     * interval.  The captured output must contain the config lines and must not include the
+     * command echo or the trailing prompt.
+     */
+    @Test
+    public void capturesWithArgument() {
+        var result = execute(
+                "send: show running-config",
+                "capture: show running-config",
+                "send: interface eth0",
+                "send: router#",
+                "await: router#"
+        );
+        assertThat(result.isSuccess(), is(true));
+        assertThat(result.capturedConfig.isPresent(), is(true));
+        var captured = new String(result.capturedConfig.get(), StandardCharsets.UTF_8);
+        assertThat(captured, containsString("interface eth0"));
+        assertThat(captured, not(containsString("show running-config")));
+        assertThat(captured, not(containsString("router#")));
     }
 
     public void testIpAddresses() throws Exception {

--- a/features/device-config/ssh-scripting/src/test/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImplTest.java
+++ b/features/device-config/ssh-scripting/src/test/java/org/opennms/features/deviceconfig/sshscripting/impl/SshScriptingServiceImplTest.java
@@ -23,13 +23,58 @@ package org.opennms.features.deviceconfig.sshscripting.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opennms.features.deviceconfig.sshscripting.impl.SshScriptingServiceImpl.extractCapturedBytes;
 import static org.opennms.features.deviceconfig.sshscripting.impl.SshScriptingServiceImpl.matchAndConsume;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
 public class SshScriptingServiceImplTest {
+
+    // =========================================================================
+    // extractCapturedBytes — unit tests for awaitAndCapture capture semantics
+    // =========================================================================
+
+    @Test
+    public void extractCapturedBytesReturnsFullTailWhenNoCaptureEnd() {
+        // captureEnd == -1: no await fired after capture, return everything from captureStart
+        var allBytes = "config data\n".getBytes(StandardCharsets.UTF_8);
+        var result = extractCapturedBytes(allBytes, 0, -1);
+        assertThat(new String(result, StandardCharsets.UTF_8), is("config data\n"));
+    }
+
+    @Test
+    public void extractCapturedBytesExcludesPromptLineWhenCaptureEndAtLineStart() {
+        // captureEnd points right to the start of the prompt line (just after the preceding \n)
+        // allBytes = "config data\nrouter#\n" — captureEnd=12 is the 'r' of "router#"
+        var allBytes = "config data\nrouter#\n".getBytes(StandardCharsets.UTF_8);
+        // allBytes[11]='\n', allBytes[12]='r' — captureEnd=12 → scan stops immediately at allBytes[11]
+        var result = extractCapturedBytes(allBytes, 0, 12);
+        assertThat(new String(result, StandardCharsets.UTF_8), is("config data\n"));
+    }
+
+    @Test
+    public void extractCapturedBytesScanBackToNewlineWhenCaptureEndMidLine() {
+        // captureEnd points mid-prompt-line (e.g. await: # on "router#");
+        // the backwards scan must remove the entire "router" prefix too
+        var allBytes = "config data\nrouter#\n".getBytes(StandardCharsets.UTF_8);
+        // allBytes: ...a(10)\n(11)r(12)o(13)u(14)t(15)e(16)r(17)#(18)\n(19)
+        // captureEnd=18 ('r' before '#') → scan: 17='r',16='e',...,12='r',11='\n' → end=12
+        var result = extractCapturedBytes(allBytes, 0, 18);
+        assertThat(new String(result, StandardCharsets.UTF_8), is("config data\n"));
+    }
+
+    @Test
+    public void extractCapturedBytesIsEmptyWhenCaptureStartEqualsEnd() {
+        // captureStart == captureEnd: nothing arrived between capture and the prompt
+        var allBytes = "router#\n".getBytes(StandardCharsets.UTF_8);
+        var result = extractCapturedBytes(allBytes, 0, 0);
+        assertThat(result.length, is(0));
+    }
+
+    // =========================================================================
 
     @Test
     public void testMatchAndConsume() throws Exception {

--- a/features/device-config/ssh-scripting/src/test/java/org/opennms/features/deviceconfig/sshscripting/impl/StatementTest.java
+++ b/features/device-config/ssh-scripting/src/test/java/org/opennms/features/deviceconfig/sshscripting/impl/StatementTest.java
@@ -22,6 +22,7 @@
 package org.opennms.features.deviceconfig.sshscripting.impl;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -48,6 +49,37 @@ public class StatementTest {
         assertThat(either.get().get(0).string, is("abc"));
         assertThat(either.get().get(1).statementType, is(Statement.StatementType.await));
         assertThat(either.get().get(1).string, is("123"));
+    }
+
+    @Test
+    public void parsesCapture() {
+        var stmt = Statement.parseStatement("capture:");
+        assertThat(stmt, notNullValue());
+        assertThat(stmt.statementType, is(Statement.StatementType.capture));
+    }
+
+    @Test
+    public void parsesScriptWithCapture() {
+        var either = Statement.parseScript("send: show running-config\ncapture:\nawait: #");
+        assertThat(either.isRight(), is(true));
+        assertThat(either.get().size(), is(3));
+        assertThat(either.get().get(0).statementType, is(Statement.StatementType.send));
+        assertThat(either.get().get(1).statementType, is(Statement.StatementType.capture));
+        assertThat(either.get().get(2).statementType, is(Statement.StatementType.await));
+    }
+
+    @Test
+    public void captureWithArgument() {
+        var stmt = Statement.parseStatement("capture: show running-config");
+        assertThat(stmt, notNullValue());
+        assertThat(stmt.statementType, is(Statement.StatementType.capture));
+        assertThat(stmt.string, is("show running-config"));
+    }
+
+    @Test
+    public void captureWithoutColonIsNotRecognized() {
+        var stmt = Statement.parseStatement("capture");
+        assertThat(stmt, org.hamcrest.CoreMatchers.nullValue());
     }
 
 }


### PR DESCRIPTION
Adds a `capture: ` DCB DSL statement that can be used to scrape the config out of the SSH session output without pushing it via TFTP.

Tested locally using a dcb script of:
```
await: ]$
send: cat /etc/hosts
await: ]$
send: cat /etc/snmp/snmpd.conf
capture: cat /etc/snmp/snmpd.conf
await: ]$
```
Only the output of `cat /etc/snmp/snmpd.conf` is captured as the configuration in this case.  

Bare `capture: ` with no args will capture everything from that point to the end of the output.  I think both cases are useful.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19754

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

