### PR TITLE
NMS-19723: Mask credentials for Trapd config Rest API and UI

### DIFF
--- a/features/config/test/src/test/java/org/opennms/features/config/service/config/FakeXsdForTest.java
+++ b/features/config/test/src/test/java/org/opennms/features/config/service/config/FakeXsdForTest.java
@@ -41,7 +41,7 @@ import org.opennms.netmgt.config.trapd.Snmpv3User;
  */
 @XmlRootElement(name = "trapd-configuration")
 @XmlAccessorType(XmlAccessType.NONE)
-@ValidateUsing("trapd-configuration.xsd")
+@ValidateUsing("trapd-configuration-1.1.xsd")
 @SuppressWarnings("all")
 public class FakeXsdForTest implements Serializable {
     private static final long serialVersionUID = 2;

--- a/features/config/upgrade/pom.xml
+++ b/features/config/upgrade/pom.xml
@@ -77,14 +77,13 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
-        <!-- tests -->
         <dependency>
             <groupId>org.opennms.features.config.service</groupId>
             <artifactId>org.opennms.features.config.service.impl</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
+
+        <!-- tests -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/features/config/upgrade/src/main/java/org/opennms/config/upgrade/TrapdSnmpv3UserIdBackfill.java
+++ b/features/config/upgrade/src/main/java/org/opennms/config/upgrade/TrapdSnmpv3UserIdBackfill.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.config.upgrade;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.opennms.features.config.dao.api.ConfigDefinition;
+import org.opennms.features.config.service.api.ConfigurationManagerService;
+import org.opennms.features.config.service.api.JsonAsString;
+import org.opennms.features.config.service.util.ConfigConvertUtil;
+import org.opennms.netmgt.config.trapd.TrapdConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One-time, idempotent backfill of server-assigned ids onto trapd SNMPv3 users
+ * that predate the id feature (NMS-19723). Runs at every startup from
+ * {@link UpgradeConfigService} after the CM changelog has applied the v1.1
+ * trapd schema. Fills only id-less users, so it is a no-op once every user has
+ * an id (and self-repairs an id-less config restored after a DB reset on the
+ * next boot). New users added at runtime are stamped by
+ * DefaultTrapdConfigDao.replaceConfig(), not here.
+ */
+public class TrapdSnmpv3UserIdBackfill {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TrapdSnmpv3UserIdBackfill.class);
+
+    static final String CONFIG_NAME = "trapd-config";
+
+    private final ConfigurationManagerService cm;
+
+    public TrapdSnmpv3UserIdBackfill(final ConfigurationManagerService cm) {
+        this.cm = Objects.requireNonNull(cm);
+    }
+
+    /**
+     * @return {@code true} if at least one id was assigned and the config was
+     *         persisted; {@code false} if there was nothing to do.
+     */
+    public boolean execute() {
+        final Optional<String> json = cm.getJSONStrConfiguration(CONFIG_NAME, ConfigDefinition.DEFAULT_CONFIG_ID);
+        if (json.isEmpty()) {
+            LOG.debug("No trapd configuration registered in CM; skipping SNMPv3 user id backfill.");
+            return false;
+        }
+
+        final TrapdConfiguration config = ConfigConvertUtil.jsonToObject(json.get(), TrapdConfiguration.class);
+        if (config == null || !config.ensureSnmpv3UserIds()) {
+            return false;
+        }
+
+        cm.updateConfiguration(CONFIG_NAME, ConfigDefinition.DEFAULT_CONFIG_ID,
+                new JsonAsString(ConfigConvertUtil.objectToJson(config)), true);
+        LOG.info("Backfilled ids onto trapd SNMPv3 user(s) lacking one.");
+        return true;
+    }
+}

--- a/features/config/upgrade/src/main/java/org/opennms/config/upgrade/TrapdSnmpv3UserIdBackfill.java
+++ b/features/config/upgrade/src/main/java/org/opennms/config/upgrade/TrapdSnmpv3UserIdBackfill.java
@@ -45,8 +45,6 @@ public class TrapdSnmpv3UserIdBackfill {
 
     private static final Logger LOG = LoggerFactory.getLogger(TrapdSnmpv3UserIdBackfill.class);
 
-    static final String CONFIG_NAME = "trapd-config";
-
     private final ConfigurationManagerService cm;
 
     public TrapdSnmpv3UserIdBackfill(final ConfigurationManagerService cm) {
@@ -58,7 +56,7 @@ public class TrapdSnmpv3UserIdBackfill {
      *         persisted; {@code false} if there was nothing to do.
      */
     public boolean execute() {
-        final Optional<String> json = cm.getJSONStrConfiguration(CONFIG_NAME, ConfigDefinition.DEFAULT_CONFIG_ID);
+        final Optional<String> json = cm.getJSONStrConfiguration(TrapdConfiguration.CM_CONFIG_NAME, ConfigDefinition.DEFAULT_CONFIG_ID);
         if (json.isEmpty()) {
             LOG.debug("No trapd configuration registered in CM; skipping SNMPv3 user id backfill.");
             return false;
@@ -69,7 +67,7 @@ public class TrapdSnmpv3UserIdBackfill {
             return false;
         }
 
-        cm.updateConfiguration(CONFIG_NAME, ConfigDefinition.DEFAULT_CONFIG_ID,
+        cm.updateConfiguration(TrapdConfiguration.CM_CONFIG_NAME, ConfigDefinition.DEFAULT_CONFIG_ID,
                 new JsonAsString(ConfigConvertUtil.objectToJson(config)), true);
         LOG.info("Backfilled ids onto trapd SNMPv3 user(s) lacking one.");
         return true;

--- a/features/config/upgrade/src/main/java/org/opennms/config/upgrade/UpgradeConfigService.java
+++ b/features/config/upgrade/src/main/java/org/opennms/config/upgrade/UpgradeConfigService.java
@@ -69,11 +69,27 @@ public class UpgradeConfigService implements InitializingBean {
             // whichever subsystem's MDC prefix happens to be active on Main.
             try (Logging.MDCCloseable ignored = Logging.withPrefixCloseable("manager")) {
                 new LiquibaseUpgrader(cm).runChangelog("changelog-cm/changelog-cm.xml", dataSource.getConnection());
+                backfillTrapdSnmpv3UserIds();
                 migrateSnmpDataCollection();
                 // Must run after the migration so first-boot imports are seen
                 // (single-boot convergence for every install type).
                 applySnmpDataCollectionDefaultUpdates();
             }
+        }
+    }
+
+    /**
+     * Assign stable ids to any pre-existing trapd SNMPv3 user that lacks one
+     * (NMS-19723). Idempotent — a no-op once every user has an id.
+     */
+    private void backfillTrapdSnmpv3UserIds() {
+        try {
+            final boolean changed = new TrapdSnmpv3UserIdBackfill(cm).execute();
+            if (changed) {
+                LOG.info("Assigned ids to trapd SNMPv3 user(s) that lacked one.");
+            }
+        } catch (final Exception e) {
+            LOG.error("Trapd SNMPv3 user id backfill failed: {}", e.getMessage(), e);
         }
     }
 

--- a/features/config/upgrade/src/main/resources/changelog-cm/36.0.0/changelog-cm.xml
+++ b/features/config/upgrade/src/main/resources/changelog-cm/36.0.0/changelog-cm.xml
@@ -18,4 +18,13 @@
         <cm:importConfig schemaId="trapd-config" filePath="trapd-configuration.xml"/>
     </changeSet>
 
+    <changeSet author="stheleman" id="36.0.0-upgrade-schema-trapd-config-1.1">
+        <!-- Upgrades the trapd-config schema to v1.1, adding the optional 'id' attribute to
+             snmpv3-user (NMS-19723). The v1.0 register changeSet above stays byte-for-byte as
+             shipped; this new changeSet is the only place the id-bearing schema is introduced.
+             Fresh installs run register (v1.0) then this upgrade (v1.1); existing 36.0.x installs
+             run only this changeSet. -->
+        <cm:importSchemaFromXsd id="trapd-config" xsdFileName="trapd-configuration-1.1.xsd" xsdFileHash="ac286bc4218126caec9417a20fb71bf957ce78810379a4fe29654dc31a68807f" rootElement="trapd-configuration"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/features/config/upgrade/src/main/resources/changelog-cm/36.0.0/changelog-cm.xml
+++ b/features/config/upgrade/src/main/resources/changelog-cm/36.0.0/changelog-cm.xml
@@ -24,7 +24,7 @@
              shipped; this new changeSet is the only place the id-bearing schema is introduced.
              Fresh installs run register (v1.0) then this upgrade (v1.1); existing 36.0.x installs
              run only this changeSet. -->
-        <cm:importSchemaFromXsd id="trapd-config" xsdFileName="trapd-configuration-1.1.xsd" xsdFileHash="ac286bc4218126caec9417a20fb71bf957ce78810379a4fe29654dc31a68807f" rootElement="trapd-configuration"/>
+        <cm:importSchemaFromXsd id="trapd-config" xsdFileName="trapd-configuration-1.1.xsd" xsdFileHash="d5fdc5b97d8ae35c9ff47f54f4975d3d6ae0e455a8da1ff0e7436bf699dae232" rootElement="trapd-configuration"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/features/config/upgrade/src/test/java/liquibase/ext2/cm/change/TrapdSchemaHashTest.java
+++ b/features/config/upgrade/src/test/java/liquibase/ext2/cm/change/TrapdSchemaHashTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package liquibase.ext2.cm.change;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+/**
+ * Tripwire: the SHA-256 hashes below MUST match the xsdFileHash values in
+ * changelog-cm/36.0.0/changelog-cm.xml for the trapd-config changeSets. If a
+ * trapd schema file changes, update both the changelog and this test in the
+ * same change (NMS-19723).
+ */
+public class TrapdSchemaHashTest {
+
+    private static final String TRAPD_V1_0_HASH =
+            "ad97a001cd7ebb8a8b1a45574ba4e681e204ecf8592bf264764d4d7f52efc7a1";
+    private static final String TRAPD_V1_1_HASH =
+            "ac286bc4218126caec9417a20fb71bf957ce78810379a4fe29654dc31a68807f";
+
+    @Test
+    public void trapdV10SchemaHashMatchesChangelog() throws IOException {
+        assertEquals(TRAPD_V1_0_HASH, HashUtil.getHash("trapd-configuration.xsd"));
+    }
+
+    @Test
+    public void trapdV11SchemaHashMatchesChangelog() throws IOException {
+        assertEquals(TRAPD_V1_1_HASH, HashUtil.getHash("trapd-configuration-1.1.xsd"));
+    }
+}

--- a/features/config/upgrade/src/test/java/liquibase/ext2/cm/change/TrapdSchemaHashTest.java
+++ b/features/config/upgrade/src/test/java/liquibase/ext2/cm/change/TrapdSchemaHashTest.java
@@ -38,7 +38,7 @@ public class TrapdSchemaHashTest {
     private static final String TRAPD_V1_0_HASH =
             "ad97a001cd7ebb8a8b1a45574ba4e681e204ecf8592bf264764d4d7f52efc7a1";
     private static final String TRAPD_V1_1_HASH =
-            "ac286bc4218126caec9417a20fb71bf957ce78810379a4fe29654dc31a68807f";
+            "d5fdc5b97d8ae35c9ff47f54f4975d3d6ae0e455a8da1ff0e7436bf699dae232";
 
     @Test
     public void trapdV10SchemaHashMatchesChangelog() throws IOException {

--- a/features/config/upgrade/src/test/java/org/opennms/config/upgrade/TrapdSnmpv3UserIdBackfillIT.java
+++ b/features/config/upgrade/src/test/java/org/opennms/config/upgrade/TrapdSnmpv3UserIdBackfillIT.java
@@ -61,7 +61,7 @@ import org.springframework.test.context.TestExecutionListeners;
 @JUnitTemporaryDatabase
 public class TrapdSnmpv3UserIdBackfillIT implements TemporaryDatabaseAware<TemporaryDatabase> {
 
-    private static final String CONFIG_NAME = "trapd-config";
+    private static final String CONFIG_NAME = TrapdConfiguration.CM_CONFIG_NAME;
 
     @Autowired
     private ConfigurationManagerService cm;

--- a/features/config/upgrade/src/test/java/org/opennms/config/upgrade/TrapdSnmpv3UserIdBackfillIT.java
+++ b/features/config/upgrade/src/test/java/org/opennms/config/upgrade/TrapdSnmpv3UserIdBackfillIT.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.config.upgrade;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.opennms.features.config.dao.api.ConfigDefinition.DEFAULT_CONFIG_ID;
+
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.TemporaryDatabase;
+import org.opennms.core.test.db.TemporaryDatabaseAware;
+import org.opennms.core.test.db.TemporaryDatabaseExecutionListener;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.features.config.dao.api.ConfigDefinition;
+import org.opennms.features.config.dao.api.ConfigConverter;
+import org.opennms.features.config.dao.impl.util.XsdHelper;
+import org.opennms.features.config.service.api.ConfigurationManagerService;
+import org.opennms.features.config.service.api.JsonAsString;
+import org.opennms.features.config.service.util.ConfigConvertUtil;
+import org.opennms.netmgt.config.trapd.TrapdConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@TestExecutionListeners({TemporaryDatabaseExecutionListener.class})
+@ContextConfiguration(locations = {
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-config-service.xml"})
+@JUnitTemporaryDatabase
+public class TrapdSnmpv3UserIdBackfillIT implements TemporaryDatabaseAware<TemporaryDatabase> {
+
+    private static final String CONFIG_NAME = "trapd-config";
+
+    @Autowired
+    private ConfigurationManagerService cm;
+
+    private DataSource dataSource;
+
+    @Override
+    public void setTemporaryDatabase(TemporaryDatabase database) {
+        this.dataSource = database;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        final ConfigDefinition def = XsdHelper.buildConfigDefinition(
+                CONFIG_NAME, "trapd-configuration-1.1.xsd", "trapd-configuration",
+                ConfigurationManagerService.BASE_PATH);
+        cm.registerConfigDefinition(CONFIG_NAME, def);
+
+        final ConfigDefinition registered = cm.getRegisteredConfigDefinition(CONFIG_NAME).get();
+        final ConfigConverter converter = XsdHelper.getConverter(registered);
+        final String xml = "<trapd-configuration snmp-trap-port=\"162\" new-suspect-on-trap=\"false\">"
+                + "<snmpv3-user security-name=\"opennms\"/>"
+                + "</trapd-configuration>";
+        cm.registerConfiguration(CONFIG_NAME, DEFAULT_CONFIG_ID, new JsonAsString(converter.xmlToJson(xml)));
+    }
+
+    @After
+    public void tearDown() {
+        if (cm.getRegisteredConfigDefinition(CONFIG_NAME).isPresent()) {
+            cm.unregisterSchema(CONFIG_NAME);
+        }
+    }
+
+    private TrapdConfiguration reload() {
+        final Optional<String> json = cm.getJSONStrConfiguration(CONFIG_NAME, DEFAULT_CONFIG_ID);
+        assertTrue(json.isPresent());
+        return ConfigConvertUtil.jsonToObject(json.get(), TrapdConfiguration.class);
+    }
+
+    @Test
+    public void assignsIdsToExistingUsersAndPersists() {
+        assertTrue(new TrapdSnmpv3UserIdBackfill(cm).execute());
+
+        final TrapdConfiguration cfg = reload();
+        final String id = cfg.getSnmpv3User(0).getId();
+        assertNotNull("id must be assigned", id);
+        assertFalse("id must not be blank", id.trim().isEmpty());
+    }
+
+    @Test
+    public void isIdempotent() {
+        assertTrue(new TrapdSnmpv3UserIdBackfill(cm).execute());
+        final String firstId = reload().getSnmpv3User(0).getId();
+
+        assertFalse("second run must report no change", new TrapdSnmpv3UserIdBackfill(cm).execute());
+        assertEquals("id must be stable across runs", firstId, reload().getSnmpv3User(0).getId());
+    }
+
+    @Test
+    public void returnsFalseWhenNoConfigPresent() {
+        // XsdHelper.buildConfigDefinition() registers this schema with allowMultiple=false,
+        // so CM refuses to delete the sole config instance (JsonConfigStoreDaoImpl throws
+        // "Deletion of the last config is not allowed"). Unregister the whole schema instead
+        // to genuinely simulate "no trapd configuration present in CM".
+        cm.unregisterSchema(CONFIG_NAME);
+        assertFalse(new TrapdSnmpv3UserIdBackfill(cm).execute());
+    }
+}

--- a/features/scv/api/src/main/java/org/opennms/features/scv/utils/ScvUtils.java
+++ b/features/scv/api/src/main/java/org/opennms/features/scv/utils/ScvUtils.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 public class ScvUtils {
@@ -39,6 +40,29 @@ public class ScvUtils {
     public static final String KEYSTORE_KEY_PROPERTY = "org.opennms.features.scv.jceks.key";
     public static final String OPENNMS_PROPERTIES_D_NAME = "opennms.properties.d";
     public static final String OPENNMS_PROPERTIES_NAME = "opennms.properties";
+
+    /**
+     * Matches a whole SCV metadata reference of the form
+     * {@code ${scv:alias:key|default}}. Mirrors the SCV_REGEX / SCV_SUBKEY rules in
+     * ui/src/lib/scvValidator.ts:
+     * <ul>
+     *   <li>alias   = [a-zA-Z0-9_] optionally followed by [a-zA-Z0-9_.-]* and a trailing [a-zA-Z0-9_]</li>
+     *   <li>:key    = same format, optional</li>
+     *   <li>|default = any chars except | and }, optional</li>
+     * </ul>
+     */
+    public static final Pattern SCV_EXPRESSION_PATTERN = Pattern.compile(
+            "^\\$\\{scv:[a-zA-Z0-9_](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9_])?" +
+            "(?::[a-zA-Z0-9_](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9_])?)?" +
+            "(?:\\|[^|}]+)?\\}$");
+
+    /**
+     * @return {@code true} if {@code value} is a well-formed SCV expression
+     *         ({@code ${scv:...}}); {@code false} for {@code null} or any other value.
+     */
+    public static boolean isScvExpression(final String value) {
+        return value != null && SCV_EXPRESSION_PATTERN.matcher(value).matches();
+    }
 
     /**
      * Loads SCV-related properties from system properties first if not found in system properties,

--- a/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/trapd/Snmpv3User.java
+++ b/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/trapd/Snmpv3User.java
@@ -37,82 +37,88 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class Snmpv3User implements java.io.Serializable {
 	private static final long serialVersionUID = 61220221955256341L;
 
-      //--------------------------/
-     //- Class/Member Variables -/
     //--------------------------/
-	
+    //- Class/Member Variables -/
+    //--------------------------/
+
+	/**
+     * Server-assigned, stable, opaque identifier for this SNMPv3 user. Used to
+     * correlate a user across config read/write cycles (e.g. when resolving masked
+     * credentials), since securityName is not guaranteed to be unique.
+     */
+	@XmlAttribute(name="id", required=false)
+    private String id;
 
 	/**
      * SNMPv3 Application Engine ID
      */
-	@XmlAttribute(name="engine-id",required=false)
-    private java.lang.String engineId;
+	@XmlAttribute(name="engine-id", required=false)
+    private String engineId;
 
     /**
      * SNMPv3 Security Name (User Name)
      */
-	@XmlAttribute(name="security-name",required=false)
-    private java.lang.String securityName;
+	@XmlAttribute(name="security-name", required=false)
+    private String securityName;
 
     /**
      * SNMPv3 Security Level (noAuthNoPriv, authNoPriv, authPriv)
      */
-	@XmlAttribute(name="security-level",required=false)
+	@XmlAttribute(name="security-level", required=false)
     private Integer securityLevel;
 
     /**
      * SNMPv3 Authentication Protocol
      */
-	@XmlAttribute(name="auth-protocol",required=false)
-    private java.lang.String authProtocol;
+	@XmlAttribute(name="auth-protocol", required=false)
+    private String authProtocol;
 
     /**
      * SNMPv3 Authentication Password Phrase
      */
-	@XmlAttribute(name="auth-passphrase",required=false)
-    private java.lang.String authPassphrase;
+	@XmlAttribute(name="auth-passphrase", required=false)
+    private String authPassphrase;
 
     /**
      * SNMPv3 Privacy Protocol
      */
-	@XmlAttribute(name="privacy-protocol",required=false)
-    private java.lang.String privacyProtocol;
+	@XmlAttribute(name="privacy-protocol", required=false)
+    private String privacyProtocol;
 
     /**
      * SNMPv3 Privacy Password Phrase
      */
-	@XmlAttribute(name="privacy-passphrase",required=false)
-    private java.lang.String privacyPassphrase;
+	@XmlAttribute(name="privacy-passphrase", required=false)
+    private String privacyPassphrase;
 
 
-      //----------------/
-     //- Constructors -/
+    //----------------/
+    //- Constructors -/
     //----------------/
 
     public Snmpv3User() {
         super();
     }
 
-
-      //-----------/
-     //- Methods -/
+    //-----------/
+    //- Methods -/
     //-----------/
 
     /**
-     * Overrides the java.lang.Object.equals method.
+     * Overrides the Object.equals method.
      * 
      * @param obj
      * @return true if the objects are equal.
      */
     @Override()
-    public boolean equals(
-            final java.lang.Object obj) {
-        if ( this == obj )
+    public boolean equals(final Object obj) {
+        if (this == obj) {
             return true;
+        }
         
         if (obj instanceof Snmpv3User) {
-        
-            Snmpv3User temp = (Snmpv3User)obj;
+            Snmpv3User temp = (Snmpv3User) obj;
+
             if (this.engineId != null) {
                 if (temp.engineId == null) return false;
                 else if (!(this.engineId.equals(temp.engineId)))
@@ -120,6 +126,7 @@ public class Snmpv3User implements java.io.Serializable {
             }
             else if (temp.engineId != null)
                 return false;
+
             if (this.securityName != null) {
                 if (temp.securityName == null) return false;
                 else if (!(this.securityName.equals(temp.securityName)))
@@ -127,8 +134,10 @@ public class Snmpv3User implements java.io.Serializable {
             }
             else if (temp.securityName != null)
                 return false;
+
             if (this.securityLevel != temp.securityLevel)
                 return false;
+
             if (this.authProtocol != null) {
                 if (temp.authProtocol == null) return false;
                 else if (!(this.authProtocol.equals(temp.authProtocol)))
@@ -169,8 +178,7 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @return the value of field 'AuthPassphrase'.
      */
-    public java.lang.String getAuthPassphrase(
-    ) {
+    public String getAuthPassphrase() {
         return this.authPassphrase;
     }
 
@@ -181,19 +189,27 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @return the value of field 'AuthProtocol'.
      */
-    public java.lang.String getAuthProtocol(
-    ) {
+    public String getAuthProtocol() {
         return this.authProtocol;
+    }
+
+    /**
+     * Returns the value of field 'id'. The field 'id' is a
+     * server-assigned, stable, opaque identifier for this SNMPv3 user.
+     *
+     * @return the value of field 'Id'.
+     */
+    public String getId() {
+        return this.id;
     }
 
     /**
      * Returns the value of field 'engineId'. The field 'engineId'
      * has the following description: SNMPv3 Application Engine ID
-     * 
+     *
      * @return the value of field 'EngineId'.
      */
-    public java.lang.String getEngineId(
-    ) {
+    public String getEngineId() {
         return this.engineId;
     }
 
@@ -204,8 +220,7 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @return the value of field 'PrivacyPassphrase'.
      */
-    public java.lang.String getPrivacyPassphrase(
-    ) {
+    public String getPrivacyPassphrase() {
         return this.privacyPassphrase;
     }
 
@@ -216,8 +231,7 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @return the value of field 'PrivacyProtocol'.
      */
-    public java.lang.String getPrivacyProtocol(
-    ) {
+    public String getPrivacyProtocol() {
         return this.privacyProtocol;
     }
 
@@ -228,8 +242,7 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @return the value of field 'SecurityLevel'.
      */
-    public Integer getSecurityLevel(
-    ) {
+    public Integer getSecurityLevel() {
         return this.securityLevel;
 
         //return this._securityLevel == null ? 0 : this._securityLevel;
@@ -242,24 +255,22 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @return the value of field 'SecurityName'.
      */
-    public java.lang.String getSecurityName(
-    ) {
+    public String getSecurityName() {
         return this.securityName;
     }
 
     /**
-     * Overrides the java.lang.Object.hashCode method.
+     * Overrides the Object.hashCode method.
      * <p>
      * The following steps came from <b>Effective Java Programming
      * Language Guide</b> by Joshua Bloch, Chapter 3
      * 
      * @return a hash code value for the object.
      */
-    public int hashCode(
-    ) {
+    public int hashCode() {
         int result = 17;
-        
         long tmp;
+
         if (engineId != null) {
            result = 37 * result + engineId.hashCode();
         }
@@ -290,8 +301,7 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @param authPassphrase the value of field 'authPassphrase'.
      */
-    public void setAuthPassphrase(
-            final java.lang.String authPassphrase) {
+    public void setAuthPassphrase(final String authPassphrase) {
         this.authPassphrase = authPassphrase;
     }
 
@@ -302,19 +312,27 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @param authProtocol the value of field 'authProtocol'.
      */
-    public void setAuthProtocol(
-            final java.lang.String authProtocol) {
+    public void setAuthProtocol(final String authProtocol) {
         this.authProtocol = authProtocol;
+    }
+
+    /**
+     * Sets the value of field 'id'. The field 'id' is a server-assigned,
+     * stable, opaque identifier for this SNMPv3 user.
+     *
+     * @param id the value of field 'id'.
+     */
+    public void setId(final String id) {
+        this.id = id;
     }
 
     /**
      * Sets the value of field 'engineId'. The field 'engineId' has
      * the following description: SNMPv3 Application Engine ID
-     * 
+     *
      * @param engineId the value of field 'engineId'.
      */
-    public void setEngineId(
-            final java.lang.String engineId) {
+    public void setEngineId(final String engineId) {
         this.engineId = engineId;
     }
 
@@ -326,8 +344,7 @@ public class Snmpv3User implements java.io.Serializable {
      * @param privacyPassphrase the value of field
      * 'privacyPassphrase'.
      */
-    public void setPrivacyPassphrase(
-            final java.lang.String privacyPassphrase) {
+    public void setPrivacyPassphrase(final String privacyPassphrase) {
         this.privacyPassphrase = privacyPassphrase;
     }
 
@@ -338,8 +355,7 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @param privacyProtocol the value of field 'privacyProtocol'.
      */
-    public void setPrivacyProtocol(
-            final java.lang.String privacyProtocol) {
+    public void setPrivacyProtocol(final String privacyProtocol) {
         this.privacyProtocol = privacyProtocol;
     }
 
@@ -361,9 +377,7 @@ public class Snmpv3User implements java.io.Serializable {
      * 
      * @param securityName the value of field 'securityName'.
      */
-    public void setSecurityName(
-            final java.lang.String securityName) {
+    public void setSecurityName(final String securityName) {
         this.securityName = securityName;
     }
-
 }

--- a/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/trapd/TrapdConfiguration.java
+++ b/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/trapd/TrapdConfiguration.java
@@ -48,6 +48,13 @@ import org.opennms.core.xml.ValidateUsing;
 public class TrapdConfiguration implements  Serializable {
 	private static final long serialVersionUID = 2;
 
+	/**
+	 * Canonical name under which the trapd configuration is registered in the
+	 * Configuration Manager (kvstore_jsonb / CM REST). Shared by every component
+	 * that addresses trapd config through CM.
+	 */
+	public static final String CM_CONFIG_NAME = "trapd-config";
+
 	public static final boolean DEFAULT_USE_ADDRESS_FROM_VARBIND = false;
 
 	/**

--- a/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/trapd/TrapdConfiguration.java
+++ b/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/trapd/TrapdConfiguration.java
@@ -23,6 +23,7 @@ package org.opennms.netmgt.config.trapd;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.UUID;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -34,8 +35,6 @@ import javax.xml.bind.annotation.XmlTransient;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.opennms.core.xml.ValidateUsing;
 
-
-
 /**
  * Top-level element for the trapd-configuration.xml
  *  configuration file.
@@ -44,7 +43,7 @@ import org.opennms.core.xml.ValidateUsing;
  */
 @XmlRootElement(name = "trapd-configuration")
 @XmlAccessorType(XmlAccessType.NONE)
-@ValidateUsing("trapd-configuration.xsd")
+@ValidateUsing("trapd-configuration-1.1.xsd")
 @SuppressWarnings("all") 
 public class TrapdConfiguration implements  Serializable {
 	private static final long serialVersionUID = 2;
@@ -513,6 +512,43 @@ public class TrapdConfiguration implements  Serializable {
     public void setSnmpv3UserCollection(
             final java.util.List<Snmpv3User> snmpv3UserList) {
         this.snmpv3User = snmpv3UserList;
+    }
+
+    /**
+     * Looks up a configured SNMPv3 user by its server-assigned id. The id is
+     * guaranteed unique, so this is the correct key for correlating a user across
+     * read/write cycles (e.g. when resolving masked credentials).
+     */
+    public Snmpv3User getSnmpv3UserById(final String id) {
+        if (id == null || this.snmpv3User == null) {
+            return null;
+        }
+        for (Snmpv3User user : this.snmpv3User) {
+            if (id.equals(user.getId())) {
+                return user;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Assigns a stable random UUID to every contained SNMPv3 user that does not
+     * already have one.
+     *
+     * @return {@code true} if at least one id was assigned (i.e. the config changed).
+     */
+    public boolean ensureSnmpv3UserIds() {
+        if (this.snmpv3User == null) {
+            return false;
+        }
+        boolean changed = false;
+        for (Snmpv3User user : this.snmpv3User) {
+            if (user != null && (user.getId() == null || user.getId().trim().isEmpty())) {
+                user.setId(UUID.randomUUID().toString());
+                changed = true;
+            }
+        }
+        return changed;
     }
 
     public boolean isIncludeRawMessage() {

--- a/opennms-config-jaxb/src/main/resources/xsds/trapd-configuration-1.1.xsd
+++ b/opennms-config-jaxb/src/main/resources/xsds/trapd-configuration-1.1.xsd
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://xmlns.opennms.org/xsd/config/trapd"
+        xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:this="http://xmlns.opennms.org/xsd/config/trapd"
+        xmlns:ns2="http://www.w3.org/1999/xhtml"
+        xmlns:ns="http://www.w3.org/2001/XMLSchema"
+		  xmlns:hfp="http://www.w3.org/2001/XMLSchema-hasFacetAndProperty"
+		  elementFormDefault="qualified">
+  <annotation>
+    <documentation>XML Schema for the trapd-configuration.xml configuration
+    file. Version: $Id$</documentation>
+  </annotation>
+
+  <element name="trapd-configuration">
+    <annotation>
+      <documentation>Top-level element for the trapd-configuration.xml
+      configuration file.</documentation>
+    </annotation>
+
+    <complexType>
+      <sequence>
+        <element maxOccurs="unbounded" minOccurs="0" ref="this:snmpv3-user">
+          <annotation>
+            <documentation>SNMPv3 configuration.</documentation>
+          </annotation>
+        </element>
+      </sequence>
+
+      <attribute name="snmp-trap-address" use="optional" type="string" default="*" >
+        <annotation>
+          <documentation>The IP address on which trapd listens for connections.
+          If "*" is specified, trapd will bind to all addresses.  The default is *.</documentation>
+        </annotation>
+      </attribute>
+
+      <attribute name="snmp-trap-port" use="required">
+        <annotation>
+          <documentation>The port on which trapd listens for SNMP traps. The
+          standard port is 162.</documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="int">
+            <minInclusive value="1"/>
+            <maxInclusive value="65535"/>
+          </restriction>
+        </simpleType>
+      </attribute>
+
+      <attribute name="new-suspect-on-trap" type="boolean" use="required">
+        <annotation>
+          <documentation>Whether traps from devices unknown to OpenNMS should
+          generate newSuspect events.</documentation>
+        </annotation>
+      </attribute>
+
+      <attribute name="include-raw-message" type="boolean" use="optional">
+        <annotation>
+          <documentation>Whether the raw trap should be included before processing the trap.</documentation>
+        </annotation>
+      </attribute>
+
+      <attribute name="use-address-from-varbind" type="boolean" use="optional">
+        <annotation>
+            <documentation>When enabled, the source address of the trap will be pulled
+            from the snmpTrapAddress (1.3.6.1.6.3.18.1.3.0) varbind when available.
+            This varbind is appended by certain trap forwarders when forwarding
+            SNMPv2 traps.</documentation>
+        </annotation>
+      </attribute>
+
+      <attribute name="threads" use="optional">
+        <annotation>
+          <documentation>Number of threads used for consuming/dispatching messages.
+            Defaults to 2 x the number of available processors.
+          </documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="int">
+            <minInclusive value="0"/>
+          </restriction>
+        </simpleType>
+      </attribute>
+      <attribute name="queue-size" use="optional" default="10000">
+        <annotation>
+          <documentation>Maximum number of messages to keep in memory while waiting
+            to be dispatched.
+          </documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="int">
+            <minInclusive value="1"/>
+          </restriction>
+        </simpleType>
+      </attribute>
+      <attribute name="batch-size" use="optional" default="1000">
+        <annotation>
+          <documentation>Messages are aggregated in batches before being dispatched.
+            When the batch reaches this size, it will be dispatched.
+          </documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="int">
+            <minInclusive value="1"/>
+          </restriction>
+        </simpleType>
+      </attribute>
+      <attribute name="batch-interval" use="optional" default="500">
+        <annotation>
+          <documentation>Messages are aggregated in batches before being dispatched.
+            When the batch has been created for longer than this interval (ms)
+            it will be dispatched, regardless of the current size.
+          </documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="int">
+            <minInclusive value="0"/>
+          </restriction>
+        </simpleType>
+      </attribute>
+    </complexType>
+  </element>
+
+
+  <element name="snmpv3-user">
+    <annotation>
+      <documentation>SNMPv3 User Configuration.</documentation>
+    </annotation>
+    <complexType>
+      <attribute name="id" type="string" use="optional">
+        <annotation>
+          <documentation>Server-assigned, stable, opaque identifier for this SNMPv3 user.
+          Used to correlate a user across config read/write cycles (e.g. when resolving
+          masked credentials), since security-name is not guaranteed to be unique.</documentation>
+        </annotation>
+      </attribute>
+
+      <attribute name="engine-id" type="string" use="optional">
+        <annotation>
+          <documentation>SNMPv3 Application Engine ID</documentation>
+        </annotation>
+      </attribute>
+
+      <attribute name="security-name" type="string" use="optional">
+        <annotation>
+          <documentation>SNMPv3 Security Name (User Name)</documentation>
+        </annotation>
+      </attribute>
+
+      <attribute name="security-level" use="optional">
+        <annotation>
+          <documentation>SNMPv3 Security Level (noAuthNoPriv, authNoPriv, authPriv)</documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="int">
+            <minInclusive value="1" />
+            <maxInclusive value="3" />
+          </restriction>
+        </simpleType>
+      </attribute>
+
+      <attribute name="auth-protocol" use="optional">
+        <annotation>
+          <documentation>SNMPv3 Authentication Protocol</documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="string">
+            <pattern value="(MD5|SHA|SHA-224|SHA-256|SHA-512)"/>
+          </restriction>
+        </simpleType>
+      </attribute>
+
+      <attribute name="auth-passphrase" type="string" use="optional">
+        <annotation>
+          <documentation>SNMPv3 Authentication Password Phrase</documentation>
+        </annotation>
+      </attribute>
+
+      <attribute name="privacy-protocol" use="optional">
+        <annotation>
+          <documentation>SNMPv3 Privacy Protocol</documentation>
+        </annotation>
+
+        <simpleType>
+          <restriction base="string">
+            <pattern value="(DES|AES|AES192|AES256)"/>
+          </restriction>
+        </simpleType>
+      </attribute>
+
+      <attribute name="privacy-passphrase" type="string" use="optional">
+        <annotation>
+          <documentation>SNMPv3 Privacy Password Phrase</documentation>
+        </annotation>
+      </attribute>
+
+    </complexType>
+  </element>
+
+</schema>

--- a/opennms-config-jaxb/src/test/java/org/opennms/netmgt/config/trapd/TrapdConfigurationTest.java
+++ b/opennms-config-jaxb/src/test/java/org/opennms/netmgt/config/trapd/TrapdConfigurationTest.java
@@ -21,6 +21,11 @@
  */
 package org.opennms.netmgt.config.trapd;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.text.ParseException;
@@ -230,7 +235,60 @@ public class TrapdConfigurationTest extends XmlTestNoCastor<TrapdConfiguration> 
             fail();
         } catch (Exception e) {
         }
-	        
+
 	    }
+
+	@Test
+	public void getSnmpv3UserByIdFindsMatchingUser() {
+		Snmpv3User a = new Snmpv3User();
+		a.setId("id-a");
+		a.setSecurityName("dup");
+		Snmpv3User b = new Snmpv3User();
+		b.setId("id-b");
+		b.setSecurityName("dup");
+
+		TrapdConfiguration config = new TrapdConfiguration(162, "*");
+		config.addSnmpv3User(a);
+		config.addSnmpv3User(b);
+
+		assertEquals("id-b", config.getSnmpv3UserById("id-b").getId());
+		assertEquals("id-a", config.getSnmpv3UserById("id-a").getId());
+		assertNull(config.getSnmpv3UserById("missing"));
+		assertNull(config.getSnmpv3UserById(null));
+	}
+
+	@Test
+	public void ensureSnmpv3UserIdsAssignsMissingIdsAndIsStable() {
+		Snmpv3User withId = new Snmpv3User();
+		withId.setId("existing-id");
+		withId.setSecurityName("hasId");
+		Snmpv3User withoutId = new Snmpv3User();
+		withoutId.setSecurityName("needsId");
+
+		TrapdConfiguration config = new TrapdConfiguration(162, "*");
+		config.addSnmpv3User(withId);
+		config.addSnmpv3User(withoutId);
+
+		assertTrue("a missing id should have been assigned", config.ensureSnmpv3UserIds());
+		assertEquals("pre-existing id must not change", "existing-id", withId.getId());
+		assertNotNull("missing id must be populated", withoutId.getId());
+		assertFalse("blank id should not remain", withoutId.getId().trim().isEmpty());
+
+		final String assignedId = withoutId.getId();
+		assertFalse("a second call must report no changes", config.ensureSnmpv3UserIds());
+		assertEquals("ids must be stable across calls", assignedId, withoutId.getId());
+		assertEquals("existing-id", withId.getId());
+	}
+
+	@Test
+	public void unmarshalsSnmpv3UserIdAgainstVersionedSchema() {
+		String xml = "<trapd-configuration xmlns=\"http://xmlns.opennms.org/xsd/config/trapd\" "
+				+ "snmp-trap-port=\"162\" new-suspect-on-trap=\"false\">"
+				+   "<snmpv3-user id=\"user-uuid-1\" security-name=\"opennms\"/>"
+				+ "</trapd-configuration>";
+
+		TrapdConfiguration cfg = JaxbUtils.unmarshal(TrapdConfiguration.class, xml);
+		assertEquals("user-uuid-1", cfg.getSnmpv3User(0).getId());
+	}
 
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/jaxb/DefaultTrapdConfigDao.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/jaxb/DefaultTrapdConfigDao.java
@@ -33,7 +33,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.function.Consumer;
 
 public class DefaultTrapdConfigDao extends AbstractCmJaxbConfigDao<TrapdConfiguration> implements TrapdConfigDao {
-    public static final String CONFIG_NAME = "trapd-config";
     public static final String DAEMON_NAME = "trapd";
 
     @Autowired
@@ -45,7 +44,7 @@ public class DefaultTrapdConfigDao extends AbstractCmJaxbConfigDao<TrapdConfigur
 
     @Override
     public String getConfigName() {
-        return CONFIG_NAME;
+        return TrapdConfiguration.CM_CONFIG_NAME;
     }
 
     @Override

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/jaxb/DefaultTrapdConfigDao.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/jaxb/DefaultTrapdConfigDao.java
@@ -65,6 +65,11 @@ public class DefaultTrapdConfigDao extends AbstractCmJaxbConfigDao<TrapdConfigur
 
     @Override
     public void replaceConfig(TrapdConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        // Stamp ids onto any new/id-less SNMPv3 users before persisting (covers PUT and uploads).
+        config.ensureSnmpv3UserIds();
         this.updateConfig(this.getDefaultConfigId(), ConfigConvertUtil.objectToJson(config), true);
     }
 }

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -477,6 +477,11 @@
     </dependency>
     <dependency>
       <groupId>org.opennms.features.scv</groupId>
+      <artifactId>org.opennms.features.scv.api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.features.scv</groupId>
       <artifactId>org.opennms.features.scv.jceks-impl</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/MaskedCredential.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/MaskedCredential.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a DTO field as a credential that should be masked in REST GET responses
+ * and resolved on write (PUT/upload) via {@link SecurityHelper#maskCredentials} and
+ * {@link SecurityHelper#resolveCredentials}.
+ *
+ * <p>Apply only to DTO fields, never to JAXB entity/DAO classes.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface MaskedCredential {
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SecurityHelper.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SecurityHelper.java
@@ -21,6 +21,9 @@
  */
 package org.opennms.web.rest.support;
 
+import java.lang.reflect.Field;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -29,6 +32,15 @@ import javax.ws.rs.core.SecurityContext;
 import org.opennms.web.api.Authentication;
 
 public class SecurityHelper {
+    public static final String MASKED_PASSWORD = "******";
+    // Mirrors the SCV_REGEX / SCV_SUBKEY rules in ui/src/lib/scvValidator.ts:
+    //   alias  = [a-zA-Z0-9_] optionally followed by [a-zA-Z0-9_.-]* and a trailing [a-zA-Z0-9_]
+    //   :key   = same format, optional
+    //   |default = any chars except | and }, optional
+    private static final Pattern SCV_PATTERN = Pattern.compile(
+            "^\\$\\{scv:[a-zA-Z0-9_](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9_])?" +
+            "(?::[a-zA-Z0-9_](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9_])?)?" +
+            "(?:\\|[^|}]+)?\\}$");
 
     public static void assertUserReadCredentials(SecurityContext securityContext) {
         final String currentUser = securityContext.getUserPrincipal().getName();
@@ -70,4 +82,90 @@ public class SecurityHelper {
         throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("User '" + currentUser + "', is not allowed to perform updates to alarms as user '" + ackUser + "'").type(MediaType.TEXT_PLAIN).build());
     }
 
+    public static boolean isMaskedPassword(final String value) {
+        return MASKED_PASSWORD.equals(value);
+    }
+
+    public static boolean isScvExpression(final String value) {
+        return value != null && SCV_PATTERN.matcher(value).matches();
+    }
+
+    /**
+     * Replaces each {@link MaskedCredential}-annotated field on {@code dto} with
+     * {@link #MASKED_PASSWORD}. Null fields and SCV expressions ({@code ${scv:...}})
+     * are left unchanged. Only the declared fields of the object's own class are inspected.
+     */
+    public static void maskCredentials(final Object dto) {
+        if (dto == null) {
+            return;
+        }
+        for (Field field : dto.getClass().getDeclaredFields()) {
+            if (!field.isAnnotationPresent(MaskedCredential.class)) {
+                continue;
+            }
+            field.setAccessible(true);
+            try {
+                final Object value = field.get(dto);
+                if (value instanceof String strValue && !isScvExpression(strValue)) {
+                    field.set(dto, MASKED_PASSWORD);
+                }
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Failed to mask credential field: " + field.getName(), e);
+            }
+        }
+    }
+
+    /**
+     * For each {@link MaskedCredential}-annotated field on {@code incomingDto}: if the
+     * field value is a mask (per {@link #isMaskedPassword}), the supplier is called to
+     * obtain the existing entity and the real value is copied from the matching field name
+     * on that entity. Non-masked values (including SCV placeholders) are left unchanged.
+     *
+     * <p>The supplier is lazy: it is only invoked the first time a masked field is
+     * encountered. If the supplier returns {@code null} and a masked field is found,
+     * an {@link IllegalArgumentException} is thrown — callers should surface this as a
+     * 400 response.</p>
+     *
+     * @throws IllegalArgumentException if a masked value is found but the supplier
+     *                                  returns {@code null} (no existing entity to look up)
+     */
+    public static void resolveCredentials(final Object incomingDto, final Supplier<?> existingEntitySupplier) {
+        if (incomingDto == null) {
+            return;
+        }
+        Object existing = null;
+        boolean existingLoaded = false;
+        for (Field field : incomingDto.getClass().getDeclaredFields()) {
+            if (!field.isAnnotationPresent(MaskedCredential.class)) {
+                continue;
+            }
+            field.setAccessible(true);
+            try {
+                final Object value = field.get(incomingDto);
+                if (!(value instanceof String) || !isMaskedPassword((String) value)) {
+                    continue;
+                }
+                if (!existingLoaded) {
+                    existing = existingEntitySupplier.get();
+                    existingLoaded = true;
+                }
+                if (existing == null) {
+                    throw new IllegalArgumentException(
+                        "Cannot use a masked passphrase for a new entry: no existing record to retrieve field '"
+                            + field.getName() + "' from");
+                }
+                try {
+                    Field entityField = existing.getClass().getDeclaredField(field.getName());
+                    entityField.setAccessible(true);
+                    field.set(incomingDto, entityField.get(existing));
+                } catch (NoSuchFieldException e) {
+                    throw new IllegalArgumentException(
+                        "Cannot resolve masked field '" + field.getName() + "': no matching field on entity "
+                            + existing.getClass().getSimpleName(), e);
+                }
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Failed to resolve credential field: " + field.getName(), e);
+            }
+        }
+    }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SecurityHelper.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SecurityHelper.java
@@ -23,24 +23,16 @@ package org.opennms.web.rest.support;
 
 import java.lang.reflect.Field;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import org.opennms.features.scv.utils.ScvUtils;
 import org.opennms.web.api.Authentication;
 
 public class SecurityHelper {
     public static final String MASKED_PASSWORD = "******";
-    // Mirrors the SCV_REGEX / SCV_SUBKEY rules in ui/src/lib/scvValidator.ts:
-    //   alias  = [a-zA-Z0-9_] optionally followed by [a-zA-Z0-9_.-]* and a trailing [a-zA-Z0-9_]
-    //   :key   = same format, optional
-    //   |default = any chars except | and }, optional
-    private static final Pattern SCV_PATTERN = Pattern.compile(
-            "^\\$\\{scv:[a-zA-Z0-9_](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9_])?" +
-            "(?::[a-zA-Z0-9_](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9_])?)?" +
-            "(?:\\|[^|}]+)?\\}$");
 
     public static void assertUserReadCredentials(SecurityContext securityContext) {
         final String currentUser = securityContext.getUserPrincipal().getName();
@@ -87,7 +79,7 @@ public class SecurityHelper {
     }
 
     public static boolean isScvExpression(final String value) {
-        return value != null && SCV_PATTERN.matcher(value).matches();
+        return ScvUtils.isScvExpression(value);
     }
 
     /**

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TrapdRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TrapdRestService.java
@@ -283,11 +283,21 @@ public class TrapdRestService implements TrapdRestApi {
         }
 
         if (configDto.getSnmpv3User() != null) {
+            final Set<String> seenUserIds = new HashSet<>();
             int index = 0;
             for (Snmpv3UserDto user : configDto.getSnmpv3User()) {
                 String userValidation = validateSnmpv3UserPayload(user);
                 if (userValidation != null) {
                     return "Invalid SNMPv3 user at index " + index + ": " + userValidation;
+                }
+                // Ids correlate users across read/write cycles; masked-credential resolution relies on
+                // getSnmpv3UserById() returning a unique match, so duplicate ids would silently corrupt
+                // credentials on the next round-trip. Blank ids are new users (assigned an id at persist
+                // time), so only guard non-blank ids here.
+                final String userId = user.getId();
+                if (StringUtils.isNotBlank(userId) && !seenUserIds.add(userId)) {
+                    return "Duplicate SNMPv3 user id '" + userId + "' at index " + index
+                            + "; each SNMPv3 user id must be unique.";
                 }
                 index++;
             }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TrapdRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TrapdRestService.java
@@ -36,8 +36,11 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.features.config.exception.ValidationException;
+import org.opennms.netmgt.config.trapd.Snmpv3User;
 import org.opennms.netmgt.config.trapd.TrapdConfiguration;
 import org.opennms.netmgt.dao.api.TrapdConfigDao;
+import org.opennms.web.api.Authentication;
+import org.opennms.web.rest.support.SecurityHelper;
 import org.opennms.web.rest.v2.api.TrapdRestApi;
 import org.opennms.web.rest.v2.model.Snmpv3UserDto;
 import org.opennms.web.rest.v2.model.TrapdConfigDto;
@@ -69,26 +72,44 @@ public class TrapdRestService implements TrapdRestApi {
     }
 
     private Response uploadTrapdConfigurationInternal(final Attachment attachment, final SecurityContext securityContext, boolean isXml) {
+        if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
+            return Response.status(Status.FORBIDDEN).entity("Admin role required to upload Trapd configuration.").build();
+        }
+
         final String fileType = isXml ? "XML" : "JSON";
 
         if (attachment == null) {
             return Response.status(Status.BAD_REQUEST).entity("Missing uploaded file for Trap Configuration " + fileType + " file upload.").build();
         }
 
-        TrapdConfiguration config;
         TrapdConfigDto dto;
 
         try (InputStream inputStream = attachment.getObject(InputStream.class)) {
             if (isXml) {
-                config = JaxbUtils.unmarshal(TrapdConfiguration.class, inputStream);
-                dto = TrapdConfigDto.toDto(config);
+                dto = TrapdConfigDto.toDto(JaxbUtils.unmarshal(TrapdConfiguration.class, inputStream));
             } else {
                 dto = objectMapper.readValue(inputStream, TrapdConfigDto.class);
-                config = dto.toEntity();
             }
         } catch (Exception e) {
             LOG.warn("Failed to parse uploaded Trapd " + fileType + " configuration.", e);
             return Response.status(Status.BAD_REQUEST).entity("Invalid Trapd " + fileType + " configuration.").build();
+        }
+
+        if (dto.getSnmpv3User() != null && !dto.getSnmpv3User().isEmpty()) {
+            final TrapdConfiguration existing = trapdConfigDao.getConfig();
+            for (Snmpv3UserDto incomingUser : dto.getSnmpv3User()) {
+                if (incomingUser == null) {
+                    continue;
+                }
+                final Snmpv3User existingUser = existing != null
+                    ? existing.getSnmpv3UserById(incomingUser.getId())
+                    : null;
+                try {
+                    SecurityHelper.resolveCredentials(incomingUser, () -> existingUser);
+                } catch (IllegalArgumentException e) {
+                    return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
+                }
+            }
         }
 
         String validationMessage = validateTrapdConfigRequest(dto);
@@ -98,7 +119,7 @@ public class TrapdRestService implements TrapdRestApi {
         }
 
         try {
-            trapdConfigDao.replaceConfig(config);
+            trapdConfigDao.replaceConfig(dto.toEntity());
             return Response.ok().build();
         } catch (ValidationException e) {
             LOG.warn("Uploaded Trapd configuration failed schema validation.", e);
@@ -110,7 +131,11 @@ public class TrapdRestService implements TrapdRestApi {
     }
 
     @Override
-    public Response downloadTrapdConfig(final String format) {
+    public Response downloadTrapdConfig(final String format, final SecurityContext securityContext) {
+        if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
+            return Response.status(Status.FORBIDDEN).entity("Admin role required to download Trapd configuration.").build();
+        }
+
         final boolean isXml = format != null && format.equalsIgnoreCase("xml");
         final String fileType = isXml ? "XML" : "JSON";
 
@@ -163,7 +188,14 @@ public class TrapdRestService implements TrapdRestApi {
             if (config == null) {
                 return Response.status(Status.NOT_FOUND).entity("Trapd configuration not found.").build();
             }
-            return Response.ok(TrapdConfigDto.toDto(config)).build();
+
+            TrapdConfigDto dto = TrapdConfigDto.toDto(config);
+            if (dto.getSnmpv3User() != null) {
+                for (Snmpv3UserDto user : dto.getSnmpv3User()) {
+                    SecurityHelper.maskCredentials(user);
+                }
+            }
+            return Response.ok(dto).build();
         } catch (Exception e) {
             LOG.error("Failed to retrieve Trapd configuration.", e);
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Failed to retrieve Trapd configuration.").build();
@@ -174,6 +206,23 @@ public class TrapdRestService implements TrapdRestApi {
     public Response updateTrapdConfiguration(TrapdConfigDto configDto, SecurityContext securityContext) {
         if (configDto == null) {
             return Response.status(Status.BAD_REQUEST).entity("Missing Trapd configuration in request body.").build();
+        }
+
+        if (configDto.getSnmpv3User() != null && !configDto.getSnmpv3User().isEmpty()) {
+            final TrapdConfiguration existing = trapdConfigDao.getConfig();
+            for (Snmpv3UserDto incomingUser : configDto.getSnmpv3User()) {
+                if (incomingUser == null) {
+                    continue;
+                }
+                final Snmpv3User existingUser = existing != null
+                    ? existing.getSnmpv3UserById(incomingUser.getId())
+                    : null;
+                try {
+                    SecurityHelper.resolveCredentials(incomingUser, () -> existingUser);
+                } catch (IllegalArgumentException e) {
+                    return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
+                }
+            }
         }
 
         String validationMessage = validateTrapdConfigRequest(configDto);
@@ -293,13 +342,24 @@ public class TrapdRestService implements TrapdRestApi {
             return "privacyProtocol and privacyPassphrase must be provided together.";
         }
 
+        // Star-prefix check before length: a value like "*short" is more usefully rejected as
+        // "must not begin with *" than as "too short", since the star prefix is the real mistake.
+        if (hasAuthPassphrase && !SecurityHelper.isMaskedPassword(user.getAuthPassphrase()) && user.getAuthPassphrase().startsWith("*")) {
+            return "authPassphrase must not begin with '*'.";
+        }
+        if (hasPrivacyPassphrase && !SecurityHelper.isMaskedPassword(user.getPrivacyPassphrase()) && user.getPrivacyPassphrase().startsWith("*")) {
+            return "privacyPassphrase must not begin with '*'.";
+        }
+
         // SNMP4J rejects short passphrases at UsmUser construction; catch it here so the trap
-        // daemon doesn't fail to restart on reload. A well-formed ${scv:...} placeholder
-        // trivially passes the length check; the resolved secret must also be long enough.
-        if (hasAuthPassphrase && user.getAuthPassphrase().getBytes(StandardCharsets.UTF_8).length < MIN_PASSPHRASE_BYTES) {
+        // daemon doesn't fail to restart on reload. A well-formed ${scv:...} placeholder or
+        // the masked sentinel trivially passes the length check.
+        if (hasAuthPassphrase && !SecurityHelper.isMaskedPassword(user.getAuthPassphrase())
+                && user.getAuthPassphrase().getBytes(StandardCharsets.UTF_8).length < MIN_PASSPHRASE_BYTES) {
             return "authPassphrase must be at least " + MIN_PASSPHRASE_BYTES + " bytes.";
         }
-        if (hasPrivacyPassphrase && user.getPrivacyPassphrase().getBytes(StandardCharsets.UTF_8).length < MIN_PASSPHRASE_BYTES) {
+        if (hasPrivacyPassphrase && !SecurityHelper.isMaskedPassword(user.getPrivacyPassphrase())
+                && user.getPrivacyPassphrase().getBytes(StandardCharsets.UTF_8).length < MIN_PASSPHRASE_BYTES) {
             return "privacyPassphrase must be at least " + MIN_PASSPHRASE_BYTES + " bytes.";
         }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/TrapdRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/TrapdRestApi.java
@@ -52,13 +52,15 @@ public interface TrapdRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Upload Trap configuration in JSON format.",
-            description = "Upload Trap configuration in JSON format and apply the changes.",
+            description = "Upload Trap configuration in JSON format and apply the changes. Requires ROLE_ADMIN.",
             operationId = "uploadTrapdConfiguration"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Trap configuration uploaded and applied successfully",
                 content = @Content),
             @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing configuration.",
+                content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden – admin role required.",
                 content = @Content),
             @ApiResponse(responseCode = "500", description = "Failed to persist Trap configuration.",
                 content = @Content)
@@ -71,13 +73,15 @@ public interface TrapdRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Upload Trap configuration in XML format.",
-            description = "Upload Trap configuration in XML format and apply the changes.",
+            description = "Upload Trap configuration in XML format and apply the changes. Requires ROLE_ADMIN.",
             operationId = "uploadTrapdConfigurationXml"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Trap configuration uploaded and applied successfully",
                 content = @Content),
             @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing configuration.",
+                content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden – admin role required.",
                 content = @Content),
             @ApiResponse(responseCode = "500", description = "Failed to persist Trap configuration.",
                 content = @Content)
@@ -89,16 +93,18 @@ public interface TrapdRestApi {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(
             summary = "Download trapd configuration",
-            description = "Download trapd configuration in JSON or XML format.",
+            description = "Download trapd configuration in JSON or XML format. Requires ROLE_ADMIN.",
             operationId = "downloadConfig"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Trapd configuration in download format retrieved successfully",
                     content = { @Content(mediaType = "application/json"), @Content(mediaType = "application/xml") }),
             @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden – admin role required.",
                     content = @Content)
     })
-    Response downloadTrapdConfig(@QueryParam("format") String format);
+    Response downloadTrapdConfig(@QueryParam("format") String format, @Context SecurityContext securityContext);
 
     @GET
     @Path("config")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/Snmpv3UserDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/Snmpv3UserDto.java
@@ -22,16 +22,28 @@
 package org.opennms.web.rest.v2.model;
 
 import org.opennms.netmgt.config.trapd.Snmpv3User;
+import org.opennms.web.rest.support.MaskedCredential;
 
 public class Snmpv3UserDto {
+    private String id;
     private String engineId;
     private String securityName;
     private Integer securityLevel;
     private String authProtocol;
+    @MaskedCredential
     private String authPassphrase;
     private String privacyProtocol;
+    @MaskedCredential
     private String privacyPassphrase;
 
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getEngineId() {
         return engineId;
@@ -94,6 +106,7 @@ public class Snmpv3UserDto {
             return null;
         }
         Snmpv3UserDto dto = new Snmpv3UserDto();
+        dto.setId(user.getId());
         dto.setEngineId(user.getEngineId());
         dto.setSecurityName(user.getSecurityName());
         dto.setSecurityLevel(user.getSecurityLevel());
@@ -106,6 +119,7 @@ public class Snmpv3UserDto {
 
     public Snmpv3User toEntity() {
         Snmpv3User user = new Snmpv3User();
+        user.setId(id);
         user.setEngineId(engineId);
         user.setSecurityName(securityName);
         if (securityLevel != null) user.setSecurityLevel(securityLevel);

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/SecurityHelperTest.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/SecurityHelperTest.java
@@ -31,8 +31,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -79,6 +82,206 @@ public class SecurityHelperTest {
         assertUserEditPrivileges(true, OTHER_USER, ROLE_USER, ROLE_DELEGATE);
         assertUserEditPrivileges(true, OTHER_USER, ROLE_REST, ROLE_DELEGATE);
         assertUserEditPrivileges(true, OTHER_USER, ROLE_MOBILE, ROLE_DELEGATE);
+    }
+
+    // --- maskCredentials tests ---
+
+    @Test
+    public void maskCredentialsShouldMaskAnnotatedNonNullFields() {
+        TestDto dto = new TestDto();
+        dto.password = "realpass";
+        dto.other = "keepme";
+
+        SecurityHelper.maskCredentials(dto);
+
+        assertEquals(SecurityHelper.MASKED_PASSWORD, dto.password);
+        assertEquals("keepme", dto.other);
+    }
+
+    @Test
+    public void maskCredentialsShouldSkipNullAnnotatedFields() {
+        TestDto dto = new TestDto();
+        dto.password = null;
+
+        SecurityHelper.maskCredentials(dto);
+
+        assertNull(dto.password);
+    }
+
+    @Test
+    public void maskCredentialsShouldNotAffectNonAnnotatedFields() {
+        TestDto dto = new TestDto();
+        dto.other = "untouched";
+
+        SecurityHelper.maskCredentials(dto);
+
+        assertEquals("untouched", dto.other);
+    }
+
+    @Test
+    public void maskCredentialsShouldHandleNullDto() {
+        SecurityHelper.maskCredentials(null); // must not throw
+    }
+
+    @Test
+    public void maskCredentialsShouldNotMaskScvExpression() {
+        TestDto dto = new TestDto();
+        dto.password = "${scv:myalias:mykey}";
+
+        SecurityHelper.maskCredentials(dto);
+
+        assertEquals("${scv:myalias:mykey}", dto.password);
+    }
+
+    @Test
+    public void maskCredentialsShouldNotMaskMinimalScvExpression() {
+        TestDto dto = new TestDto();
+        dto.password = "${scv:a:k}";
+
+        SecurityHelper.maskCredentials(dto);
+
+        assertEquals("${scv:a:k}", dto.password);
+    }
+
+    // --- resolveCredentials tests ---
+
+    @Test
+    public void resolveCredentialsShouldFillMaskedFieldFromEntity() {
+        TestDto incoming = new TestDto();
+        incoming.password = SecurityHelper.MASKED_PASSWORD;
+
+        TestDto existing = new TestDto();
+        existing.password = "realpass";
+
+        SecurityHelper.resolveCredentials(incoming, () -> existing);
+
+        assertEquals("realpass", incoming.password);
+    }
+
+    @Test
+    public void resolveCredentialsShouldLeaveRealValueUnchanged() {
+        TestDto incoming = new TestDto();
+        incoming.password = "newpass";
+
+        SecurityHelper.resolveCredentials(incoming, () -> { throw new AssertionError("supplier must not be called"); });
+
+        assertEquals("newpass", incoming.password);
+    }
+
+    @Test
+    public void resolveCredentialsShouldLeaveScvPlaceholderUnchanged() {
+        TestDto incoming = new TestDto();
+        incoming.password = "${scv:alias:key}";
+
+        SecurityHelper.resolveCredentials(incoming, () -> { throw new AssertionError("supplier must not be called"); });
+
+        assertEquals("${scv:alias:key}", incoming.password);
+    }
+
+    // --- isMaskedPassword tests ---
+
+    @Test
+    public void isMaskedPasswordShouldReturnTrueForExactMaskedPassword() {
+        assertTrue(SecurityHelper.isMaskedPassword(SecurityHelper.MASKED_PASSWORD));
+    }
+
+    @Test
+    public void isMaskedPasswordShouldReturnFalseForNull() {
+        assertFalse(SecurityHelper.isMaskedPassword(null));
+    }
+
+    @Test
+    public void isMaskedPasswordShouldReturnFalseForFewerStars() {
+        assertFalse(SecurityHelper.isMaskedPassword("*****")); // 5 asterisks
+        assertFalse(SecurityHelper.isMaskedPassword("**"));    // 2 asterisks
+    }
+
+    @Test
+    public void isMaskedPasswordShouldReturnFalseForMoreStars() {
+        assertFalse(SecurityHelper.isMaskedPassword("*******")); // 7 asterisks
+    }
+
+    @Test
+    public void isMaskedPasswordShouldReturnFalseForNonMaskedValues() {
+        assertFalse(SecurityHelper.isMaskedPassword(""));
+        assertFalse(SecurityHelper.isMaskedPassword("realpassword"));
+        assertFalse(SecurityHelper.isMaskedPassword("*password"));
+    }
+
+    // --- isScvExpression tests ---
+
+    @Test
+    public void isScvExpressionShouldReturnTrueForWellFormedExpressions() {
+        assertTrue(SecurityHelper.isScvExpression("${scv:alias:key}"));
+        assertTrue(SecurityHelper.isScvExpression("${scv:a:k}"));
+        assertTrue(SecurityHelper.isScvExpression("${scv:my-alias:my-key}"));
+    }
+
+    @Test
+    public void isScvExpressionShouldReturnFalseForNonScvValues() {
+        assertFalse(SecurityHelper.isScvExpression(null));
+        assertFalse(SecurityHelper.isScvExpression(""));
+        assertFalse(SecurityHelper.isScvExpression("realpassword"));
+        assertFalse(SecurityHelper.isScvExpression(SecurityHelper.MASKED_PASSWORD));
+        assertFalse(SecurityHelper.isScvExpression("${scv:}"));   // no content after prefix
+        assertFalse(SecurityHelper.isScvExpression("${other:a:k}"));
+    }
+
+    @Test
+    public void resolveCredentialsShouldLeaveNullFieldUnchanged() {
+        TestDto incoming = new TestDto();
+        incoming.password = null;
+
+        SecurityHelper.resolveCredentials(incoming, () -> { throw new AssertionError("supplier must not be called"); });
+
+        assertNull(incoming.password);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void resolveCredentialsShouldThrowWhenEntityNullAndValueMasked() {
+        TestDto incoming = new TestDto();
+        incoming.password = SecurityHelper.MASKED_PASSWORD;
+
+        SecurityHelper.resolveCredentials(incoming, () -> null);
+    }
+
+    @Test
+    public void resolveCredentialsShouldHandleNullIncomingDto() {
+        SecurityHelper.resolveCredentials(null, () -> { throw new AssertionError("supplier must not be called"); });
+    }
+
+    @Test
+    public void resolveCredentialsShouldCallSupplierOnlyOnce() {
+        int[] callCount = {0};
+        TestDtoTwoFields incoming = new TestDtoTwoFields();
+        incoming.password1 = SecurityHelper.MASKED_PASSWORD;
+        incoming.password2 = SecurityHelper.MASKED_PASSWORD;
+
+        TestDtoTwoFields existing = new TestDtoTwoFields();
+        existing.password1 = "real1";
+        existing.password2 = "real2";
+
+        SecurityHelper.resolveCredentials(incoming, () -> {
+            callCount[0]++;
+            return existing;
+        });
+
+        assertEquals(1, callCount[0]);
+        assertEquals("real1", incoming.password1);
+        assertEquals("real2", incoming.password2);
+    }
+
+    private static class TestDto {
+        @MaskedCredential
+        String password;
+        String other;
+    }
+
+    private static class TestDtoTwoFields {
+        @MaskedCredential
+        String password1;
+        @MaskedCredential
+        String password2;
     }
 
     private void assertUserEditPrivileges(boolean isAllowed, String ackUser, String... roles) {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/TrapdRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/TrapdRestServiceIT.java
@@ -22,6 +22,7 @@
 package org.opennms.web.rest.v2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -44,10 +45,14 @@ import org.mockito.ArgumentCaptor;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.features.config.exception.ValidationException;
+import org.opennms.netmgt.config.trapd.Snmpv3User;
 import org.opennms.netmgt.config.trapd.TrapdConfiguration;
 import org.opennms.netmgt.dao.api.TrapdConfigDao;
+import org.opennms.web.api.Authentication;
+import org.opennms.web.rest.support.SecurityHelper;
 import org.opennms.test.JUnitConfigurationEnvironment;
-import org.opennms.netmgt.config.trapd.Snmpv3User;
+
+import javax.ws.rs.core.SecurityContext;
 import org.opennms.web.rest.v2.model.Snmpv3UserDto;
 import org.opennms.web.rest.v2.model.TrapdConfigDto;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,7 +92,7 @@ public class TrapdRestServiceIT {
     public void downloadXmlShouldReturnOkWithCorrectHeaders() {
         when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
 
-        try (Response response = trapdRestService.downloadTrapdConfig("xml")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("xml", adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             assertTrue(response.getMediaType().toString().contains("application/xml"));
             assertEquals("attachment; filename=trapd-config.xml", response.getHeaderString("Content-Disposition"));
@@ -100,7 +105,7 @@ public class TrapdRestServiceIT {
     public void downloadXmlShouldReturnBodyWithConfigData() {
         when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
 
-        try (Response response = trapdRestService.downloadTrapdConfig("xml")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("xml", adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             String xml = new String((byte[]) response.getEntity(), StandardCharsets.UTF_8);
             assertTrue(xml.contains("snmp-trap-port=\"162\""));
@@ -112,7 +117,7 @@ public class TrapdRestServiceIT {
     public void downloadXmlShouldReturnNotFoundWhenConfigMissing() {
         when(trapdConfigDao.getConfig()).thenReturn(null);
 
-        try (Response response = trapdRestService.downloadTrapdConfig("xml")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("xml", adminSecurityContext())) {
             assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
             assertEquals("Trapd configuration not found.", response.getEntity());
         }
@@ -122,7 +127,7 @@ public class TrapdRestServiceIT {
     public void downloadXmlShouldReturnServerErrorWhenExceptionThrown() {
         org.mockito.Mockito.doThrow(new RuntimeException("db down")).when(trapdConfigDao).getConfig();
 
-        try (Response response = trapdRestService.downloadTrapdConfig("xml")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("xml", adminSecurityContext())) {
             assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
             assertEquals("Error retrieving Trapd config.", response.getEntity());
         }
@@ -133,7 +138,7 @@ public class TrapdRestServiceIT {
         when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
 
         for (String format : new String[]{"XML", "Xml", "xMl"}) {
-            try (Response response = trapdRestService.downloadTrapdConfig(format)) {
+            try (Response response = trapdRestService.downloadTrapdConfig(format, adminSecurityContext())) {
                 assertEquals("Expected XML response for format=" + format,
                         Response.Status.OK.getStatusCode(), response.getStatus());
                 assertEquals("attachment; filename=trapd-config.xml", response.getHeaderString("Content-Disposition"));
@@ -147,7 +152,7 @@ public class TrapdRestServiceIT {
     public void downloadJsonShouldReturnOkWithCorrectHeaders() {
         when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
 
-        try (Response response = trapdRestService.downloadTrapdConfig("json")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("json", adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             assertTrue(response.getMediaType().toString().contains("application/json"));
             assertEquals("attachment; filename=trapd-config.json", response.getHeaderString("Content-Disposition"));
@@ -160,7 +165,7 @@ public class TrapdRestServiceIT {
     public void downloadJsonShouldReturnBodyWithConfigData() {
         when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
 
-        try (Response response = trapdRestService.downloadTrapdConfig("json")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("json", adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             String json = new String((byte[]) response.getEntity(), StandardCharsets.UTF_8);
             assertTrue(json.contains("snmpTrapPort"));
@@ -172,7 +177,7 @@ public class TrapdRestServiceIT {
     public void downloadJsonShouldDefaultToJsonWhenFormatIsNull() {
         when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
 
-        try (Response response = trapdRestService.downloadTrapdConfig(null)) {
+        try (Response response = trapdRestService.downloadTrapdConfig(null, adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             assertEquals("attachment; filename=trapd-config.json", response.getHeaderString("Content-Disposition"));
         }
@@ -182,7 +187,7 @@ public class TrapdRestServiceIT {
     public void downloadJsonShouldReturnNotFoundWhenConfigMissing() {
         when(trapdConfigDao.getConfig()).thenReturn(null);
 
-        try (Response response = trapdRestService.downloadTrapdConfig("json")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("json", adminSecurityContext())) {
             assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
             assertEquals("Trapd configuration not found.", response.getEntity());
         }
@@ -192,7 +197,7 @@ public class TrapdRestServiceIT {
     public void downloadJsonShouldReturnServerErrorWhenExceptionThrown() {
         org.mockito.Mockito.doThrow(new RuntimeException("db down")).when(trapdConfigDao).getConfig();
 
-        try (Response response = trapdRestService.downloadTrapdConfig("json")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("json", adminSecurityContext())) {
             assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
             assertEquals("Error retrieving Trapd config.", response.getEntity());
         }
@@ -200,7 +205,7 @@ public class TrapdRestServiceIT {
 
     @Test
     public void downloadShouldReturnBadRequestForUnsupportedFormat() {
-        try (Response response = trapdRestService.downloadTrapdConfig("csv")) {
+        try (Response response = trapdRestService.downloadTrapdConfig("csv", adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertEquals("Invalid format parameter. Supported values are 'json' and 'xml'.", response.getEntity());
         }
@@ -211,7 +216,7 @@ public class TrapdRestServiceIT {
         when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
 
         for (String format : new String[]{"JSON", "Json", "jSoN"}) {
-            try (Response response = trapdRestService.downloadTrapdConfig(format)) {
+            try (Response response = trapdRestService.downloadTrapdConfig(format, adminSecurityContext())) {
                 assertEquals("Expected JSON response for format=" + format,
                         Response.Status.OK.getStatusCode(), response.getStatus());
                 assertEquals("attachment; filename=trapd-config.json", response.getHeaderString("Content-Disposition"));
@@ -223,7 +228,7 @@ public class TrapdRestServiceIT {
 
     @Test
     public void uploadShouldReturnBadRequestWhenAttachmentMissingXml() {
-        try (Response response = trapdRestService.uploadTrapdConfigurationXml(null, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfigurationXml(null, adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertEquals("Missing uploaded file for Trap Configuration XML file upload.", response.getEntity());
         }
@@ -236,7 +241,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream("<trapd-configuration".getBytes(StandardCharsets.UTF_8))
         );
 
-        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertEquals("Invalid Trapd XML configuration.", response.getEntity());
         }
@@ -249,7 +254,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream(validTrapdConfigXml().getBytes(StandardCharsets.UTF_8))
         );
 
-        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             assertNull(response.getEntity());
         }
@@ -266,7 +271,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream(validTrapdConfigXmlWithUseAddressFromVarbind().getBytes(StandardCharsets.UTF_8))
         );
 
-        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             assertNull(response.getEntity());
         }
@@ -284,7 +289,7 @@ public class TrapdRestServiceIT {
         );
         whenValidationFailsOnUpdate("Invalid Trapd XML configuration.");
 
-        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertEquals("Invalid Trapd XML configuration.", response.getEntity());
         }
@@ -298,7 +303,7 @@ public class TrapdRestServiceIT {
         );
         org.mockito.Mockito.doThrow(new RuntimeException("db down")).when(trapdConfigDao).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
 
-        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
             assertEquals("Failed to persist Trapd configuration.", response.getEntity());
         }
@@ -308,7 +313,7 @@ public class TrapdRestServiceIT {
 
     @Test
     public void uploadShouldReturnBadRequestWhenAttachmentMissingJson() {
-        try (Response response = trapdRestService.uploadTrapdConfiguration(null, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfiguration(null, adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertEquals("Missing uploaded file for Trap Configuration JSON file upload.", response.getEntity());
         }
@@ -321,7 +326,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream("<trapd-configuration".getBytes(StandardCharsets.UTF_8))
         );
 
-        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertEquals("Invalid Trapd JSON configuration.", response.getEntity());
         }
@@ -334,7 +339,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream("{ \"something }".getBytes(StandardCharsets.UTF_8))
         );
 
-        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertEquals("Invalid Trapd JSON configuration.", response.getEntity());
         }
@@ -347,7 +352,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream(validTrapdConfigJson().getBytes(StandardCharsets.UTF_8))
         );
 
-        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             assertNull(response.getEntity());
         }
@@ -364,7 +369,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream(validTrapdConfigJsonWithUseAddressFromVarbind().getBytes(StandardCharsets.UTF_8))
         );
 
-        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             assertNull(response.getEntity());
         }
@@ -382,7 +387,7 @@ public class TrapdRestServiceIT {
         );
         whenValidationFailsOnUpdate("Invalid Trapd JSON configuration.");
 
-        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertEquals("Invalid Trapd JSON configuration.", response.getEntity());
         }
@@ -396,7 +401,7 @@ public class TrapdRestServiceIT {
         );
         org.mockito.Mockito.doThrow(new RuntimeException("db down")).when(trapdConfigDao).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
 
-        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
             assertEquals("Failed to persist Trapd configuration.", response.getEntity());
         }
@@ -442,9 +447,10 @@ public class TrapdRestServiceIT {
     }
 
     @Test
-    public void getShouldReturnSnmpv3UserFieldsUnchanged() {
+    public void getShouldReturnSnmpv3UserFieldsUnchangedButStillMaskCredentials() {
         TrapdConfiguration config = buildMinimalConfig();
         Snmpv3User user = new Snmpv3User();
+        user.setId("test-user-id-1");
         user.setSecurityName("engine-user");
         user.setEngineId("0x8000000001020304");
         user.setSecurityLevel(3);
@@ -459,13 +465,14 @@ public class TrapdRestServiceIT {
             assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
             TrapdConfigDto returned = (TrapdConfigDto) response.getEntity();
             Snmpv3UserDto returnedUser = returned.getSnmpv3User().get(0);
+            assertEquals("test-user-id-1", returnedUser.getId());
             assertEquals("engine-user", returnedUser.getSecurityName());
             assertEquals("0x8000000001020304", returnedUser.getEngineId());
             assertEquals("SHA", returnedUser.getAuthProtocol());
             assertEquals("AES", returnedUser.getPrivacyProtocol());
             assertEquals(Integer.valueOf(3), returnedUser.getSecurityLevel());
-            assertEquals("authpass", returnedUser.getAuthPassphrase());
-            assertEquals("privpass", returnedUser.getPrivacyPassphrase());
+            assertEquals(SecurityHelper.MASKED_PASSWORD, returnedUser.getAuthPassphrase());
+            assertEquals(SecurityHelper.MASKED_PASSWORD, returnedUser.getPrivacyPassphrase());
         }
     }
 
@@ -856,6 +863,58 @@ public class TrapdRestServiceIT {
     }
 
     @Test
+    public void updateShouldRejectAuthPassphraseStartingWithStar() {
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto user = new Snmpv3UserDto();
+        user.setSecurityName("user1");
+        user.setAuthProtocol("SHA");
+        user.setAuthPassphrase("*notmasked"); // starts with * but is not MASKED_PASSWORD
+        payload.setSnmpv3User(java.util.List.of(user));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            assertTrue(((String) response.getEntity()).contains("authPassphrase must not begin with '*'."));
+        }
+
+        verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    @Test
+    public void updateShouldRejectPrivacyPassphraseStartingWithStar() {
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto user = new Snmpv3UserDto();
+        user.setSecurityName("user1");
+        user.setAuthProtocol("SHA");
+        user.setAuthPassphrase("authpass1");
+        user.setPrivacyProtocol("AES");
+        user.setPrivacyPassphrase("*notmasked"); // starts with * but is not MASKED_PASSWORD
+        payload.setSnmpv3User(java.util.List.of(user));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            assertTrue(((String) response.getEntity()).contains("privacyPassphrase must not begin with '*'."));
+        }
+
+        verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    @Test
+    public void updateShouldAcceptPassphraseWithStarNotAtStart() {
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto user = new Snmpv3UserDto();
+        user.setSecurityName("user1");
+        user.setAuthProtocol("SHA");
+        user.setAuthPassphrase("pass*word"); // * is not at the start
+        payload.setSnmpv3User(java.util.List.of(user));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        }
+
+        verify(trapdConfigDao).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    @Test
     public void updateShouldAcceptScvPlaceholderPassphrase() {
         // ${scv:alias:key} is always > 8 bytes; the literal length check passes trivially
         // and the placeholder is resolved by the daemon at runtime via SecureCredentialsVault.
@@ -1121,7 +1180,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream("<trapd-configuration".getBytes(StandardCharsets.UTF_8))
         );
 
-        trapdRestService.uploadTrapdConfigurationXml(attachment, null);
+        trapdRestService.uploadTrapdConfigurationXml(attachment, adminSecurityContext());
 
         verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
     }
@@ -1139,7 +1198,7 @@ public class TrapdRestServiceIT {
                 new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))
         );
 
-        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, null)) {
+        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, adminSecurityContext())) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
             assertTrue(((String) response.getEntity()).contains("securityLevel 3 requires both auth and privacy credentials."));
         }
@@ -1263,8 +1322,359 @@ public class TrapdRestServiceIT {
         verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
     }
 
+    // --- Credential masking tests ---
+
+    @Test
+    public void getShouldReturnMaskedPassphrasesForSnmpv3Users() {
+        TrapdConfiguration config = buildMinimalConfig();
+        Snmpv3User user = new Snmpv3User();
+        user.setSecurityName("testUser");
+        user.setAuthProtocol("SHA");
+        user.setAuthPassphrase("realAuthPass");
+        user.setPrivacyProtocol("AES");
+        user.setPrivacyPassphrase("realPrivPass");
+        config.addSnmpv3User(user);
+        when(trapdConfigDao.getConfig()).thenReturn(config);
+
+        try (Response response = trapdRestService.getTrapdConfiguration(null)) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            TrapdConfigDto returned = (TrapdConfigDto) response.getEntity();
+            assertEquals(1, returned.getSnmpv3User().size());
+            Snmpv3UserDto userDto = returned.getSnmpv3User().get(0);
+            assertEquals(SecurityHelper.MASKED_PASSWORD, userDto.getAuthPassphrase());
+            assertEquals(SecurityHelper.MASKED_PASSWORD, userDto.getPrivacyPassphrase());
+            // original entity must not be mutated
+            assertEquals("realAuthPass", user.getAuthPassphrase());
+            assertEquals("realPrivPass", user.getPrivacyPassphrase());
+        }
+    }
+
+    @Test
+    public void downloadShouldReturnPlaintextPassphrasesNotMasked() {
+        TrapdConfiguration config = buildMinimalConfig();
+        Snmpv3User user = new Snmpv3User();
+        user.setSecurityName("testUser");
+        user.setAuthProtocol("SHA");
+        user.setAuthPassphrase("realAuthPass");
+        config.addSnmpv3User(user);
+        when(trapdConfigDao.getConfig()).thenReturn(config);
+
+        try (Response response = trapdRestService.downloadTrapdConfig("json", adminSecurityContext())) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            String json = new String((byte[]) response.getEntity(), StandardCharsets.UTF_8);
+            assertTrue(json.contains("realAuthPass"));
+            assertFalse(json.contains(SecurityHelper.MASKED_PASSWORD));
+        }
+    }
+
+    @Test
+    public void updateWithMaskedPassphraseShouldPreserveExistingCredential() {
+        TrapdConfiguration existingConfig = buildMinimalConfig();
+        Snmpv3User existingUser = new Snmpv3User();
+        existingUser.setId("user-id-1");
+        existingUser.setSecurityName("testUser");
+        existingUser.setAuthProtocol("SHA");
+        existingUser.setAuthPassphrase("realAuthPass");
+        existingConfig.addSnmpv3User(existingUser);
+        when(trapdConfigDao.getConfig()).thenReturn(existingConfig);
+
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto incomingUser = new Snmpv3UserDto();
+        incomingUser.setId("user-id-1");
+        incomingUser.setSecurityName("testUser");
+        incomingUser.setAuthProtocol("SHA");
+        incomingUser.setAuthPassphrase(SecurityHelper.MASKED_PASSWORD);
+        payload.setSnmpv3User(java.util.List.of(incomingUser));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        }
+
+        ArgumentCaptor<TrapdConfiguration> captor = ArgumentCaptor.forClass(TrapdConfiguration.class);
+        verify(trapdConfigDao).replaceConfig(captor.capture());
+        assertEquals("realAuthPass", captor.getValue().getSnmpv3User(0).getAuthPassphrase());
+    }
+
+    /**
+     * Two users sharing the same securityName but with different credentials must each
+     * resolve a masked passphrase against <em>their own</em> stored secret, correlated by id.
+     * This is the core scenario that securityName-based matching could not handle.
+     */
+    @Test
+    public void updateWithDuplicateSecurityNamesResolvesEachByItsOwnId() {
+        TrapdConfiguration existingConfig = buildMinimalConfig();
+        Snmpv3User userA = new Snmpv3User();
+        userA.setId("id-a");
+        userA.setSecurityName("dupUser");
+        userA.setAuthProtocol("SHA");
+        userA.setAuthPassphrase("secretPassphraseA");
+        existingConfig.addSnmpv3User(userA);
+        Snmpv3User userB = new Snmpv3User();
+        userB.setId("id-b");
+        userB.setSecurityName("dupUser");
+        userB.setAuthProtocol("MD5");
+        userB.setAuthPassphrase("secretPassphraseB");
+        existingConfig.addSnmpv3User(userB);
+        when(trapdConfigDao.getConfig()).thenReturn(existingConfig);
+
+        // Submit both users back with masked passphrases, in reverse order, to prove the
+        // resolution is keyed by id and not by list position or security name.
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto incomingB = new Snmpv3UserDto();
+        incomingB.setId("id-b");
+        incomingB.setSecurityName("dupUser");
+        incomingB.setAuthProtocol("MD5");
+        incomingB.setAuthPassphrase(SecurityHelper.MASKED_PASSWORD);
+        Snmpv3UserDto incomingA = new Snmpv3UserDto();
+        incomingA.setId("id-a");
+        incomingA.setSecurityName("dupUser");
+        incomingA.setAuthProtocol("SHA");
+        incomingA.setAuthPassphrase(SecurityHelper.MASKED_PASSWORD);
+        payload.setSnmpv3User(java.util.List.of(incomingB, incomingA));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        }
+
+        ArgumentCaptor<TrapdConfiguration> captor = ArgumentCaptor.forClass(TrapdConfiguration.class);
+        verify(trapdConfigDao).replaceConfig(captor.capture());
+        TrapdConfiguration saved = captor.getValue();
+        assertEquals("secretPassphraseA", saved.getSnmpv3UserById("id-a").getAuthPassphrase());
+        assertEquals("secretPassphraseB", saved.getSnmpv3UserById("id-b").getAuthPassphrase());
+    }
+
+    /**
+     * A masked passphrase paired with an id that does not match any stored user must be
+     * rejected — there is no secret to resolve, so it is treated like a new entry.
+     */
+    @Test
+    public void updateWithMaskedPassphraseAndUnknownIdReturnsBadRequest() {
+        TrapdConfiguration existingConfig = buildMinimalConfig();
+        Snmpv3User existingUser = new Snmpv3User();
+        existingUser.setId("known-id");
+        existingUser.setSecurityName("testUser");
+        existingUser.setAuthProtocol("SHA");
+        existingUser.setAuthPassphrase("realAuthPass");
+        existingConfig.addSnmpv3User(existingUser);
+        when(trapdConfigDao.getConfig()).thenReturn(existingConfig);
+
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto incomingUser = new Snmpv3UserDto();
+        incomingUser.setId("stale-or-unknown-id");
+        incomingUser.setSecurityName("testUser");
+        incomingUser.setAuthProtocol("SHA");
+        incomingUser.setAuthPassphrase(SecurityHelper.MASKED_PASSWORD);
+        payload.setSnmpv3User(java.util.List.of(incomingUser));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            assertTrue(((String) response.getEntity()).contains("masked passphrase"));
+        }
+
+        verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    @Test
+    public void updateWithRealPassphraseShouldUpdateToNewValue() {
+        TrapdConfiguration existingConfig = buildMinimalConfig();
+        Snmpv3User existingUser = new Snmpv3User();
+        existingUser.setSecurityName("testUser");
+        existingUser.setAuthProtocol("SHA");
+        existingUser.setAuthPassphrase("oldAuthPass");
+        existingConfig.addSnmpv3User(existingUser);
+        when(trapdConfigDao.getConfig()).thenReturn(existingConfig);
+
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto incomingUser = new Snmpv3UserDto();
+        incomingUser.setSecurityName("testUser");
+        incomingUser.setAuthProtocol("SHA");
+        incomingUser.setAuthPassphrase("newAuthPass");
+        payload.setSnmpv3User(java.util.List.of(incomingUser));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        }
+
+        ArgumentCaptor<TrapdConfiguration> captor = ArgumentCaptor.forClass(TrapdConfiguration.class);
+        verify(trapdConfigDao).replaceConfig(captor.capture());
+        assertEquals("newAuthPass", captor.getValue().getSnmpv3User(0).getAuthPassphrase());
+    }
+
+    @Test
+    public void updateWithMaskedPassphraseForNewUserShouldReturnBadRequest() {
+        when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig()); // no users
+
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto incomingUser = new Snmpv3UserDto();
+        incomingUser.setSecurityName("brandNewUser");
+        incomingUser.setAuthProtocol("SHA");
+        incomingUser.setAuthPassphrase(SecurityHelper.MASKED_PASSWORD);
+        payload.setSnmpv3User(java.util.List.of(incomingUser));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            assertTrue(((String) response.getEntity()).contains("masked passphrase"));
+        }
+
+        verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    // --- SCV expression tests ---
+
+    @Test
+    public void getShouldReturnScvExpressionUnmasked() {
+        TrapdConfiguration config = buildMinimalConfig();
+        Snmpv3User user = new Snmpv3User();
+        user.setSecurityName("scvUser");
+        user.setAuthProtocol("SHA");
+        user.setAuthPassphrase("${scv:myalias:authkey}");
+        user.setPrivacyProtocol("AES");
+        user.setPrivacyPassphrase("${scv:myalias:privkey}");
+        config.addSnmpv3User(user);
+        when(trapdConfigDao.getConfig()).thenReturn(config);
+
+        try (Response response = trapdRestService.getTrapdConfiguration(null)) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            TrapdConfigDto returned = (TrapdConfigDto) response.getEntity();
+            Snmpv3UserDto userDto = returned.getSnmpv3User().get(0);
+            assertEquals("${scv:myalias:authkey}", userDto.getAuthPassphrase());
+            assertEquals("${scv:myalias:privkey}", userDto.getPrivacyPassphrase());
+        }
+    }
+
+    @Test
+    public void updateWithScvExpressionShouldPersistItAsIs() {
+        when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
+
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto incomingUser = new Snmpv3UserDto();
+        incomingUser.setSecurityName("scvUser");
+        incomingUser.setAuthProtocol("SHA");
+        incomingUser.setAuthPassphrase("${scv:myalias:authkey}");
+        payload.setSnmpv3User(java.util.List.of(incomingUser));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        }
+
+        ArgumentCaptor<TrapdConfiguration> captor = ArgumentCaptor.forClass(TrapdConfiguration.class);
+        verify(trapdConfigDao).replaceConfig(captor.capture());
+        assertEquals("${scv:myalias:authkey}", captor.getValue().getSnmpv3User(0).getAuthPassphrase());
+    }
+
+    @Test
+    public void uploadJsonWithScvExpressionShouldPersistItAsIs() {
+        when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
+
+        String json = """
+                {"snmpTrapAddress":"*","snmpTrapPort":162,"newSuspectOnTrap":false,\
+                "snmpv3User":[{"securityName":"scvUser","authProtocol":"SHA",\
+                "authPassphrase":"${scv:myalias:authkey}"}]}""";
+        Attachment attachment = mock(Attachment.class);
+        when(attachment.getObject(InputStream.class)).thenReturn(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))
+        );
+
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        }
+
+        ArgumentCaptor<TrapdConfiguration> captor = ArgumentCaptor.forClass(TrapdConfiguration.class);
+        verify(trapdConfigDao).replaceConfig(captor.capture());
+        assertEquals("${scv:myalias:authkey}", captor.getValue().getSnmpv3User(0).getAuthPassphrase());
+    }
+
+    @Test
+    public void uploadJsonWithMaskedPassphraseShouldPreserveExistingCredential() {
+        TrapdConfiguration existingConfig = buildMinimalConfig();
+        Snmpv3User existingUser = new Snmpv3User();
+        existingUser.setId("upload-id-1");
+        existingUser.setSecurityName("testUser");
+        existingUser.setAuthProtocol("SHA");
+        existingUser.setAuthPassphrase("realAuthPass");
+        existingConfig.addSnmpv3User(existingUser);
+        when(trapdConfigDao.getConfig()).thenReturn(existingConfig);
+
+        String json = """
+                {"snmpTrapAddress":"*","snmpTrapPort":162,"newSuspectOnTrap":false,\
+                "snmpv3User":[{"id":"upload-id-1","securityName":"testUser","authProtocol":"SHA",\
+                "authPassphrase":"******"}]}""";
+        Attachment attachment = mock(Attachment.class);
+        when(attachment.getObject(InputStream.class)).thenReturn(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))
+        );
+
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        }
+
+        ArgumentCaptor<TrapdConfiguration> captor = ArgumentCaptor.forClass(TrapdConfiguration.class);
+        verify(trapdConfigDao).replaceConfig(captor.capture());
+        assertEquals("realAuthPass", captor.getValue().getSnmpv3User(0).getAuthPassphrase());
+    }
+
+    // --- Authorization Tests ---
+
+    @Test
+    public void downloadShouldReturn403ForNonAdminUser() {
+        try (Response response = trapdRestService.downloadTrapdConfig("json", nonAdminSecurityContext())) {
+            assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+            assertEquals("Admin role required to download Trapd configuration.", response.getEntity());
+        }
+        verify(trapdConfigDao, never()).getConfig();
+    }
+
+    @Test
+    public void downloadXmlShouldReturn403ForNonAdminUser() {
+        try (Response response = trapdRestService.downloadTrapdConfig("xml", nonAdminSecurityContext())) {
+            assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+            assertEquals("Admin role required to download Trapd configuration.", response.getEntity());
+        }
+        verify(trapdConfigDao, never()).getConfig();
+    }
+
+    @Test
+    public void uploadJsonShouldReturn403ForNonAdminUser() {
+        Attachment attachment = mock(Attachment.class);
+        when(attachment.getObject(InputStream.class)).thenReturn(
+                new ByteArrayInputStream(validTrapdConfigJson().getBytes(StandardCharsets.UTF_8))
+        );
+
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, nonAdminSecurityContext())) {
+            assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+            assertEquals("Admin role required to upload Trapd configuration.", response.getEntity());
+        }
+        verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    @Test
+    public void uploadXmlShouldReturn403ForNonAdminUser() {
+        Attachment attachment = mock(Attachment.class);
+        when(attachment.getObject(InputStream.class)).thenReturn(
+                new ByteArrayInputStream(validTrapdConfigXml().getBytes(StandardCharsets.UTF_8))
+        );
+
+        try (Response response = trapdRestService.uploadTrapdConfigurationXml(attachment, nonAdminSecurityContext())) {
+            assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+            assertEquals("Admin role required to upload Trapd configuration.", response.getEntity());
+        }
+        verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
     private void whenValidationFailsOnUpdate(final String message) {
         org.mockito.Mockito.doThrow(new ValidationException(message)).when(trapdConfigDao).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    private static SecurityContext adminSecurityContext() {
+        SecurityContext sc = mock(SecurityContext.class);
+        when(sc.isUserInRole(Authentication.ROLE_ADMIN)).thenReturn(true);
+        return sc;
+    }
+
+    private static SecurityContext nonAdminSecurityContext() {
+        SecurityContext sc = mock(SecurityContext.class);
+        when(sc.isUserInRole(Authentication.ROLE_ADMIN)).thenReturn(false);
+        return sc;
     }
 
     private static void setField(final Object target, final String fieldName, final Object value) throws Exception {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/TrapdRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/TrapdRestServiceIT.java
@@ -1519,6 +1519,74 @@ public class TrapdRestServiceIT {
         verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
     }
 
+    /**
+     * Two incoming users sharing the same non-blank id would break id-based credential
+     * correlation and persist an unreachable duplicate, so the request must be rejected.
+     */
+    @Test
+    public void updateWithDuplicateUserIdsReturnsBadRequest() {
+        when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
+
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto userA = new Snmpv3UserDto();
+        userA.setId("dup-id");
+        userA.setSecurityName("userA");
+        Snmpv3UserDto userB = new Snmpv3UserDto();
+        userB.setId("dup-id");
+        userB.setSecurityName("userB");
+        payload.setSnmpv3User(java.util.List.of(userA, userB));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            assertTrue(((String) response.getEntity()).contains("Duplicate SNMPv3 user id"));
+        }
+
+        verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    /**
+     * Multiple new users with blank ids are legitimate (ids are assigned at persist time) and
+     * must not be mistaken for duplicates.
+     */
+    @Test
+    public void updateWithMultipleBlankUserIdsIsAllowed() {
+        when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
+
+        TrapdConfigDto payload = buildMinimalUpdatePayload();
+        Snmpv3UserDto userA = new Snmpv3UserDto();
+        userA.setSecurityName("newUserA");
+        Snmpv3UserDto userB = new Snmpv3UserDto();
+        userB.setSecurityName("newUserB");
+        payload.setSnmpv3User(java.util.List.of(userA, userB));
+
+        try (Response response = trapdRestService.updateTrapdConfiguration(payload, null)) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        }
+
+        verify(trapdConfigDao).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
+    @Test
+    public void uploadJsonWithDuplicateUserIdsReturnsBadRequest() {
+        when(trapdConfigDao.getConfig()).thenReturn(buildMinimalConfig());
+
+        String json = """
+                {"snmpTrapAddress":"*","snmpTrapPort":162,"newSuspectOnTrap":false,\
+                "snmpv3User":[{"id":"dup-id","securityName":"userA"},\
+                {"id":"dup-id","securityName":"userB"}]}""";
+        Attachment attachment = mock(Attachment.class);
+        when(attachment.getObject(InputStream.class)).thenReturn(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))
+        );
+
+        try (Response response = trapdRestService.uploadTrapdConfiguration(attachment, adminSecurityContext())) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            assertTrue(((String) response.getEntity()).contains("Duplicate SNMPv3 user id"));
+        }
+
+        verify(trapdConfigDao, never()).replaceConfig(org.mockito.Mockito.any(TrapdConfiguration.class));
+    }
+
     // --- SCV expression tests ---
 
     @Test

--- a/ui/src/components/TrapdConfiguration/CreateSnmpV3User.vue
+++ b/ui/src/components/TrapdConfiguration/CreateSnmpV3User.vue
@@ -26,13 +26,13 @@
           <FormField
             label="Security Name"
             for="security-name"
-            :error="error.securityName"
+            :error="formError.securityName"
           >
             <PInputText
               id="security-name"
               data-test="security-name-input"
               v-model="securityName"
-              :invalid="!!error.securityName"
+              :invalid="!!formError.securityName"
             />
           </FormField>
         </div>
@@ -40,13 +40,13 @@
           <FormField
             label="Engine ID"
             for="engine-id"
-            :error="error.engineId"
+            :error="formError.engineId"
           >
             <PInputText
               id="engine-id"
               data-test="engine-id-input"
               v-model="engineId"
-              :invalid="!!error.engineId"
+              :invalid="!!formError.engineId"
             />
           </FormField>
         </div>
@@ -59,7 +59,7 @@
           <FormField
             label="Security Level"
             for="security-level"
-            :error="error.securityLevel"
+            :error="formError.securityLevel"
           >
             <PSelect
               inputId="security-level"
@@ -68,7 +68,7 @@
               showClear
               optionLabel="_text"
               :options="SECURITY_LEVEL_OPTIONS"
-              :invalid="!!error.securityLevel"
+              :invalid="!!formError.securityLevel"
             />
           </FormField>
         </div>
@@ -82,7 +82,7 @@
           <FormField
             label="Auth Protocol"
             for="auth-protocol"
-            :error="error.authProtocol"
+            :error="formError.authProtocol"
           >
             <PSelect
               inputId="auth-protocol"
@@ -90,7 +90,7 @@
               showClear
               optionLabel="_text"
               :options="AUTH_PROTOCOL_OPTIONS"
-              :invalid="!!error.authProtocol"
+              :invalid="!!formError.authProtocol"
             />
           </FormField>
         </div>
@@ -98,20 +98,24 @@
           <FormField
             label="Auth Passphrase"
             for="auth-passphrase"
-            :error="error.authPassphrase"
+            :error="formError.authPassphrase"
           >
-            <PInputText
-              id="auth-passphrase"
-              type="password"
-              data-test="auth-passphrase-input"
-              v-model="authPassphrase"
-              :invalid="!!error.authPassphrase"
-            />
+            <div class="input-with-icon">
+              <PPassword
+                inputId="auth-passphrase"
+                data-test="auth-passphrase-input"
+                v-model="authPassphrase"
+                :invalid="!!formError.authPassphrase"
+                toggleMask
+                :feedback="false"
+                fluid
+              />
+              <ScvInputIcon
+                data-test="auth-passphrase-save-button"
+                @click="store.openCredentialDrawer('auth')"
+              />
+            </div>
           </FormField>
-          <ScvInputIcon
-            data-test="auth-passphrase-save-button"
-            @click="store.openCredentialDrawer('auth')"
-          />
         </div>
       </div>
       <div
@@ -122,7 +126,7 @@
           <FormField
             label="Privacy Protocol"
             for="privacy-protocol"
-            :error="error.privacyProtocol"
+            :error="formError.privacyProtocol"
           >
             <PSelect
               inputId="privacy-protocol"
@@ -130,7 +134,7 @@
               showClear
               optionLabel="_text"
               :options="PRIVACY_PROTOCOL_OPTIONS"
-              :invalid="!!error.privacyProtocol"
+              :invalid="!!formError.privacyProtocol"
             />
           </FormField>
         </div>
@@ -138,20 +142,24 @@
           <FormField
             label="Privacy Passphrase"
             for="privacy-passphrase"
-            :error="error.privacyPassphrase"
+            :error="formError.privacyPassphrase"
           >
-            <PInputText
-              id="privacy-passphrase"
-              type="password"
-              data-test="privacy-passphrase-input"
-              v-model="privacyPassphrase"
-              :invalid="!!error.privacyPassphrase"
-            />
+            <div class="input-with-icon">
+              <PPassword
+                inputId="privacy-passphrase"
+                data-test="privacy-passphrase-input"
+                v-model="privacyPassphrase"
+                :invalid="!!formError.privacyPassphrase"
+                toggleMask
+                :feedback="false"
+                fluid
+              />
+              <ScvInputIcon
+                data-test="privacy-passphrase-save-button"
+                @click="store.openCredentialDrawer('privacy')"
+              />
+            </div>
           </FormField>
-          <ScvInputIcon
-            data-test="privacy-passphrase-save-button"
-            @click="store.openCredentialDrawer('privacy')"
-          />
         </div>
       </div>
     </div>
@@ -182,7 +190,13 @@ import { computed, nextTick, onMounted, ref, watch, watchEffect } from 'vue'
 
 import useSnackbar from '@/composables/useSnackbar'
 import { DEFAULT_SNMP_V3_AUTH_PROTOCOL, DEFAULT_SNMP_V3_PRIVACY_PROTOCOL } from '@/lib/constants'
-import { AUTH_PROTOCOL_OPTIONS, MIN_PASSPHRASE_CHARACTERS, PRIVACY_PROTOCOL_OPTIONS, SECURITY_LEVEL_OPTIONS, SecurityLevel, passphraseByteLength } from '@/lib/trapdValidator'
+import {
+  AUTH_PROTOCOL_OPTIONS,
+  PRIVACY_PROTOCOL_OPTIONS,
+  SECURITY_LEVEL_OPTIONS,
+  SecurityLevel,
+  validateSnmpV3UserForm }
+  from '@/lib/trapdValidator'
 import { mapUserToServer } from '@/mappers/trapdConfig.mapper'
 import { updateTrapdConfiguration } from '@/services/trapdConfigurationService'
 import { useScvStore } from '@/stores/scvStore'
@@ -192,6 +206,7 @@ import type { SnmpV3UserError } from '@/types/trapConfig'
 import Button from 'primevue/button'
 import FormField from '../Common/FormField.vue'
 import InputText from 'primevue/inputtext'
+import Password from 'primevue/password'
 import Select from 'primevue/select'
 import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import ChevronLeft from '@/components/icons/navigation/ChevronLeft.vue'
@@ -202,11 +217,13 @@ import ScvSearchDrawer from '../SCV/ScvSearchDrawer.vue'
 
 const PButton = Button
 const PInputText = InputText
+const PPassword = Password
 const PSelect = Select
 
 const store = useTrapdConfigStore()
 const { showSnackBar } = useSnackbar()
 const createEmptySelectItem = (): ISelectItemType => (undefined as unknown as ISelectItemType)
+const id = ref<string | undefined>(undefined)
 const securityName = ref<string>('')
 const engineId = ref<string>('')
 const securityLevel = ref<ISelectItemType>(createEmptySelectItem())
@@ -216,7 +233,7 @@ const authPassphrase = ref<string>('')
 const privacyPassphrase = ref<string>('')
 const isSaveDisabled = ref<boolean>(true)
 const isSaving = ref<boolean>(false)
-const error = ref<SnmpV3UserError>({})
+const formError = ref<SnmpV3UserError>({})
 const scvStore = useScvStore()
 
 const authProtocolVisible = computed(() => {
@@ -230,7 +247,7 @@ const privacyProtocolVisible = computed(() => {
 })
 
 const saveUser = async () => {
-  const validationError = validateInputs()
+  const validationError = validateSnmpV3UserForm(securityName.value, securityLevel.value, authProtocol.value, authPassphrase.value, privacyProtocol.value, privacyPassphrase.value)
   if (Object.keys(validationError).length > 0) {
     showSnackBar({ msg: 'Please fix validation errors before saving.', error: true })
     return
@@ -241,6 +258,7 @@ const saveUser = async () => {
   }
 
   const payload = mapUserToServer({
+    id: id.value,
     securityName: securityName.value,
     engineId: engineId.value,
     securityLevel: Number(securityLevel.value?._value),
@@ -321,52 +339,6 @@ const onSecurityLevelChange = async () => {
   }
 }
 
-const validateInputs = () => {
-  const newError: SnmpV3UserError = {}
-  const levelValue = Number(securityLevel.value?._value)
-
-  if (!securityName.value) {
-    newError.securityName = 'Security Name is required'
-  }
-
-  // Level 1 (NoAuthNoPriv) must not carry auth or privacy credentials (backend rule)
-  if (levelValue === SecurityLevel.NoAuthNoPriv && (authProtocol.value || privacyProtocol.value)) {
-    newError.securityLevel = 'Security level 1 does not allow auth or privacy credentials'
-  }
-
-  // Level 2 (AuthNoPriv) must not carry privacy credentials (backend rule)
-  if (levelValue === SecurityLevel.AuthNoPriv && privacyProtocol.value) {
-    newError.privacyProtocol = 'Security level 2 does not allow privacy credentials'
-  }
-
-  // authProtocol and authPassphrase must be provided together (backend rule)
-  if (authProtocolVisible.value && !authProtocol.value) {
-    newError.authProtocol = authPassphrase.value
-      ? 'Auth Passphrase requires an Auth Protocol to be selected'
-      : 'Auth Protocol is required for selected security level'
-  }
-
-  if (authProtocolVisible.value && authProtocol.value && !authPassphrase.value) {
-    newError.authPassphrase = 'Auth Passphrase is required for selected auth protocol'
-  } else if (authPassphrase.value && passphraseByteLength(authPassphrase.value) < MIN_PASSPHRASE_CHARACTERS) {
-    newError.authPassphrase = `Auth Passphrase must be at least ${MIN_PASSPHRASE_CHARACTERS} characters`
-  }
-
-  // privacyProtocol and privacyPassphrase must be provided together (backend rule)
-  if (privacyProtocolVisible.value && !privacyProtocol.value) {
-    newError.privacyProtocol = privacyPassphrase.value
-      ? 'Privacy Passphrase requires a Privacy Protocol to be selected'
-      : 'Privacy Protocol is required for selected security level'
-  }
-
-  if (privacyProtocolVisible.value && privacyProtocol.value && !privacyPassphrase.value) {
-    newError.privacyPassphrase = 'Privacy Passphrase is required for selected privacy protocol'
-  } else if (privacyPassphrase.value && passphraseByteLength(privacyPassphrase.value) < MIN_PASSPHRASE_CHARACTERS) {
-    newError.privacyPassphrase = `Privacy Passphrase must be at least ${MIN_PASSPHRASE_CHARACTERS} characters`
-  }
-  return newError
-}
-
 const loadUserData = async (drawerState: typeof store.createUserDrawerState) => {
   if (drawerState.mode === CreateEditMode.Edit && drawerState.selectedUserIndex > -1) {
     const selectedUser = store.snmpV3Users ? store.snmpV3Users[drawerState.selectedUserIndex] : null
@@ -381,6 +353,7 @@ const loadUserData = async (drawerState: typeof store.createUserDrawerState) => 
       privacyProtocol.value = selectedSecurityLevel === SecurityLevel.AuthPriv
         ? PRIVACY_PROTOCOL_OPTIONS.find(option => option._value === selectedUser.privacyProtocol) ?? createEmptySelectItem()
         : createEmptySelectItem()
+      id.value = selectedUser.id
       securityName.value = selectedUser.securityName
       engineId.value = selectedUser.engineId || ''
       authPassphrase.value = selectedUser.authPassphrase || ''
@@ -390,6 +363,7 @@ const loadUserData = async (drawerState: typeof store.createUserDrawerState) => 
     securityLevel.value = SECURITY_LEVEL_OPTIONS.find(option => option._value === String(SecurityLevel.NoAuthNoPriv)) ?? createEmptySelectItem()
     authProtocol.value = createEmptySelectItem()
     privacyProtocol.value = createEmptySelectItem()
+    id.value = undefined
     securityName.value = ''
     engineId.value = ''
     authPassphrase.value = ''
@@ -412,13 +386,13 @@ watch(securityLevel, (selectedSecurityLevel) => {
     privacyPassphrase.value = ''
   }
 
-  error.value = validateInputs()
-  isSaveDisabled.value = Object.keys(error.value).length > 0
+  formError.value = validateSnmpV3UserForm(securityName.value, securityLevel.value, authProtocol.value, authPassphrase.value, privacyProtocol.value, privacyPassphrase.value)
+  isSaveDisabled.value = Object.keys(formError.value).length > 0
 })
 
 watchEffect(() => {
-  error.value = validateInputs()
-  isSaveDisabled.value = Object.keys(error.value).length > 0
+  formError.value = validateSnmpV3UserForm(securityName.value, securityLevel.value, authProtocol.value, authPassphrase.value, privacyProtocol.value, privacyPassphrase.value)
+  isSaveDisabled.value = Object.keys(formError.value).length > 0
 })
 
 watch(
@@ -496,12 +470,14 @@ onMounted(() => {
       }
 
       .right {
-        display: flex;
-        align-items: center;
-        gap: 10px;
+        .input-with-icon {
+          display: flex;
+          align-items: center;
+          gap: 10px;
 
-        .form-field {
-          flex: 1;
+          :deep(.p-password) {
+            flex: 1;
+          }
         }
       }
     }

--- a/ui/src/components/TrapdConfiguration/SnmpV3UserManagement.vue
+++ b/ui/src/components/TrapdConfiguration/SnmpV3UserManagement.vue
@@ -101,6 +101,18 @@
         <div>
           <p>Configure SNMPv3 user settings.</p>
           <p><strong>Note</strong> that the settings here apply to the OpenNMS core system as well as to any Minions or other distributed components.</p>
+          <br />
+          <p><strong>Credentials</strong></p>
+          <br />
+          <p>Credentials for SNMPv3 users have the following requirements:</p>
+          <ul>
+            <li>Authentication Passphrase: at least 8 characters</li>
+            <li>Privacy Passphrase: at least 8 characters</li>
+          </ul>
+          <br />
+          <p>Note that credentials are <em>masked</em>, displayed as a series of '*' characters, and cannot be viewed in the UI once set.</p>
+          <p>If you want to change a credential, you may enter a new one. Note that new credentials must not begin with a '*' character.</p>
+          <p>We strongly suggest that you use an SCV (Secure Credentials Vault) expression for storing credentials securely, rather than entering them directly.</p>
         </div>
       </template>
     </MessageDialog>

--- a/ui/src/components/TrapdConfiguration/TrapdAdvancedConfiguration.vue
+++ b/ui/src/components/TrapdConfiguration/TrapdAdvancedConfiguration.vue
@@ -120,7 +120,7 @@ const uploadType = ref<'xml' | 'json' | null>(null)
 const uploadFile = ref<File | null>(null)
 
 const onDownload = async (isXml: boolean) => {
-  if (!adminRole) {
+  if (!adminRole.value) {
     return
   }
 
@@ -142,7 +142,7 @@ const onDownload = async (isXml: boolean) => {
 }
 
 const initiateUpload = async (isXml: boolean) => {
-  if (!adminRole) {
+  if (!adminRole.value) {
     return
   }
 
@@ -199,7 +199,7 @@ const onUploadConfirm = async () => {
 }
 
 const performUpload = async (isXml: boolean) => {
-  if (!adminRole) {
+  if (!adminRole.value) {
     return
   }
 

--- a/ui/src/components/TrapdConfiguration/TrapdAdvancedConfiguration.vue
+++ b/ui/src/components/TrapdConfiguration/TrapdAdvancedConfiguration.vue
@@ -8,6 +8,11 @@
               <strong>Use caution</strong> when uploading Trap configuration files, as this will overwrite the existing configuration and may impact device monitoring if the uploaded configuration is not correct.</span>
           </div>
         </div>
+        <div class="onms-row" v-if="!adminRole">
+          <div class="onms-col-12">
+            <span class="label">You need Admin access to upload/download Trap configuration files.</span>
+          </div>
+        </div>
         <div class="onms-row">
           <div class="onms-col-6">
             <label class="label">Download file in XML format:</label>
@@ -16,6 +21,7 @@
             <PButton
               data-test="download-xml-button"
               class="upload-download-button"
+              :disabled="!adminRole"
               @click="onDownload(true)"
             >
               <OnmsIcon :icon="IconDownload" aria-hidden="true" focusable="false" class="upload-download-icon" />
@@ -31,6 +37,7 @@
             <PButton
               data-test="download-json-button"
               class="upload-download-button"
+              :disabled="!adminRole"
               @click="onDownload(false)"
             >
               <OnmsIcon :icon="IconDownload" aria-hidden="true" focusable="false" class="upload-download-icon" />
@@ -46,6 +53,7 @@
             <PButton
               data-test="upload-xml-button"
               class="upload-download-button"
+              :disabled="!adminRole"
               @click="initiateUpload(true)"
             >
               <OnmsIcon :icon="IconUpload" aria-hidden="true" focusable="false" class="upload-download-icon" />
@@ -61,6 +69,7 @@
             <PButton
               data-test="upload-json-button"
               class="upload-download-button"
+              :disabled="!adminRole"
               @click="initiateUpload(false)"
             >
               <OnmsIcon :icon="IconUpload" aria-hidden="true" focusable="false" class="upload-download-icon" />
@@ -93,6 +102,7 @@ import IconUpload from '@/components/icons/action/UploadFile.vue'
 import useDownload from '@/composables/useDownload'
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
+import useRole from '@/composables/useRole'
 import { validateTrapdXml, validateTrapdJson } from '@/lib/trapdValidator'
 import { downloadTrapdConfig, uploadTrapdConfiguration } from '@/services/trapdConfigurationService'
 import { useTrapdConfigStore } from '@/stores/trapdConfigStore'
@@ -101,6 +111,7 @@ import ConfirmationDialog from '../Common/ConfirmationDialog.vue'
 const PButton = Button
 
 const { downloadFile } = useDownload()
+const { adminRole } = useRole()
 const snackbar = useSnackbar()
 const { startSpinner, stopSpinner } = useSpinner()
 const trapdConfigStore = useTrapdConfigStore()
@@ -109,6 +120,10 @@ const uploadType = ref<'xml' | 'json' | null>(null)
 const uploadFile = ref<File | null>(null)
 
 const onDownload = async (isXml: boolean) => {
+  if (!adminRole) {
+    return
+  }
+
   try {
     startSpinner()
     const response = await downloadTrapdConfig(isXml)
@@ -127,9 +142,14 @@ const onDownload = async (isXml: boolean) => {
 }
 
 const initiateUpload = async (isXml: boolean) => {
+  if (!adminRole) {
+    return
+  }
+
   uploadType.value = isXml ? 'xml' : 'json'
 
   const file = await new Promise<File | null>((resolve) => {
+
     const input = document.createElement('input')
     input.type = 'file'
     input.accept = isXml ? '.xml' : '.json'
@@ -179,6 +199,10 @@ const onUploadConfirm = async () => {
 }
 
 const performUpload = async (isXml: boolean) => {
+  if (!adminRole) {
+    return
+  }
+
   if (!uploadFile.value) {
     return
   }

--- a/ui/src/lib/securityHelper.ts
+++ b/ui/src/lib/securityHelper.ts
@@ -20,16 +20,8 @@
 /// License.
 ///
 
-const SCV_SUBKEY = /[a-zA-Z0-9_]([a-zA-Z0-9_.-]*[a-zA-Z0-9_])?/
-const SCV_DEFAULT = /[^|}]+/
-const SCV_REGEX = new RegExp(`^\\$\\{scv:${SCV_SUBKEY.source}(:${SCV_SUBKEY.source})?(\\|${SCV_DEFAULT.source})?\\}$`)
+export const MASKED_PASSWORD = '******'
 
-export const SCV_PREFIX_REGEX = /^\$\{/
-
-export const validateScvPattern = (scv: string): boolean => {
-  return SCV_REGEX.test(scv)
-}
-
-export const hasScvPrefix = (value: string): boolean => {
-  return SCV_PREFIX_REGEX.test(value)
+export const isMaskedPassword = (value: string): boolean => {
+  return value === MASKED_PASSWORD
 }

--- a/ui/src/lib/snmpValidator.ts
+++ b/ui/src/lib/snmpValidator.ts
@@ -23,7 +23,7 @@
 import { isIP } from 'is-ip'
 import { IpAddressRange, SnmpBaseConfiguration, SnmpConfigFormErrors, SnmpDefinition, SnmpProfileFormErrors, SnmpSecurityLevel } from '@/types/snmpConfig'
 import { DEFAULT_SNMP_V3_SECURITY_LEVEL } from './constants'
-import { SCV_PREFIX_REGEX, validateScvPattern } from './scvValidator'
+import { hasScvPrefix, validateScvPattern } from './scvValidator'
 
 const SNMP_VERSIONS = ['v1', 'v2c', 'v3']
 const VALID_SECURITY_LEVELS = [SnmpSecurityLevel.NoAuthNoPriv, SnmpSecurityLevel.AuthNoPriv, SnmpSecurityLevel.AuthPriv]
@@ -63,7 +63,7 @@ export const validateSnmpConfiguration = (config: SnmpBaseConfiguration, snmpVer
   scvEnabledKeys.forEach((key) => {
     const value = (config as any)[key]
 
-    if (typeof value === 'string' && SCV_PREFIX_REGEX.test(value)) {
+    if (typeof value === 'string' && hasScvPrefix(value)) {
       if (!validateScvPattern(value)) {
         (errors as any)[key] = 'Invalid SCV expression'
       }

--- a/ui/src/lib/trapdValidator.ts
+++ b/ui/src/lib/trapdValidator.ts
@@ -20,9 +20,11 @@
 /// License.
 ///
 
-import { TrapConfig, TrapdValidationError, TrapdValidationResult } from '@/types/trapConfig'
+import { SnmpV3UserError, TrapConfig, TrapdValidationError, TrapdValidationResult } from '@/types/trapConfig'
 import { ISelectItemType } from '@/types'
 import { DEFAULT_TRAPD_BIND_ADDRESS } from './constants'
+import { hasScvPrefix, validateScvPattern } from './scvValidator'
+import { isMaskedPassword } from './securityHelper'
 import { isConvertibleToInteger } from './utils'
 
 export const MIN_PORT = 1
@@ -106,6 +108,82 @@ export const PRIVACY_PROTOCOL_OPTIONS: ISelectItemType[] = PrivacyProtocols.map(
   _text: protocol,
   _value: protocol
 }))
+
+export const validateSnmpV3UserForm = (
+  securityName: string,
+  securityLevel: ISelectItemType | undefined,
+  authProtocol: ISelectItemType | undefined,
+  authPassphrase: string,
+  privacyProtocol: ISelectItemType | undefined,
+  privacyPassphrase: string
+): SnmpV3UserError => {
+  const newError: SnmpV3UserError = {}
+  const levelValue = Number(securityLevel?._value)
+  const authProtocolVisible = levelValue === SecurityLevel.AuthNoPriv || levelValue === SecurityLevel.AuthPriv
+  const privacyProtocolVisible = levelValue === SecurityLevel.AuthPriv
+
+  if (!securityName) {
+    newError.securityName = 'Security Name is required'
+  }
+
+  if (levelValue === SecurityLevel.NoAuthNoPriv && (authProtocol || authPassphrase || privacyProtocol || privacyPassphrase)) {
+    newError.securityLevel = 'Security level 1 does not allow auth or privacy credentials'
+  }
+
+  if (levelValue === SecurityLevel.AuthNoPriv && (privacyProtocol || privacyPassphrase)) {
+    newError.privacyProtocol = 'Security level 2 does not allow privacy credentials'
+  }
+
+  if (authProtocolVisible) {
+    if (!authProtocol) {
+      newError.authProtocol = 'Auth Protocol is required for selected security level'
+    }
+
+    if (authPassphrase && !authProtocol) {
+      newError.authPassphrase = 'Auth Passphrase requires an Auth Protocol to be selected'
+    }
+
+    if (!!authProtocol && !authPassphrase) {
+      newError.authPassphrase = 'Auth Passphrase is required for selected auth protocol'
+    }
+
+    if (!!authProtocol && authPassphrase && !isMaskedPassword(authPassphrase)) {
+      if (hasScvPrefix(authPassphrase) && !validateScvPattern(authPassphrase)) {
+        newError.authPassphrase = 'Invalid SCV expression'
+      } else if (authPassphrase.startsWith('*')) {
+        newError.authPassphrase = 'Auth Passphrase should not start with a \'*\' character.'
+      } else if (!hasScvPrefix(authPassphrase) && passphraseByteLength(authPassphrase) < MIN_PASSPHRASE_CHARACTERS) {
+        newError.authPassphrase = `Auth Passphrase must be at least ${MIN_PASSPHRASE_CHARACTERS} characters`
+      }
+    }
+  }
+
+  if (privacyProtocolVisible) {
+    if (!privacyProtocol) {
+      newError.privacyProtocol = 'Privacy Protocol is required for selected security level'
+    }
+
+    if (privacyPassphrase && !privacyProtocol) {
+      newError.privacyPassphrase = 'Privacy Passphrase requires a Privacy Protocol to be selected'
+    }
+
+    if (!!privacyProtocol && !privacyPassphrase) {
+      newError.privacyPassphrase = 'Privacy Passphrase is required for selected privacy protocol'
+    }
+
+    if (!!privacyProtocol && privacyPassphrase && !isMaskedPassword(privacyPassphrase)) {
+      if (hasScvPrefix(privacyPassphrase) && !validateScvPattern(privacyPassphrase)) {
+        newError.privacyPassphrase = 'Invalid SCV expression'
+      } else if (privacyPassphrase.startsWith('*')) {
+        newError.privacyPassphrase = 'Privacy Passphrase should not start with a \'*\' character.'
+      } else if (!hasScvPrefix(privacyPassphrase) && passphraseByteLength(privacyPassphrase) < MIN_PASSPHRASE_CHARACTERS) {
+        newError.privacyPassphrase = `Privacy Passphrase must be at least ${MIN_PASSPHRASE_CHARACTERS} characters`
+      }
+    }
+  }
+
+  return newError
+}
 
 export const getDefaultTrapdConfig = (): TrapConfig => ({
   snmpTrapAddress: DEFAULT_TRAPD_BIND_ADDRESS,
@@ -217,10 +295,10 @@ const validateSnmpV3UserValues = (
   const privacyProtocolVal = privacyProtocol ?? null
   const privacyPassphraseVal = privacyPassphrase ?? null
 
-  if (authPassphraseVal && authPassphraseVal.trim() !== '' && passphraseByteLength(authPassphraseVal) < MIN_PASSPHRASE_CHARACTERS) {
+  if (authPassphraseVal && authPassphraseVal.trim() !== '' && !isMaskedPassword(authPassphraseVal) && passphraseByteLength(authPassphraseVal) < MIN_PASSPHRASE_CHARACTERS) {
     addError(errors, `${prefix}.${appField}`, `${prefix}: ${appField} must be at least ${MIN_PASSPHRASE_CHARACTERS} characters`)
   }
-  if (privacyPassphraseVal && privacyPassphraseVal.trim() !== '' && passphraseByteLength(privacyPassphraseVal) < MIN_PASSPHRASE_CHARACTERS) {
+  if (privacyPassphraseVal && privacyPassphraseVal.trim() !== '' && !isMaskedPassword(privacyPassphraseVal) && passphraseByteLength(privacyPassphraseVal) < MIN_PASSPHRASE_CHARACTERS) {
     addError(errors, `${prefix}.${pppField}`, `${prefix}: ${pppField} must be at least ${MIN_PASSPHRASE_CHARACTERS} characters`)
   }
 

--- a/ui/src/mappers/trapdConfig.mapper.ts
+++ b/ui/src/mappers/trapdConfig.mapper.ts
@@ -12,6 +12,7 @@ export const mapTrapdConfigFromServer = (data: any): TrapConfig => {
     batchInterval: data.batchInterval,
     useAddressFromVarbind: data.useAddressFromVarbind,
     snmpv3User: (data.snmpv3User || []).map((user: any) => ({
+      id: user.id,
       engineId: user.engineId,
       securityName: user.securityName,
       securityLevel: user.securityLevel,
@@ -29,6 +30,12 @@ export const mapUserToServer = (payload: any): SnmpV3User => {
     engineId: payload.engineId,
     securityLevel: payload.securityLevel
   } as SnmpV3User
+
+  // Preserve the server-assigned id so existing users round-trip correctly
+  // (the server correlates masked credentials by id). New users have no id.
+  if (payload.id) {
+    user.id = payload.id
+  }
 
   if (payload.securityLevel === 1) {
     user.authProtocol = null

--- a/ui/src/types/trapConfig.d.ts
+++ b/ui/src/types/trapConfig.d.ts
@@ -52,6 +52,7 @@ export interface TrapConfig {
 }
 
 export interface SnmpV3User {
+  id?: string
   engineId: string | null
   securityName: string
   securityLevel: number

--- a/ui/tests/components/TrapdConfiguration/CreateSnmpV3User.test.ts
+++ b/ui/tests/components/TrapdConfiguration/CreateSnmpV3User.test.ts
@@ -401,7 +401,7 @@ describe('CreateSnmpV3User.vue', () => {
     await setInputValue(wrapper, 'security-name-input', 'new-user')
     await setBindingValue(wrapper, 'securityLevel', createEmptySelectItem())
 
-    expect((wrapper.vm as any).error.securityLevel).toBeUndefined()
+    expect((wrapper.vm as any).formError.securityLevel).toBeUndefined()
   })
 
   it('shows validation error when level 1 has auth credentials (backend cross-field rule)', async () => {
@@ -413,7 +413,7 @@ describe('CreateSnmpV3User.vue', () => {
     ;(wrapper.vm as any).authProtocol = AUTH_PROTOCOL_OPTIONS[0]
     await nextTick()
 
-    expect((wrapper.vm as any).error.securityLevel).toBe(
+    expect((wrapper.vm as any).formError.securityLevel).toBe(
       'Security level 1 does not allow auth or privacy credentials'
     )
     expect((wrapper.vm as any).isSaveDisabled).toBe(true)
@@ -427,7 +427,7 @@ describe('CreateSnmpV3User.vue', () => {
     ;(wrapper.vm as any).privacyProtocol = PRIVACY_PROTOCOL_OPTIONS[0]
     await nextTick()
 
-    expect((wrapper.vm as any).error.securityLevel).toBe(
+    expect((wrapper.vm as any).formError.securityLevel).toBe(
       'Security level 1 does not allow auth or privacy credentials'
     )
     expect((wrapper.vm as any).isSaveDisabled).toBe(true)
@@ -440,12 +440,11 @@ describe('CreateSnmpV3User.vue', () => {
     ;(wrapper.vm as any).securityLevel = SECURITY_LEVEL_OPTIONS[1]
     await nextTick()
 
-    // Now inject dirty privacy state AFTER the watcher ran, and call validateInputs
-    // directly before the Vue scheduler has a chance to run watchEffect again
+    // Now inject dirty privacy state AFTER the watcher ran and let watchEffect re-run
     ;(wrapper.vm as any).privacyProtocol = PRIVACY_PROTOCOL_OPTIONS[0]
-    const errors = (wrapper.vm as any).validateInputs()
+    await nextTick()
 
-    expect(errors.privacyProtocol).toBe('Security level 2 does not allow privacy credentials')
+    expect((wrapper.vm as any).formError.privacyProtocol).toBe('Security level 2 does not allow privacy credentials')
   })
 
   it('requires auth protocol and auth passphrase for auth-only security level', async () => {
@@ -464,7 +463,7 @@ describe('CreateSnmpV3User.vue', () => {
     })
   })
 
-  it('shows auth protocol error with passphrase-specific message when passphrase is set but protocol is cleared', async () => {
+  it('shows auth protocol error and passphrase-specific error message when passphrase is set but protocol is cleared', async () => {
     const wrapper = mountComponent()
 
     await setInputValue(wrapper, 'security-name-input', 'auth-user')
@@ -472,10 +471,11 @@ describe('CreateSnmpV3User.vue', () => {
     await setBindingValue(wrapper, 'authProtocol', createEmptySelectItem())
     await setBindingValue(wrapper, 'authPassphrase', 'some-passphrase')
 
-    expect((wrapper.vm as any).error.authProtocol).toBe('Auth Passphrase requires an Auth Protocol to be selected')
+    expect((wrapper.vm as any).formError.authProtocol).toBe('Auth Protocol is required for selected security level')
+    expect((wrapper.vm as any).formError.authPassphrase).toBe('Auth Passphrase requires an Auth Protocol to be selected')
   })
 
-  it('shows generic auth protocol error when passphrase is also missing', async () => {
+  it('shows generic auth protocol error but no authPassphrase error when passphrase is also missing', async () => {
     const wrapper = mountComponent()
 
     await setInputValue(wrapper, 'security-name-input', 'auth-user')
@@ -483,7 +483,8 @@ describe('CreateSnmpV3User.vue', () => {
     await setBindingValue(wrapper, 'authProtocol', createEmptySelectItem())
     await setBindingValue(wrapper, 'authPassphrase', '')
 
-    expect((wrapper.vm as any).error.authProtocol).toBe('Auth Protocol is required for selected security level')
+    expect((wrapper.vm as any).formError.authProtocol).toBe('Auth Protocol is required for selected security level')
+    expect((wrapper.vm as any).formError.authPassphrase).toBeUndefined()
   })
 
   it('requires privacy protocol and privacy passphrase for auth-priv security level', async () => {
@@ -512,7 +513,8 @@ describe('CreateSnmpV3User.vue', () => {
     await setBindingValue(wrapper, 'privacyProtocol', createEmptySelectItem())
     await setBindingValue(wrapper, 'privacyPassphrase', 'privacy-secret')
 
-    expect((wrapper.vm as any).error.privacyProtocol).toBe('Privacy Passphrase requires a Privacy Protocol to be selected')
+    expect((wrapper.vm as any).formError.privacyProtocol).toBe('Privacy Protocol is required for selected security level')
+    expect((wrapper.vm as any).formError.privacyPassphrase).toBe('Privacy Passphrase requires a Privacy Protocol to be selected')
   })
 
   it('shows generic privacy protocol error when privacy passphrase is also missing', async () => {
@@ -525,7 +527,8 @@ describe('CreateSnmpV3User.vue', () => {
     await setBindingValue(wrapper, 'privacyProtocol', createEmptySelectItem())
     await setBindingValue(wrapper, 'privacyPassphrase', '')
 
-    expect((wrapper.vm as any).error.privacyProtocol).toBe('Privacy Protocol is required for selected security level')
+    expect((wrapper.vm as any).formError.privacyProtocol).toBe('Privacy Protocol is required for selected security level')
+    expect((wrapper.vm as any).formError.privacyPassphrase).toBeUndefined()
   })
 
   it('shows service error when updateTrapdConfiguration throws Error', async () => {

--- a/ui/tests/components/TrapdConfiguration/TrapdAdvancedConfiguration.test.ts
+++ b/ui/tests/components/TrapdConfiguration/TrapdAdvancedConfiguration.test.ts
@@ -21,6 +21,10 @@ vi.mock('@/composables/useDownload', () => ({
   default: () => ({ downloadFile: downloadFileMock })
 }))
 
+vi.mock('@/composables/useRole', () => ({
+  default: () => ({ adminRole: true, filesystemEditorRole: false, dcbRole: false, snmpRole: true, rolesAreLoaded: true })
+}))
+
 vi.mock('@/composables/useSpinner', () => ({
   default: () => ({ startSpinner: vi.fn(), stopSpinner: vi.fn() })
 }))

--- a/ui/tests/components/TrapdConfiguration/TrapdAdvancedConfiguration.test.ts
+++ b/ui/tests/components/TrapdConfiguration/TrapdAdvancedConfiguration.test.ts
@@ -21,9 +21,19 @@ vi.mock('@/composables/useDownload', () => ({
   default: () => ({ downloadFile: downloadFileMock })
 }))
 
-vi.mock('@/composables/useRole', () => ({
-  default: () => ({ adminRole: true, filesystemEditorRole: false, dcbRole: false, snmpRole: true, rolesAreLoaded: true })
-}))
+// useRole returns computed refs, so the component accesses them via .value; the mock must do the same.
+vi.mock('@/composables/useRole', async () => {
+  const { computed } = await import('vue')
+  return {
+    default: () => ({
+      adminRole: computed(() => true),
+      filesystemEditorRole: computed(() => false),
+      dcbRole: computed(() => false),
+      snmpRole: computed(() => true),
+      rolesAreLoaded: computed(() => true)
+    })
+  }
+})
 
 vi.mock('@/composables/useSpinner', () => ({
   default: () => ({ startSpinner: vi.fn(), stopSpinner: vi.fn() })

--- a/ui/tests/lib/trapdValidatorForm.test.ts
+++ b/ui/tests/lib/trapdValidatorForm.test.ts
@@ -1,0 +1,310 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { ISelectItemType } from '@/types'
+import { describe, expect, it } from 'vitest'
+import {
+  AUTH_PROTOCOL_OPTIONS,
+  MIN_PASSPHRASE_CHARACTERS,
+  PRIVACY_PROTOCOL_OPTIONS,
+  SECURITY_LEVEL_OPTIONS,
+  validateSnmpV3UserForm
+} from '@/lib/trapdValidator'
+
+const createEmptySelectItem = (): ISelectItemType => (undefined as unknown as ISelectItemType)
+
+// Minimal valid level-2 call: name + level + protocol + long-enough passphrase
+const validAuthNoPriv = () =>
+  validateSnmpV3UserForm('user', SECURITY_LEVEL_OPTIONS[1], AUTH_PROTOCOL_OPTIONS[0], 'longenough', createEmptySelectItem(), '')
+
+// Minimal valid level-3 call: name + level + auth + privacy credentials
+const validAuthPriv = () =>
+  validateSnmpV3UserForm('user', SECURITY_LEVEL_OPTIONS[2], AUTH_PROTOCOL_OPTIONS[0], 'longenough', PRIVACY_PROTOCOL_OPTIONS[0], 'longenough')
+
+describe('validateSnmpV3UserForm – security level cross-field rules', () => {
+  it('reports error when level 1 has auth credentials', () => {
+    const errors = validateSnmpV3UserForm(
+      'new-user',
+      SECURITY_LEVEL_OPTIONS[0],
+      AUTH_PROTOCOL_OPTIONS[0],
+      '',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.securityLevel).toBe('Security level 1 does not allow auth or privacy credentials')
+  })
+
+  it('reports error when level 1 has privacy credentials', () => {
+    const errors = validateSnmpV3UserForm(
+      'new-user',
+      SECURITY_LEVEL_OPTIONS[0],
+      createEmptySelectItem(),
+      '',
+      PRIVACY_PROTOCOL_OPTIONS[0],
+      ''
+    )
+
+    expect(errors.securityLevel).toBe('Security level 1 does not allow auth or privacy credentials')
+  })
+
+  it('reports error when level 2 has privacy credentials', () => {
+    const errors = validateSnmpV3UserForm(
+      'new-user',
+      SECURITY_LEVEL_OPTIONS[1],
+      createEmptySelectItem(),
+      '',
+      PRIVACY_PROTOCOL_OPTIONS[0],
+      ''
+    )
+
+    expect(errors.privacyProtocol).toBe('Security level 2 does not allow privacy credentials')
+  })
+})
+
+describe('validateSnmpV3UserForm – auth-only security level (level 2)', () => {
+  it('reports auth protocol but no authPassphrase errors when both are missing', () => {
+    const errors = validateSnmpV3UserForm(
+      'auth-only-user',
+      SECURITY_LEVEL_OPTIONS[1],
+      createEmptySelectItem(),
+      '',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authProtocol).toBeDefined()
+    expect(errors.authPassphrase).toBeUndefined()
+  })
+
+  it('reports specific passphrase error when passphrase is set but protocol is cleared', () => {
+    const errors = validateSnmpV3UserForm(
+      'auth-user',
+      SECURITY_LEVEL_OPTIONS[1],
+      createEmptySelectItem(),
+      'some-passphrase',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authProtocol).toBe('Auth Protocol is required for selected security level')
+    expect(errors.authPassphrase).toBe('Auth Passphrase requires an Auth Protocol to be selected')
+  })
+
+  it('reports generic protocol error but no authPassphrase error when protocol and passphrase are both missing', () => {
+    const errors = validateSnmpV3UserForm(
+      'auth-user',
+      SECURITY_LEVEL_OPTIONS[1],
+      createEmptySelectItem(),
+      '',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authProtocol).toBe('Auth Protocol is required for selected security level')
+    expect(errors.authPassphrase).toBeUndefined()
+  })
+
+  it('accepts a valid level-2 configuration with no errors', () => {
+    expect(validAuthNoPriv()).toEqual({})
+  })
+})
+
+describe('validateSnmpV3UserForm – auth-priv security level (level 3)', () => {
+  it('reports privacy protocol but no privacy passphrase errors when both are missing', () => {
+    const errors = validateSnmpV3UserForm(
+      'auth-priv-user',
+      SECURITY_LEVEL_OPTIONS[2],
+      AUTH_PROTOCOL_OPTIONS[0],
+      'auth-secret',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.privacyProtocol).toBeDefined()
+    expect(errors.privacyPassphrase).toBeUndefined()
+  })
+
+  it('reports specific privacy passphrase error when passphrase is set but protocol is cleared', () => {
+    const errors = validateSnmpV3UserForm(
+      'priv-user',
+      SECURITY_LEVEL_OPTIONS[2],
+      AUTH_PROTOCOL_OPTIONS[0],
+      'auth-secret',
+      createEmptySelectItem(),
+      'privacy-secret'
+    )
+
+    expect(errors.privacyProtocol).toBe('Privacy Protocol is required for selected security level')
+    expect(errors.privacyPassphrase).toBe('Privacy Passphrase requires a Privacy Protocol to be selected')
+  })
+
+  it('reports generic protocol but no privacy passphrase error when both protocol and passphrase are missing', () => {
+    const errors = validateSnmpV3UserForm(
+      'priv-user',
+      SECURITY_LEVEL_OPTIONS[2],
+      AUTH_PROTOCOL_OPTIONS[0],
+      'auth-secret',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.privacyProtocol).toBe('Privacy Protocol is required for selected security level')
+    expect(errors.privacyPassphrase).toBeUndefined()
+  })
+
+  it('accepts a valid level-3 configuration with no errors', () => {
+    expect(validAuthPriv()).toEqual({})
+  })
+})
+
+describe('validateSnmpV3UserForm – passphrase length and SCV', () => {
+  it('reports error when auth passphrase is too short', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[1],
+      AUTH_PROTOCOL_OPTIONS[0],
+      'short',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authPassphrase).toBe(`Auth Passphrase must be at least ${MIN_PASSPHRASE_CHARACTERS} characters`)
+  })
+
+  it('reports error when privacy passphrase is too short', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[2],
+      AUTH_PROTOCOL_OPTIONS[0],
+      'longenough',
+      PRIVACY_PROTOCOL_OPTIONS[0],
+      'short'
+    )
+
+    expect(errors.privacyPassphrase).toBe(`Privacy Passphrase must be at least ${MIN_PASSPHRASE_CHARACTERS} characters`)
+  })
+
+  it('accepts a masked auth passphrase without length validation', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[1],
+      AUTH_PROTOCOL_OPTIONS[0],
+      '******',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authPassphrase).toBeUndefined()
+  })
+
+  it('accepts a masked privacy passphrase without length validation', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[2],
+      AUTH_PROTOCOL_OPTIONS[0],
+      'longenough',
+      PRIVACY_PROTOCOL_OPTIONS[0],
+      '******'
+    )
+
+    expect(errors.privacyPassphrase).toBeUndefined()
+  })
+
+  it('reports error when auth passphrase starts with \'*\' but is not the masked value', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[1],
+      AUTH_PROTOCOL_OPTIONS[0],
+      '*notmasked',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authPassphrase).toBe('Auth Passphrase should not start with a \'*\' character.')
+  })
+
+  it('reports error when auth passphrase is a single \'*\'', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[1],
+      AUTH_PROTOCOL_OPTIONS[0],
+      '*',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authPassphrase).toBe('Auth Passphrase should not start with a \'*\' character.')
+  })
+
+  it('reports error when privacy passphrase starts with \'*\' but is not the masked value', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[2],
+      AUTH_PROTOCOL_OPTIONS[0],
+      'longenough',
+      PRIVACY_PROTOCOL_OPTIONS[0],
+      '*notmasked'
+    )
+
+    expect(errors.privacyPassphrase).toBe('Privacy Passphrase should not start with a \'*\' character.')
+  })
+
+  it('reports error for invalid SCV expression in auth passphrase', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[1],
+      AUTH_PROTOCOL_OPTIONS[0],
+      '${scv:bad',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authPassphrase).toBe('Invalid SCV expression')
+  })
+
+  it('reports error for invalid SCV expression in privacy passphrase', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[2],
+      AUTH_PROTOCOL_OPTIONS[0],
+      'longenough',
+      PRIVACY_PROTOCOL_OPTIONS[0],
+      '${scv:bad'
+    )
+
+    expect(errors.privacyPassphrase).toBe('Invalid SCV expression')
+  })
+
+  it('accepts a valid SCV expression in auth passphrase', () => {
+    const errors = validateSnmpV3UserForm(
+      'user',
+      SECURITY_LEVEL_OPTIONS[1],
+      AUTH_PROTOCOL_OPTIONS[0],
+      '${scv:vault:auth-key}',
+      createEmptySelectItem(),
+      ''
+    )
+
+    expect(errors.authPassphrase).toBeUndefined()
+  })
+})

--- a/ui/tests/mappers/trapdConfig.mapper.test.ts
+++ b/ui/tests/mappers/trapdConfig.mapper.test.ts
@@ -1,0 +1,66 @@
+import { mapTrapdConfigFromServer, mapUserToServer } from '@/mappers/trapdConfig.mapper'
+import { describe, expect, it } from 'vitest'
+
+describe('trapdConfig.mapper', () => {
+  describe('mapTrapdConfigFromServer', () => {
+    it('preserves the server-assigned id on each SNMPv3 user', () => {
+      const serverData = {
+        snmpTrapPort: 162,
+        snmpTrapAddress: '*',
+        newSuspectOnTrap: false,
+        snmpv3User: [
+          {
+            id: 'id-a',
+            securityName: 'dupUser',
+            securityLevel: 3,
+            engineId: null,
+            authProtocol: 'SHA',
+            authPassphrase: '******',
+            privacyProtocol: 'AES',
+            privacyPassphrase: '******'
+          }
+        ]
+      }
+
+      const result = mapTrapdConfigFromServer(serverData)
+
+      expect(result.snmpv3User[0].id).toBe('id-a')
+      expect(result.snmpv3User[0].securityName).toBe('dupUser')
+    })
+
+    it('leaves id undefined when the server omits it', () => {
+      const result = mapTrapdConfigFromServer({
+        snmpv3User: [{ securityName: 'noId', securityLevel: 1 }]
+      })
+
+      expect(result.snmpv3User[0].id).toBeUndefined()
+    })
+  })
+
+  describe('mapUserToServer', () => {
+    it('echoes the id back so an existing user round-trips', () => {
+      const user = mapUserToServer({
+        id: 'id-b',
+        securityName: 'dupUser',
+        engineId: null,
+        securityLevel: 3,
+        authProtocol: 'SHA',
+        authPassphrase: '******',
+        privacyProtocol: 'AES',
+        privacyPassphrase: '******'
+      })
+
+      expect(user.id).toBe('id-b')
+    })
+
+    it('omits the id for a new user', () => {
+      const user = mapUserToServer({
+        securityName: 'brandNew',
+        engineId: null,
+        securityLevel: 1
+      })
+
+      expect(user.id).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Mask credentials in the Trap Config Rest API and UI.

Credentials (like SNMP v3 Auth Passphrase and Privacy Passphrase) are masked with `'******'` when returned from Rest GET APIs.

Annotations are used on the Java side to mark those fields, and new methods in `SecurityHelper` automatically process them. Any Rest API calls to get items will have those fields masked.

If a user edits an SNMP user, when the server receives the mask, it will substitute the actual current credential we have stored in the DB/DAO. If the user wants to change the credential, the credential will be POSTed as-is and the server will know to persist the change.

The system also handles SCV expressions correctly, they are *not* masked. SCV is the preferred way of handling credentials.

We also reject any credentials starting with `'*'` to prevent users from using the mask to bypass credential checking.

Upload/download Rest APIs do *not* mask credentials. If needed we can protect those specific endpoints by roles if needed. User must have an Admin role in order to upload/download.

On the UI side, added `PrimeVue` `InputPassword` fields which by default mask the credential. you can click the "eye" view icon to view the credential, but only SCV expressions will be shown; any else will still be masked.

The annotation and `SecurityHelper` pattern can be used in other cases where we want to mask credentials.

## Update - addressing the securityName uniqueness issue

The latest update addresses the issue where `securityName` is not unique. The situation is that in OpenNMS, one could provision a bunch of devices which have the same security name, but may have one of several credentials and/or security protocols. OpenNMS will try the different protocols/credentials to find one that works. Unfortunately this means we don't respect any kind of uniqueness for the `securityName`, so masking is difficult because it's not reliable to match masked or updated credentials with the correct SNMPv3 user.

The latest changes address this by adding a unique UUID `id` field to each `snmpv3User`.

The liquibase upgrade has been updated to a 1.1 version of the XSD schema to add the `id` field.

The startup liquibase / `UpgradeConfigService` has been updated to add ids to any snmpv3Users that didn't already have one, so by the time OpenNMS is running, all existing configs have been "self-healed" to have unique IDs.

A unique ID will automatically be added any time a new `snmpV3User` is added via UI or REST API.

*Note*, if a user was to change or add a user directly in the DB or via CM directly, and didn't add a unique ID, this would not be fixed until next OpenNMS startup. This path is not supported, and users should not be doing this anyway.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19723
