### PR TITLE
NMS-19795: Password Gate: Complexity checking on client side not working correctly

### DIFF
--- a/opennms-webapp/src/main/webapp/account/selfService/passwordGate.jsp
+++ b/opennms-webapp/src/main/webapp/account/selfService/passwordGate.jsp
@@ -160,8 +160,8 @@
 
     if (document.goForm.pass1.value == document.goForm.pass2.value) {
       let newPassword = document.goForm.pass1.value
-      const passwordRegex = /${fn:escapeXml(PasswordGateActionServlet.PASSWORD_REGEX)}/;
-      const sameCharacterRegex = /${fn:escapeXml(PasswordGateActionServlet.SAME_CHARACTER_REGEX)}/;
+      const passwordRegex = /${PasswordGateActionServlet.PASSWORD_REGEX}/;
+      const sameCharacterRegex = /${PasswordGateActionServlet.SAME_CHARACTER_REGEX}/;
 
       if (newPassword.match(passwordRegex) && !newPassword.match(sameCharacterRegex)) {
         document.goForm.currentPassword.value = document.goForm.oldpass.value;

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -24,6 +24,8 @@ package org.opennms.smoketest.selenium;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 
@@ -500,17 +502,21 @@ public abstract class AbstractOpenNMSSeleniumHelper {
     }
 
     protected String handleAlert() {
-        return handleAlert(null);
+        return handleAlert(null, true);
     }
 
-    protected String handleAlert(final String expectedText) {
+    protected String handleAlert(final String expectedText, final boolean exactMatch) {
         LOG.debug("handleAlert: expectedText={}", expectedText);
 
         try {
             final Alert alert = getDriver().switchTo().alert();
             final String alertText = alert.getText();
             if (expectedText != null) {
-                assertEquals(expectedText, alertText);
+                if (exactMatch) {
+                    assertEquals(expectedText, alertText);
+                } else {
+                    assertThat(alertText, containsString(expectedText));
+                }
             }
             alert.dismiss();
             return alertText;

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminPasswordGateIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminPasswordGateIT.java
@@ -46,6 +46,7 @@ public class AdminPasswordGateIT extends OpenNMSSeleniumIT {
     private static final Logger LOG = LoggerFactory.getLogger(AdminPasswordGateIT.class);
 
     private static final String ALTERNATE_ADMIN_PASSWORD = "Admin!admin1";
+    private static final String INVALID_ADMIN_PASSWORD = "jwV5wddWoSCFS6Vn7JTRZVGvVGfgBaEL";
 
     @Before
     public void setUp() throws Exception {
@@ -86,6 +87,35 @@ public class AdminPasswordGateIT extends OpenNMSSeleniumIT {
         LOG.debug("Test admin login with default password and skip");
         logout();
         loginAndSkip();
+    }
+
+    /**
+     * Tests:
+     * - logging in as "admin/admin", then getting the Password Change gate.
+     * - attempting to change password to one which does not contain a special character
+     * - should be rejected on client side
+     */
+    @Test
+    public void testAdminPasswordGateWithInvalidPasswordHavingNoSpecialCharacters() {
+        // login with "admin/admin", do not skip the password gate but instead change the password
+        LOG.debug("Test admin login and password change with invalid password having no special characters.");
+        logout();
+
+        // login with "admin/admin", do not skip past the password gate, skip cookie deletion
+        login(PASSWORD_GATE_USERNAME, PASSWORD_GATE_PASSWORD, false, false, true, true);
+
+        if (!driver.getCurrentUrl().contains("passwordGate.jsp")) {
+            fail("Failed to get password gate page after 'admin/admin' login attempt.");
+        }
+
+        // Change the admin password to an invalid one
+        enterText(By.name("oldpass"), PASSWORD_GATE_PASSWORD);
+        enterText(By.name("pass1"), INVALID_ADMIN_PASSWORD);
+        enterText(By.name("pass2"), INVALID_ADMIN_PASSWORD);
+        clickElement(By.name("btn_change_password"));
+
+        // should stay on page and get an alert message
+        handleAlert("Password complexity is not correct!", false);
     }
 
     @Ignore("Not currently working. RequestCache may not be saving correct page.")

--- a/smoke-test/src/test/java/org/opennms/smoketest/UserIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/UserIT.java
@@ -110,14 +110,14 @@ public class UserIT extends OpenNMSSeleniumIT {
 
         findElementByLink("Group List").click();
         findElementById(GROUP_NAME + ".doDelete").click();
-        handleAlert("Are you sure you want to delete the group " + GROUP_NAME + "?");
+        handleAlert("Are you sure you want to delete the group " + GROUP_NAME + "?", true);
         assertElementDoesNotExist(By.id(GROUP_NAME));
 
         findElementByLink("Users and Groups").click();
         findElementByLink("Configure Users").click();
         findElementById("user-" + USER_NAME);
         findElementById("users(" + USER_NAME + ").doDelete").click();
-        handleAlert("Are you sure you want to delete the user " + USER_NAME + "?");
+        handleAlert("Are you sure you want to delete the user " + USER_NAME + "?", true);
         assertElementDoesNotExist(By.id(USER_NAME));
     }
 
@@ -312,6 +312,6 @@ public class UserIT extends OpenNMSSeleniumIT {
         findElementByLink("Configure Users").click();
 
         findElementById("users(user).doDelete").click();
-        handleAlert("Are you sure you want to delete the user user?");
+        handleAlert("Are you sure you want to delete the user user?", true);
     }
 }


### PR DESCRIPTION
The client side checking for password complexity on the password gate page had a bug where certain passwords that did not contain the required one or more special characters were getting through, resulting in a generic error message.

The error was caused by HTML-encoding the Java regex when included in the Javscript on the JSP page. `&` was being encoded as `&amp;`, and those literal characters were being matched for the password having a special character, so any passwords containing `[a|m|p|;]` would pass.

Note that we should handle the service side error more gracefully - it's thrown when the server detects an invalid password, but currently it looks like the server had an error, and gives no useful information. We can tackle that separately, but with this client side fix, users should not really encounter that any more.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19795
