### PR TITLE
NMS-19773: Emit an event when config changes between DCB backup intervals

### DIFF
--- a/core/schema/src/main/liquibase/36.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/36.0.0/changelog.xml
@@ -298,4 +298,50 @@
         </sql>
     </changeSet>
 
+    <changeSet author="dino2gnt" id="36.0.0-dcb-configchanged-event">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="eventconf_events"/>
+                <sqlCheck expectedResult="0">
+                    SELECT COUNT(*) FROM eventconf_events
+                    WHERE uei = 'uei.opennms.org/deviceconfig/configChanged'
+                </sqlCheck>
+            </and>
+        </preConditions>
+        <sql>
+            INSERT INTO eventconf_events
+            (id,
+             source_id,
+             uei,
+             event_label,
+             description,
+             enabled,
+             xml_content,
+             created_time,
+             last_modified,
+             modified_by,
+             severity)
+VALUES      (Nextval('eventconf_events_id_seq'),
+             15,
+             'uei.opennms.org/deviceconfig/configChanged',
+             'OpenNMS-defined node event: configChanged',
+             '&lt;p>Config backup changed on %service%
+            during the last poll on interface %interface%.&lt;/p>',
+             TRUE,
+             '&lt;event xmlns="http://xmlns.opennms.org/xsd/eventconf">
+&lt;uei>uei.opennms.org/deviceconfig/configChanged&lt;/uei>
+&lt;event-label>OpenNMS-defined node event: configChanged&lt;/event-label>
+&lt;descr>&amp;lt;p>Config backup changed on %service% during the last poll on interface %interface%.&amp;lt;/p>&lt;/descr>
+&lt;logmsg dest="logndisplay">
+    %service% config backup changed on interface %interface%.
+&lt;/logmsg>
+&lt;severity>Warning&lt;/severity>
+&lt;alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%service%" alarm-type="3" auto-clean="false"/>
+&lt;/event>',
+             Current_timestamp,
+             Current_timestamp,
+             'system-migration',
+             'Warning');
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/docs/modules/operation/pages/deep-dive/device-config-backup/configuration.adoc
+++ b/docs/modules/operation/pages/deep-dive/device-config-backup/configuration.adoc
@@ -149,6 +149,9 @@ Pollerd can generate the following device configuration backup events in {page-c
 
 | uei.opennms.org/deviceconfig/configBackupSucceeded
 | Configuration backup succeeded on a given service during the last poll on a given interface.
+
+| uei.opennms.org/deviceconfig/configChanged
+| Configuration backup on a given service has changed from the last poll on a given interface.
 |===
 
 == Device configuration backup parameters

--- a/docs/modules/operation/pages/deep-dive/device-config-backup/introduction.adoc
+++ b/docs/modules/operation/pages/deep-dive/device-config-backup/introduction.adoc
@@ -11,6 +11,7 @@ Through the UI, users can:
 * Create a user-defined schedule to automate configuration backups.
 * Trigger backups to occur when a device’s configuration changes, to ensure you always have a copy of the active device configuration.
 * View backup history, download configurations, search, and compare configurations for specific devices at different points in time.
+* Monitor device configurations for expected or unexpected changes
 
 Only users with the xref:operation:deep-dive/user-management/security-roles.adoc#ga-role-user-management-roles[ROLE_DEVICE_CONFIG_BACKUP role] can perform and monitor device configuration backups.
 

--- a/docs/modules/reference/pages/service-assurance/monitors/DeviceConfigMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/DeviceConfigMonitor.adoc
@@ -94,6 +94,10 @@ Example: `P20Y2M25D` means 20 years, 2 months, and 25 days.
 | If specified, this command is executed on the remote host instead of a login shell.
 | _Default login shell_
 
+|ignore-comments
+|Whether to ignore commented lines when checking the configuration for drift versus the previous backup
+|false
+
 |===
 
 == Schedule and interval

--- a/features/device-config/api/pom.xml
+++ b/features/device-config/api/pom.xml
@@ -39,5 +39,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigConstants.java
+++ b/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigConstants.java
@@ -33,4 +33,5 @@ public interface DeviceConfigConstants {
     static final String PARM_DEVICE_CONFIG_BACKUP_START_TIME = "backupStartTime";
     static final String PARM_DEVICE_CONFIG_BACKUP_DATA_PROTOCOL = "backupDataProtocol";
     static final String PARM_DEVICE_CONFIG_BACKUP_CONTROL_PROTOCOL = "backupControlProtocol";
+    static final String COMPARE_IGNORE_COMMENTS = "ignore-comments";
 }

--- a/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigUtil.java
+++ b/features/device-config/api/src/main/java/org/opennms/features/deviceconfig/service/DeviceConfigUtil.java
@@ -27,10 +27,55 @@ import com.google.common.io.ByteStreams;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 
 public class DeviceConfigUtil {
-    
+
+    /**
+     * Returns true if two config byte arrays are considered equal.
+     * Comparison is done as text using the given encoding.
+     * When {@code ignoreComments} is true, C-style comments ({@code //}, {@code #},
+     * {@code /* ... *\/}) are stripped from both sides before comparing.
+     */
+    public static boolean configsAreEqual(byte[] a, byte[] b, String encoding, boolean ignoreComments) {
+        if (a == null && b == null) return true;
+        if (a == null || b == null) return false;
+        if (!ignoreComments) {
+            return Arrays.equals(a, b);
+        }
+        try {
+            Charset charset = Charset.forName(encoding);
+            return stripComments(new String(a, charset)).equals(stripComments(new String(b, charset)));
+        } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+            return Arrays.equals(a, b);
+        }
+    }
+
+    /**
+     * Removes C-style comments from a configuration string:
+     * <ul>
+     *   <li>{@code /* ... *\/} block comments (including multi-line)</li>
+     *   <li>{@code //} line comments</li>
+     *   <li>{@code #} line comments</li>
+     * </ul>
+     * Lines that are empty or whitespace-only after removal are also dropped,
+     * so a diff that only adds or removes comments is not treated as a change.
+     */
+    public static String stripComments(String content) {
+        // block comments /* ... */ — (?s) makes . match newlines
+        content = content.replaceAll("(?s)/\\*.*?\\*/", "");
+        // // line comments
+        content = content.replaceAll("//[^\r\n]*", "");
+        // # line comments
+        content = content.replaceAll("#[^\r\n]*", "");
+        // drop lines that are now blank or whitespace-only
+        content = content.replaceAll("(?m)^[ \t]*\r?\n", "");
+        return content;
+    }
 
     public static byte[] decompressGzipToBytes(byte[] source) throws IOException {
         try (GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(source))) {

--- a/features/device-config/api/src/test/java/org/opennms/features/deviceconfig/service/DeviceConfigUtilTest.java
+++ b/features/device-config/api/src/test/java/org/opennms/features/deviceconfig/service/DeviceConfigUtilTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.deviceconfig.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class DeviceConfigUtilTest {
+
+    private static byte[] utf8(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    // -------------------------------------------------------------------------
+    // stripComments
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void stripsLineCommentSlashSlash() {
+        assertEquals("hostname router \n", DeviceConfigUtil.stripComments("hostname router // generated\n"));
+    }
+
+    @Test
+    public void stripsLineCommentHash() {
+        assertEquals("set system host-name router \n", DeviceConfigUtil.stripComments("set system host-name router # generated\n"));
+    }
+
+    @Test
+    public void stripsBlockComment() {
+        assertEquals("interface eth0  {\n}\n", DeviceConfigUtil.stripComments("interface eth0 /* management */ {\n}\n"));
+    }
+
+    @Test
+    public void stripsMultiLineBlockComment() {
+        String input = "interface eth0 {\n/* last modified:\n   2024-01-01 */\n  address 10.0.0.1;\n}\n";
+        String expected = "interface eth0 {\n  address 10.0.0.1;\n}\n";
+        assertEquals(expected, DeviceConfigUtil.stripComments(input));
+    }
+
+    @Test
+    public void dropsBlankLinesLeftByStripping() {
+        // A line that consists entirely of a comment should disappear
+        String input = "hostname router\n// auto-generated timestamp\ninterface eth0\n";
+        String expected = "hostname router\ninterface eth0\n";
+        assertEquals(expected, DeviceConfigUtil.stripComments(input));
+    }
+
+    // -------------------------------------------------------------------------
+    // configsAreEqual
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void equalBytesAreEqual() {
+        byte[] a = utf8("hostname router\n");
+        assertTrue(DeviceConfigUtil.configsAreEqual(a, a, "UTF-8", false));
+    }
+
+    @Test
+    public void differentBytesAreNotEqual() {
+        assertFalse(DeviceConfigUtil.configsAreEqual(utf8("hostname router\n"), utf8("hostname switch\n"), "UTF-8", false));
+    }
+
+    @Test
+    public void commentOnlyDiffIsEqualWhenIgnoring() {
+        byte[] a = utf8("hostname router\n// timestamp: 2024-01-01\n");
+        byte[] b = utf8("hostname router\n// timestamp: 2024-01-02\n");
+        assertTrue(DeviceConfigUtil.configsAreEqual(a, b, "UTF-8", true));
+    }
+
+    @Test
+    public void commentOnlyDiffIsNotEqualWhenNotIgnoring() {
+        byte[] a = utf8("hostname router\n// timestamp: 2024-01-01\n");
+        byte[] b = utf8("hostname router\n// timestamp: 2024-01-02\n");
+        assertFalse(DeviceConfigUtil.configsAreEqual(a, b, "UTF-8", false));
+    }
+
+    @Test
+    public void realChangeIsDetectedEvenWhenIgnoringComments() {
+        byte[] a = utf8("hostname router\n// comment\n");
+        byte[] b = utf8("hostname switch\n// comment\n");
+        assertFalse(DeviceConfigUtil.configsAreEqual(a, b, "UTF-8", true));
+    }
+
+    @Test
+    public void nullBothIsEqual() {
+        assertTrue(DeviceConfigUtil.configsAreEqual(null, null, "UTF-8", false));
+    }
+
+    @Test
+    public void nullOneIsNotEqual() {
+        assertFalse(DeviceConfigUtil.configsAreEqual(utf8("x"), null, "UTF-8", false));
+        assertFalse(DeviceConfigUtil.configsAreEqual(null, utf8("x"), "UTF-8", false));
+    }
+}

--- a/features/device-config/monitor-adaptor/src/main/java/org/opennms/features/deviceconfig/monitor/adaptor/DeviceConfigMonitorAdaptor.java
+++ b/features/device-config/monitor-adaptor/src/main/java/org/opennms/features/deviceconfig/monitor/adaptor/DeviceConfigMonitorAdaptor.java
@@ -159,6 +159,13 @@ public class DeviceConfigMonitorAdaptor implements ServiceMonitorAdaptor {
                 }
             }
 
+            // capture whether the content differs before the DAO call overwrites the stored bytes
+            final byte[] previousContent = latestConfig.map(DeviceConfig::getConfig).orElse(null);
+            final boolean ignoreComments = Boolean.parseBoolean(
+                    getKeyedString(parameters, DeviceConfigConstants.COMPARE_IGNORE_COMMENTS, "false"));
+            final boolean configChanged = previousContent != null
+                    && !DeviceConfigUtil.configsAreEqual(previousContent, content, encoding, ignoreComments);
+
             Optional<Long> updatedId = deviceConfigDao.updateDeviceConfigContent(
                 ipInterface,
                 svc.getSvcName(),
@@ -167,6 +174,12 @@ public class DeviceConfigMonitorAdaptor implements ServiceMonitorAdaptor {
                 content,
                 deviceConfig.getFilename());
             sendEvent(ipInterface, svc.getSvcName(), EventConstants.DEVICE_CONFIG_BACKUP_SUCCEEDED_UEI, svc.getNodeId(), Map.of());
+
+            if (configChanged) {
+                sendEvent(ipInterface, svc.getSvcName(), EventConstants.DEVICE_CONFIG_CHANGED_UEI, svc.getNodeId(), Map.of(
+                        DeviceConfigConstants.CONFIG_TYPE, configType
+                ));
+            }
 
             // if no record previously existed, don't need to call cleanup since
             // we just added the first record

--- a/features/device-config/monitor-adaptor/src/test/java/org/opennms/features/deviceconfig/monitor/adaptor/DeviceConfigMonitorAdaptorTest.java
+++ b/features/device-config/monitor-adaptor/src/test/java/org/opennms/features/deviceconfig/monitor/adaptor/DeviceConfigMonitorAdaptorTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.deviceconfig.monitor.adaptor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opennms.features.deviceconfig.persistence.api.DeviceConfig;
+import org.opennms.features.deviceconfig.persistence.api.DeviceConfigDao;
+import org.opennms.features.deviceconfig.service.DeviceConfigConstants;
+import org.opennms.features.usageanalytics.api.UsageAnalyticDao;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.poller.MonitoredService;
+import org.opennms.netmgt.poller.PollStatus;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeviceConfigMonitorAdaptorTest {
+
+    @Mock private DeviceConfigDao deviceConfigDao;
+    @Mock private IpInterfaceDao ipInterfaceDao;
+    @Mock private EventForwarder eventForwarder;
+    @Mock private UsageAnalyticDao usageAnalyticDao;
+    @Mock private NodeDao nodeDao;
+    @Mock private SessionUtils sessionUtils;
+
+    @InjectMocks
+    private DeviceConfigMonitorAdaptor adaptor;
+
+    private static final int    NODE_ID      = 1;
+    private static final String IP_ADDR      = "192.168.1.1";
+    private static final String SERVICE_NAME = "DeviceConfig-default";
+
+    private MonitoredService  service;
+    private OnmsIpInterface   ipInterface;
+
+    @Before
+    public void setUp() {
+        service = mock(MonitoredService.class);
+        when(service.getNodeId()).thenReturn(NODE_ID);
+        when(service.getIpAddr()).thenReturn(IP_ADDR);
+        when(service.getSvcName()).thenReturn(SERVICE_NAME);
+
+        ipInterface = mock(OnmsIpInterface.class);
+        when(ipInterfaceDao.findByNodeIdAndIpAddress(NODE_ID, IP_ADDR)).thenReturn(ipInterface);
+
+        when(deviceConfigDao.updateDeviceConfigContent(any(), any(), any(), any(), any(), any()))
+                .thenReturn(Optional.of(1L));
+
+        // lenient: not called when latestConfig is empty (noConfigChangedEventOnFirstBackup)
+        Mockito.lenient()
+               .when(deviceConfigDao.findStaleConfigs(any(), any(), any(), any()))
+               .thenReturn(Collections.emptyList());
+    }
+
+    // -------------------------------------------------------------------------
+    // configChanged event emission
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void configChangedEventFiredWhenContentDiffers() {
+        stubPrevious("old config\n".getBytes(StandardCharsets.UTF_8));
+        adaptor.handlePollResult(service, params(false),
+                pollStatus("new config\n".getBytes(StandardCharsets.UTF_8)));
+
+        List<String> ueis = capturedUeis(3);
+        assertThat(ueis.get(0), is(EventConstants.DEVICE_CONFIG_BACKUP_STARTED_UEI));
+        assertThat(ueis.get(1), is(EventConstants.DEVICE_CONFIG_BACKUP_SUCCEEDED_UEI));
+        assertThat(ueis.get(2), is(EventConstants.DEVICE_CONFIG_CHANGED_UEI));
+    }
+
+    @Test
+    public void noConfigChangedEventWhenContentUnchanged() {
+        byte[] config = "same config\n".getBytes(StandardCharsets.UTF_8);
+        stubPrevious(config);
+        adaptor.handlePollResult(service, params(false), pollStatus(config));
+
+        List<String> ueis = capturedUeis(2);
+        assertThat(ueis, not(hasItem(EventConstants.DEVICE_CONFIG_CHANGED_UEI)));
+    }
+
+    @Test
+    public void noConfigChangedEventOnFirstBackup() {
+        // No stored config exists yet: previousContent is null, so configChanged cannot be true
+        when(deviceConfigDao.getLatestConfigForInterface(any(), any())).thenReturn(Optional.empty());
+        adaptor.handlePollResult(service, params(false),
+                pollStatus("first config\n".getBytes(StandardCharsets.UTF_8)));
+
+        List<String> ueis = capturedUeis(2);
+        assertThat(ueis, not(hasItem(EventConstants.DEVICE_CONFIG_CHANGED_UEI)));
+    }
+
+    @Test
+    public void noConfigChangedEventWhenOnlyCommentsDifferWithIgnoreComments() {
+        // Configs differ only in a // timestamp comment; with ignore-comments=true they are equal
+        stubPrevious("hostname router\n// timestamp: 2024-01-01\n".getBytes(StandardCharsets.UTF_8));
+        adaptor.handlePollResult(service, params(true),
+                pollStatus("hostname router\n// timestamp: 2024-01-02\n".getBytes(StandardCharsets.UTF_8)));
+
+        List<String> ueis = capturedUeis(2);
+        assertThat(ueis, not(hasItem(EventConstants.DEVICE_CONFIG_CHANGED_UEI)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void stubPrevious(byte[] content) {
+        DeviceConfig prev = mock(DeviceConfig.class);
+        when(prev.getConfig()).thenReturn(content);
+        when(deviceConfigDao.getLatestConfigForInterface(any(), any())).thenReturn(Optional.of(prev));
+    }
+
+    private PollStatus pollStatus(byte[] content) {
+        var dc = new org.opennms.netmgt.poller.DeviceConfig(content, "config.txt");
+        PollStatus ps = mock(PollStatus.class);
+        when(ps.getDeviceConfig()).thenReturn(dc);
+        when(ps.isUp()).thenReturn(true);
+        return ps;
+    }
+
+    private Map<String, Object> params(boolean ignoreComments) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("encoding", "UTF-8");
+        m.put(DeviceConfigConstants.COMPARE_IGNORE_COMMENTS, String.valueOf(ignoreComments));
+        return m;
+    }
+
+    private List<String> capturedUeis(int expectedCount) {
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(eventForwarder, times(expectedCount)).sendNowSync(captor.capture());
+        return captor.getAllValues().stream().map(Event::getUei).collect(Collectors.toList());
+    }
+}

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
@@ -531,6 +531,7 @@ public abstract class EventConstants {
     public static final String DEVICE_CONFIG_BACKUP_STARTED_UEI = "uei.opennms.org/deviceconfig/configBackupStarted";
     public static final String DEVICE_CONFIG_BACKUP_FAILED_UEI = "uei.opennms.org/deviceconfig/configBackupFailed";
     public static final String DEVICE_CONFIG_BACKUP_SUCCEEDED_UEI = "uei.opennms.org/deviceconfig/configBackupSucceeded";
+    public static final String DEVICE_CONFIG_CHANGED_UEI = "uei.opennms.org/deviceconfig/configChanged";
     //
     // end eventUEIs
     //


### PR DESCRIPTION
Backport to `release-36.x` so this doesn't languish for another six months.

* DCB: Emit configChanged event when stored config differs from new backup

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19773
* PR into `develop` https://github.com/OpenNMS/opennms/pull/8507

