### PR TITLE
Update backshift

### DIFF
--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -208,7 +208,6 @@
             "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -3988,7 +3987,6 @@
             "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.18.0",
                 "@typescript-eslint/types": "7.18.0",
@@ -4392,7 +4390,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4467,7 +4464,6 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -4522,8 +4518,7 @@
             "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.3.tgz",
             "integrity": "sha512-5qjkWIQQVsHj4Sb5TcEs4WZWpFeVFHXwxEBHUhrny41D8UrBAd6T/6nPPAsLngJCReIOqi95W3mxdveveutpZw==",
             "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/angular-animate": {
             "version": "1.8.3",
@@ -4604,8 +4599,7 @@
             "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.8.3.tgz",
             "integrity": "sha512-2rxdqzlUVafUeWOwvY/FtyWk1pFTyCtzreeiTytG9m4smpuAEKaIJAjYeVwWsoV+nlTOcgpwV4W1OCmR+BQbUg==",
             "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/angular-ui-router": {
             "version": "1.0.30",
@@ -5991,11 +5985,11 @@
             }
         },
         "node_modules/backshift": {
-            "version": "1.3.3",
-            "resolved": "git+ssh://git@github.com/OpenNMS/backshift.git#079a5c2eae839e5deab4666e16688b9aa5ee79b7",
+            "version": "1.3.5",
+            "resolved": "git+ssh://git@github.com/OpenNMS/backshift.git#8ee66684309cf06ba82067c1166730ebf631934c",
             "dependencies": {
-                "c3": "~0.4.11",
-                "d3": "~3.5.16",
+                "c3": "~0.4.24",
+                "d3": "~3.5.17",
                 "dcjs": "https://github.com/dc-js/dc.js.git#2.0.0-beta.27",
                 "flot": "~0.8.3",
                 "flot-axislabels": "https://github.com/j-white/flot-axislabels.git#master",
@@ -6005,6 +5999,12 @@
                 "flot-saveas": "https://github.com/j-white/flot-saveas.git#master",
                 "jquery": "~2.1.4",
                 "jquery.flot.tooltip": "~0.9.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.2"
             }
         },
         "node_modules/balanced-match": {
@@ -6175,7 +6175,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "jquery": "1.9.1 - 3",
                 "popper.js": "^1.16.1"
@@ -6360,7 +6359,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001735",
                 "electron-to-chromium": "^1.5.204",
@@ -8803,7 +8801,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -9897,7 +9894,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -12054,7 +12050,6 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -13885,8 +13880,7 @@
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
             "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/jquery-migrate": {
             "version": "3.5.2",
@@ -14266,8 +14260,7 @@
             "version": "1.9.4",
             "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
             "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-            "license": "BSD-2-Clause",
-            "peer": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/leaflet.markercluster": {
             "version": "1.5.3",
@@ -14953,7 +14946,6 @@
             "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
             "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "moment": "^2.29.4"
             },
@@ -16256,7 +16248,6 @@
             "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
             "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -19637,7 +19628,6 @@
             "resolved": "https://registry.npmjs.org/tempusdominus-core/-/tempusdominus-core-5.19.3.tgz",
             "integrity": "sha512-WXBVXcBG/hErB6u9gdUs+vzANvCU1kd1ykzL4kolPB3h1OEv20OKUW5qz1iynxyqRFPa1NWY9gwRu5d+MjXEuQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "jquery": "^3.6.0",
                 "moment": "~2.29.2",
@@ -20396,7 +20386,6 @@
             "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -21267,7 +21256,6 @@
             "integrity": "sha512-td7fYwgLSrky3fI1EuU5cneU4+pbH6GgOfuKNS1tNPcfdGinGELAqsb/BP4nnvZyKSG2i/xFGU7+n2PvZA8HJQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.9.0",
                 "@webassemblyjs/helper-module-context": "1.9.0",

--- a/core/web-assets/package.json
+++ b/core/web-assets/package.json
@@ -129,6 +129,7 @@
     },
     "overrides": {
         "atob": "^2.1.0",
+        "backshift": "github:OpenNMS/backshift#v1.3.5",
         "cipher-base": "~1.0.6",
         "clean-css": "^4.1.11",
         "cross-spawn": "^7.0.6",


### PR DESCRIPTION
Looks like backshift didn't actually move to 1.3.5 in package-lock.json.
Removing `"node_modules/backshift": ` section and doing clean npm install updated the version.

