### PR TITLE
NMS-19719: Bring SNMP Data Collection Config from plugins to DB

### DIFF
--- a/features/api-layer/core/src/main/java/org/opennms/features/apilayer/config/SnmpCollectionExtensionManager.java
+++ b/features/api-layer/core/src/main/java/org/opennms/features/apilayer/config/SnmpCollectionExtensionManager.java
@@ -21,13 +21,14 @@
  */
 package org.opennms.features.apilayer.config;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.opennms.integration.api.v1.config.datacollection.SnmpCollectionExtension;
 import org.opennms.integration.api.v1.config.datacollection.SnmpDataCollection;
-import org.opennms.netmgt.config.api.DataCollectionConfigDao;
 import org.opennms.netmgt.config.datacollection.Collect;
 import org.opennms.netmgt.config.datacollection.DataCollectionGroups;
 import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
@@ -37,14 +38,23 @@ import org.opennms.netmgt.config.datacollection.MibObj;
 import org.opennms.netmgt.config.datacollection.MibObjProperty;
 import org.opennms.netmgt.config.datacollection.Parameter;
 import org.opennms.netmgt.config.datacollection.SystemDef;
+import org.opennms.netmgt.dao.support.SnmpDataCollectionConfigLoader;
+import org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDb;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SnmpCollectionExtensionManager extends ConfigExtensionManager<SnmpCollectionExtension, DataCollectionGroups> {
 
-    private final DataCollectionConfigDao dataCollectionConfigDao;
+    private static final Logger LOG = LoggerFactory.getLogger(SnmpCollectionExtensionManager.class);
 
-    public SnmpCollectionExtensionManager(DataCollectionConfigDao dataCollectionConfigDao) {
+    private final SnmpDataCollectionSyncToDb syncToDb;
+    private final SnmpDataCollectionConfigLoader configLoader;
+
+    public SnmpCollectionExtensionManager(final SnmpDataCollectionSyncToDb syncToDb,
+                                          final SnmpDataCollectionConfigLoader configLoader) {
         super(DataCollectionGroups.class, new DataCollectionGroups());
-        this.dataCollectionConfigDao = dataCollectionConfigDao;
+        this.syncToDb = Objects.requireNonNull(syncToDb);
+        this.configLoader = Objects.requireNonNull(configLoader);
     }
 
     @Override
@@ -57,7 +67,30 @@ public class SnmpCollectionExtensionManager extends ConfigExtensionManager<SnmpC
 
     @Override
     protected void triggerReload() {
-        dataCollectionConfigDao.reload();
+        try {
+            final List<DatacollectionGroup> flattened = flatten(getObject());
+            final boolean changed = syncToDb.syncPluginGroupsToDb(flattened);
+            if (changed) {
+                LOG.debug("Plugin SNMP data collection sync produced changes; scheduling runtime reload.");
+                configLoader.scheduleDataCollectionConfigReload();
+            } else {
+                LOG.debug("Plugin SNMP data collection sync produced no changes; skipping runtime reload.");
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to sync plugin SNMP data collection extensions to database", e);
+        }
+    }
+
+    /** Flatten the per-collection map of plugin groups into one list for the sync helper. */
+    private static List<DatacollectionGroup> flatten(final DataCollectionGroups aggregated) {
+        if (aggregated == null) {
+            return List.of();
+        }
+        final List<DatacollectionGroup> out = new ArrayList<>();
+        for (final String collectionName : aggregated.getSnmpCollectionNames()) {
+            out.addAll(aggregated.getDataCollectionGroup(collectionName));
+        }
+        return out;
     }
 
 

--- a/features/api-layer/core/src/main/java/org/opennms/features/apilayer/config/SnmpCollectionExtensionManager.java
+++ b/features/api-layer/core/src/main/java/org/opennms/features/apilayer/config/SnmpCollectionExtensionManager.java
@@ -21,8 +21,8 @@
  */
 package org.opennms.features.apilayer.config;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -68,8 +68,10 @@ public class SnmpCollectionExtensionManager extends ConfigExtensionManager<SnmpC
     @Override
     protected void triggerReload() {
         try {
-            final List<DatacollectionGroup> flattened = flatten(getObject());
-            final boolean changed = syncToDb.syncPluginGroupsToDb(flattened);
+            final DataCollectionGroups aggregated = getObject();
+            final Map<String, List<DatacollectionGroup>> byCollection =
+                    aggregated == null ? Map.of() : aggregated.getDataCollectionGroupByName();
+            final boolean changed = syncToDb.syncPluginGroupsToDb(byCollection);
             if (changed) {
                 LOG.debug("Plugin SNMP data collection sync produced changes; scheduling runtime reload.");
                 configLoader.scheduleDataCollectionConfigReload();
@@ -79,18 +81,6 @@ public class SnmpCollectionExtensionManager extends ConfigExtensionManager<SnmpC
         } catch (Exception e) {
             LOG.error("Failed to sync plugin SNMP data collection extensions to database", e);
         }
-    }
-
-    /** Flatten the per-collection map of plugin groups into one list for the sync helper. */
-    private static List<DatacollectionGroup> flatten(final DataCollectionGroups aggregated) {
-        if (aggregated == null) {
-            return List.of();
-        }
-        final List<DatacollectionGroup> out = new ArrayList<>();
-        for (final String collectionName : aggregated.getSnmpCollectionNames()) {
-            out.addAll(aggregated.getDataCollectionGroup(collectionName));
-        }
-        return out;
     }
 
 

--- a/features/api-layer/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -149,9 +149,12 @@
 
   <!-- Snmp Data Collection Config Extension-->
   <reference id="dataCollectionConfigDao" interface="org.opennms.netmgt.config.api.DataCollectionConfigDao" availability="mandatory" />
+  <reference id="snmpDataCollectionSyncToDb" interface="org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDb" availability="mandatory" />
+  <reference id="snmpDataCollectionConfigLoader" interface="org.opennms.netmgt.dao.support.SnmpDataCollectionConfigLoader" availability="mandatory" />
 
   <bean id="snmpCollectionExtensionManager" class="org.opennms.features.apilayer.config.SnmpCollectionExtensionManager">
-    <argument ref="dataCollectionConfigDao"/>
+    <argument ref="snmpDataCollectionSyncToDb"/>
+    <argument ref="snmpDataCollectionConfigLoader"/>
   </bean>
 
   <reference-list interface="org.opennms.integration.api.v1.config.datacollection.SnmpCollectionExtension" availability="optional">

--- a/features/config/upgrade/src/main/java/org/opennms/config/upgrade/datacollection/SnmpDataCollectionMigration.java
+++ b/features/config/upgrade/src/main/java/org/opennms/config/upgrade/datacollection/SnmpDataCollectionMigration.java
@@ -515,7 +515,7 @@ public class SnmpDataCollectionMigration {
             @SuppressWarnings("unchecked")
             final T result = (T) unmarshaller.unmarshal(source);
             return result;
-        } catch (JAXBException | SAXException | ParserConfigurationException | java.io.IOException e) {
+        } catch (JAXBException | SAXException | ParserConfigurationException | IOException e) {
             throw new SQLException("Failed to unmarshal " + file.getAbsolutePath(), e);
         }
     }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpCollectionSourceDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpCollectionSourceDao.java
@@ -38,6 +38,12 @@ public interface SnmpCollectionSourceDao extends OnmsDao<SnmpCollectionSource, I
 
     List<SnmpCollectionSource> findAllEnabled();
 
+    /**
+     * Find all sources whose {@code uploadedBy} matches the given marker.
+     * Used by plugin sync paths to enumerate plugin-managed rows.
+     */
+    List<SnmpCollectionSource> findByUploadedBy(String uploadedBy);
+
     void delete(SnmpCollectionSource source);
 
     void deleteAll(final Collection<SnmpCollectionSource> list);

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/SnmpCollectionSourceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/SnmpCollectionSourceDaoHibernate.java
@@ -61,6 +61,11 @@ public class SnmpCollectionSourceDaoHibernate extends AbstractDaoHibernate<SnmpC
     }
 
     @Override
+    public List<SnmpCollectionSource> findByUploadedBy(String uploadedBy) {
+        return find("from SnmpCollectionSource s where s.uploadedBy = ?", uploadedBy);
+    }
+
+    @Override
     public void deleteAll(final Collection<SnmpCollectionSource> list) {
         super.deleteAll(list);
     }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionConfigLoader.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionConfigLoader.java
@@ -21,372 +21,49 @@
  */
 package org.opennms.netmgt.dao.support;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.opennms.netmgt.config.api.DataCollectionConfigDao;
-import org.opennms.netmgt.config.api.DataCollectionConfigLookupUtils;
-import org.opennms.netmgt.config.api.DatacollectionJsonHelper;
-import org.opennms.netmgt.config.datacollection.Collect;
-import org.opennms.netmgt.config.datacollection.DatacollectionConfig;
 import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
-import org.opennms.netmgt.config.datacollection.Group;
-import org.opennms.netmgt.config.datacollection.Groups;
-import org.opennms.netmgt.config.datacollection.PersistenceSelectorStrategy;
-import org.opennms.netmgt.config.datacollection.ResourceType;
-import org.opennms.netmgt.config.datacollection.Rrd;
-import org.opennms.netmgt.config.datacollection.SnmpCollection;
-import org.opennms.netmgt.config.datacollection.StorageStrategy;
-import org.opennms.netmgt.config.datacollection.SystemDef;
-import org.opennms.netmgt.config.datacollection.Systems;
-import org.opennms.netmgt.dao.api.SnmpCollectionMibGroupDao;
-import org.opennms.netmgt.dao.api.SnmpCollectionProfileDao;
-import org.opennms.netmgt.dao.api.SnmpCollectionResourceTypeDao;
-import org.opennms.netmgt.dao.api.SnmpCollectionSourceDao;
-import org.opennms.netmgt.dao.api.SnmpCollectionSystemDefDao;
-import org.opennms.netmgt.model.SnmpCollectionMibGroup;
-import org.opennms.netmgt.model.SnmpCollectionProfile;
-import org.opennms.netmgt.model.SnmpCollectionResourceType;
 import org.opennms.netmgt.model.SnmpCollectionSource;
-import org.opennms.netmgt.model.SnmpCollectionSystemDef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
-
-import javax.annotation.PreDestroy;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * Builds the in-memory SNMP data collection config from the database and
  * publishes it into {@link DataCollectionConfigDao}.
  *
- * <p>Lives in the DAO application context so that both the config DAO and
- * the Hibernate DAOs it needs are available at init time. The initial load
- * runs synchronously in {@link #afterPropertiesSet()} so that downstream
+ * <p>Initial load runs synchronously at startup so that downstream
  * components (collectd, pollerd) see a populated config before they start
  * scheduling work.
  *
- * <p>Post-startup reloads (triggered by CRUD on the REST layer) are submitted
- * asynchronously via a single-threaded executor, which serializes concurrent
- * reload requests and keeps reloads off the caller's transaction thread.
+ * <p>Post-startup reloads (triggered by CRUD on the REST layer and by plugin
+ * extension sync) are submitted asynchronously via a single-threaded
+ * executor, which serializes concurrent reload requests and keeps reloads
+ * off the caller's transaction thread.
+ *
+ * <p>Implementation is {@link SnmpDataCollectionConfigLoaderImpl}. The
+ * interface exists so OSGi consumers in other bundles get a JDK-proxyable
+ * type (concrete classes need {@code ext:proxy-method="classes"} which is
+ * best avoided when the boundary can be expressed as an interface).
  */
-public class SnmpDataCollectionConfigLoader implements InitializingBean {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SnmpDataCollectionConfigLoader.class);
-
-    private static final String RESOURCE_TYPE_COLLECTION_NAME = "__resource_type_collection";
-
-    private DataCollectionConfigDao dataCollectionConfigDao;
-    private SnmpCollectionProfileDao snmpCollectionProfileDao;
-    private SnmpCollectionSourceDao snmpCollectionSourceDao;
-    private SnmpCollectionResourceTypeDao snmpCollectionResourceTypeDao;
-    private SnmpCollectionMibGroupDao snmpCollectionMibGroupDao;
-    private SnmpCollectionSystemDefDao snmpCollectionSystemDefDao;
-
-    private final ExecutorService dataCollectionReloadExecutor =
-            Executors.newSingleThreadExecutor(r -> new Thread(r, "load-DataCollection-Config"));
-
-    private volatile boolean hasPublishedFromDb = false;
-
-    @Override
-    public void afterPropertiesSet() {
-        try {
-            reloadDataCollectionConfigFromDb();
-        } catch (Exception e) {
-            LOG.error("Failed to load SNMP data collection config from DB at startup — "
-                    + "collection will not work until config is reloaded.", e);
-        }
-    }
-
-    @PreDestroy
-    public void shutdown() {
-        dataCollectionReloadExecutor.shutdownNow();
-    }
+public interface SnmpDataCollectionConfigLoader {
 
     /**
      * Submit a reload on the dedicated single-threaded executor so it runs
      * outside any active transaction on the caller thread and serializes
      * concurrent requests.
      */
-    public void scheduleDataCollectionConfigReload() {
-        dataCollectionReloadExecutor.submit(() -> {
-            try {
-                reloadDataCollectionConfigFromDb();
-            } catch (Exception e) {
-                LOG.error("Failed to reload SNMP data collection config: {}", e.getMessage(), e);
-            }
-        });
-    }
-
-
-    public void reloadDataCollectionConfigFromDb() {
-        final MaterializedConfig materialized = materializeFromDb();
-
-        // First-time load with no DB profiles: don't clobber XML-loaded state.
-        // The "admin cleared all profiles" case (publish empty to drop stale DB state)
-        // is gated on a previous successful DB publish having happened.
-        if (materialized.profileCount == 0 && !hasPublishedFromDb) {
-            return;
-        }
-
-        try {
-            DataCollectionConfigLookupUtils.validateResourceTypes(
-                    materialized.config.getSnmpCollections(),
-                    materialized.allResourceTypes.keySet());
-        } catch (IllegalArgumentException e) {
-            LOG.warn("Resource type validation warning during DB config load: {}", e.getMessage());
-        }
-
-        dataCollectionConfigDao.loadFromDatabase(
-                materialized.config, materialized.allResourceTypes, materialized.allGroups);
-        hasPublishedFromDb = true;
-        LOG.info("Loaded SNMP data collection config from DB: {} profiles, {} resource types, {} sources",
-                materialized.profileCount, materialized.allResourceTypes.size(), materialized.allGroups.size());
-    }
+    void scheduleDataCollectionConfigReload();
 
     /**
-     * Build the in-memory {@link DatacollectionConfig} from the DB without
-     * publishing it. When there are no enabled profiles, returns an empty
-     * config so the caller can replace any stale in-memory state on reload.
-     *
-     * <p>Package-private for tests
+     * Synchronous reload: materialize from DB and publish to the DAO. Most
+     * production callers should use {@link #scheduleDataCollectionConfigReload()}
+     * instead. Used directly by lifecycle hooks and tests.
      */
-    MaterializedConfig materializeFromDb() {
-        final List<SnmpCollectionProfile> profiles = snmpCollectionProfileDao.findAllEnabled();
-
-        final DatacollectionConfig config = new DatacollectionConfig();
-        String rrdPath = dataCollectionConfigDao.getRrdPath();
-        if (!rrdPath.endsWith("/")) {
-            rrdPath = rrdPath + "/";
-        }
-        config.setRrdRepository(rrdPath);
-        final Map<String, ResourceType> allResourceTypes = new HashMap<>();
-        final List<String> allGroups = new ArrayList<>();
-
-        if (profiles == null || profiles.isEmpty()) {
-            LOG.info("No SNMP collection profiles in the database — publishing empty config; "
-                    + "SNMP data collection is inactive until profiles and sources are uploaded.");
-            return new MaterializedConfig(config, allResourceTypes, allGroups, 0);
-        }
-
-        LOG.info("Loading SNMP data collection config from database ({} profiles)...", profiles.size());
-
-        final SnmpCollection rtCollection = new SnmpCollection();
-        rtCollection.setName(RESOURCE_TYPE_COLLECTION_NAME);
-        rtCollection.setSnmpStorageFlag("select");
-        rtCollection.setGroups(new Groups());
-        rtCollection.setSystems(new Systems());
-        final Rrd rtRrd = new Rrd();
-        rtRrd.setStep(300);
-        rtCollection.setRrd(rtRrd);
-
-        for (final SnmpCollectionProfile profile : profiles) {
-            final SnmpCollection coll = new SnmpCollection();
-            coll.setName(profile.getName());
-            coll.setSnmpStorageFlag(profile.getStorageFlag());
-            coll.setMaxVarsPerPdu(profile.getMaxVarsPerPdu());
-
-            final Rrd rrd = new Rrd();
-            rrd.setStep(profile.getRrdStep());
-            final List<String> rras = DatacollectionJsonHelper.fromJson(
-                    profile.getRrdRras(), new TypeReference<List<String>>() {});
-            if (rras != null) rras.forEach(rrd::addRra);
-            coll.setRrd(rrd);
-
-            final Groups groups = new Groups();
-            final Systems systems = new Systems();
-            coll.setGroups(groups);
-            coll.setSystems(systems);
-
-            // Dedupe by name as we merge content from multiple sources into this collection.
-            // Mirrors DataCollectionConfigParser.addSystemDef's contains-check behavior.
-            final Set<String> addedGroupNames = new HashSet<>();
-            final Set<String> addedSystemDefNames = new HashSet<>();
-
-            final List<String> sourceNames = DatacollectionJsonHelper.fromJson(
-                    profile.getSourceNames(), new TypeReference<>() {});
-            if (sourceNames != null) {
-                for (final String sourceName : sourceNames) {
-                    final SnmpCollectionSource source = snmpCollectionSourceDao.findByName(sourceName);
-                    if (source == null) {
-                        LOG.warn("Profile '{}' references source '{}' not found — skipping.",
-                                profile.getName(), sourceName);
-                        continue;
-                    }
-                    if (!source.getEnabled()) {
-                        LOG.debug("Profile '{}': source '{}' is disabled — skipping.",
-                                profile.getName(), sourceName);
-                        continue;
-                    }
-                    if (!allGroups.contains(sourceName)) {
-                        allGroups.add(sourceName);
-                    }
-
-                    final DatacollectionGroup dcGroup = buildDataCollectionGroupFromDb(source);
-                    for (final Group g : dcGroup.getGroups()) {
-                        if (g.getName() != null && addedGroupNames.add(g.getName())) {
-                            groups.addGroup(g);
-                        }
-                    }
-                    for (final SystemDef sd : dcGroup.getSystemDefs()) {
-                        if (sd.getName() != null && addedSystemDefNames.add(sd.getName())) {
-                            systems.addSystemDef(sd);
-                        }
-                    }
-                    for (final ResourceType rt : dcGroup.getResourceTypes()) {
-                        coll.addResourceType(rt);
-                        rtCollection.addResourceType(rt);
-                        allResourceTypes.put(rt.getName(), rt);
-                    }
-                }
-            }
-
-            config.addSnmpCollection(coll);
-        }
-
-        config.insertSnmpCollection(rtCollection);
-        return new MaterializedConfig(config, allResourceTypes, allGroups, profiles.size());
-    }
-
-    /** Bundle of values produced by {@link #materializeFromDb()}. */
-    static final class MaterializedConfig {
-        final DatacollectionConfig config;
-        final Map<String, ResourceType> allResourceTypes;
-        final List<String> allGroups;
-        final int profileCount;
-
-        MaterializedConfig(final DatacollectionConfig config,
-                           final Map<String, ResourceType> allResourceTypes,
-                           final List<String> allGroups,
-                           final int profileCount) {
-            this.config = config;
-            this.allResourceTypes = allResourceTypes;
-            this.allGroups = allGroups;
-            this.profileCount = profileCount;
-        }
-    }
+    void reloadDataCollectionConfigFromDb();
 
     /**
-     * Materialize a {@link DatacollectionGroup} from a persisted
-     * {@link SnmpCollectionSource} plus its child rows.
+     * Materialize a {@link DatacollectionGroup} (the on-wire/import format)
+     * from a persisted {@link SnmpCollectionSource} plus its child rows.
+     * Used by the REST download endpoint to assemble the legacy XML shape
+     * for a single source on demand.
      */
-    public DatacollectionGroup buildDataCollectionGroupFromDb(final SnmpCollectionSource source) {
-        final DatacollectionGroup group = new DatacollectionGroup();
-        group.setName(source.getName());
-
-        final List<SnmpCollectionResourceType> rtEntities =
-                snmpCollectionResourceTypeDao.findAllEnabledBySource(source.getId());
-        group.setResourceTypes(rtEntities.stream().map(e -> {
-            final ResourceType rt = new ResourceType();
-            rt.setName(e.getName());
-            rt.setLabel(e.getLabel());
-            if (e.getResourceLabel() != null) {
-                rt.setResourceLabel(e.getResourceLabel());
-            }
-            if (e.getStorageStrategy() != null) {
-                final StorageStrategy ss = new StorageStrategy();
-                ss.setClazz(e.getStorageStrategy());
-                final var ssParams = DatacollectionJsonHelper.fromJsonToParameters(e.getStorageStrategyParams());
-                if (ssParams != null) {
-                    ss.setParameters(ssParams);
-                }
-                rt.setStorageStrategy(ss);
-            }
-            if (e.getPersistenceSelectorStrategy() != null) {
-                final PersistenceSelectorStrategy ps = new PersistenceSelectorStrategy();
-                ps.setClazz(e.getPersistenceSelectorStrategy());
-                final var psParams = DatacollectionJsonHelper.fromJsonToParameters(e.getPersistenceSelectorParams());
-                if (psParams != null) {
-                    ps.setParameters(psParams);
-                }
-                rt.setPersistenceSelectorStrategy(ps);
-            }
-            return rt;
-        }).toList());
-
-        final List<SnmpCollectionMibGroup> mgEntities =
-                snmpCollectionMibGroupDao.findAllEnabledBySource(source.getId());
-        group.setGroups(mgEntities.stream().map(e -> {
-            final Group g = new Group();
-            g.setName(e.getName());
-            g.setIfType(e.getIfType());
-            // Preserve JAXB's empty-list defaults when the JSON is null/empty.
-            // DataCollectionConfigLookupUtils#processGroupForProperties (and
-            // similar collectd hot-path code) calls getProperties().forEach
-            // without a null check, so a null here would NPE at runtime.
-            final var mibObjs = DatacollectionJsonHelper.fromJsonToMibObjs(e.getMibObjects());
-            if (mibObjs != null) g.setMibObjs(mibObjs);
-            final var props = DatacollectionJsonHelper.fromJsonToProperties(e.getMibObjProperties());
-            if (props != null) g.setProperties(props);
-            final List<String> includeGroups = DatacollectionJsonHelper.fromJson(
-                    e.getMibGroupNames(), new TypeReference<List<String>>() {});
-            if (includeGroups != null) {
-                g.setIncludeGroups(includeGroups);
-            }
-            return g;
-        }).toList());
-
-        final List<SnmpCollectionSystemDef> sdEntities =
-                snmpCollectionSystemDefDao.findAllEnabledBySource(source.getId());
-        group.setSystemDefs(sdEntities.stream()
-                .filter(e -> {
-                    final boolean hasSysoid = e.getSysoid() != null && !e.getSysoid().isBlank();
-                    final boolean hasSysoidMask = e.getSysoidMask() != null && !e.getSysoidMask().isBlank();
-                    if (!hasSysoid && !hasSysoidMask) {
-                        LOG.warn("Skipping SystemDef '{}' (id={}) in source '{}': no sysoid or sysoidMask in DB.",
-                                e.getName(), e.getId(), source.getName());
-                        return false;
-                    }
-                    return true;
-                })
-                .map(e -> {
-            final SystemDef sd = new SystemDef();
-            sd.setName(e.getName());
-            if (e.getSysoid() != null && !e.getSysoid().isBlank()) {
-                sd.setSysoid(e.getSysoid());
-            } else {
-                sd.setSysoidMask(e.getSysoidMask());
-            }
-            final List<String> includeGroups = DatacollectionJsonHelper.fromJson(
-                    e.getMibGroupNames(), new TypeReference<List<String>>() {});
-            final Collect collect = new Collect();
-            if (includeGroups != null) {
-                collect.setIncludeGroups(includeGroups);
-            }
-            sd.setCollect(collect);
-            sd.setIpList(DatacollectionJsonHelper.fromJsonToIpList(e.getIpAddresses()));
-            return sd;
-        }).toList());
-
-        return group;
-    }
-
-    public void setDataCollectionConfigDao(final DataCollectionConfigDao dataCollectionConfigDao) {
-        this.dataCollectionConfigDao = dataCollectionConfigDao;
-    }
-
-    public void setSnmpCollectionProfileDao(final SnmpCollectionProfileDao snmpCollectionProfileDao) {
-        this.snmpCollectionProfileDao = snmpCollectionProfileDao;
-    }
-
-    public void setSnmpCollectionSourceDao(final SnmpCollectionSourceDao snmpCollectionSourceDao) {
-        this.snmpCollectionSourceDao = snmpCollectionSourceDao;
-    }
-
-    public void setSnmpCollectionResourceTypeDao(final SnmpCollectionResourceTypeDao snmpCollectionResourceTypeDao) {
-        this.snmpCollectionResourceTypeDao = snmpCollectionResourceTypeDao;
-    }
-
-    public void setSnmpCollectionMibGroupDao(final SnmpCollectionMibGroupDao snmpCollectionMibGroupDao) {
-        this.snmpCollectionMibGroupDao = snmpCollectionMibGroupDao;
-    }
-
-    public void setSnmpCollectionSystemDefDao(final SnmpCollectionSystemDefDao snmpCollectionSystemDefDao) {
-        this.snmpCollectionSystemDefDao = snmpCollectionSystemDefDao;
-    }
+    DatacollectionGroup buildDataCollectionGroupFromDb(SnmpCollectionSource source);
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionConfigLoaderImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionConfigLoaderImpl.java
@@ -1,0 +1,378 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.dao.support;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.opennms.netmgt.config.api.DataCollectionConfigDao;
+import org.opennms.netmgt.config.api.DataCollectionConfigLookupUtils;
+import org.opennms.netmgt.config.api.DatacollectionJsonHelper;
+import org.opennms.netmgt.config.datacollection.Collect;
+import org.opennms.netmgt.config.datacollection.DatacollectionConfig;
+import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
+import org.opennms.netmgt.config.datacollection.Group;
+import org.opennms.netmgt.config.datacollection.Groups;
+import org.opennms.netmgt.config.datacollection.PersistenceSelectorStrategy;
+import org.opennms.netmgt.config.datacollection.ResourceType;
+import org.opennms.netmgt.config.datacollection.Rrd;
+import org.opennms.netmgt.config.datacollection.SnmpCollection;
+import org.opennms.netmgt.config.datacollection.StorageStrategy;
+import org.opennms.netmgt.config.datacollection.SystemDef;
+import org.opennms.netmgt.config.datacollection.Systems;
+import org.opennms.netmgt.dao.api.SnmpCollectionMibGroupDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionProfileDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionResourceTypeDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionSourceDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionSystemDefDao;
+import org.opennms.netmgt.model.SnmpCollectionMibGroup;
+import org.opennms.netmgt.model.SnmpCollectionProfile;
+import org.opennms.netmgt.model.SnmpCollectionResourceType;
+import org.opennms.netmgt.model.SnmpCollectionSource;
+import org.opennms.netmgt.model.SnmpCollectionSystemDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+
+import javax.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Default implementation of {@link SnmpDataCollectionConfigLoader}. See the
+ * interface for the design contract.
+ */
+public class SnmpDataCollectionConfigLoaderImpl implements SnmpDataCollectionConfigLoader, InitializingBean {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SnmpDataCollectionConfigLoaderImpl.class);
+
+    private static final String RESOURCE_TYPE_COLLECTION_NAME = "__resource_type_collection";
+
+    private DataCollectionConfigDao dataCollectionConfigDao;
+    private SnmpCollectionProfileDao snmpCollectionProfileDao;
+    private SnmpCollectionSourceDao snmpCollectionSourceDao;
+    private SnmpCollectionResourceTypeDao snmpCollectionResourceTypeDao;
+    private SnmpCollectionMibGroupDao snmpCollectionMibGroupDao;
+    private SnmpCollectionSystemDefDao snmpCollectionSystemDefDao;
+
+    private final ExecutorService dataCollectionReloadExecutor =
+            Executors.newSingleThreadExecutor(r -> new Thread(r, "load-DataCollection-Config"));
+
+    private volatile boolean hasPublishedFromDb = false;
+
+    @Override
+    public void afterPropertiesSet() {
+        try {
+            reloadDataCollectionConfigFromDb();
+        } catch (Exception e) {
+            LOG.error("Failed to load SNMP data collection config from DB at startup — "
+                    + "collection will not work until config is reloaded.", e);
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        dataCollectionReloadExecutor.shutdownNow();
+    }
+
+    @Override
+    public void scheduleDataCollectionConfigReload() {
+        dataCollectionReloadExecutor.submit(() -> {
+            try {
+                reloadDataCollectionConfigFromDb();
+            } catch (Exception e) {
+                LOG.error("Failed to reload SNMP data collection config: {}", e.getMessage(), e);
+            }
+        });
+    }
+
+    @Override
+    public void reloadDataCollectionConfigFromDb() {
+        final MaterializedConfig materialized = materializeFromDb();
+
+        // First-time load with no DB profiles: don't clobber XML-loaded state.
+        // The "admin cleared all profiles" case (publish empty to drop stale DB state)
+        // is gated on a previous successful DB publish having happened.
+        if (materialized.profileCount == 0 && !hasPublishedFromDb) {
+            return;
+        }
+
+        try {
+            DataCollectionConfigLookupUtils.validateResourceTypes(
+                    materialized.config.getSnmpCollections(),
+                    materialized.allResourceTypes.keySet());
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Resource type validation warning during DB config load: {}", e.getMessage());
+        }
+
+        dataCollectionConfigDao.loadFromDatabase(
+                materialized.config, materialized.allResourceTypes, materialized.allGroups);
+        hasPublishedFromDb = true;
+        LOG.info("Loaded SNMP data collection config from DB: {} profiles, {} resource types, {} sources",
+                materialized.profileCount, materialized.allResourceTypes.size(), materialized.allGroups.size());
+    }
+
+    /**
+     * Build the in-memory {@link DatacollectionConfig} from the DB without
+     * publishing it. When there are no enabled profiles, returns an empty
+     * config so the caller can replace any stale in-memory state on reload.
+     *
+     * <p>Package-private for tests
+     */
+    MaterializedConfig materializeFromDb() {
+        final List<SnmpCollectionProfile> profiles = snmpCollectionProfileDao.findAllEnabled();
+
+        final DatacollectionConfig config = new DatacollectionConfig();
+        String rrdPath = dataCollectionConfigDao.getRrdPath();
+        if (!rrdPath.endsWith("/")) {
+            rrdPath = rrdPath + "/";
+        }
+        config.setRrdRepository(rrdPath);
+        final Map<String, ResourceType> allResourceTypes = new HashMap<>();
+        final List<String> allGroups = new ArrayList<>();
+
+        if (profiles == null || profiles.isEmpty()) {
+            LOG.info("No SNMP collection profiles in the database — publishing empty config; "
+                    + "SNMP data collection is inactive until profiles and sources are uploaded.");
+            return new MaterializedConfig(config, allResourceTypes, allGroups, 0);
+        }
+
+        LOG.info("Loading SNMP data collection config from database ({} profiles)...", profiles.size());
+
+        final SnmpCollection rtCollection = new SnmpCollection();
+        rtCollection.setName(RESOURCE_TYPE_COLLECTION_NAME);
+        rtCollection.setSnmpStorageFlag("select");
+        rtCollection.setGroups(new Groups());
+        rtCollection.setSystems(new Systems());
+        final Rrd rtRrd = new Rrd();
+        rtRrd.setStep(300);
+        rtCollection.setRrd(rtRrd);
+
+        for (final SnmpCollectionProfile profile : profiles) {
+            final SnmpCollection coll = new SnmpCollection();
+            coll.setName(profile.getName());
+            coll.setSnmpStorageFlag(profile.getStorageFlag());
+            coll.setMaxVarsPerPdu(profile.getMaxVarsPerPdu());
+
+            final Rrd rrd = new Rrd();
+            rrd.setStep(profile.getRrdStep());
+            final List<String> rras = DatacollectionJsonHelper.fromJson(
+                    profile.getRrdRras(), new TypeReference<List<String>>() {});
+            if (rras != null) rras.forEach(rrd::addRra);
+            coll.setRrd(rrd);
+
+            final Groups groups = new Groups();
+            final Systems systems = new Systems();
+            coll.setGroups(groups);
+            coll.setSystems(systems);
+
+            // Dedupe by name as we merge content from multiple sources into this collection.
+            // Mirrors DataCollectionConfigParser.addSystemDef's contains-check behavior.
+            final Set<String> addedGroupNames = new HashSet<>();
+            final Set<String> addedSystemDefNames = new HashSet<>();
+
+            final List<String> sourceNames = DatacollectionJsonHelper.fromJson(
+                    profile.getSourceNames(), new TypeReference<>() {});
+            if (sourceNames != null) {
+                for (final String sourceName : sourceNames) {
+                    final SnmpCollectionSource source = snmpCollectionSourceDao.findByName(sourceName);
+                    if (source == null) {
+                        LOG.warn("Profile '{}' references source '{}' not found — skipping.",
+                                profile.getName(), sourceName);
+                        continue;
+                    }
+                    if (!source.getEnabled()) {
+                        LOG.debug("Profile '{}': source '{}' is disabled — skipping.",
+                                profile.getName(), sourceName);
+                        continue;
+                    }
+                    if (!allGroups.contains(sourceName)) {
+                        allGroups.add(sourceName);
+                    }
+
+                    final DatacollectionGroup dcGroup = buildDataCollectionGroupFromDb(source);
+                    for (final Group g : dcGroup.getGroups()) {
+                        if (g.getName() != null && addedGroupNames.add(g.getName())) {
+                            groups.addGroup(g);
+                        }
+                    }
+                    for (final SystemDef sd : dcGroup.getSystemDefs()) {
+                        if (sd.getName() != null && addedSystemDefNames.add(sd.getName())) {
+                            systems.addSystemDef(sd);
+                        }
+                    }
+                    for (final ResourceType rt : dcGroup.getResourceTypes()) {
+                        coll.addResourceType(rt);
+                        rtCollection.addResourceType(rt);
+                        allResourceTypes.put(rt.getName(), rt);
+                    }
+                }
+            }
+
+            config.addSnmpCollection(coll);
+        }
+
+        config.insertSnmpCollection(rtCollection);
+        return new MaterializedConfig(config, allResourceTypes, allGroups, profiles.size());
+    }
+
+    /** Bundle of values produced by {@link #materializeFromDb()}. */
+    static final class MaterializedConfig {
+        final DatacollectionConfig config;
+        final Map<String, ResourceType> allResourceTypes;
+        final List<String> allGroups;
+        final int profileCount;
+
+        MaterializedConfig(final DatacollectionConfig config,
+                           final Map<String, ResourceType> allResourceTypes,
+                           final List<String> allGroups,
+                           final int profileCount) {
+            this.config = config;
+            this.allResourceTypes = allResourceTypes;
+            this.allGroups = allGroups;
+            this.profileCount = profileCount;
+        }
+    }
+
+    /**
+     * Materialize a {@link DatacollectionGroup} from a persisted
+     * {@link SnmpCollectionSource} plus its child rows.
+     */
+    public DatacollectionGroup buildDataCollectionGroupFromDb(final SnmpCollectionSource source) {
+        final DatacollectionGroup group = new DatacollectionGroup();
+        group.setName(source.getName());
+
+        final List<SnmpCollectionResourceType> rtEntities =
+                snmpCollectionResourceTypeDao.findAllEnabledBySource(source.getId());
+        group.setResourceTypes(rtEntities.stream().map(e -> {
+            final ResourceType rt = new ResourceType();
+            rt.setName(e.getName());
+            rt.setLabel(e.getLabel());
+            if (e.getResourceLabel() != null) {
+                rt.setResourceLabel(e.getResourceLabel());
+            }
+            if (e.getStorageStrategy() != null) {
+                final StorageStrategy ss = new StorageStrategy();
+                ss.setClazz(e.getStorageStrategy());
+                final var ssParams = DatacollectionJsonHelper.fromJsonToParameters(e.getStorageStrategyParams());
+                if (ssParams != null) {
+                    ss.setParameters(ssParams);
+                }
+                rt.setStorageStrategy(ss);
+            }
+            if (e.getPersistenceSelectorStrategy() != null) {
+                final PersistenceSelectorStrategy ps = new PersistenceSelectorStrategy();
+                ps.setClazz(e.getPersistenceSelectorStrategy());
+                final var psParams = DatacollectionJsonHelper.fromJsonToParameters(e.getPersistenceSelectorParams());
+                if (psParams != null) {
+                    ps.setParameters(psParams);
+                }
+                rt.setPersistenceSelectorStrategy(ps);
+            }
+            return rt;
+        }).toList());
+
+        final List<SnmpCollectionMibGroup> mgEntities =
+                snmpCollectionMibGroupDao.findAllEnabledBySource(source.getId());
+        group.setGroups(mgEntities.stream().map(e -> {
+            final Group g = new Group();
+            g.setName(e.getName());
+            g.setIfType(e.getIfType());
+            // Preserve JAXB's empty-list defaults when the JSON is null/empty.
+            // DataCollectionConfigLookupUtils#processGroupForProperties (and
+            // similar collectd hot-path code) calls getProperties().forEach
+            // without a null check, so a null here would NPE at runtime.
+            final var mibObjs = DatacollectionJsonHelper.fromJsonToMibObjs(e.getMibObjects());
+            if (mibObjs != null) g.setMibObjs(mibObjs);
+            final var props = DatacollectionJsonHelper.fromJsonToProperties(e.getMibObjProperties());
+            if (props != null) g.setProperties(props);
+            final List<String> includeGroups = DatacollectionJsonHelper.fromJson(
+                    e.getMibGroupNames(), new TypeReference<List<String>>() {});
+            if (includeGroups != null) {
+                g.setIncludeGroups(includeGroups);
+            }
+            return g;
+        }).toList());
+
+        final List<SnmpCollectionSystemDef> sdEntities =
+                snmpCollectionSystemDefDao.findAllEnabledBySource(source.getId());
+        group.setSystemDefs(sdEntities.stream()
+                .filter(e -> {
+                    final boolean hasSysoid = e.getSysoid() != null && !e.getSysoid().isBlank();
+                    final boolean hasSysoidMask = e.getSysoidMask() != null && !e.getSysoidMask().isBlank();
+                    if (!hasSysoid && !hasSysoidMask) {
+                        LOG.warn("Skipping SystemDef '{}' (id={}) in source '{}': no sysoid or sysoidMask in DB.",
+                                e.getName(), e.getId(), source.getName());
+                        return false;
+                    }
+                    return true;
+                })
+                .map(e -> {
+            final SystemDef sd = new SystemDef();
+            sd.setName(e.getName());
+            if (e.getSysoid() != null && !e.getSysoid().isBlank()) {
+                sd.setSysoid(e.getSysoid());
+            } else {
+                sd.setSysoidMask(e.getSysoidMask());
+            }
+            final List<String> includeGroups = DatacollectionJsonHelper.fromJson(
+                    e.getMibGroupNames(), new TypeReference<List<String>>() {});
+            final Collect collect = new Collect();
+            if (includeGroups != null) {
+                collect.setIncludeGroups(includeGroups);
+            }
+            sd.setCollect(collect);
+            sd.setIpList(DatacollectionJsonHelper.fromJsonToIpList(e.getIpAddresses()));
+            return sd;
+        }).toList());
+
+        return group;
+    }
+
+    public void setDataCollectionConfigDao(final DataCollectionConfigDao dataCollectionConfigDao) {
+        this.dataCollectionConfigDao = dataCollectionConfigDao;
+    }
+
+    public void setSnmpCollectionProfileDao(final SnmpCollectionProfileDao snmpCollectionProfileDao) {
+        this.snmpCollectionProfileDao = snmpCollectionProfileDao;
+    }
+
+    public void setSnmpCollectionSourceDao(final SnmpCollectionSourceDao snmpCollectionSourceDao) {
+        this.snmpCollectionSourceDao = snmpCollectionSourceDao;
+    }
+
+    public void setSnmpCollectionResourceTypeDao(final SnmpCollectionResourceTypeDao snmpCollectionResourceTypeDao) {
+        this.snmpCollectionResourceTypeDao = snmpCollectionResourceTypeDao;
+    }
+
+    public void setSnmpCollectionMibGroupDao(final SnmpCollectionMibGroupDao snmpCollectionMibGroupDao) {
+        this.snmpCollectionMibGroupDao = snmpCollectionMibGroupDao;
+    }
+
+    public void setSnmpCollectionSystemDefDao(final SnmpCollectionSystemDefDao snmpCollectionSystemDefDao) {
+        this.snmpCollectionSystemDefDao = snmpCollectionSystemDefDao;
+    }
+}

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDb.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDb.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.dao.support;
+
+import java.util.Collection;
+
+import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
+import org.opennms.netmgt.model.SnmpCollectionSource;
+
+/**
+ * Persists plugin-contributed SNMP data collection groups into the DB tables
+ * that back the runtime config. One {@code DatacollectionGroup} from a plugin
+ * extension maps to one {@link SnmpCollectionSource} row whose {@code uploadedBy}
+ * is {@link #PLUGIN_UPLOADED_BY}; the source's child entities (MIB groups,
+ * resource types, system defs) are replaced wholesale on each sync.
+ *
+ * <p>Mirrors the eventconf {@code EventConfExtensionManager} pattern: the
+ * marker column is {@code uploaded_by}, sources outside that marker are never
+ * touched, and the source's {@code enabled} flag is preserved across syncs so
+ * that an admin's disable intent survives plugin reloads.
+ *
+ * <p>Profile attachment is not handled here — matches XML migration semantics:
+ * sources are inserted independently, and admins attach them to profiles
+ * through the admin page when they want them active.
+ *
+ * <p>Implementation is {@link SnmpDataCollectionSyncToDbImpl}. The interface
+ * exists so that OSGi consumers in other bundles get a JDK-proxyable type
+ * (concrete classes need {@code ext:proxy-method="classes"} which is best
+ * avoided when the boundary can be expressed cleanly as an interface).
+ */
+public interface SnmpDataCollectionSyncToDb {
+
+    /**
+     * Marker value written to {@link SnmpCollectionSource#getUploadedBy()} for
+     * rows owned by the plugin sync. Sources outside this marker are user
+     * uploads or migration artifacts and are never touched by sync.
+     */
+    String PLUGIN_UPLOADED_BY = "opennms-plugins";
+
+    /**
+     * Reconcile the DB's plugin-marker rows with the supplied aggregated set.
+     * Plugin sources not present in {@code aggregated} are removed; new ones
+     * are inserted; existing ones have their child entities (MIB groups,
+     * resource types, system defs) replaced. The source's {@code enabled}
+     * flag is preserved when the row already exists.
+     *
+     * <p>Runs under a single transaction.
+     *
+     * @return {@code true} if any row was inserted, updated, or deleted.
+     */
+    boolean syncPluginGroupsToDb(Collection<DatacollectionGroup> aggregated);
+
+    /**
+     * Whether a source row is managed by the plugin sync. Callers in the REST
+     * and UI layers use this to enforce read-only semantics on plugin rows.
+     */
+    static boolean isPluginSourced(final SnmpCollectionSource source) {
+        return source != null && PLUGIN_UPLOADED_BY.equals(source.getUploadedBy());
+    }
+
+    /**
+     * Convenience for guarding write paths: throws if the source is plugin-managed.
+     * {@code op} appears in the error message for context.
+     */
+    static void requireNotPluginSourced(final SnmpCollectionSource source, final String op) {
+        if (isPluginSourced(source)) {
+            throw new IllegalArgumentException(op + " not allowed on plugin-sourced source '"
+                    + source.getName() + "'; sources whose uploadedBy is '"
+                    + PLUGIN_UPLOADED_BY + "' are managed by plugin sync and are read-only "
+                    + "(enable/disable is still permitted).");
+        }
+    }
+}

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDb.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDb.java
@@ -21,7 +21,8 @@
  */
 package org.opennms.netmgt.dao.support;
 
-import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
 import org.opennms.netmgt.model.SnmpCollectionSource;
@@ -33,14 +34,18 @@ import org.opennms.netmgt.model.SnmpCollectionSource;
  * is {@link #PLUGIN_UPLOADED_BY}; the source's child entities (MIB groups,
  * resource types, system defs) are replaced wholesale on each sync.
  *
- * <p>Mirrors the eventconf {@code EventConfExtensionManager} pattern: the
- * marker column is {@code uploaded_by}, sources outside that marker are never
- * touched, and the source's {@code enabled} flag is preserved across syncs so
- * that an admin's disable intent survives plugin reloads.
+ * <p>Plugin extensions declare a target snmp-collection name via
+ * {@code SnmpCollectionExtension.getSnmpCollectionName()}. The sync uses that
+ * key to auto-attach each source row to the matching profile (by adding the
+ * source name to that profile's {@code source_names} JSON column) — mirrors
+ * the pre-DB behavior in {@code DefaultDataCollectionConfigDao#translateConfig}
+ * that auto-added plugin groups to the targeted snmp-collection via
+ * {@code <include-collection>} entries. Sources whose target profile doesn't
+ * exist remain detached; the operator can attach them later via the UI.
  *
- * <p>Profile attachment is not handled here — matches XML migration semantics:
- * sources are inserted independently, and admins attach them to profiles
- * through the admin page when they want them active.
+ * <p>The {@code uploaded_by} marker column means user/migration-uploaded
+ * sources are never touched by sync; the source's {@code enabled} flag is
+ * preserved across syncs so an admin's disable intent survives plugin reloads.
  *
  * <p>Implementation is {@link SnmpDataCollectionSyncToDbImpl}. The interface
  * exists so that OSGi consumers in other bundles get a JDK-proxyable type
@@ -58,16 +63,26 @@ public interface SnmpDataCollectionSyncToDb {
 
     /**
      * Reconcile the DB's plugin-marker rows with the supplied aggregated set.
-     * Plugin sources not present in {@code aggregated} are removed; new ones
-     * are inserted; existing ones have their child entities (MIB groups,
-     * resource types, system defs) replaced. The source's {@code enabled}
-     * flag is preserved when the row already exists.
+     * The map key is the target snmp-collection name (matches the profile name
+     * in the new world); the value is the list of {@code DatacollectionGroup}s
+     * the plugin contributes to that target.
+     *
+     * <p>For each {@code (target, group)}:
+     * <ul>
+     *   <li>Upsert the source row (replacing children).</li>
+     *   <li>Add the source name to the target profile's {@code source_names}
+     *       (idempotent). If no profile of that name exists, log a WARN and
+     *       leave the source detached.</li>
+     * </ul>
+     *
+     * <p>Plugin-marker sources not present in any incoming entry are removed
+     * (orphan cleanup). Non-plugin rows are untouched.
      *
      * <p>Runs under a single transaction.
      *
      * @return {@code true} if any row was inserted, updated, or deleted.
      */
-    boolean syncPluginGroupsToDb(Collection<DatacollectionGroup> aggregated);
+    boolean syncPluginGroupsToDb(Map<String, List<DatacollectionGroup>> groupsByCollection);
 
     /**
      * Whether a source row is managed by the plugin sync. Callers in the REST

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDbImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDbImpl.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.dao.support;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.opennms.netmgt.config.api.DatacollectionJsonHelper;
+import org.opennms.netmgt.config.datacollection.Collect;
+import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
+import org.opennms.netmgt.config.datacollection.Group;
+import org.opennms.netmgt.config.datacollection.IpList;
+import org.opennms.netmgt.config.datacollection.ResourceType;
+import org.opennms.netmgt.config.datacollection.SystemDef;
+import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.dao.api.SnmpCollectionMibGroupDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionResourceTypeDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionSourceDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionSystemDefDao;
+import org.opennms.netmgt.model.SnmpCollectionMibGroup;
+import org.opennms.netmgt.model.SnmpCollectionResourceType;
+import org.opennms.netmgt.model.SnmpCollectionSource;
+import org.opennms.netmgt.model.SnmpCollectionSystemDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link SnmpDataCollectionSyncToDb}.
+ *
+ * <p>See the interface's javadoc for the design contract (one source per
+ * plugin group, {@code uploaded_by} marker, child-entity wholesale replace,
+ * preserved {@code enabled} flag, no profile attachment).
+ */
+public class SnmpDataCollectionSyncToDbImpl implements SnmpDataCollectionSyncToDb {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SnmpDataCollectionSyncToDbImpl.class);
+
+    private final SnmpCollectionSourceDao sourceDao;
+    private final SnmpCollectionMibGroupDao mibGroupDao;
+    private final SnmpCollectionResourceTypeDao resourceTypeDao;
+    private final SnmpCollectionSystemDefDao systemDefDao;
+    private final SessionUtils sessionUtils;
+
+    public SnmpDataCollectionSyncToDbImpl(final SnmpCollectionSourceDao sourceDao,
+                                          final SnmpCollectionMibGroupDao mibGroupDao,
+                                          final SnmpCollectionResourceTypeDao resourceTypeDao,
+                                          final SnmpCollectionSystemDefDao systemDefDao,
+                                          final SessionUtils sessionUtils) {
+        this.sourceDao = Objects.requireNonNull(sourceDao);
+        this.mibGroupDao = Objects.requireNonNull(mibGroupDao);
+        this.resourceTypeDao = Objects.requireNonNull(resourceTypeDao);
+        this.systemDefDao = Objects.requireNonNull(systemDefDao);
+        this.sessionUtils = Objects.requireNonNull(sessionUtils);
+    }
+
+    @Override
+    public boolean syncPluginGroupsToDb(final Collection<DatacollectionGroup> aggregated) {
+        return sessionUtils.withTransaction(() -> doSync(aggregated == null ? Collections.emptyList() : aggregated));
+    }
+
+    private boolean doSync(final Collection<DatacollectionGroup> aggregated) {
+        boolean changed = false;
+        final Date now = new Date();
+
+        // Orphan removal only operates on rows already under the plugin marker:
+        // we never auto-delete user/migration sources just because no plugin
+        // contributes a group of that name.
+        final List<SnmpCollectionSource> existingPluginSources =
+                sourceDao.findByUploadedBy(PLUGIN_UPLOADED_BY);
+
+        final Set<String> incomingNames = new HashSet<>();
+
+        for (final DatacollectionGroup group : aggregated) {
+            if (group == null || group.getName() == null || group.getName().isBlank()) {
+                LOG.warn("Skipping plugin DatacollectionGroup with null/blank name");
+                continue;
+            }
+
+            // Look up across ALL sources: if a non-plugin row already owns the
+            // name, we take over (matches pre-DB-migration behavior where the
+            // plugin's <datacollection-group> overrode the shipped XML group
+            // of the same name in DefaultDataCollectionConfigDao#translateConfig).
+            SnmpCollectionSource source = sourceDao.findByName(group.getName());
+            if (source == null) {
+                source = new SnmpCollectionSource();
+                source.setName(group.getName());
+                source.setUploadedBy(PLUGIN_UPLOADED_BY);
+                source.setEnabled(Boolean.TRUE);
+                source.setCreatedTime(now);
+                source.setLastModified(now);
+                sourceDao.save(source);
+                LOG.info("Created plugin-sourced datacollection source '{}'", group.getName());
+            } else if (!PLUGIN_UPLOADED_BY.equals(source.getUploadedBy())) {
+                LOG.warn("Plugin group '{}' is taking over existing non-plugin source (was uploadedBy='{}'); "
+                                + "previous content will be replaced.",
+                        group.getName(), source.getUploadedBy());
+                source.setUploadedBy(PLUGIN_UPLOADED_BY);
+                source.setLastModified(now);
+                // enabled flag is preserved as-is across the takeover
+                sourceDao.saveOrUpdate(source);
+            } else {
+                // Already plugin-managed: preserve enabled flag; just refresh lastModified.
+                source.setLastModified(now);
+                sourceDao.saveOrUpdate(source);
+            }
+
+            // Replace children wholesale. Simpler than per-child diffing and
+            // correct given the source has no admin-editable children (they
+            // are read-only in the UI for plugin-sourced rows).
+            mibGroupDao.deleteBySourceId(source.getId());
+            resourceTypeDao.deleteBySourceId(source.getId());
+            systemDefDao.deleteBySourceId(source.getId());
+
+            saveMibGroups(source, group.getGroups());
+            saveResourceTypes(source, group.getResourceTypes());
+            saveSystemDefs(source, group.getSystemDefs());
+
+            incomingNames.add(group.getName());
+            changed = true;
+        }
+
+        // Drop plugin sources no longer present in the aggregated set (plugin
+        // uninstalled or stopped contributing that group). Cascade removes
+        // their children.
+        for (final SnmpCollectionSource existing : existingPluginSources) {
+            if (!incomingNames.contains(existing.getName())) {
+                sourceDao.delete(existing);
+                changed = true;
+                LOG.info("Removed plugin-sourced datacollection source '{}' (no longer contributed by any plugin)",
+                        existing.getName());
+            }
+        }
+
+        return changed;
+    }
+
+    private void saveMibGroups(final SnmpCollectionSource source, final List<Group> groups) {
+        if (groups == null || groups.isEmpty()) {
+            return;
+        }
+        final List<SnmpCollectionMibGroup> rows = new ArrayList<>(groups.size());
+        for (final Group g : groups) {
+            if (g == null) continue;
+            final SnmpCollectionMibGroup row = new SnmpCollectionMibGroup();
+            row.setCollectionSource(source);
+            row.setName(g.getName());
+            row.setIfType(g.getIfType());
+            row.setMibGroupNames(jsonOrNull(g.getIncludeGroups()));
+            // Match migration: mib_objects defaults to "[]" rather than null when empty
+            row.setMibObjects(g.getMibObjs() == null || g.getMibObjs().isEmpty() ? "[]"
+                    : DatacollectionJsonHelper.toJson(g.getMibObjs()));
+            row.setMibObjProperties(jsonOrNull(g.getProperties()));
+            row.setEnabled(Boolean.TRUE);
+            rows.add(row);
+        }
+        mibGroupDao.saveAll(rows);
+    }
+
+    private void saveResourceTypes(final SnmpCollectionSource source, final List<ResourceType> resourceTypes) {
+        if (resourceTypes == null || resourceTypes.isEmpty()) {
+            return;
+        }
+        final List<SnmpCollectionResourceType> rows = new ArrayList<>(resourceTypes.size());
+        for (final ResourceType rt : resourceTypes) {
+            if (rt == null) continue;
+            final SnmpCollectionResourceType row = new SnmpCollectionResourceType();
+            row.setCollectionSource(source);
+            row.setName(rt.getName());
+            // Mirror migration's label fallback so we never violate NOT NULL.
+            row.setLabel(rt.getLabel() != null && !rt.getLabel().isBlank() ? rt.getLabel() : rt.getName());
+            row.setResourceLabel(rt.getResourceLabel());
+            row.setPersistenceSelectorStrategy(rt.getPersistenceSelectorStrategy() != null
+                    ? rt.getPersistenceSelectorStrategy().getClazz() : null);
+            row.setPersistenceSelectorParams(rt.getPersistenceSelectorStrategy() != null
+                    && rt.getPersistenceSelectorStrategy().getParameters() != null
+                    && !rt.getPersistenceSelectorStrategy().getParameters().isEmpty()
+                    ? DatacollectionJsonHelper.toJson(rt.getPersistenceSelectorStrategy().getParameters()) : null);
+            row.setStorageStrategy(rt.getStorageStrategy() != null
+                    ? rt.getStorageStrategy().getClazz() : null);
+            row.setStorageStrategyParams(rt.getStorageStrategy() != null
+                    && rt.getStorageStrategy().getParameters() != null
+                    && !rt.getStorageStrategy().getParameters().isEmpty()
+                    ? DatacollectionJsonHelper.toJson(rt.getStorageStrategy().getParameters()) : null);
+            row.setEnabled(Boolean.TRUE);
+            rows.add(row);
+        }
+        resourceTypeDao.saveAll(rows);
+    }
+
+    private void saveSystemDefs(final SnmpCollectionSource source, final List<SystemDef> systemDefs) {
+        if (systemDefs == null || systemDefs.isEmpty()) {
+            return;
+        }
+        final List<SnmpCollectionSystemDef> rows = new ArrayList<>(systemDefs.size());
+        for (final SystemDef sd : systemDefs) {
+            if (sd == null) continue;
+            if ((sd.getSysoid() == null || sd.getSysoid().isBlank())
+                    && (sd.getSysoidMask() == null || sd.getSysoidMask().isBlank())) {
+                LOG.warn("Skipping plugin SystemDef '{}' on source '{}': no sysoid or sysoidMask",
+                        sd.getName(), source.getName());
+                continue;
+            }
+            final SnmpCollectionSystemDef row = new SnmpCollectionSystemDef();
+            row.setCollectionSource(source);
+            row.setName(sd.getName());
+            row.setSysoid(sd.getSysoid());
+            row.setSysoidMask(sd.getSysoidMask());
+            final IpList ipList = sd.getIpList();
+            row.setIpAddresses(ipList != null ? DatacollectionJsonHelper.toJson(ipList) : null);
+            row.setIpAddressMasks(ipList != null && ipList.getIpAddressMasks() != null
+                    && !ipList.getIpAddressMasks().isEmpty()
+                    ? DatacollectionJsonHelper.toJson(ipList.getIpAddressMasks()) : null);
+            final List<String> includeGroups = Optional.ofNullable(sd.getCollect())
+                    .map(Collect::getIncludeGroups)
+                    .orElse(Collections.emptyList());
+            row.setMibGroupNames(DatacollectionJsonHelper.toJson(includeGroups));
+            row.setEnabled(Boolean.TRUE);
+            rows.add(row);
+        }
+        systemDefDao.saveAll(rows);
+    }
+
+    private static String jsonOrNull(final List<?> items) {
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+        return DatacollectionJsonHelper.toJson(items);
+    }
+}

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDbImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDbImpl.java
@@ -22,14 +22,17 @@
 package org.opennms.netmgt.dao.support;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import org.opennms.netmgt.config.api.DatacollectionJsonHelper;
 import org.opennms.netmgt.config.datacollection.Collect;
@@ -40,10 +43,12 @@ import org.opennms.netmgt.config.datacollection.ResourceType;
 import org.opennms.netmgt.config.datacollection.SystemDef;
 import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.dao.api.SnmpCollectionMibGroupDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionProfileDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionResourceTypeDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionSourceDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionSystemDefDao;
 import org.opennms.netmgt.model.SnmpCollectionMibGroup;
+import org.opennms.netmgt.model.SnmpCollectionProfile;
 import org.opennms.netmgt.model.SnmpCollectionResourceType;
 import org.opennms.netmgt.model.SnmpCollectionSource;
 import org.opennms.netmgt.model.SnmpCollectionSystemDef;
@@ -65,26 +70,30 @@ public class SnmpDataCollectionSyncToDbImpl implements SnmpDataCollectionSyncToD
     private final SnmpCollectionMibGroupDao mibGroupDao;
     private final SnmpCollectionResourceTypeDao resourceTypeDao;
     private final SnmpCollectionSystemDefDao systemDefDao;
+    private final SnmpCollectionProfileDao profileDao;
     private final SessionUtils sessionUtils;
 
     public SnmpDataCollectionSyncToDbImpl(final SnmpCollectionSourceDao sourceDao,
                                           final SnmpCollectionMibGroupDao mibGroupDao,
                                           final SnmpCollectionResourceTypeDao resourceTypeDao,
                                           final SnmpCollectionSystemDefDao systemDefDao,
+                                          final SnmpCollectionProfileDao profileDao,
                                           final SessionUtils sessionUtils) {
         this.sourceDao = Objects.requireNonNull(sourceDao);
         this.mibGroupDao = Objects.requireNonNull(mibGroupDao);
         this.resourceTypeDao = Objects.requireNonNull(resourceTypeDao);
         this.systemDefDao = Objects.requireNonNull(systemDefDao);
+        this.profileDao = Objects.requireNonNull(profileDao);
         this.sessionUtils = Objects.requireNonNull(sessionUtils);
     }
 
     @Override
-    public boolean syncPluginGroupsToDb(final Collection<DatacollectionGroup> aggregated) {
-        return sessionUtils.withTransaction(() -> doSync(aggregated == null ? Collections.emptyList() : aggregated));
+    public boolean syncPluginGroupsToDb(final Map<String, List<DatacollectionGroup>> groupsByCollection) {
+        return sessionUtils.withTransaction(() ->
+                doSync(groupsByCollection == null ? Collections.emptyMap() : groupsByCollection));
     }
 
-    private boolean doSync(final Collection<DatacollectionGroup> aggregated) {
+    private boolean doSync(final Map<String, List<DatacollectionGroup>> groupsByCollection) {
         boolean changed = false;
         final Date now = new Date();
 
@@ -96,60 +105,63 @@ public class SnmpDataCollectionSyncToDbImpl implements SnmpDataCollectionSyncToD
 
         final Set<String> incomingNames = new HashSet<>();
 
-        for (final DatacollectionGroup group : aggregated) {
-            if (group == null || group.getName() == null || group.getName().isBlank()) {
-                LOG.warn("Skipping plugin DatacollectionGroup with null/blank name");
-                continue;
+        for (final Map.Entry<String, List<DatacollectionGroup>> entry : groupsByCollection.entrySet()) {
+            final String targetCollection = entry.getKey();
+            final List<DatacollectionGroup> groups = entry.getValue();
+            if (groups == null) continue;
+
+            for (final DatacollectionGroup group : groups) {
+                if (group == null || group.getName() == null || group.getName().isBlank()) {
+                    LOG.warn("Skipping plugin DatacollectionGroup with null/blank name");
+                    continue;
+                }
+
+                // Collision on a non-plugin row → take over (matches pre-DB override behavior
+                // in DefaultDataCollectionConfigDao#translateConfig).
+                SnmpCollectionSource source = sourceDao.findByName(group.getName());
+                if (source == null) {
+                    source = new SnmpCollectionSource();
+                    source.setName(group.getName());
+                    source.setUploadedBy(PLUGIN_UPLOADED_BY);
+                    source.setEnabled(Boolean.TRUE);
+                    source.setCreatedTime(now);
+                    source.setLastModified(now);
+                    sourceDao.save(source);
+                    LOG.info("Created plugin-sourced datacollection source '{}'", group.getName());
+                } else if (!PLUGIN_UPLOADED_BY.equals(source.getUploadedBy())) {
+                    LOG.warn("Plugin group '{}' is taking over existing non-plugin source (was uploadedBy='{}'); "
+                                    + "previous content will be replaced.",
+                            group.getName(), source.getUploadedBy());
+                    source.setUploadedBy(PLUGIN_UPLOADED_BY);
+                    source.setLastModified(now);
+                    // enabled is intentionally not reset — admin disable must survive takeover.
+                    sourceDao.saveOrUpdate(source);
+                } else {
+                    source.setLastModified(now);
+                    sourceDao.saveOrUpdate(source);
+                }
+
+                // Children are read-only in the UI for plugin rows, so wholesale replace is safe.
+                mibGroupDao.deleteBySourceId(source.getId());
+                resourceTypeDao.deleteBySourceId(source.getId());
+                systemDefDao.deleteBySourceId(source.getId());
+
+                saveMibGroups(source, group.getGroups());
+                saveResourceTypes(source, group.getResourceTypes());
+                saveSystemDefs(source, group.getSystemDefs());
+
+                if (targetCollection != null && !targetCollection.isBlank()) {
+                    attachSourceToProfile(targetCollection, source.getName());
+                }
+
+                incomingNames.add(group.getName());
+                changed = true;
             }
-
-            // Look up across ALL sources: if a non-plugin row already owns the
-            // name, we take over (matches pre-DB-migration behavior where the
-            // plugin's <datacollection-group> overrode the shipped XML group
-            // of the same name in DefaultDataCollectionConfigDao#translateConfig).
-            SnmpCollectionSource source = sourceDao.findByName(group.getName());
-            if (source == null) {
-                source = new SnmpCollectionSource();
-                source.setName(group.getName());
-                source.setUploadedBy(PLUGIN_UPLOADED_BY);
-                source.setEnabled(Boolean.TRUE);
-                source.setCreatedTime(now);
-                source.setLastModified(now);
-                sourceDao.save(source);
-                LOG.info("Created plugin-sourced datacollection source '{}'", group.getName());
-            } else if (!PLUGIN_UPLOADED_BY.equals(source.getUploadedBy())) {
-                LOG.warn("Plugin group '{}' is taking over existing non-plugin source (was uploadedBy='{}'); "
-                                + "previous content will be replaced.",
-                        group.getName(), source.getUploadedBy());
-                source.setUploadedBy(PLUGIN_UPLOADED_BY);
-                source.setLastModified(now);
-                // enabled flag is preserved as-is across the takeover
-                sourceDao.saveOrUpdate(source);
-            } else {
-                // Already plugin-managed: preserve enabled flag; just refresh lastModified.
-                source.setLastModified(now);
-                sourceDao.saveOrUpdate(source);
-            }
-
-            // Replace children wholesale. Simpler than per-child diffing and
-            // correct given the source has no admin-editable children (they
-            // are read-only in the UI for plugin-sourced rows).
-            mibGroupDao.deleteBySourceId(source.getId());
-            resourceTypeDao.deleteBySourceId(source.getId());
-            systemDefDao.deleteBySourceId(source.getId());
-
-            saveMibGroups(source, group.getGroups());
-            saveResourceTypes(source, group.getResourceTypes());
-            saveSystemDefs(source, group.getSystemDefs());
-
-            incomingNames.add(group.getName());
-            changed = true;
         }
 
-        // Drop plugin sources no longer present in the aggregated set (plugin
-        // uninstalled or stopped contributing that group). Cascade removes
-        // their children.
         for (final SnmpCollectionSource existing : existingPluginSources) {
             if (!incomingNames.contains(existing.getName())) {
+                detachSourceFromAllProfiles(existing.getName());
                 sourceDao.delete(existing);
                 changed = true;
                 LOG.info("Removed plugin-sourced datacollection source '{}' (no longer contributed by any plugin)",
@@ -158,6 +170,45 @@ public class SnmpDataCollectionSyncToDbImpl implements SnmpDataCollectionSyncToD
         }
 
         return changed;
+    }
+
+    private void detachSourceFromAllProfiles(final String sourceName) {
+        for (final SnmpCollectionProfile profile : profileDao.findAll()) {
+            final List<String> existing = DatacollectionJsonHelper.fromJson(
+                    profile.getSourceNames(), new TypeReference<List<String>>() {});
+            if (existing == null || !existing.contains(sourceName)) {
+                continue;
+            }
+            final List<String> filtered = new ArrayList<>(existing.size());
+            for (final String name : existing) {
+                if (!sourceName.equals(name)) {
+                    filtered.add(name);
+                }
+            }
+            profile.setSourceNames(DatacollectionJsonHelper.toJson(filtered));
+            profileDao.saveOrUpdate(profile);
+            LOG.info("Detached plugin source '{}' from profile '{}' (source being removed).",
+                    sourceName, profile.getName());
+        }
+    }
+
+    private void attachSourceToProfile(final String profileName, final String sourceName) {
+        final SnmpCollectionProfile profile = profileDao.findByName(profileName);
+        if (profile == null) {
+            LOG.warn("Plugin source '{}' targets snmp-collection '{}' but no profile of that name exists; "
+                            + "source remains detached. Attach it manually via the admin page if desired.",
+                    sourceName, profileName);
+            return;
+        }
+        final List<String> existing = DatacollectionJsonHelper.fromJson(
+                profile.getSourceNames(), new TypeReference<List<String>>() {});
+        final Set<String> merged = new LinkedHashSet<>();
+        if (existing != null) merged.addAll(existing);
+        if (merged.add(sourceName)) {
+            profile.setSourceNames(DatacollectionJsonHelper.toJson(new ArrayList<>(merged)));
+            profileDao.saveOrUpdate(profile);
+            LOG.info("Auto-attached plugin source '{}' to profile '{}'.", sourceName, profileName);
+        }
     }
 
     private void saveMibGroups(final SnmpCollectionSource source, final List<Group> groups) {

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
@@ -86,6 +86,7 @@
       <constructor-arg ref="snmpCollectionMibGroupDao"/>
       <constructor-arg ref="snmpCollectionResourceTypeDao"/>
       <constructor-arg ref="snmpCollectionSystemDefDao"/>
+      <constructor-arg ref="snmpCollectionProfileDao"/>
       <constructor-arg ref="sessionUtils"/>
   </bean>
   <onmsgi:service interface="org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDb" ref="snmpDataCollectionSyncToDb" />

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
@@ -69,7 +69,7 @@
   <import resource="classpath*:/META-INF/opennms/applicationContext-config-service.xml"/>
 
   <!-- SNMP data collection config loader — must run after upgradeConfigService populates the DB -->
-  <bean id="snmpDataCollectionConfigLoader" class="org.opennms.netmgt.dao.support.SnmpDataCollectionConfigLoader"
+  <bean id="snmpDataCollectionConfigLoader" class="org.opennms.netmgt.dao.support.SnmpDataCollectionConfigLoaderImpl"
         depends-on="upgradeConfigService">
       <property name="dataCollectionConfigDao"        ref="dataCollectionConfigDao" />
       <property name="snmpCollectionProfileDao"       ref="snmpCollectionProfileDao" />
@@ -79,6 +79,16 @@
       <property name="snmpCollectionSystemDefDao"     ref="snmpCollectionSystemDefDao" />
   </bean>
   <onmsgi:service interface="org.opennms.netmgt.dao.support.SnmpDataCollectionConfigLoader" ref="snmpDataCollectionConfigLoader" />
+
+  <!-- Plugin sync helper: persists SnmpCollectionExtension contributions into the DB -->
+  <bean id="snmpDataCollectionSyncToDb" class="org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDbImpl">
+      <constructor-arg ref="snmpCollectionSourceDao"/>
+      <constructor-arg ref="snmpCollectionMibGroupDao"/>
+      <constructor-arg ref="snmpCollectionResourceTypeDao"/>
+      <constructor-arg ref="snmpCollectionSystemDefDao"/>
+      <constructor-arg ref="sessionUtils"/>
+  </bean>
+  <onmsgi:service interface="org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDb" ref="snmpDataCollectionSyncToDb" />
 
   <!-- Configuration File DAOs -->
   <bean id="surveillanceViewConfigResourceLocation" class="java.lang.String">

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/SnmpDataCollectionConfigLoaderTest.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/SnmpDataCollectionConfigLoaderTest.java
@@ -88,7 +88,7 @@ public class SnmpDataCollectionConfigLoaderTest {
         // Override buildDataCollectionGroupFromDb so we don't need to mock the
         // three child DAOs (resourceType/mibGroup/systemDef) — the dedup logic
         // we're testing is in the merge step, not the materialization step.
-        final SnmpDataCollectionConfigLoader loader = new SnmpDataCollectionConfigLoader() {
+        final SnmpDataCollectionConfigLoaderImpl loader = new SnmpDataCollectionConfigLoaderImpl() {
             @Override
             public DatacollectionGroup buildDataCollectionGroupFromDb(final SnmpCollectionSource s) {
                 return s.getId() == 1 ? dcA : dcB;

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDbIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDbIT.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -40,6 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.config.api.DatacollectionJsonHelper;
 import org.opennms.netmgt.config.datacollection.Collect;
 import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
 import org.opennms.netmgt.config.datacollection.Group;
@@ -50,9 +52,11 @@ import org.opennms.netmgt.config.datacollection.ResourceType;
 import org.opennms.netmgt.config.datacollection.StorageStrategy;
 import org.opennms.netmgt.config.datacollection.SystemDef;
 import org.opennms.netmgt.dao.api.SnmpCollectionMibGroupDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionProfileDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionResourceTypeDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionSourceDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionSystemDefDao;
+import org.opennms.netmgt.model.SnmpCollectionProfile;
 import org.opennms.netmgt.model.SnmpCollectionSource;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,11 +96,18 @@ public class SnmpDataCollectionSyncToDbIT {
     @Autowired
     private SnmpCollectionSystemDefDao systemDefDao;
 
+    @Autowired
+    private SnmpCollectionProfileDao profileDao;
+
+    private static final String DEFAULT_TARGET = "default";
+
     @Before
     @Transactional
     public void wipe() {
         sourceDao.deleteAll(sourceDao.findAll());
         sourceDao.flush();
+        profileDao.deleteAll(profileDao.findAll());
+        profileDao.flush();
     }
 
     @After
@@ -104,13 +115,19 @@ public class SnmpDataCollectionSyncToDbIT {
     public void cleanup() {
         sourceDao.deleteAll(sourceDao.findAll());
         sourceDao.flush();
+        profileDao.deleteAll(profileDao.findAll());
+        profileDao.flush();
+    }
+
+    private static Map<String, List<DatacollectionGroup>> targeted(final DatacollectionGroup... groups) {
+        return Map.of(DEFAULT_TARGET, Arrays.asList(groups));
     }
 
     @Test
     public void initialSync_createsSourceAndChildren() {
         final DatacollectionGroup grp = buildGroup("plugin-foo", 2, 1, 1);
 
-        final boolean changed = syncToDb.syncPluginGroupsToDb(List.of(grp));
+        final boolean changed = syncToDb.syncPluginGroupsToDb(targeted(grp));
 
         assertTrue("Initial sync of a new group should report changed=true", changed);
 
@@ -126,10 +143,10 @@ public class SnmpDataCollectionSyncToDbIT {
     @Test
     public void resync_withChangedContent_replacesChildren() {
         final DatacollectionGroup v1 = buildGroup("plugin-foo", 2, 1, 1);
-        syncToDb.syncPluginGroupsToDb(List.of(v1));
+        syncToDb.syncPluginGroupsToDb(targeted(v1));
 
         final DatacollectionGroup v2 = buildGroup("plugin-foo", 4, 2, 3);
-        final boolean changed = syncToDb.syncPluginGroupsToDb(List.of(v2));
+        final boolean changed = syncToDb.syncPluginGroupsToDb(targeted(v2));
 
         assertTrue(changed);
         final SnmpCollectionSource saved = sourceDao.findByName("plugin-foo");
@@ -141,7 +158,7 @@ public class SnmpDataCollectionSyncToDbIT {
     @Test
     public void resync_preservesEnabledFlag_setByAdmin() {
         final DatacollectionGroup grp = buildGroup("plugin-foo", 2, 1, 1);
-        syncToDb.syncPluginGroupsToDb(List.of(grp));
+        syncToDb.syncPluginGroupsToDb(targeted(grp));
 
         // Admin disables the plugin source via the UI/REST.
         final SnmpCollectionSource saved = sourceDao.findByName("plugin-foo");
@@ -150,7 +167,7 @@ public class SnmpDataCollectionSyncToDbIT {
         sourceDao.flush();
 
         // Plugin reloads (same content). The disable intent must survive.
-        syncToDb.syncPluginGroupsToDb(List.of(grp));
+        syncToDb.syncPluginGroupsToDb(targeted(grp));
 
         final SnmpCollectionSource afterResync = sourceDao.findByName("plugin-foo");
         assertNotNull(afterResync);
@@ -161,13 +178,13 @@ public class SnmpDataCollectionSyncToDbIT {
     public void resync_withFewerGroups_deletesOrphans() {
         final DatacollectionGroup a = buildGroup("plugin-a", 1, 0, 0);
         final DatacollectionGroup b = buildGroup("plugin-b", 1, 0, 0);
-        syncToDb.syncPluginGroupsToDb(Arrays.asList(a, b));
+        syncToDb.syncPluginGroupsToDb(targeted(a, b));
 
         assertNotNull(sourceDao.findByName("plugin-a"));
         assertNotNull(sourceDao.findByName("plugin-b"));
 
         // Plugin stops contributing 'plugin-b'.
-        final boolean changed = syncToDb.syncPluginGroupsToDb(List.of(a));
+        final boolean changed = syncToDb.syncPluginGroupsToDb(targeted(a));
 
         assertTrue(changed);
         assertNotNull("Still-contributed group should remain", sourceDao.findByName("plugin-a"));
@@ -187,14 +204,14 @@ public class SnmpDataCollectionSyncToDbIT {
         sourceDao.save(user);
         sourceDao.flush();
 
-        syncToDb.syncPluginGroupsToDb(List.of(buildGroup("plugin-foo", 1, 0, 0)));
+        syncToDb.syncPluginGroupsToDb(targeted(buildGroup("plugin-foo", 1, 0, 0)));
 
         // Both should coexist.
         assertNotNull(sourceDao.findByName("user-uploaded"));
         assertNotNull(sourceDao.findByName("plugin-foo"));
 
         // A sync with no incoming groups must NOT delete the user row.
-        syncToDb.syncPluginGroupsToDb(Collections.emptyList());
+        syncToDb.syncPluginGroupsToDb(Collections.emptyMap());
 
         assertNotNull("User-uploaded sources are never touched by plugin sync",
                 sourceDao.findByName("user-uploaded"));
@@ -219,7 +236,7 @@ public class SnmpDataCollectionSyncToDbIT {
         // Plugin contributes a group with the same name; sync should take over
         // the existing row (matches pre-DB-migration override behavior).
         final boolean changed = syncToDb.syncPluginGroupsToDb(
-                List.of(buildGroup("Cisco Nexus", 2, 0, 1)));
+                targeted(buildGroup("Cisco Nexus", 2, 0, 1)));
 
         assertTrue("Take-over reports changed=true", changed);
         final SnmpCollectionSource taken = sourceDao.findByName("Cisco Nexus");
@@ -235,7 +252,7 @@ public class SnmpDataCollectionSyncToDbIT {
 
     @Test
     public void emptyInput_isNoOp_whenNoPluginRowsExist() {
-        final boolean changed = syncToDb.syncPluginGroupsToDb(Collections.emptyList());
+        final boolean changed = syncToDb.syncPluginGroupsToDb(Collections.emptyMap());
         assertFalse("Sync of empty input with no existing plugin rows should report no change", changed);
     }
 
@@ -252,9 +269,87 @@ public class SnmpDataCollectionSyncToDbIT {
 
         final DatacollectionGroup valid = buildGroup("plugin-foo", 1, 0, 0);
 
-        syncToDb.syncPluginGroupsToDb(Arrays.asList(nameless, valid));
+        syncToDb.syncPluginGroupsToDb(targeted(nameless, valid));
 
         assertNotNull(sourceDao.findByName("plugin-foo"));
+    }
+
+    @Test
+    public void autoAttach_addsSourceNameToTargetProfile() {
+        final SnmpCollectionProfile profile = newProfile(DEFAULT_TARGET);
+        profileDao.saveOrUpdate(profile);
+        profileDao.flush();
+
+        syncToDb.syncPluginGroupsToDb(targeted(buildGroup("plugin-foo", 1, 0, 0)));
+
+        final SnmpCollectionProfile after = profileDao.findByName(DEFAULT_TARGET);
+        assertNotNull(after);
+        assertNotNull("source_names should be populated after auto-attach", after.getSourceNames());
+        assertTrue("Profile's source_names should contain the plugin source name",
+                after.getSourceNames().contains("plugin-foo"));
+    }
+
+    @Test
+    public void autoAttach_isIdempotent_acrossResyncs() {
+        final SnmpCollectionProfile profile = newProfile(DEFAULT_TARGET);
+        profileDao.saveOrUpdate(profile);
+        profileDao.flush();
+
+        syncToDb.syncPluginGroupsToDb(targeted(buildGroup("plugin-foo", 1, 0, 0)));
+        syncToDb.syncPluginGroupsToDb(targeted(buildGroup("plugin-foo", 2, 0, 0)));
+        syncToDb.syncPluginGroupsToDb(targeted(buildGroup("plugin-foo", 1, 0, 0)));
+
+        final SnmpCollectionProfile after = profileDao.findByName(DEFAULT_TARGET);
+        final String names = after.getSourceNames();
+        final int firstIdx = names.indexOf("plugin-foo");
+        assertTrue(firstIdx >= 0);
+        assertEquals("plugin-foo should appear exactly once across re-syncs",
+                firstIdx, names.lastIndexOf("plugin-foo"));
+    }
+
+    @Test
+    public void orphanCleanup_detachesSourceFromProfiles() {
+        final SnmpCollectionProfile profile = newProfile(DEFAULT_TARGET);
+        profileDao.saveOrUpdate(profile);
+        profileDao.flush();
+
+        syncToDb.syncPluginGroupsToDb(targeted(buildGroup("plugin-foo", 1, 0, 0)));
+        assertTrue(profileDao.findByName(DEFAULT_TARGET).getSourceNames().contains("plugin-foo"));
+
+        syncToDb.syncPluginGroupsToDb(Collections.emptyMap());
+
+        assertNull(sourceDao.findByName("plugin-foo"));
+        final SnmpCollectionProfile after = profileDao.findByName(DEFAULT_TARGET);
+        if (after.getSourceNames() != null) {
+            assertFalse(after.getSourceNames().contains("plugin-foo"));
+        }
+    }
+
+    @Test
+    public void orphanCleanup_leavesOtherProfileEntriesUntouched() {
+        final SnmpCollectionProfile profile = newProfile(DEFAULT_TARGET);
+        profile.setSourceNames(DatacollectionJsonHelper.toJson(List.of("plugin-foo", "user-source")));
+        profileDao.saveOrUpdate(profile);
+        profileDao.flush();
+
+        syncToDb.syncPluginGroupsToDb(targeted(buildGroup("plugin-foo", 1, 0, 0)));
+        syncToDb.syncPluginGroupsToDb(Collections.emptyMap());
+
+        final SnmpCollectionProfile after = profileDao.findByName(DEFAULT_TARGET);
+        assertFalse(after.getSourceNames().contains("plugin-foo"));
+        assertTrue(after.getSourceNames().contains("user-source"));
+    }
+
+    @Test
+    public void missingTargetProfile_doesNotFailSync() {
+        final boolean changed = syncToDb.syncPluginGroupsToDb(
+                Map.of("no-such-profile", List.of(buildGroup("plugin-foo", 1, 0, 0))));
+
+        assertTrue(changed);
+        assertNotNull("Source row is created even when target profile is missing",
+                sourceDao.findByName("plugin-foo"));
+        assertNull("No profile of that name should magically appear",
+                profileDao.findByName("no-such-profile"));
     }
 
     @Test
@@ -291,6 +386,17 @@ public class SnmpDataCollectionSyncToDbIT {
     }
 
     // ─── fixture builders ──────────────────────────────────────────────
+
+    private static SnmpCollectionProfile newProfile(final String name) {
+        final SnmpCollectionProfile p = new SnmpCollectionProfile();
+        p.setName(name);
+        p.setRrdStep(300);
+        p.setEnabled(Boolean.TRUE);
+        final Date now = new Date();
+        p.setCreatedTime(now);
+        p.setLastModified(now);
+        return p;
+    }
 
     private static DatacollectionGroup buildGroup(final String name,
                                                   final int mibGroupCount,

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDbIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/SnmpDataCollectionSyncToDbIT.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.dao.support;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.config.datacollection.Collect;
+import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
+import org.opennms.netmgt.config.datacollection.Group;
+import org.opennms.netmgt.config.datacollection.IpList;
+import org.opennms.netmgt.config.datacollection.MibObj;
+import org.opennms.netmgt.config.datacollection.PersistenceSelectorStrategy;
+import org.opennms.netmgt.config.datacollection.ResourceType;
+import org.opennms.netmgt.config.datacollection.StorageStrategy;
+import org.opennms.netmgt.config.datacollection.SystemDef;
+import org.opennms.netmgt.dao.api.SnmpCollectionMibGroupDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionResourceTypeDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionSourceDao;
+import org.opennms.netmgt.dao.api.SnmpCollectionSystemDefDao;
+import org.opennms.netmgt.model.SnmpCollectionSource;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Round-trip IT for {@link SnmpDataCollectionSyncToDb}: synthetic plugin
+ * groups are persisted, re-synced, mutated, and removed; we assert the DB
+ * matches expectation at each step and that the admin-set {@code enabled}
+ * flag survives across syncs (the design contract for plugin-sourced rows).
+ */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockEventForwarder.xml",
+})
+@JUnitConfigurationEnvironment(systemProperties = "org.opennms.timeseries.strategy=osgi")
+@JUnitTemporaryDatabase
+public class SnmpDataCollectionSyncToDbIT {
+
+    @Autowired
+    private SnmpDataCollectionSyncToDb syncToDb;
+
+    @Autowired
+    private SnmpCollectionSourceDao sourceDao;
+
+    @Autowired
+    private SnmpCollectionMibGroupDao mibGroupDao;
+
+    @Autowired
+    private SnmpCollectionResourceTypeDao resourceTypeDao;
+
+    @Autowired
+    private SnmpCollectionSystemDefDao systemDefDao;
+
+    @Before
+    @Transactional
+    public void wipe() {
+        sourceDao.deleteAll(sourceDao.findAll());
+        sourceDao.flush();
+    }
+
+    @After
+    @Transactional
+    public void cleanup() {
+        sourceDao.deleteAll(sourceDao.findAll());
+        sourceDao.flush();
+    }
+
+    @Test
+    public void initialSync_createsSourceAndChildren() {
+        final DatacollectionGroup grp = buildGroup("plugin-foo", 2, 1, 1);
+
+        final boolean changed = syncToDb.syncPluginGroupsToDb(List.of(grp));
+
+        assertTrue("Initial sync of a new group should report changed=true", changed);
+
+        final SnmpCollectionSource saved = sourceDao.findByName("plugin-foo");
+        assertNotNull("Plugin source should exist", saved);
+        assertEquals(SnmpDataCollectionSyncToDb.PLUGIN_UPLOADED_BY, saved.getUploadedBy());
+        assertTrue("New plugin sources default to enabled", saved.getEnabled());
+        assertEquals(2, mibGroupDao.findAllBySource(saved.getId()).size());
+        assertEquals(1, resourceTypeDao.findAllBySource(saved.getId()).size());
+        assertEquals(1, systemDefDao.findAllBySource(saved.getId()).size());
+    }
+
+    @Test
+    public void resync_withChangedContent_replacesChildren() {
+        final DatacollectionGroup v1 = buildGroup("plugin-foo", 2, 1, 1);
+        syncToDb.syncPluginGroupsToDb(List.of(v1));
+
+        final DatacollectionGroup v2 = buildGroup("plugin-foo", 4, 2, 3);
+        final boolean changed = syncToDb.syncPluginGroupsToDb(List.of(v2));
+
+        assertTrue(changed);
+        final SnmpCollectionSource saved = sourceDao.findByName("plugin-foo");
+        assertEquals(4, mibGroupDao.findAllBySource(saved.getId()).size());
+        assertEquals(2, resourceTypeDao.findAllBySource(saved.getId()).size());
+        assertEquals(3, systemDefDao.findAllBySource(saved.getId()).size());
+    }
+
+    @Test
+    public void resync_preservesEnabledFlag_setByAdmin() {
+        final DatacollectionGroup grp = buildGroup("plugin-foo", 2, 1, 1);
+        syncToDb.syncPluginGroupsToDb(List.of(grp));
+
+        // Admin disables the plugin source via the UI/REST.
+        final SnmpCollectionSource saved = sourceDao.findByName("plugin-foo");
+        saved.setEnabled(Boolean.FALSE);
+        sourceDao.saveOrUpdate(saved);
+        sourceDao.flush();
+
+        // Plugin reloads (same content). The disable intent must survive.
+        syncToDb.syncPluginGroupsToDb(List.of(grp));
+
+        final SnmpCollectionSource afterResync = sourceDao.findByName("plugin-foo");
+        assertNotNull(afterResync);
+        assertFalse("Admin-set disable should survive a plugin re-sync", afterResync.getEnabled());
+    }
+
+    @Test
+    public void resync_withFewerGroups_deletesOrphans() {
+        final DatacollectionGroup a = buildGroup("plugin-a", 1, 0, 0);
+        final DatacollectionGroup b = buildGroup("plugin-b", 1, 0, 0);
+        syncToDb.syncPluginGroupsToDb(Arrays.asList(a, b));
+
+        assertNotNull(sourceDao.findByName("plugin-a"));
+        assertNotNull(sourceDao.findByName("plugin-b"));
+
+        // Plugin stops contributing 'plugin-b'.
+        final boolean changed = syncToDb.syncPluginGroupsToDb(List.of(a));
+
+        assertTrue(changed);
+        assertNotNull("Still-contributed group should remain", sourceDao.findByName("plugin-a"));
+        assertNull("Dropped group should be deleted", sourceDao.findByName("plugin-b"));
+    }
+
+    @Test
+    public void sync_doesNotTouch_nonPluginSources() {
+        // Pre-populate a user/migration-uploaded source.
+        final SnmpCollectionSource user = new SnmpCollectionSource();
+        user.setName("user-uploaded");
+        user.setUploadedBy("admin");
+        user.setEnabled(Boolean.TRUE);
+        final Date now = new Date();
+        user.setCreatedTime(now);
+        user.setLastModified(now);
+        sourceDao.save(user);
+        sourceDao.flush();
+
+        syncToDb.syncPluginGroupsToDb(List.of(buildGroup("plugin-foo", 1, 0, 0)));
+
+        // Both should coexist.
+        assertNotNull(sourceDao.findByName("user-uploaded"));
+        assertNotNull(sourceDao.findByName("plugin-foo"));
+
+        // A sync with no incoming groups must NOT delete the user row.
+        syncToDb.syncPluginGroupsToDb(Collections.emptyList());
+
+        assertNotNull("User-uploaded sources are never touched by plugin sync",
+                sourceDao.findByName("user-uploaded"));
+        assertNull("Plugin source should be removed when no plugin contributes it",
+                sourceDao.findByName("plugin-foo"));
+    }
+
+    @Test
+    public void pluginGroupCollidesWithNonPluginSourceName_takesOver() {
+        // Pre-existing non-plugin source occupying the name a plugin will try to use.
+        final SnmpCollectionSource shipped = new SnmpCollectionSource();
+        shipped.setName("Cisco Nexus");
+        shipped.setUploadedBy("system-migration");
+        shipped.setEnabled(Boolean.FALSE);  // also verify enabled flag survives takeover
+        final Date now = new Date();
+        shipped.setCreatedTime(now);
+        shipped.setLastModified(now);
+        sourceDao.save(shipped);
+        sourceDao.flush();
+        final Integer originalId = shipped.getId();
+
+        // Plugin contributes a group with the same name; sync should take over
+        // the existing row (matches pre-DB-migration override behavior).
+        final boolean changed = syncToDb.syncPluginGroupsToDb(
+                List.of(buildGroup("Cisco Nexus", 2, 0, 1)));
+
+        assertTrue("Take-over reports changed=true", changed);
+        final SnmpCollectionSource taken = sourceDao.findByName("Cisco Nexus");
+        assertNotNull(taken);
+        assertEquals("Row should keep its id across takeover", originalId, taken.getId());
+        assertEquals("Row should now be plugin-managed",
+                SnmpDataCollectionSyncToDb.PLUGIN_UPLOADED_BY, taken.getUploadedBy());
+        assertEquals("Enabled flag is preserved across takeover", Boolean.FALSE, taken.getEnabled());
+        assertEquals("Children should be replaced by plugin content",
+                2, mibGroupDao.findAllBySource(taken.getId()).size());
+        assertEquals(1, systemDefDao.findAllBySource(taken.getId()).size());
+    }
+
+    @Test
+    public void emptyInput_isNoOp_whenNoPluginRowsExist() {
+        final boolean changed = syncToDb.syncPluginGroupsToDb(Collections.emptyList());
+        assertFalse("Sync of empty input with no existing plugin rows should report no change", changed);
+    }
+
+    @Test
+    public void nullInput_isTreatedAsEmpty() {
+        final boolean changed = syncToDb.syncPluginGroupsToDb(null);
+        assertFalse(changed);
+    }
+
+    @Test
+    public void groupWithNullOrBlankName_isSkipped() {
+        final DatacollectionGroup nameless = new DatacollectionGroup();
+        nameless.setGroups(List.of(buildMibGroup("group-1")));
+
+        final DatacollectionGroup valid = buildGroup("plugin-foo", 1, 0, 0);
+
+        syncToDb.syncPluginGroupsToDb(Arrays.asList(nameless, valid));
+
+        assertNotNull(sourceDao.findByName("plugin-foo"));
+    }
+
+    @Test
+    public void isPluginSourced_helper() {
+        final SnmpCollectionSource userOwned = new SnmpCollectionSource();
+        userOwned.setUploadedBy("admin");
+        assertFalse(SnmpDataCollectionSyncToDb.isPluginSourced(userOwned));
+
+        final SnmpCollectionSource pluginOwned = new SnmpCollectionSource();
+        pluginOwned.setUploadedBy(SnmpDataCollectionSyncToDb.PLUGIN_UPLOADED_BY);
+        assertTrue(SnmpDataCollectionSyncToDb.isPluginSourced(pluginOwned));
+
+        assertFalse("Null source defaults to non-plugin", SnmpDataCollectionSyncToDb.isPluginSourced(null));
+    }
+
+    @Test
+    public void requireNotPluginSourced_throwsForPluginRow() {
+        final SnmpCollectionSource pluginOwned = new SnmpCollectionSource();
+        pluginOwned.setName("plugin-foo");
+        pluginOwned.setUploadedBy(SnmpDataCollectionSyncToDb.PLUGIN_UPLOADED_BY);
+
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> SnmpDataCollectionSyncToDb.requireNotPluginSourced(pluginOwned, "Delete Source"));
+        assertTrue("Error message should name the operation", ex.getMessage().contains("Delete Source"));
+        assertTrue("Error message should name the source", ex.getMessage().contains("plugin-foo"));
+    }
+
+    @Test
+    public void requireNotPluginSourced_allowsUserRow() {
+        final SnmpCollectionSource userOwned = new SnmpCollectionSource();
+        userOwned.setUploadedBy("admin");
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(userOwned, "Delete Source");
+        // no throw
+    }
+
+    // ─── fixture builders ──────────────────────────────────────────────
+
+    private static DatacollectionGroup buildGroup(final String name,
+                                                  final int mibGroupCount,
+                                                  final int resourceTypeCount,
+                                                  final int systemDefCount) {
+        final DatacollectionGroup g = new DatacollectionGroup();
+        g.setName(name);
+
+        final List<Group> groups = new ArrayList<>();
+        for (int i = 0; i < mibGroupCount; i++) {
+            groups.add(buildMibGroup(name + "-group-" + i));
+        }
+        g.setGroups(groups);
+
+        final List<ResourceType> rts = new ArrayList<>();
+        for (int i = 0; i < resourceTypeCount; i++) {
+            rts.add(buildResourceType(name + "-rt-" + i));
+        }
+        g.setResourceTypes(rts);
+
+        final List<SystemDef> sds = new ArrayList<>();
+        for (int i = 0; i < systemDefCount; i++) {
+            sds.add(buildSystemDef(name + "-sd-" + i));
+        }
+        g.setSystemDefs(sds);
+
+        return g;
+    }
+
+    private static Group buildMibGroup(final String name) {
+        final Group group = new Group();
+        group.setName(name);
+        group.setIfType("ignore");
+        final MibObj obj = new MibObj();
+        obj.setOid(".1.3.6.1.2.1.1.3");
+        obj.setAlias("sysUpTime");
+        obj.setType("timeticks");
+        obj.setInstance("0");
+        group.setMibObjs(List.of(obj));
+        return group;
+    }
+
+    private static ResourceType buildResourceType(final String name) {
+        final ResourceType rt = new ResourceType();
+        rt.setName(name);
+        rt.setLabel(name + "-label");
+        final PersistenceSelectorStrategy ps = new PersistenceSelectorStrategy();
+        ps.setClazz("org.opennms.netmgt.collection.support.PersistAllSelectorStrategy");
+        rt.setPersistenceSelectorStrategy(ps);
+        final StorageStrategy ss = new StorageStrategy();
+        ss.setClazz("org.opennms.netmgt.dao.support.IndexStorageStrategy");
+        rt.setStorageStrategy(ss);
+        return rt;
+    }
+
+    private static SystemDef buildSystemDef(final String name) {
+        final SystemDef sd = new SystemDef();
+        sd.setName(name);
+        sd.setSysoid(".1.3.6.1.4.1.42." + name.hashCode());
+        final Collect collect = new Collect();
+        collect.setIncludeGroups(List.of("dummy-mib-group"));
+        sd.setCollect(collect);
+        final IpList ipList = new IpList();
+        ipList.setIpAddresses(List.of("127.0.0.1"));
+        sd.setIpList(ipList);
+        return sd;
+    }
+}

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/SnmpDataCollectionXmlToDbParityIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/SnmpDataCollectionXmlToDbParityIT.java
@@ -383,7 +383,7 @@ public class SnmpDataCollectionXmlToDbParityIT implements TemporaryDatabaseAware
         final DefaultDataCollectionConfigDao dbDao = new DefaultDataCollectionConfigDao();
         dbDao.afterPropertiesSet();
 
-        final SnmpDataCollectionConfigLoader loader = new SnmpDataCollectionConfigLoader();
+        final SnmpDataCollectionConfigLoaderImpl loader = new SnmpDataCollectionConfigLoaderImpl();
         loader.setSnmpCollectionProfileDao(profileDao);
         loader.setSnmpCollectionSourceDao(sourceDao);
         loader.setSnmpCollectionResourceTypeDao(resourceTypeDao);
@@ -391,7 +391,7 @@ public class SnmpDataCollectionXmlToDbParityIT implements TemporaryDatabaseAware
         loader.setSnmpCollectionSystemDefDao(systemDefDao);
         loader.setDataCollectionConfigDao(dbDao);
 
-        final SnmpDataCollectionConfigLoader.MaterializedConfig m = loader.materializeFromDb();
+        final SnmpDataCollectionConfigLoaderImpl.MaterializedConfig m = loader.materializeFromDb();
         if (m == null) return null;
         dbDao.loadFromDatabase(m.config, m.allResourceTypes, m.allGroups);
         return dbDao;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DataCollectionConfPersistenceService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DataCollectionConfPersistenceService.java
@@ -21,6 +21,8 @@
  */
 package org.opennms.web.rest.v2;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import org.opennms.netmgt.config.datacollection.DatacollectionConfig;
 import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
 import org.opennms.netmgt.config.datacollection.Collect;
@@ -35,6 +37,7 @@ import org.opennms.netmgt.dao.api.SnmpCollectionProfileDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionResourceTypeDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionSourceDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionSystemDefDao;
+import org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDb;
 import org.opennms.netmgt.model.PageResponse;
 import org.opennms.netmgt.model.SnmpCollectionMibGroup;
 import org.opennms.netmgt.model.SnmpCollectionResourceType;
@@ -168,7 +171,7 @@ public class DataCollectionConfPersistenceService {
 
     @Transactional
     public Integer addMibGroupToSnmpCollectionSources(final SnmpCollectionSource snmpCollectionSource, final SnmpCollectionMibGroupDto request) {
-
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(snmpCollectionSource, "Add MibGroup");
         final var entity = SnmpCollectionMibGroupDto.updateEntity(new SnmpCollectionMibGroup(), request);
         entity.setCollectionSource(snmpCollectionSource);
         return snmpCollectionMibGroupDao.save(entity);
@@ -178,7 +181,7 @@ public class DataCollectionConfPersistenceService {
     public Integer addResourceTypeToSnmpCollectionSources(
             final SnmpCollectionSource snmpCollectionSource,
             final SnmpCollectionResourceTypeDto request) {
-
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(snmpCollectionSource, "Add ResourceType");
         final var entity = SnmpCollectionResourceTypeDto.updateEntity(new SnmpCollectionResourceType(), request);
         entity.setCollectionSource(snmpCollectionSource);
         return snmpCollectionResourceTypeDao.save(entity);
@@ -188,7 +191,7 @@ public class DataCollectionConfPersistenceService {
     public Integer addSystemDefToSnmpCollectionSources(
             final SnmpCollectionSource snmpCollectionSource,
             final SnmpCollectionSystemDefDto request) {
-
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(snmpCollectionSource, "Add SystemDef");
         final var entity = applySystemDefDtoToEntity(request, new SnmpCollectionSystemDef());
         entity.setCollectionSource(snmpCollectionSource);
         return snmpCollectionSystemDefDao.save(entity);
@@ -224,6 +227,8 @@ public class DataCollectionConfPersistenceService {
         requirePathMatchesDto("MibGroup", id, snmpCollectionSourceId,
                 request.getId(), request.getCollectionSourceId());
 
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(requireSource(snmpCollectionSourceId), "Update MibGroup");
+
         final var snmpCollectionMibGroupEntity = snmpCollectionMibGroupDao.findBySnmpSourceCollectionIdAndId(snmpCollectionSourceId, id);
 
         if (snmpCollectionMibGroupEntity == null) {
@@ -243,6 +248,8 @@ public class DataCollectionConfPersistenceService {
 
         requirePathMatchesDto("ResourceType", id, snmpCollectionSourceId,
                 request.getId(), request.getCollectionSourceId());
+
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(requireSource(snmpCollectionSourceId), "Update ResourceType");
 
         final var snmpCollectionResourceTypeEntity =
                 snmpCollectionResourceTypeDao.findBySnmpSourceCollectionIdAndId(snmpCollectionSourceId, id);
@@ -265,6 +272,8 @@ public class DataCollectionConfPersistenceService {
 
         requirePathMatchesDto("SystemDef", id, snmpCollectionSourceId,
                 request.getId(), request.getCollectionSourceId());
+
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(requireSource(snmpCollectionSourceId), "Update SystemDef");
 
         final var snmpCollectionSystemDefEntity =
                 snmpCollectionSystemDefDao.findBySnmpSourceCollectionIdAndId(snmpCollectionSourceId, id);
@@ -294,6 +303,7 @@ public class DataCollectionConfPersistenceService {
             if (source == null) {
                 continue;
             }
+            SnmpDataCollectionSyncToDb.requireNotPluginSourced(source, "Delete Source");
             removeSourceFromProfiles(source.getName());
             snmpCollectionSourceDao.delete(source);
         }
@@ -309,7 +319,7 @@ public class DataCollectionConfPersistenceService {
         }
         for (final SnmpCollectionProfile profile : profiles) {
             List<String> sourceNames = DatacollectionJsonHelper.fromJson(
-                    profile.getSourceNames(), new com.fasterxml.jackson.core.type.TypeReference<List<String>>() {});
+                    profile.getSourceNames(), new TypeReference<List<String>>() {});
             if (sourceNames != null && sourceNames.contains(sourceName)) {
                 sourceNames = new ArrayList<>(sourceNames);
                 sourceNames.remove(sourceName);
@@ -324,6 +334,7 @@ public class DataCollectionConfPersistenceService {
     public void deleteSnmpDataCollectionMibGroups(final Integer snmpDataCollectionSourceId,
                                                   final List<Integer> ids) {
         final var source = requireSource(snmpDataCollectionSourceId);
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(source, "Delete MibGroup");
         deleteChildren(
                 source.getId(),
                 ids,
@@ -337,6 +348,7 @@ public class DataCollectionConfPersistenceService {
     public void deleteSnmpDataCollectionResourceTypes(final Integer snmpDataCollectionSourceId,
                                                       final List<Integer> ids) {
         final var source = requireSource(snmpDataCollectionSourceId);
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(source, "Delete ResourceType");
         deleteChildren(
                 source.getId(),
                 ids,
@@ -350,6 +362,7 @@ public class DataCollectionConfPersistenceService {
     public void deleteSnmpDataCollectionSystemDefs(final Integer snmpDataCollectionSourceId,
                                                    final List<Integer> ids) {
         final var source = requireSource(snmpDataCollectionSourceId);
+        SnmpDataCollectionSyncToDb.requireNotPluginSourced(source, "Delete SystemDef");
         deleteChildren(
                 source.getId(),
                 ids,
@@ -546,7 +559,7 @@ public class DataCollectionConfPersistenceService {
      */
     private void appendSourceToProfile(final SnmpCollectionProfile profile, final String sourceName) {
         List<String> sourceNames = DatacollectionJsonHelper.fromJson(
-                profile.getSourceNames(), new com.fasterxml.jackson.core.type.TypeReference<List<String>>() {});
+                profile.getSourceNames(), new TypeReference<List<String>>() {});
         sourceNames = (sourceNames == null) ? new ArrayList<>() : new ArrayList<>(sourceNames);
 
         if (!sourceNames.contains(sourceName)) {
@@ -579,7 +592,7 @@ public class DataCollectionConfPersistenceService {
     public void removeSourceFromProfile(final Integer profileId, final String sourceName) {
         final SnmpCollectionProfile profile = requireProfile(profileId);
         List<String> sourceNames = DatacollectionJsonHelper.fromJson(
-                profile.getSourceNames(), new com.fasterxml.jackson.core.type.TypeReference<List<String>>() {});
+                profile.getSourceNames(), new TypeReference<List<String>>() {});
         if (sourceNames == null || !sourceNames.contains(sourceName)) {
             return;
         }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/DataCollectionConfLifecycleIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/DataCollectionConfLifecycleIT.java
@@ -24,6 +24,7 @@ package org.opennms.web.rest.v2;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,6 +47,7 @@ import javax.ws.rs.core.SecurityContext;
 
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.ContentDisposition;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,11 +56,14 @@ import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.netmgt.config.DefaultDataCollectionConfigDao;
 import org.opennms.netmgt.config.api.DataCollectionConfigDao;
 import org.opennms.netmgt.config.datacollection.DatacollectionConfig;
+import org.opennms.netmgt.config.datacollection.DatacollectionGroup;
 import org.opennms.netmgt.config.datacollection.Group;
+import org.opennms.netmgt.config.datacollection.MibObj;
 import org.opennms.netmgt.config.datacollection.SnmpCollection;
 import org.opennms.netmgt.dao.api.SnmpCollectionProfileDao;
 import org.opennms.netmgt.dao.api.SnmpCollectionSourceDao;
 import org.opennms.netmgt.dao.support.SnmpDataCollectionConfigLoader;
+import org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDb;
 import org.opennms.netmgt.model.SnmpCollectionProfile;
 import org.opennms.netmgt.model.SnmpCollectionSource;
 import org.opennms.test.JUnitConfigurationEnvironment;
@@ -116,6 +121,7 @@ public class DataCollectionConfLifecycleIT {
     @Autowired private SnmpCollectionProfileDao profileDao;
     @Autowired private DataCollectionConfigDao dataCollectionConfigDao;
     @Autowired private SnmpDataCollectionConfigLoader loader;
+    @Autowired private SnmpDataCollectionSyncToDb syncToDb;
 
     private SecurityContext securityContext;
 
@@ -125,6 +131,20 @@ public class DataCollectionConfLifecycleIT {
         when(principal.getName()).thenReturn("lifecycle-IT");
         securityContext = mock(SecurityContext.class);
         when(securityContext.getUserPrincipal()).thenReturn(principal);
+    }
+
+    /**
+     * The plugin sync tests insert rows marked {@code uploadedBy=opennms-plugins}.
+     * Wipe those after every test so non-plugin tests don't trip over leftover
+     * plugin sources (the temporary DB is per-class, not per-test).
+     */
+    @After
+    public void wipePluginSources() {
+        try {
+            syncToDb.syncPluginGroupsToDb(List.of());
+        } catch (Exception ignored) {
+            // best-effort cleanup; subsequent tests should not depend on this succeeding
+        }
     }
 
     /**
@@ -474,6 +494,126 @@ public class DataCollectionConfLifecycleIT {
         } catch (Exception e) {
             throw new RuntimeException("Failed to build attachment for " + file, e);
         }
+    }
+
+    // ─── Plugin sync round-trip ────────────────────────────────────────
+
+    /**
+     * Round-trip the plugin sync path that
+     * {@link org.opennms.features.apilayer.config.SnmpCollectionExtensionManager}
+     * drives in production: a plugin-contributed group is persisted via
+     * {@link org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDb}, the
+     * runtime reload picks it up, and the source becomes attachable to a
+     * profile via the existing REST endpoint. Then we drop it from the
+     * aggregated set and assert it disappears.
+     */
+    @Test
+    public void pluginSync_publishesGroup_andRuntimeReloadPicksItUp() throws Exception {
+        uploadBaseline();
+        final SnmpCollectionProfile defaultProfile = profileDao.findByName("default");
+        assertNotNull("'default' profile should exist after upload", defaultProfile);
+
+        final String pluginSourceName = "plugin-test-source";
+        final String pluginGroupName = "plugin-test-group";
+
+        // 1. Plugin contributes a group via the sync helper (the same call the
+        //    OSGi-bound extension manager makes inside triggerReload()).
+        syncToDb.syncPluginGroupsToDb(List.of(buildPluginGroup(pluginSourceName, pluginGroupName)));
+
+        // 2. Source row exists in DB with the plugin marker.
+        final SnmpCollectionSource pluginSource = sourceDao.findByName(pluginSourceName);
+        assertNotNull("Plugin source should be persisted", pluginSource);
+        assertEquals("opennms-plugins", pluginSource.getUploadedBy());
+
+        // 3. Attach it to the default profile via REST, then wait for the
+        //    runtime reload to publish the new group into in-memory state.
+        final Response resp = rest.addSourceToProfile(
+                defaultProfile.getId(), pluginSourceName, securityContext);
+        assertEquals(200, resp.getStatus());
+        await().atMost(RELOAD_TIMEOUT).pollInterval(Duration.ofMillis(200))
+                .until(() -> inMemoryGroupNames().contains(pluginGroupName));
+        assertTrue("Plugin-contributed group should be visible in the runtime config",
+                inMemoryGroupNames().contains(pluginGroupName));
+
+        // 4. Plugin stops contributing the group. Re-sync with an empty set —
+        //    the source row is removed (since it was plugin-owned) and the
+        //    profile reload drops the group from in-memory state.
+        syncToDb.syncPluginGroupsToDb(List.of());
+        loader.scheduleDataCollectionConfigReload();
+        await().atMost(RELOAD_TIMEOUT).pollInterval(Duration.ofMillis(200))
+                .until(() -> !inMemoryGroupNames().contains(pluginGroupName));
+        assertNull("Plugin source should be removed when the plugin stops contributing it",
+                sourceDao.findByName(pluginSourceName));
+    }
+
+    /**
+     * Admin disable should survive a plugin re-sync. This is the contract
+     * that prevents plugin reloads from re-enabling rows operators have
+     * intentionally disabled.
+     */
+    @Test
+    public void pluginSync_preservesEnabledFlag_setByAdmin() throws Exception {
+        final String pluginSourceName = "plugin-toggle-source";
+        syncToDb.syncPluginGroupsToDb(List.of(buildPluginGroup(pluginSourceName, "plugin-toggle-group")));
+
+        SnmpCollectionSource pluginSource = sourceDao.findByName(pluginSourceName);
+        assertNotNull(pluginSource);
+        assertTrue("Plugin sources default to enabled on first sync", pluginSource.getEnabled());
+
+        // Admin disables via the REST enable/disable endpoint (which is
+        // permitted on plugin-sourced rows by design).
+        final Response resp = rest.enableDisableSnmpDataCollectionSources(
+                false, List.of(pluginSource.getId()), securityContext);
+        assertEquals(200, resp.getStatus());
+
+        // Plugin re-syncs the same group. Disable intent must survive.
+        syncToDb.syncPluginGroupsToDb(List.of(buildPluginGroup(pluginSourceName, "plugin-toggle-group")));
+
+        pluginSource = sourceDao.findByName(pluginSourceName);
+        assertNotNull(pluginSource);
+        assertEquals("Admin disable should survive plugin re-sync",
+                Boolean.FALSE, pluginSource.getEnabled());
+    }
+
+    /**
+     * REST guard: content edits and source delete are blocked on
+     * plugin-sourced rows. Defense-in-depth against bypassing the UI
+     * affordances that hide these buttons.
+     */
+    @Test
+    public void pluginSync_restRejectsDeleteOnPluginSource() throws Exception {
+        final String pluginSourceName = "plugin-readonly-source";
+        syncToDb.syncPluginGroupsToDb(List.of(buildPluginGroup(pluginSourceName, "plugin-readonly-group")));
+
+        final SnmpCollectionSource pluginSource = sourceDao.findByName(pluginSourceName);
+        assertNotNull(pluginSource);
+
+        try {
+            rest.deleteSnmpDataCollectionSources(List.of(pluginSource.getId()), securityContext);
+            // Source should still exist — delete must have been rejected.
+            assertNotNull("Plugin source should not be deleted by REST",
+                    sourceDao.findByName(pluginSourceName));
+        } catch (final IllegalArgumentException expected) {
+            // Service layer throws IAE; mapped to 400 in production. Either
+            // shape (exception thrown OR error response) is acceptable —
+            // both prove the guard fired.
+        }
+    }
+
+    private static DatacollectionGroup buildPluginGroup(final String groupName, final String mibGroupName) {
+        final DatacollectionGroup g = new DatacollectionGroup();
+        g.setName(groupName);
+        final Group inner = new Group();
+        inner.setName(mibGroupName);
+        inner.setIfType("ignore");
+        final MibObj obj = new MibObj();
+        obj.setOid(".1.3.6.1.2.1.1.3");
+        obj.setAlias("sysUpTime");
+        obj.setType("timeticks");
+        obj.setInstance("0");
+        inner.setMibObjs(List.of(obj));
+        g.setGroups(List.of(inner));
+        return g;
     }
 
     // ─── XML reference loader ──────────────────────────────────────────

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/DataCollectionConfLifecycleIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/DataCollectionConfLifecycleIT.java
@@ -141,7 +141,7 @@ public class DataCollectionConfLifecycleIT {
     @After
     public void wipePluginSources() {
         try {
-            syncToDb.syncPluginGroupsToDb(List.of());
+            syncToDb.syncPluginGroupsToDb(Map.of());
         } catch (Exception ignored) {
             // best-effort cleanup; subsequent tests should not depend on this succeeding
         }
@@ -498,17 +498,8 @@ public class DataCollectionConfLifecycleIT {
 
     // ─── Plugin sync round-trip ────────────────────────────────────────
 
-    /**
-     * Round-trip the plugin sync path that
-     * {@link org.opennms.features.apilayer.config.SnmpCollectionExtensionManager}
-     * drives in production: a plugin-contributed group is persisted via
-     * {@link org.opennms.netmgt.dao.support.SnmpDataCollectionSyncToDb}, the
-     * runtime reload picks it up, and the source becomes attachable to a
-     * profile via the existing REST endpoint. Then we drop it from the
-     * aggregated set and assert it disappears.
-     */
     @Test
-    public void pluginSync_publishesGroup_andRuntimeReloadPicksItUp() throws Exception {
+    public void pluginSync_autoAttachesToTargetCollection_byCollectionName() throws Exception {
         uploadBaseline();
         final SnmpCollectionProfile defaultProfile = profileDao.findByName("default");
         assertNotNull("'default' profile should exist after upload", defaultProfile);
@@ -516,34 +507,30 @@ public class DataCollectionConfLifecycleIT {
         final String pluginSourceName = "plugin-test-source";
         final String pluginGroupName = "plugin-test-group";
 
-        // 1. Plugin contributes a group via the sync helper (the same call the
-        //    OSGi-bound extension manager makes inside triggerReload()).
-        syncToDb.syncPluginGroupsToDb(List.of(buildPluginGroup(pluginSourceName, pluginGroupName)));
+        syncToDb.syncPluginGroupsToDb(targeted(
+                defaultProfile.getName(), buildPluginGroup(pluginSourceName, pluginGroupName)));
 
-        // 2. Source row exists in DB with the plugin marker.
         final SnmpCollectionSource pluginSource = sourceDao.findByName(pluginSourceName);
-        assertNotNull("Plugin source should be persisted", pluginSource);
+        assertNotNull(pluginSource);
         assertEquals("opennms-plugins", pluginSource.getUploadedBy());
 
-        // 3. Attach it to the default profile via REST, then wait for the
-        //    runtime reload to publish the new group into in-memory state.
-        final Response resp = rest.addSourceToProfile(
-                defaultProfile.getId(), pluginSourceName, securityContext);
-        assertEquals(200, resp.getStatus());
+        await().atMost(Duration.ofSeconds(2)).pollInterval(Duration.ofMillis(100))
+                .until(() -> {
+                    final SnmpCollectionProfile p = profileDao.findByName("default");
+                    return p != null && p.getSourceNames() != null
+                            && p.getSourceNames().contains(pluginSourceName);
+                });
+
+        loader.scheduleDataCollectionConfigReload();
         await().atMost(RELOAD_TIMEOUT).pollInterval(Duration.ofMillis(200))
                 .until(() -> inMemoryGroupNames().contains(pluginGroupName));
-        assertTrue("Plugin-contributed group should be visible in the runtime config",
-                inMemoryGroupNames().contains(pluginGroupName));
+        assertTrue(inMemoryGroupNames().contains(pluginGroupName));
 
-        // 4. Plugin stops contributing the group. Re-sync with an empty set —
-        //    the source row is removed (since it was plugin-owned) and the
-        //    profile reload drops the group from in-memory state.
-        syncToDb.syncPluginGroupsToDb(List.of());
+        syncToDb.syncPluginGroupsToDb(Map.of());
         loader.scheduleDataCollectionConfigReload();
         await().atMost(RELOAD_TIMEOUT).pollInterval(Duration.ofMillis(200))
                 .until(() -> !inMemoryGroupNames().contains(pluginGroupName));
-        assertNull("Plugin source should be removed when the plugin stops contributing it",
-                sourceDao.findByName(pluginSourceName));
+        assertNull(sourceDao.findByName(pluginSourceName));
     }
 
     /**
@@ -554,7 +541,8 @@ public class DataCollectionConfLifecycleIT {
     @Test
     public void pluginSync_preservesEnabledFlag_setByAdmin() throws Exception {
         final String pluginSourceName = "plugin-toggle-source";
-        syncToDb.syncPluginGroupsToDb(List.of(buildPluginGroup(pluginSourceName, "plugin-toggle-group")));
+        syncToDb.syncPluginGroupsToDb(targeted(
+                "default", buildPluginGroup(pluginSourceName, "plugin-toggle-group")));
 
         SnmpCollectionSource pluginSource = sourceDao.findByName(pluginSourceName);
         assertNotNull(pluginSource);
@@ -567,7 +555,8 @@ public class DataCollectionConfLifecycleIT {
         assertEquals(200, resp.getStatus());
 
         // Plugin re-syncs the same group. Disable intent must survive.
-        syncToDb.syncPluginGroupsToDb(List.of(buildPluginGroup(pluginSourceName, "plugin-toggle-group")));
+        syncToDb.syncPluginGroupsToDb(targeted(
+                "default", buildPluginGroup(pluginSourceName, "plugin-toggle-group")));
 
         pluginSource = sourceDao.findByName(pluginSourceName);
         assertNotNull(pluginSource);
@@ -583,7 +572,8 @@ public class DataCollectionConfLifecycleIT {
     @Test
     public void pluginSync_restRejectsDeleteOnPluginSource() throws Exception {
         final String pluginSourceName = "plugin-readonly-source";
-        syncToDb.syncPluginGroupsToDb(List.of(buildPluginGroup(pluginSourceName, "plugin-readonly-group")));
+        syncToDb.syncPluginGroupsToDb(targeted(
+                "default", buildPluginGroup(pluginSourceName, "plugin-readonly-group")));
 
         final SnmpCollectionSource pluginSource = sourceDao.findByName(pluginSourceName);
         assertNotNull(pluginSource);
@@ -598,6 +588,11 @@ public class DataCollectionConfLifecycleIT {
             // shape (exception thrown OR error response) is acceptable —
             // both prove the guard fired.
         }
+    }
+
+    private static Map<String, List<DatacollectionGroup>> targeted(final String target,
+                                                                   final DatacollectionGroup group) {
+        return Map.of(target, List.of(group));
     }
 
     private static DatacollectionGroup buildPluginGroup(final String groupName, final String mibGroupName) {

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourcesTable.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourcesTable.vue
@@ -158,6 +158,7 @@
                     {{ source.enabled ? 'Disable' : 'Enable' }} Source
                   </FeatherDropdownItem>
                   <FeatherDropdownItem
+                    v-if="!isPluginSourced(source)"
                     data-test="delete-source-button"
                     @click="openDeleteCollectionSourceDialog(source)"
                   >
@@ -210,6 +211,7 @@
 
 <script lang="ts" setup>
 import useSnackbar from '@/composables/useSnackbar'
+import { isPluginSourced } from '@/lib/snmpDataCollectionHelpers'
 import { deleteSnmpCollectionSources, downloadSnmpDataCollectionById, enableDisableSnmpDataCollectionSources, getAllSnmpCollectionProfiles } from '@/services/snmpDataCollectionService'
 import { useSnmpDataCollectionStore } from '@/stores/snmpDataCollectionStore'
 import { SnmpCollectionProfile } from '@/types/snmpDataCollection'

--- a/ui/src/components/SnmpDataCollectionDetail/MibGroupsTable.vue
+++ b/ui/src/components/SnmpDataCollectionDetail/MibGroupsTable.vue
@@ -27,7 +27,10 @@
         </div>
       </div>
       <div class="section-right">
-        <div class="add">
+        <div
+          class="add"
+          v-if="!isPluginSourced(store.selectedCollectionSource)"
+        >
           <FeatherButton
             secondary
             data-test="add-mib-group-button"
@@ -83,6 +86,7 @@
               <td>
                 <div class="action-container">
                   <FeatherButton
+                    v-if="!isPluginSourced(store.selectedCollectionSource)"
                     icon="Edit"
                     :title="`Edit ${mibGroup.name}`"
                     data-test="edit-button"
@@ -109,6 +113,7 @@
                       {{ mibGroup.enabled ? 'Disable MIB Group' : 'Enable MIB Group' }}
                     </FeatherDropdownItem>
                     <FeatherDropdownItem
+                      v-if="!isPluginSourced(store.selectedCollectionSource)"
                       data-test="delete-mib-group-button"
                       @click="openDeleteMibGroupDialog(mibGroup)"
                     >
@@ -201,6 +206,7 @@
 
 <script setup lang="ts">
 import useSnackbar from '@/composables/useSnackbar'
+import { isPluginSourced } from '@/lib/snmpDataCollectionHelpers'
 import { deleteMibGroups, enableDisableSnmpMibGroups } from '@/services/snmpDataCollectionService'
 import { useSnmpDataCollectionDetailStore } from '@/stores/snmpDataCollectionDetailStore'
 import { CreateEditMode } from '@/types'

--- a/ui/src/components/SnmpDataCollectionDetail/ResourceTypesTable.vue
+++ b/ui/src/components/SnmpDataCollectionDetail/ResourceTypesTable.vue
@@ -27,7 +27,10 @@
         </div>
       </div>
       <div class="section-right">
-        <div class="add">
+        <div
+          class="add"
+          v-if="!isPluginSourced(store.selectedCollectionSource)"
+        >
           <FeatherButton
             secondary
             data-test="add-resource-type-button"
@@ -84,6 +87,7 @@
               <td>
                 <div class="action-container">
                   <FeatherButton
+                    v-if="!isPluginSourced(store.selectedCollectionSource)"
                     icon="Edit"
                     :title="`Edit ${resourceType.name}`"
                     data-test="edit-button"
@@ -110,6 +114,7 @@
                       {{ resourceType.enabled ? 'Disable Resource Type' : 'Enable Resource Type' }}
                     </FeatherDropdownItem>
                     <FeatherDropdownItem
+                      v-if="!isPluginSourced(store.selectedCollectionSource)"
                       data-test="delete-resource-type-button"
                       @click="openResourceTypeDeleteDialog(resourceType)"
                     >
@@ -189,6 +194,7 @@
 
 <script setup lang="ts">
 import useSnackbar from '@/composables/useSnackbar'
+import { isPluginSourced } from '@/lib/snmpDataCollectionHelpers'
 import { deleteResourceTypes, enableDisableSnmpResourceTypes } from '@/services/snmpDataCollectionService'
 import { useSnmpDataCollectionDetailStore } from '@/stores/snmpDataCollectionDetailStore'
 import { CreateEditMode } from '@/types'

--- a/ui/src/components/SnmpDataCollectionDetail/SystemDefinitionsTable.vue
+++ b/ui/src/components/SnmpDataCollectionDetail/SystemDefinitionsTable.vue
@@ -27,7 +27,10 @@
         </div>
       </div>
       <div class="section-right">
-        <div class="add">
+        <div
+          class="add"
+          v-if="!isPluginSourced(store.selectedCollectionSource)"
+        >
           <FeatherButton
             secondary
             data-test="add-system-definition-button"
@@ -84,6 +87,7 @@
               <td>
                 <div class="action-container">
                   <FeatherButton
+                    v-if="!isPluginSourced(store.selectedCollectionSource)"
                     icon="Edit"
                     :title="`Edit ${systemDefinition.name}`"
                     data-test="edit-button"
@@ -110,6 +114,7 @@
                       {{ systemDefinition.enabled ? 'Disable Definition' : 'Enable Definition' }}
                     </FeatherDropdownItem>
                     <FeatherDropdownItem
+                      v-if="!isPluginSourced(store.selectedCollectionSource)"
                       data-test="delete-definition-button"
                       @click="openDeleteSystemDefDialog(systemDefinition)"
                     >
@@ -187,6 +192,7 @@
 
 <script setup lang="ts">
 import useSnackbar from '@/composables/useSnackbar'
+import { isPluginSourced } from '@/lib/snmpDataCollectionHelpers'
 import { deleteSystemDefinitions, enableDisableSnmpSystemDefs } from '@/services/snmpDataCollectionService'
 import { useSnmpDataCollectionDetailStore } from '@/stores/snmpDataCollectionDetailStore'
 import { CreateEditMode } from '@/types'

--- a/ui/src/containers/SnmpDataCollectionDetail.vue
+++ b/ui/src/containers/SnmpDataCollectionDetail.vue
@@ -51,6 +51,7 @@
           Disable Source
         </FeatherButton>
         <FeatherButton
+          v-if="!isPluginSourced(store.selectedCollectionSource)"
           secondary
           data-test="delete-source"
           @click="openDeleteCollectionSourceDialog(store.selectedCollectionSource)"
@@ -145,6 +146,7 @@ import MibGroupsTable from '@/components/SnmpDataCollectionDetail/MibGroupsTable
 import ResourceTypesTable from '@/components/SnmpDataCollectionDetail/ResourceTypesTable.vue'
 import SystemDefinitionsTable from '@/components/SnmpDataCollectionDetail/SystemDefinitionsTable.vue'
 import useSnackbar from '@/composables/useSnackbar'
+import { isPluginSourced } from '@/lib/snmpDataCollectionHelpers'
 import { deleteSnmpCollectionSources, enableDisableSnmpDataCollectionSources } from '@/services/snmpDataCollectionService'
 import { useSnmpDataCollectionDetailStore } from '@/stores/snmpDataCollectionDetailStore'
 import { useSnmpDataCollectionStore } from '@/stores/snmpDataCollectionStore'

--- a/ui/src/lib/snmpDataCollectionHelpers.ts
+++ b/ui/src/lib/snmpDataCollectionHelpers.ts
@@ -1,0 +1,26 @@
+/**
+ * Helpers for the SNMP Data Collection admin pages.
+ *
+ * The single source of truth for "is this row managed by a plugin?" lives on
+ * the backend (SnmpDataCollectionSyncToDb.PLUGIN_UPLOADED_BY). Plugin-managed
+ * sources are read-only in the UI for content edits and deletes, but admins
+ * can still toggle their enabled flag.
+ */
+
+/**
+ * Marker value the backend writes to {@code SnmpCollectionSource.uploaded_by}
+ * for rows owned by the plugin sync. Must stay in sync with the constant of
+ * the same name in {@code SnmpDataCollectionSyncToDb.java}.
+ */
+export const PLUGIN_UPLOADED_BY = 'opennms-plugins'
+
+/**
+ * Whether a source row was contributed by a plugin (and is therefore
+ * read-only for content edits/deletes in the UI).
+ *
+ * Accepts a partial source object so it can be called against the various
+ * table-row shapes the UI uses without coercion.
+ */
+export const isPluginSourced = (source: { uploadedBy?: string | null } | null | undefined): boolean => {
+  return !!source && source.uploadedBy === PLUGIN_UPLOADED_BY
+}


### PR DESCRIPTION
This update brings SNMP data collection config from plugins to DB.
If there is a match, it will update with config from plugins.
Also disables deleting config from Plugins. Only enable/disable is possible.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19719

