### PR TITLE
NMS-16118: Structured Node List Page: handle query params

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
@@ -177,6 +177,7 @@ public abstract class CriteriaBehaviors {
     public static final Map<String,CriteriaBehavior<?>> REDUCTION_KEY_MEMO_BEHAVIORS = new HashMap<>();
     public static final Map<String,CriteriaBehavior<?>> SERVICE_TYPE_BEHAVIORS = new HashMap<>();
     public static final Map<String,CriteriaBehavior<?>> SNMP_INTERFACE_BEHAVIORS = new HashMap<>();
+    public static final Map<String,CriteriaBehavior<?>> NODE_SERVICE_TYPE_BEHAVIORS = new HashMap<>();
 
     static {
         ALARM_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
@@ -391,10 +392,38 @@ public abstract class CriteriaBehaviors {
         SNMP_INTERFACE_BEHAVIORS.put("ifOperStatus", new CriteriaBehavior<Integer>(INT_CONVERTER));
         SNMP_INTERFACE_BEHAVIORS.put("ifSpeed", new CriteriaBehavior<Long>(LONG_CONVERTER));
         SNMP_INTERFACE_BEHAVIORS.put("ifType", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        SNMP_INTERFACE_BEHAVIORS.put("physAddr", new CriteriaBehavior<String>(STRING_CONVERTER));
         SNMP_INTERFACE_BEHAVIORS.put("lastCapsdPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
         SNMP_INTERFACE_BEHAVIORS.put("lastEgressFlow", new CriteriaBehavior<Date>(DATE_CONVERTER));
         SNMP_INTERFACE_BEHAVIORS.put("lastIngressFlow", new CriteriaBehavior<Date>(DATE_CONVERTER));
         SNMP_INTERFACE_BEHAVIORS.put("lastSnmpPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
+
+        CriteriaBehavior<String> serviceTypeName = new StringCriteriaBehavior(Aliases.serviceType.prop("name"), (b, v, c, w) -> {
+            switch (c) {
+            case EQUALS:
+                b.sql(String.format(
+                    "{alias}.nodeid in (select ipinterface.nodeid from ipinterface, ifservices, service" +
+                    " where ipinterface.id = ifservices.ipinterfaceid" +
+                    " and ifservices.serviceid = service.serviceid" +
+                    " and service.servicename %s ?" +
+                    " and ifservices.status != 'D')",
+                    w ? "like" : "="), v, Type.STRING);
+                break;
+            case NOT_EQUALS:
+                b.sql(String.format(
+                    "{alias}.nodeid not in (select ipinterface.nodeid from ipinterface, ifservices, service" +
+                    " where ipinterface.id = ifservices.ipinterfaceid" +
+                    " and ifservices.serviceid = service.serviceid" +
+                    " and service.servicename %s ?" +
+                    " and ifservices.status != 'D')",
+                    w ? "like" : "="), v, Type.STRING);
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal condition type when filtering serviceType.name: " + c.toString());
+            }
+        });
+        serviceTypeName.setSkipPropertyByDefault(true);
+        NODE_SERVICE_TYPE_BEHAVIORS.put("name", serviceTypeName);
     }
 
     private static String stringForNumericCondition(ConditionType c, String property) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
@@ -407,7 +407,7 @@ public abstract class CriteriaBehaviors {
                     " and ifservices.serviceid = service.serviceid" +
                     " and service.servicename %s ?" +
                     " and ifservices.status != 'D')",
-                    w ? "like" : "="), v, Type.STRING);
+                    w ? "ilike" : "="), v, Type.STRING);
                 break;
             case NOT_EQUALS:
                 b.sql(String.format(
@@ -416,7 +416,7 @@ public abstract class CriteriaBehaviors {
                     " and ifservices.serviceid = service.serviceid" +
                     " and service.servicename %s ?" +
                     " and ifservices.status != 'D')",
-                    w ? "like" : "="), v, Type.STRING);
+                    w ? "ilike" : "="), v, Type.STRING);
                 break;
             default:
                 throw new IllegalArgumentException("Illegal condition type when filtering serviceType.name: " + c.toString());

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -389,6 +389,7 @@ public abstract class SearchProperties {
 		new SearchProperty(OnmsSnmpInterface.class, "ifOperStatus", "Operational Status", INTEGER),
 		new SearchProperty(OnmsSnmpInterface.class, "ifSpeed", "Interface Speed (Bits per second)", LONG),
 		new SearchProperty(OnmsSnmpInterface.class, "ifType", "Interface Type", INTEGER),
+		new SearchProperty(OnmsSnmpInterface.class, "physAddr", "Physical Address (MAC)", STRING),
 		new SearchProperty(OnmsSnmpInterface.class, "lastCapsdPoll", "Last Provisioning Scan", TIMESTAMP),
 		new SearchProperty(OnmsSnmpInterface.class, "lastEgressFlow", "Last Egress Flow", TIMESTAMP),
 		new SearchProperty(OnmsSnmpInterface.class, "lastIngressFlow", "Last Ingress Flow", TIMESTAMP),
@@ -546,6 +547,7 @@ public abstract class SearchProperties {
 		//NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.monitoredService, "Monitored Service", IF_SERVICE_PROPERTIES, false));
 		//NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.serviceType, "Service", SERVICE_TYPE_PROPERTIES, false));
 		NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.snmpInterface, "SNMP Interface", SNMP_INTERFACE_PROPERTIES, false));
+		NODE_SERVICE_PROPERTIES.add(new SearchProperty(OnmsServiceType.class, Aliases.serviceType.prop("name"), "Service Name", STRING));
 
 		// Root prefix
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(NOTIFICATION_PROPERTIES);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -547,7 +547,11 @@ public abstract class SearchProperties {
 		//NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.monitoredService, "Monitored Service", IF_SERVICE_PROPERTIES, false));
 		//NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.serviceType, "Service", SERVICE_TYPE_PROPERTIES, false));
 		NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.snmpInterface, "SNMP Interface", SNMP_INTERFACE_PROPERTIES, false));
-		NODE_SERVICE_PROPERTIES.add(new SearchProperty(OnmsServiceType.class, Aliases.serviceType.prop("name"), "Service Name", STRING));
+		// serviceType.name uses a raw SQL subquery in NodeRestService (no direct Hibernate association),
+		// so ordering by this field is not supported.
+		SearchProperty serviceNameProp = new SearchProperty(OnmsServiceType.class, Aliases.serviceType.prop("name"), "Service Name", STRING);
+		serviceNameProp.orderBy = false;
+		NODE_SERVICE_PROPERTIES.add(serviceNameProp);
 
 		// Root prefix
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(NOTIFICATION_PROPERTIES);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -22,7 +22,9 @@
 package org.opennms.web.rest.v2;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,11 +57,13 @@ import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.ServiceTypeDao;
 import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.model.OnmsMetaData;
 import org.opennms.netmgt.model.OnmsMetaDataList;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsNodeList;
+import org.opennms.netmgt.model.OnmsServiceType;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.netmgt.xml.event.Event;
@@ -104,6 +108,9 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
 
     @Autowired
     private MonitoringLocationDao m_locationDao;
+
+    @Autowired
+    private ServiceTypeDao m_serviceTypeDao;
 
     @Autowired
     private NodeDao m_dao;
@@ -285,6 +292,24 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @Override
     protected OnmsNode doGet(UriInfo uriInfo, String id) {
         return getDao().get(id);
+    }
+
+    @GET
+    @Path("service-types")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Transactional(readOnly = true)
+    @Operation(summary = "Get all service types", description = "Returns all monitored service types for use in node filtering", operationId = "NodeRestServiceGETServiceTypes")
+    public Response getServiceTypes() {
+        final List<Map<String,Object>> result = m_serviceTypeDao.findAll().stream()
+            .sorted(Comparator.comparing(OnmsServiceType::getName))
+            .map(st -> {
+                final Map<String,Object> item = new HashMap<>();
+                item.put("id", st.getId());
+                item.put("name", st.getName());
+                return item;
+            })
+            .collect(Collectors.toList());
+        return Response.ok(result).build();
     }
 
     @Path("{nodeCriteria}/ipinterfaces")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -183,6 +183,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         }
 
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.location, CriteriaBehaviors.MONITORING_LOCATION_BEHAVIORS));
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.serviceType, CriteriaBehaviors.NODE_SERVICE_TYPE_BEHAVIORS));
 
         // Use join conditions for one-to-many aliases
         for (Map.Entry<String,CriteriaBehavior<?>> entry : CriteriaBehaviors.SNMP_INTERFACE_BEHAVIORS.entrySet()) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -206,7 +206,10 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
                 // String field: use SQL subquery so that wildcard (LIKE) and exact (=) both work.
                 // A JOIN condition with Restrictions.eq cannot perform LIKE matching, so wildcard
                 // searches like snmpInterface.ifAlias==*value* would return nothing with a join approach.
-                map.put(Aliases.snmpInterface.prop(key), new CriteriaBehavior(entry.getValue().getPropertyName(), entry.getValue().getConverter(), (b,v,c,w)-> {
+                // skipProperty=true: the SQL subquery handles the full restriction; the snmpInterface
+                // alias is never joined, so the default Hibernate property restriction must not be added
+                // (it would cause a QueryException: could not resolve property: snmpInterface).
+                CriteriaBehavior<?> snmpStringBehavior = new CriteriaBehavior(entry.getValue().getPropertyName(), entry.getValue().getConverter(), (b,v,c,w)-> {
                     switch (c) {
                     case EQUALS:
                         b.sql(String.format("{alias}.nodeid in (select snmpinterface.nodeid from snmpinterface where snmpinterface.%s %s ?)", dbCol, w ? "like" : "="), v, Type.STRING);
@@ -217,7 +220,9 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
                     default:
                         throw new IllegalArgumentException("Illegal condition type when filtering snmpInterface." + key + ": " + c);
                     }
-                }));
+                });
+                snmpStringBehavior.setSkipPropertyByDefault(true);
+                map.put(Aliases.snmpInterface.prop(key), snmpStringBehavior);
             } else {
                 // Non-string field: join condition for exact matching (wildcards not applicable)
                 map.put(Aliases.snmpInterface.prop(key), new CriteriaBehavior(entry.getValue().getPropertyName(), entry.getValue().getConverter(), (b,v,c,w)-> {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -97,7 +97,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
 
     // Maps SNMP interface FIQL field names to their lowercase DB column names in the snmpinterface table.
-    // Used to build SQL subqueries that support both exact (=) and wildcard (like) matching.
+    // Used to build SQL subqueries with ilike for case-insensitive matching (exact and wildcard).
     // Non-string SNMP fields (ifIndex, ifType, etc.) are absent; they use a different join strategy.
     private static final Map<String,String> SNMP_STRING_COLUMN = Map.of(
         "ifAlias",  "snmpifalias",
@@ -210,7 +210,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
             final String key = entry.getKey();
             final String dbCol = SNMP_STRING_COLUMN.get(key);
             if (dbCol != null) {
-                // String field: use SQL subquery so that wildcard (LIKE) and exact (=) both work.
+                // String field: use SQL subquery with ilike for case-insensitive matching.
                 // A JOIN condition with Restrictions.eq cannot perform LIKE matching, so wildcard
                 // searches like snmpInterface.ifAlias==*value* would return nothing with a join approach.
                 // skipProperty=true: the SQL subquery handles the full restriction; the snmpInterface
@@ -219,10 +219,10 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
                 CriteriaBehavior<?> snmpStringBehavior = new CriteriaBehavior(entry.getValue().getPropertyName(), entry.getValue().getConverter(), (b,v,c,w)-> {
                     switch (c) {
                     case EQUALS:
-                        b.sql(String.format("{alias}.nodeid in (select snmpinterface.nodeid from snmpinterface where snmpinterface.%s %s ?)", dbCol, w ? "like" : "="), v, Type.STRING);
+                        b.sql(String.format("{alias}.nodeid in (select snmpinterface.nodeid from snmpinterface where snmpinterface.%s ilike ?)", dbCol), v, Type.STRING);
                         break;
                     case NOT_EQUALS:
-                        b.sql(String.format("{alias}.nodeid not in (select snmpinterface.nodeid from snmpinterface where snmpinterface.%s %s ?)", dbCol, w ? "like" : "="), v, Type.STRING);
+                        b.sql(String.format("{alias}.nodeid not in (select snmpinterface.nodeid from snmpinterface where snmpinterface.%s ilike ?)", dbCol), v, Type.STRING);
                         break;
                     default:
                         throw new IllegalArgumentException("Illegal condition type when filtering snmpInterface." + key + ": " + c);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -27,6 +27,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.cxf.jaxrs.ext.search.ConditionType;
+import org.opennms.core.criteria.restrictions.SqlRestriction.Type;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -88,6 +91,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,Integer,String> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
+
+    // Maps SNMP interface FIQL field names to their lowercase DB column names in the snmpinterface table.
+    // Used to build SQL subqueries that support both exact (=) and wildcard (like) matching.
+    // Non-string SNMP fields (ifIndex, ifType, etc.) are absent; they use a different join strategy.
+    private static final Map<String,String> SNMP_STRING_COLUMN = Map.of(
+        "ifAlias",  "snmpifalias",
+        "ifDescr",  "snmpifdescr",
+        "ifName",   "snmpifname",
+        "physAddr", "snmpphysaddr"
+    );
 
     @Autowired
     private MonitoringLocationDao m_locationDao;
@@ -187,16 +200,37 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
 
         // Use join conditions for one-to-many aliases
         for (Map.Entry<String,CriteriaBehavior<?>> entry : CriteriaBehaviors.SNMP_INTERFACE_BEHAVIORS.entrySet()) {
-            map.put(Aliases.snmpInterface.prop(entry.getKey()), new CriteriaBehavior(entry.getValue().getPropertyName(), entry.getValue().getConverter(), (b,v,c,w)-> {
-                b.alias(
-                    "snmpInterfaces",
-                    Aliases.snmpInterface.toString(),
-                    JoinType.LEFT_JOIN,
-                    Restrictions.or(Restrictions.eq(Aliases.snmpInterface.prop(entry.getKey()), v), Restrictions.isNull(Aliases.snmpInterface.prop(entry.getKey())))
-                );
-            }));
+            final String key = entry.getKey();
+            final String dbCol = SNMP_STRING_COLUMN.get(key);
+            if (dbCol != null) {
+                // String field: use SQL subquery so that wildcard (LIKE) and exact (=) both work.
+                // A JOIN condition with Restrictions.eq cannot perform LIKE matching, so wildcard
+                // searches like snmpInterface.ifAlias==*value* would return nothing with a join approach.
+                map.put(Aliases.snmpInterface.prop(key), new CriteriaBehavior(entry.getValue().getPropertyName(), entry.getValue().getConverter(), (b,v,c,w)-> {
+                    switch (c) {
+                    case EQUALS:
+                        b.sql(String.format("{alias}.nodeid in (select snmpinterface.nodeid from snmpinterface where snmpinterface.%s %s ?)", dbCol, w ? "like" : "="), v, Type.STRING);
+                        break;
+                    case NOT_EQUALS:
+                        b.sql(String.format("{alias}.nodeid not in (select snmpinterface.nodeid from snmpinterface where snmpinterface.%s %s ?)", dbCol, w ? "like" : "="), v, Type.STRING);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Illegal condition type when filtering snmpInterface." + key + ": " + c);
+                    }
+                }));
+            } else {
+                // Non-string field: join condition for exact matching (wildcards not applicable)
+                map.put(Aliases.snmpInterface.prop(key), new CriteriaBehavior(entry.getValue().getPropertyName(), entry.getValue().getConverter(), (b,v,c,w)-> {
+                    b.alias(
+                        "snmpInterfaces",
+                        Aliases.snmpInterface.toString(),
+                        JoinType.LEFT_JOIN,
+                        Restrictions.or(Restrictions.eq(Aliases.snmpInterface.prop(key), v), Restrictions.isNull(Aliases.snmpInterface.prop(key)))
+                    );
+                }));
+            }
         }
-        // There are no extra String properties on node.snmpInterfaces 
+        // There are no extra String properties on node.snmpInterfaces
 
         // TODO: Figure out if it makes sense to search/orderBy on 2nd-level and greater JOINed properties
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -252,6 +252,26 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         LOG.warn(sendRequest(GET, "/nodes/1/categories", 200));
     }
     @Test
+    @JUnitTemporaryDatabase
+    public void testSnmpInterfaceStringSearchIsCaseInsensitive() throws Exception {
+        // DatabasePopulator seeds node1 with physAddr="34E45604BB69" and ifAlias="Initial ifAlias value".
+        // Both must be findable via lowercase wildcard FIQL (ilike, not like).
+        m_databasePopulator.populateDatabase();
+
+        // MAC stored uppercase, search lowercase — without ilike this returns 204 (no match)
+        sendRequest(GET, "/nodes", parseParamData("_s=snmpInterface.physAddr==*34e456*"), 200);
+
+        // Exact-case MAC search still works
+        sendRequest(GET, "/nodes", parseParamData("_s=snmpInterface.physAddr==*34E456*"), 200);
+
+        // ifAlias stored mixed-case, search all-lowercase
+        sendRequest(GET, "/nodes", parseParamData("_s=snmpInterface.ifAlias==*ifalias*"), 200);
+
+        // Negative: unknown MAC returns no results
+        sendRequest(GET, "/nodes", parseParamData("_s=snmpInterface.physAddr==*000000000000*"), 204);
+    }
+
+    @Test
     public void createNodeWithParent() throws Exception{
 
         final NetworkBuilder builder = new NetworkBuilder();

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -70,7 +70,7 @@
         text-prop="_text"
       ></FeatherAutocomplete>
       <FeatherAutocomplete
-        class="last-filter-autocomplete"
+        class="filter-autocomplete"
         label="Locations"
         type="multi"
         v-model="selectedFilters.locations"
@@ -80,6 +80,16 @@
         @update:modelValue="(items: any) => updateFilter('locations', items)"
       >
       </FeatherAutocomplete>
+      <FeatherAutocomplete
+        class="last-filter-autocomplete"
+        label="Monitored Services"
+        type="multi"
+        v-model="selectedFilters.services"
+        :results="serviceResults"
+        @search="handleServiceSearch"
+        @update:modelValue="(items: any) => updateFilter('services', items)"
+        text-prop="_text"
+      ></FeatherAutocomplete>
       <div class="spacer-medium"></div>
       <div>
         <h4 class="title">Extended Search</h4>
@@ -111,7 +121,7 @@ import { FeatherButton } from '@featherds/button'
 import { FeatherIcon } from '@featherds/icon'
 import AddIcon from '@featherds/icon/action/Add'
 import DeleteIcon from '@featherds/icon/action/Delete'
-import { ref } from 'vue'
+import { ref, reactive, watch } from 'vue'
 import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 
@@ -124,6 +134,7 @@ const flowsLoading = ref(false)
 const flowResults = ref<IAutocompleteItemType[]>([])
 const locationsLoading = ref(false)
 const locationResults = ref<IAutocompleteItemType[]>([])
+const serviceResults = ref<IAutocompleteItemType[]>([])
 // we already have items in memory, don't really need to use setTimeout at all,
 // but will keep it just to have the pattern. Timeout can be minimal (5ms)
 const TIMEOUT = 5
@@ -134,7 +145,8 @@ const selectedFilters = reactive({
   categories: [] as IAutocompleteItemType[],
   categories2: [] as IAutocompleteItemType[],
   flows: [] as IAutocompleteItemType[],
-  locations: [] as IAutocompleteItemType[]
+  locations: [] as IAutocompleteItemType[],
+  services: [] as IAutocompleteItemType[]
 })
 
 const filterCategoryItems = (query: string): IAutocompleteItemType[] => {
@@ -194,6 +206,13 @@ const handleLocationSearch = (query: string) => {
   }, TIMEOUT)
 }
 
+const handleServiceSearch = (query: string) => {
+  const lower = query.toLowerCase()
+  serviceResults.value = nodeStructureStore.allServiceTypes
+    .filter(s => s.name.toLowerCase().includes(lower))
+    .map(s => ({ _value: s.id, _text: s.name } as IAutocompleteItemType))
+}
+
 const updateFilter = (key: keyof typeof selectedFilters, items: IAutocompleteItemType[]) => {
   selectedFilters[key] = items
 }
@@ -208,6 +227,7 @@ const applySelectedFilters = () => {
   nodeStructureStore.updateSelectedCategories2(showSecondCategories.value ? selectedFilters.categories2 : [])
   nodeStructureStore.updateSelectedFlows(selectedFilters.flows)
   nodeStructureStore.updateSelectedMonitoringLocations(selectedFilters.locations)
+  nodeStructureStore.updateSelectedServices(selectedFilters.services)
   nodeStructureStore.closeInstancesDrawerModal()
 }
 
@@ -218,6 +238,8 @@ watch(() => nodeStructureStore.drawerState.visible, (visible) => {
     showSecondCategories.value = nodeStructureStore.selectedCategories2.length > 0
     selectedFilters.flows = [...nodeStructureStore.selectedFlows]
     selectedFilters.locations = [...nodeStructureStore.selectedMonitoringLocations]
+    selectedFilters.services = [...nodeStructureStore.selectedServices]
+    serviceResults.value = nodeStructureStore.allServiceTypes.map(s => ({ _value: s.id, _text: s.name } as IAutocompleteItemType))
   }
 })
 </script>

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -11,10 +11,16 @@
       <section>
         <h3>Advanced Filters</h3>
       </section>
-      <div class="spacer-large"></div>
-      <div class="spacer-large"></div>
-      <div>Choose one or more attributes to find a service.</div>
-      <div class="spacer-large"></div>
+      <div class="info-section">
+        <span>Choose one or more attributes to find matching nodes.</span>
+        <FeatherIcon
+          :icon="InfoIcon"
+          class="info-icon"
+          @click="isMessageDialogVisible = true"
+          data-test="snmp-config-lookup-info-icon"
+        />
+      </div>
+      <h4 class="title">Categories</h4>
       <div class="category-row">
         <FeatherAutocomplete
           class="category-autocomplete"
@@ -26,6 +32,7 @@
           @search="handleCategorySearch"
           :allow-new="false"
           text-prop="_text"
+          hint="You may select up to two category groups to filter nodes by"
           @update:modelValue="(items: any) => updateFilter('categories', items)"
         ></FeatherAutocomplete>
         <FeatherButton
@@ -58,6 +65,7 @@
           <FeatherIcon :icon="DeleteIcon" />
         </FeatherButton>
       </div>
+      <div class="spacer-large"></div>
       <FeatherAutocomplete
         class="filter-autocomplete"
         label="Flows"
@@ -71,7 +79,7 @@
       ></FeatherAutocomplete>
       <FeatherAutocomplete
         class="filter-autocomplete"
-        label="Locations"
+        label="Monitoring Locations"
         type="multi"
         v-model="selectedFilters.locations"
         :loading="locationsLoading"
@@ -90,6 +98,8 @@
         @update:modelValue="(items: any) => updateFilter('services', items)"
         text-prop="_text"
       ></FeatherAutocomplete>
+      <div class="spacer-large"></div>
+      <hr />
       <div class="spacer-medium"></div>
       <div>
         <h4 class="title">Extended Search</h4>
@@ -112,16 +122,34 @@
       </div>
     </div>
   </FeatherDrawer>
+  <MessageDialog
+    :visible="isMessageDialogVisible"
+    maxHeight="22em"
+    maxWidth="50em"
+    title="Advanced Filters"
+    @close="isMessageDialogVisible = false"
+  >
+    <template #content>
+      <div>
+        <p>Use the advanced filters to find nodes that match specific criteria.</p>
+        <p>You can filter by categories, flows, locations, and monitored services.</p>
+        <p>You may select up to two category groups to filter nodes by. Each category group can contain multiple categories "unioned" together.</p>
+        <p>Category groups are then "intersected" with each other to refine the search results.</p>
+      </div>
+    </template>
+  </MessageDialog>
 </template>
 
 <script lang="ts" setup>
+import { ref, reactive, watch } from 'vue'
 import { FeatherAutocomplete, IAutocompleteItemType } from '@featherds/autocomplete'
 import { FeatherDrawer } from '@featherds/drawer'
 import { FeatherButton } from '@featherds/button'
 import { FeatherIcon } from '@featherds/icon'
 import AddIcon from '@featherds/icon/action/Add'
 import DeleteIcon from '@featherds/icon/action/Delete'
-import { ref, reactive, watch } from 'vue'
+import InfoIcon from '@featherds/icon/action/Info'
+import MessageDialog from '../Common/MessageDialog.vue'
 import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 
@@ -135,6 +163,7 @@ const flowResults = ref<IAutocompleteItemType[]>([])
 const locationsLoading = ref(false)
 const locationResults = ref<IAutocompleteItemType[]>([])
 const serviceResults = ref<IAutocompleteItemType[]>([])
+const isMessageDialogVisible = ref(false)
 // we already have items in memory, don't really need to use setTimeout at all,
 // but will keep it just to have the pattern. Timeout can be minimal (5ms)
 const TIMEOUT = 5
@@ -245,10 +274,10 @@ watch(() => nodeStructureStore.drawerState.visible, (visible) => {
 </script>
 
 <style lang="scss" scoped>
-@import "@featherds/table/scss/table";
-@import "@featherds/styles/mixins/elevation";
-@import "@featherds/styles/mixins/typography";
-@import "@featherds/styles/themes/variables";
+@use '@featherds/styles/themes/variables';
+@use '@featherds/styles/mixins/typography';
+@use '@featherds/styles/mixins/elevation';
+@use '@featherds/table/scss/table';
 
 .feather-drawer-custom-padding {
   padding: 20px;
@@ -298,7 +327,25 @@ watch(() => nodeStructureStore.drawerState.visible, (visible) => {
 }
 
 .category-add-btn {
-  margin-top: 0.5rem;
   flex-shrink: 0;
+}
+
+.info-section {
+  margin-bottom: 1em;
+
+  .label {
+    color: var(variables.$primary-text-on-surface);
+  }
+
+  .info-icon {
+    cursor: pointer;
+    font-size: 1.5em;
+    margin-left: 0.5em;
+    color: var(variables.$primary);
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
 }
 </style>

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -154,6 +154,7 @@ import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 
 const searchTimeout = ref<number>(-1)
+const category2SearchTimeout = ref<number>(-1)
 const categoriesLoading = ref(false)
 const categoryResults = ref([] as IAutocompleteItemType[])
 const categories2Loading = ref(false)
@@ -198,8 +199,8 @@ const handleCategorySearch = (query: string) => {
 
 const handleCategory2Search = (query: string) => {
   categories2Loading.value = true
-  clearTimeout(searchTimeout.value)
-  searchTimeout.value = window.setTimeout(() => {
+  clearTimeout(category2SearchTimeout.value)
+  category2SearchTimeout.value = window.setTimeout(() => {
     category2Results.value = filterCategoryItems(query)
     categories2Loading.value = false
   }, TIMEOUT)

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -15,18 +15,49 @@
       <div class="spacer-large"></div>
       <div>Choose one or more attributes to find a service.</div>
       <div class="spacer-large"></div>
-      <FeatherAutocomplete
-        class="my-autocomplete"
-        label="Categories"
-        type="multi"
-        v-model="selectedFilters.categories"
-        :loading="categoriesLoading"
-        :results="categoryResults"
-        @search="handleCategorySearch"
-        :allow-new="false"
-        text-prop="_text"
-        @update:modelValue="(items: any) => updateFilter('categories', items)"
-      ></FeatherAutocomplete>
+      <div class="category-row">
+        <FeatherAutocomplete
+          class="category-autocomplete"
+          label="Categories"
+          type="multi"
+          v-model="selectedFilters.categories"
+          :loading="categoriesLoading"
+          :results="categoryResults"
+          @search="handleCategorySearch"
+          :allow-new="false"
+          text-prop="_text"
+          @update:modelValue="(items: any) => updateFilter('categories', items)"
+        ></FeatherAutocomplete>
+        <FeatherButton
+          v-if="!showSecondCategories"
+          icon="Add category group"
+          class="category-add-btn"
+          @click="showSecondCategories = true"
+        >
+          <FeatherIcon :icon="AddIcon" />
+        </FeatherButton>
+      </div>
+      <div v-if="showSecondCategories" class="category-row">
+        <FeatherAutocomplete
+          class="category-autocomplete"
+          label="Additional Categories"
+          type="multi"
+          v-model="selectedFilters.categories2"
+          :loading="categories2Loading"
+          :results="category2Results"
+          @search="handleCategory2Search"
+          :allow-new="false"
+          text-prop="_text"
+          @update:modelValue="(items: any) => updateFilter('categories2', items)"
+        ></FeatherAutocomplete>
+        <FeatherButton
+          icon="Remove category group"
+          class="category-add-btn"
+          @click="removeSecondCategories"
+        >
+          <FeatherIcon :icon="DeleteIcon" />
+        </FeatherButton>
+      </div>
       <FeatherAutocomplete
         class="filter-autocomplete"
         label="Flows"
@@ -77,6 +108,9 @@
 import { FeatherAutocomplete, IAutocompleteItemType } from '@featherds/autocomplete'
 import { FeatherDrawer } from '@featherds/drawer'
 import { FeatherButton } from '@featherds/button'
+import { FeatherIcon } from '@featherds/icon'
+import AddIcon from '@featherds/icon/action/Add'
+import DeleteIcon from '@featherds/icon/action/Delete'
 import { ref } from 'vue'
 import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
@@ -84,6 +118,8 @@ import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 const searchTimeout = ref<number>(-1)
 const categoriesLoading = ref(false)
 const categoryResults = ref([] as IAutocompleteItemType[])
+const categories2Loading = ref(false)
+const category2Results = ref<IAutocompleteItemType[]>([])
 const flowsLoading = ref(false)
 const flowResults = ref<IAutocompleteItemType[]>([])
 const locationsLoading = ref(false)
@@ -93,31 +129,38 @@ const locationResults = ref<IAutocompleteItemType[]>([])
 const TIMEOUT = 5
 
 const nodeStructureStore = useNodeStructureStore()
+const showSecondCategories = ref(false)
 const selectedFilters = reactive({
   categories: [] as IAutocompleteItemType[],
+  categories2: [] as IAutocompleteItemType[],
   flows: [] as IAutocompleteItemType[],
   locations: [] as IAutocompleteItemType[]
 })
 
+const filterCategoryItems = (query: string): IAutocompleteItemType[] => {
+  const categoriesArray = Array.isArray(nodeStructureStore.categories)
+    ? nodeStructureStore.categories
+    : []
+  return categoriesArray
+    .filter(c => c.name && c.name.toLowerCase().includes(query.toLowerCase()))
+    .map(c => ({ _text: c.name, _value: c.id } as IAutocompleteItemType))
+}
+
 const handleCategorySearch = (query: string) => {
   categoriesLoading.value = true
   clearTimeout(searchTimeout.value)
-
   searchTimeout.value = window.setTimeout(() => {
-    const categoriesArray = Array.isArray(nodeStructureStore.categories)
-      ? nodeStructureStore.categories
-      : []
-
-    const filteredCategories = categoriesArray
-      .filter((category) =>
-        category.name && category.name.toLowerCase().includes(query.toLowerCase())
-      )
-      .map((category) => ({
-        _text: category.name,
-        _value: category.id
-      } as IAutocompleteItemType))
-    categoryResults.value = filteredCategories
+    categoryResults.value = filterCategoryItems(query)
     categoriesLoading.value = false
+  }, TIMEOUT)
+}
+
+const handleCategory2Search = (query: string) => {
+  categories2Loading.value = true
+  clearTimeout(searchTimeout.value)
+  searchTimeout.value = window.setTimeout(() => {
+    category2Results.value = filterCategoryItems(query)
+    categories2Loading.value = false
   }, TIMEOUT)
 }
 
@@ -155,10 +198,15 @@ const updateFilter = (key: keyof typeof selectedFilters, items: IAutocompleteIte
   selectedFilters[key] = items
 }
 
+const removeSecondCategories = () => {
+  showSecondCategories.value = false
+  selectedFilters.categories2 = []
+}
+
 const applySelectedFilters = () => {
   nodeStructureStore.updateSelectedCategories(selectedFilters.categories)
+  nodeStructureStore.updateSelectedCategories2(showSecondCategories.value ? selectedFilters.categories2 : [])
   nodeStructureStore.updateSelectedFlows(selectedFilters.flows)
-
   nodeStructureStore.updateSelectedMonitoringLocations(selectedFilters.locations)
   nodeStructureStore.closeInstancesDrawerModal()
 }
@@ -166,6 +214,8 @@ const applySelectedFilters = () => {
 watch(() => nodeStructureStore.drawerState.visible, (visible) => {
   if (visible) {
     selectedFilters.categories = [...nodeStructureStore.selectedCategories]
+    selectedFilters.categories2 = [...nodeStructureStore.selectedCategories2]
+    showSecondCategories.value = nodeStructureStore.selectedCategories2.length > 0
     selectedFilters.flows = [...nodeStructureStore.selectedFlows]
     selectedFilters.locations = [...nodeStructureStore.selectedMonitoringLocations]
   }
@@ -213,5 +263,20 @@ watch(() => nodeStructureStore.drawerState.visible, (visible) => {
   :deep(.feather-input-sub-text) {
     display: none !important;
   }
+}
+
+.category-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.category-autocomplete {
+  flex: 1;
+}
+
+.category-add-btn {
+  margin-top: 0.5rem;
+  flex-shrink: 0;
 }
 </style>

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -106,6 +106,17 @@
               </FeatherChip>
 
               <FeatherChip
+                v-for="(svc, index) in nodeStructureStore.selectedServices"
+                :key="`svc-${index}`"
+              >
+                <template #icon>
+                  <FeatherIcon :icon="cancelIcon" class="icon"
+                    @click="removeItem(svc, FilterTypeEnum.MonitoredService)" />
+                </template>
+                {{ `Service: ${svc._text}` }}
+              </FeatherChip>
+
+              <FeatherChip
                 v-if="hasExtendedSearchParams"
               >
                 <template #icon>
@@ -524,6 +535,9 @@ const removeItem = (item: IAutocompleteItemType, type: FilterTypeEnum) => {
       break
     case FilterTypeEnum.MonitoringLocation:
       nodeStructureStore.removeMonitoringLocation(item)
+      break
+    case FilterTypeEnum.MonitoredService:
+      nodeStructureStore.removeService(item)
       break
     default:
       console.warn(`Unknown filter type: ${type}`)

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -64,6 +64,20 @@
               </FeatherChip>
 
               <FeatherChip
+                v-for="(cat, index) in nodeStructureStore.selectedCategories2"
+                :key="`cat2-${index}`"
+              >
+                <template #icon>
+                  <FeatherIcon
+                    :icon="cancelIcon"
+                    class="icon"
+                    @click="removeItem(cat, FilterTypeEnum.Category2)"
+                  />
+                </template>
+                {{ `Category (2): ${cat._text}` }}
+              </FeatherChip>
+
+              <FeatherChip
                 v-for="(flow, index) in nodeStructureStore.selectedFlows"
                 :key="`flow-${index}`"
               >
@@ -501,6 +515,9 @@ const removeItem = (item: IAutocompleteItemType, type: FilterTypeEnum) => {
   switch (type) {
     case FilterTypeEnum.Category:
       nodeStructureStore.removeCategory(item)
+      break
+    case FilterTypeEnum.Category2:
+      nodeStructureStore.removeCategory2(item)
       break
     case FilterTypeEnum.Flow:
       nodeStructureStore.removeFlow(item)

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -38,56 +38,71 @@ export const parseNodeLabel = (queryObject: any) => {
 
 /**
  * Parse categories from a vue-router route.query object.
- * The route.query 'categories' string can be a comma- or semicolon-separated list of either
- * numeric Category ids or names.
- * comma: Union; semicolon: Intersection
- * 
- * @returns The category mode and categories parsed from the queryObject. If 'selectedCategories' is empty,
- * it means no categories were present.
+ *
+ * Two formats are supported:
+ * - 'categories': flat comma- or semicolon-separated list (comma=Union, semicolon=Intersection).
+ *   Returns a single group in selectedCategories with selectedCategories2 empty.
+ * - 'category1' / 'category2': legacy format from surveillance-view links. Each param may be a
+ *   single string or an array (vue-router repeats params as arrays). Each group is union internally;
+ *   when both groups are non-empty, intersection is applied between them via selectedCategories2.
+ *   If only one of the two is present, all items go into selectedCategories.
+ *
+ * @returns categoryMode, selectedCategories (group 1), selectedCategories2 (group 2, may be empty)
  */
-export const parseCategories = (queryObject: any, categories: Category[]) => {
+export const parseCategories = (queryObject: any, categories: Category[]): {
+  categoryMode: SetOperator
+  selectedCategories: Category[]
+  selectedCategories2: Category[]
+} => {
   let categoryMode: SetOperator = SetOperator.Union
   const selectedCategories: Category[] = []
+  const selectedCategories2: Category[] = []
 
-  // 'category1' + 'category2' is a legacy format for the intersection of two categories.
-  // the newer 'categories' param is preferred
-  const queryCategories = (queryObject.categories as string)
-    || [queryObject.category1 as string, queryObject.category2 as string]
-        .filter(Boolean)
-        .join(';')
-    || ''
+  if (categories.length === 0) {
+    return { categoryMode, selectedCategories, selectedCategories2 }
+  }
 
-  if (categories.length > 0) {
-    categoryMode = queryCategories.includes(';') ? SetOperator.Intersection : SetOperator.Union
-
-    const cats: string[] = queryCategories.replace(/;/g, ',').split(',')
-
-    // add any valid categories
-    cats.forEach(c => {
-      if (/\d+/.test(c)) {
-        // category id number
-        const id = parseInt(c)
-
-        const item = categories.find(x => x.id === id)
-
-        if (item) {
-          selectedCategories.push(item)
-        }
+  const resolveCategory = (vals: string[]): Category[] => {
+    const result: Category[] = []
+    vals.forEach(c => {
+      if (!c) return
+      if (/^\d+$/.test(c)) {
+        const item = categories.find(x => x.id === parseInt(c))
+        if (item) result.push(item)
       } else {
-        // category name, case insensitive
         const item = categories.find(x => x.name.toLowerCase() === c.toLowerCase())
-
-        if (item) {
-          selectedCategories.push(item)
-        }
+        if (item) result.push(item)
       }
     })
+    return result
   }
 
-  return {
-    categoryMode,
-    selectedCategories
+  if (queryObject.categories) {
+    // Flat 'categories' string: comma=union, semicolon=intersection
+    const queryCategories = queryObject.categories as string
+    categoryMode = queryCategories.includes(';') ? SetOperator.Intersection : SetOperator.Union
+    const cats = queryCategories.replace(/;/g, ',').split(',')
+    selectedCategories.push(...resolveCategory(cats))
+  } else if (queryObject.category1 || queryObject.category2) {
+    // Legacy category1/category2: union within each group, intersection between groups.
+    // Vue-router gives a string for a single occurrence, array for multiple occurrences.
+    const toArray = (v: any): string[] =>
+      Array.isArray(v) ? (v as string[]) : v ? [v as string] : []
+
+    const group1 = resolveCategory(toArray(queryObject.category1))
+    const group2 = resolveCategory(toArray(queryObject.category2))
+
+    if (group1.length > 0 && group2.length > 0) {
+      selectedCategories.push(...group1)
+      selectedCategories2.push(...group2)
+    } else {
+      // Only one group present — treat as a flat union (backwards compat)
+      selectedCategories.push(...group1, ...group2)
+    }
+    categoryMode = SetOperator.Union
   }
+
+  return { categoryMode, selectedCategories, selectedCategories2 }
 }
 
 export const parseMonitoringLocation = (queryObject: any, monitoringLocations: MonitoringLocation[]) => {

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -27,6 +27,7 @@ import {
   NodeQueryForeignSourceParams,
   NodeQuerySnmpParams,
   NodeQuerySysParams,
+  ServiceType,
   SetOperator
 } from '@/types'
 import { isIP } from 'is-ip'
@@ -282,17 +283,27 @@ export const parseMaclike = (queryObject: any): string | null => {
 }
 
 /**
- * Maps the monitoredService param to a service name for FIQL filtering via serviceType.name.
- * The legacy service=<id> (numeric ID) param is intentionally not supported — IDs cannot be
- * resolved to names without an additional API call. Pages updated in PR 3 will send
- * monitoredService=<name> instead.
+ * Maps monitoredService or service query params to canonical service names for FIQL filtering.
+ * Resolves by exact or case-insensitive name match, or by numeric ID lookup via serviceTypes.
+ * monitoredService takes precedence over service when both are present.
  */
-export const parseMonitoredService = (queryObject: any): string | null => {
-  const serviceName = queryObject.monitoredService as string || ''
+export const parseMonitoredServices = (
+  queryObject: any,
+  serviceTypes: ServiceType[]
+): string[] => {
+  const raw: string = (queryObject.monitoredService ?? queryObject.service ?? '') as string
+  if (!raw) return []
 
-  if (!serviceName) {
-    return null
+  const resolve = (val: string): string | null => {
+    if (/^\d+$/.test(val)) {
+      const found = serviceTypes.find(s => s.id === parseInt(val))
+      return found ? found.name : null
+    }
+    const lower = val.toLowerCase()
+    const found = serviceTypes.find(s => s.name.toLowerCase() === lower)
+    return found ? found.name : null
   }
 
-  return serviceName
+  const name = resolve(raw)
+  return name ? [name] : []
 }

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -291,7 +291,7 @@ export const parseMonitoredServices = (
   queryObject: any,
   serviceTypes: ServiceType[]
 ): string[] => {
-  const raw: string = (queryObject.monitoredService ?? queryObject.service ?? '') as string
+  const raw = queryObject.monitoredService ?? queryObject.service
   if (!raw) return []
 
   const resolve = (val: string): string | null => {
@@ -304,6 +304,6 @@ export const parseMonitoredServices = (
     return found ? found.name : null
   }
 
-  const name = resolve(raw)
-  return name ? [name] : []
+  const values: string[] = Array.isArray(raw) ? raw : [raw as string]
+  return values.map(v => resolve(v)).filter((n): n is string => n !== null)
 }

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -49,7 +49,11 @@ export const parseCategories = (queryObject: any, categories: Category[]) => {
   let categoryMode: SetOperator = SetOperator.Union
   const selectedCategories: Category[] = []
 
-  const queryCategories = queryObject.categories as string ?? ''
+  const queryCategories = (queryObject.categories as string)
+    || [queryObject.category1 as string, queryObject.category2 as string]
+        .filter(Boolean)
+        .join(',')
+    || ''
 
   if (categories.length > 0) {
     categoryMode = queryCategories.includes(';') ? SetOperator.Intersection : SetOperator.Union
@@ -125,7 +129,7 @@ export const parseIplike = (queryObject: any) => {
 }
 
 export const parseForeignSource = (queryObject: any) => {
-  const foreignSource = queryObject.foreignSource || ''
+  const foreignSource = queryObject.foreignSource || queryObject.foreignsource || ''
   const foreignId = queryObject.foreignId || ''
   const foreignSourceId = queryObject.foreignSourceId || queryObject.fsfid || ''
 
@@ -180,4 +184,98 @@ export const parseSysParams = (queryObject: any) => {
   }
 
   return null
+}
+
+const snmpParmToFieldMap: Record<string, keyof NodeQuerySnmpParams> = {
+  ifAlias: 'snmpIfAlias',
+  ifName: 'snmpIfName',
+  ifDescr: 'snmpIfDescription'
+}
+
+/**
+ * Maps legacy snmpParm/snmpParmValue/snmpParmMatchType params to NodeQuerySnmpParams.
+ * snmpParm must be one of: ifAlias, ifName, ifDescr.
+ * snmpParmMatchType=contains applies wildcard matching; default is exact match.
+ */
+export const parseSnmpParmParams = (queryObject: any): NodeQuerySnmpParams | null => {
+  const parm = queryObject.snmpParm as string || ''
+  const value = queryObject.snmpParmValue as string || ''
+  const matchTypeStr = (queryObject.snmpParmMatchType as string || '').toLowerCase()
+
+  if (!parm || !value || !snmpParmToFieldMap[parm]) {
+    return null
+  }
+
+  const snmpMatchType = matchTypeStr === 'contains' ? MatchType.Contains : MatchType.Equals
+
+  return {
+    snmpIfAlias: '',
+    snmpIfDescription: '',
+    snmpIfIndex: '',
+    snmpIfName: '',
+    snmpIfType: '',
+    snmpMatchType,
+    [snmpParmToFieldMap[parm]]: value
+  } as NodeQuerySnmpParams
+}
+
+/**
+ * Maps the legacy mib2Parm/mib2ParmValue/mib2ParmMatchType params to NodeQuerySysParams.
+ * mib2Parm must be one of: sysDescription, sysObjectId, sysContact, sysName, sysLocation.
+ */
+export const parseMib2Params = (queryObject: any): NodeQuerySysParams | null => {
+  const parm = queryObject.mib2Parm as string || ''
+  const value = queryObject.mib2ParmValue as string || ''
+  const matchTypeStr = (queryObject.mib2ParmMatchType as string || '').toLowerCase()
+
+  const validParms: Array<keyof NodeQuerySysParams> = [
+    'sysContact', 'sysDescription', 'sysLocation', 'sysName', 'sysObjectId'
+  ]
+
+  if (!parm || !value || !validParms.includes(parm as keyof NodeQuerySysParams)) {
+    return null
+  }
+
+  const sysMatchType = matchTypeStr === 'equals' ? MatchType.Equals : MatchType.Contains
+
+  return {
+    sysContact: '',
+    sysDescription: '',
+    sysLocation: '',
+    sysName: '',
+    sysObjectId: '',
+    sysMatchType,
+    [parm]: value
+  } as NodeQuerySysParams
+}
+
+/**
+ * Maps legacy maclike/snmpphysaddr params to a stripped, lowercase MAC address string
+ * suitable for wildcard FIQL matching against snmpInterface.physAddr.
+ * Colons and dashes are stripped to match the format stored in the database.
+ */
+export const parseMaclike = (queryObject: any): string | null => {
+  const mac = queryObject.maclike as string || queryObject.snmpphysaddr as string || ''
+
+  if (!mac) {
+    return null
+  }
+
+  return mac.replace(/[:-]/g, '').toLowerCase()
+}
+
+/**
+ * Maps the monitoredService param to a service name for FIQL filtering via serviceType.name.
+ * The legacy service=<id> (numeric ID) param is intentionally not supported — IDs cannot be
+ * resolved to names without an additional API call. Pages updated in PR 3 will send
+ * monitoredService=<name> instead.
+ */
+export const parseMonitoredService = (queryObject: any): string | null => {
+  const serviceName = queryObject.monitoredService as string || ''
+
+  if (!serviceName) {
+    return null
+  }
+
+  return serviceName
 }

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -49,10 +49,12 @@ export const parseCategories = (queryObject: any, categories: Category[]) => {
   let categoryMode: SetOperator = SetOperator.Union
   const selectedCategories: Category[] = []
 
+  // 'category1' + 'category2' is a legacy format for the intersection of two categories.
+  // the newer 'categories' param is preferred
   const queryCategories = (queryObject.categories as string)
     || [queryObject.category1 as string, queryObject.category2 as string]
         .filter(Boolean)
-        .join(',')
+        .join(';')
     || ''
 
   if (categories.length > 0) {

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -210,6 +210,7 @@ export const useNodeQuery = () => {
     'snmpifdescription',
     'snmpifindex',
     'snmpifname',
+    'snmpiftype',
     'snmpMatchType',
     'snmpphysaddr',
     'snmpParm',
@@ -384,6 +385,7 @@ const buildIpAddressQuery = (ipAddress?: string) => {
 const buildCategoryQuery = (selectedCategories: Category[], categoryMode: SetOperator, selectedCategories2?: Category[]) => {
   if (selectedCategories2 && selectedCategories2.length > 0) {
     // Grouped mode: union within each group, intersection between groups
+    // In this case, we ignore categoryMode
     const buildGroup = (cats: Category[]) => {
       const items = cats.map(cat => `category.id==${cat.id}`)
       if (items.length === 0) return ''
@@ -396,6 +398,7 @@ const buildCategoryQuery = (selectedCategories: Category[], categoryMode: SetOpe
     return group1 || group2
   }
 
+  // Single category group: use categoryMode to determine union or intersection
   const categoryItems = selectedCategories.map(cat => `category.id==${cat.id}`)
   if (categoryItems.length === 1) return `${categoryItems[0]}`
   if (categoryItems.length > 1) {
@@ -483,9 +486,18 @@ const buildForeignSourceQuery = (fsParams?: NodeQueryForeignSourceParams) => {
 }
 
 const buildServiceQuery = (selectedServices: string[]) => {
-  if (!selectedServices || selectedServices.length === 0) return ''
-  const items = selectedServices.map(name => `serviceType.name==${name}`)
-  if (items.length === 1) return items[0]
+  if (!selectedServices || selectedServices.length === 0) {
+    return ''
+  }
+
+  const items = selectedServices
+    .filter(name => name && name.trim().length > 0)
+    .map(name => `serviceType.name==${name}`)
+
+  if (items.length === 1) {
+    return items[0]
+  }
+
   return `(${items.join(',')})`
 }
 
@@ -552,7 +564,7 @@ const buildSysQuery = (sysParams?: NodeQuerySysParams) => {
  * May need to do additional replacements here.
  */
 export const sanitizeSearchTerm = (s?: string) => {
-  return (s || '').replace(/[,;]/, ' ')
+  return (s || '').replace(/[,;]/g, ' ')
 }
 
 export const getFiqlSetOperator = (op: SetOperator) => {

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -92,6 +92,7 @@ export const useNodeQuery = () => {
       searchTerm: '',
       categoryMode: SetOperator.Union,
       selectedCategories: [] as Category[],
+      selectedCategories2: [] as Category[],
       selectedFlows: [] as string[],
       selectedMonitoringLocations: [] as MonitoringLocation[],
       extendedSearch: getDefaultNodeQueryExtendedSearchParams()
@@ -245,10 +246,11 @@ export const useNodeQuery = () => {
 
     filter.searchTerm = parseNodeLabel(queryObject)
 
-    const { categoryMode, selectedCategories } = parseCategories(queryObject, categories)
+    const { categoryMode, selectedCategories, selectedCategories2 } = parseCategories(queryObject, categories)
     if (selectedCategories.length > 0) {
       filter.categoryMode = categoryMode
       filter.selectedCategories = selectedCategories
+      filter.selectedCategories2 = selectedCategories2
     }
 
     const location = parseMonitoringLocation(queryObject, monitoringLocations)
@@ -337,7 +339,7 @@ const buildNodeStructureQuery = (filter: NodeQueryFilter) => {
 
   const searchQuery = buildSearchQuery(searchTerm)
   const ipAddressQuery = buildIpAddressQuery(ipAddress)
-  const categoryQuery = buildCategoryQuery(filter.selectedCategories, filter.categoryMode)
+  const categoryQuery = buildCategoryQuery(filter.selectedCategories, filter.categoryMode, filter.selectedCategories2)
   const flowsQuery = buildFlowsQuery(filter.selectedFlows)
   const locationQuery = buildLocationsQuery(filter.selectedMonitoringLocations)
   const foreignSourceQuery = buildForeignSourceQuery(filter.extendedSearch.foreignSourceParams)
@@ -380,16 +382,27 @@ const buildIpAddressQuery = (ipAddress?: string) => {
   return ''
 }
 
-const buildCategoryQuery = (selectedCategories: Category[], categoryMode: SetOperator) => {
-  const categoryItems = selectedCategories.map(cat => `category.id==${cat.id}`)
+const buildCategoryQuery = (selectedCategories: Category[], categoryMode: SetOperator, selectedCategories2?: Category[]) => {
+  if (selectedCategories2 && selectedCategories2.length > 0) {
+    // Grouped mode: union within each group, intersection between groups
+    const buildGroup = (cats: Category[]) => {
+      const items = cats.map(cat => `category.id==${cat.id}`)
+      if (items.length === 0) return ''
+      if (items.length === 1) return items[0]
+      return `(${items.join(',')})`
+    }
+    const group1 = buildGroup(selectedCategories)
+    const group2 = buildGroup(selectedCategories2)
+    if (group1 && group2) return `${group1};${group2}`
+    return group1 || group2
+  }
 
-  if (categoryItems.length === 1) {
-    return `${categoryItems[0]}`
-  } else if (categoryItems.length > 1) {
+  const categoryItems = selectedCategories.map(cat => `category.id==${cat.id}`)
+  if (categoryItems.length === 1) return `${categoryItems[0]}`
+  if (categoryItems.length > 1) {
     const separator = getFiqlSetOperator(categoryMode)
     return `(${categoryItems.join(separator)})`
   }
-
   return ''
 }
 

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -31,6 +31,7 @@ import {
   NodeQuerySnmpParams,
   NodeQuerySysParams,
   QueryParameters,
+  ServiceType,
   SetOperator
 } from '@/types'
 import {
@@ -40,7 +41,7 @@ import {
   parseIplike,
   parseMaclike,
   parseMib2Params,
-  parseMonitoredService,
+  parseMonitoredServices,
   parseMonitoringLocation,
   parseNodeLabel,
   parseSnmpParams,
@@ -93,6 +94,7 @@ export const useNodeQuery = () => {
       categoryMode: SetOperator.Union,
       selectedCategories: [] as Category[],
       selectedCategories2: [] as Category[],
+      selectedServices: [] as string[],
       selectedFlows: [] as string[],
       selectedMonitoringLocations: [] as MonitoringLocation[],
       extendedSearch: getDefaultNodeQueryExtendedSearchParams()
@@ -140,9 +142,6 @@ export const useNodeQuery = () => {
         }
       }
 
-      if (extendedSearch.selectedService && extendedSearch.selectedService.length > 0) {
-        return true
-      }
     }
 
     return false
@@ -241,7 +240,7 @@ export const useNodeQuery = () => {
    *
    * @param query query object from vue-router route.query
    */
-  const buildNodeQueryFilterFromQueryString = (queryObject: any, categories: Category[], monitoringLocations: MonitoringLocation[]) => {
+  const buildNodeQueryFilterFromQueryString = (queryObject: any, categories: Category[], monitoringLocations: MonitoringLocation[], serviceTypes: ServiceType[] = []) => {
     const filter: NodeQueryFilter = getDefaultNodeQueryFilter()
 
     filter.searchTerm = parseNodeLabel(queryObject)
@@ -301,9 +300,9 @@ export const useNodeQuery = () => {
       filter.extendedSearch.snmpParams.physAddr = macAddr
     }
 
-    const serviceName = parseMonitoredService(queryObject)
-    if (serviceName) {
-      filter.extendedSearch.selectedService = serviceName
+    const serviceNames = parseMonitoredServices(queryObject, serviceTypes)
+    if (serviceNames.length > 0) {
+      filter.selectedServices = serviceNames
     }
 
     // listInterfaces: intentionally not handled — the Vue node list page has no interface-listing mode,
@@ -345,7 +344,7 @@ const buildNodeStructureQuery = (filter: NodeQueryFilter) => {
   const foreignSourceQuery = buildForeignSourceQuery(filter.extendedSearch.foreignSourceParams)
   const snmpQuery = buildSnmpQuery(filter.extendedSearch.snmpParams)
   const sysQuery = buildSysQuery(filter.extendedSearch.sysParams)
-  const serviceQuery = buildServiceQuery(filter.extendedSearch.selectedService)
+  const serviceQuery = buildServiceQuery(filter.selectedServices ?? [])
 
   // TODO: May need more search term sanitizing and/or restrict characters in the FeatherInput above
   const querySeparator = getFiqlSetOperator(SetOperator.Intersection)
@@ -483,11 +482,11 @@ const buildForeignSourceQuery = (fsParams?: NodeQueryForeignSourceParams) => {
   return ''
 }
 
-const buildServiceQuery = (selectedService?: string) => {
-  if (isValidParam(selectedService)) {
-    return `serviceType.name==${selectedService!}`
-  }
-  return ''
+const buildServiceQuery = (selectedServices: string[]) => {
+  if (!selectedServices || selectedServices.length === 0) return ''
+  const items = selectedServices.map(name => `serviceType.name==${name}`)
+  if (items.length === 1) return items[0]
+  return `(${items.join(',')})`
 }
 
 const buildSnmpQuery = (snmpParams?: NodeQuerySnmpParams) => {

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -23,6 +23,7 @@
 import { isConvertibleToInteger } from '@/lib/utils'
 import {
   Category,
+  MatchType,
   MonitoringLocation,
   NodeQueryExtendedSearchParams,
   NodeQueryFilter,
@@ -37,9 +38,13 @@ import {
   parseFlows,
   parseForeignSource,
   parseIplike,
+  parseMaclike,
+  parseMib2Params,
+  parseMonitoredService,
   parseMonitoringLocation,
   parseNodeLabel,
   parseSnmpParams,
+  parseSnmpParmParams,
   parseSysParams
 } from './queryStringParser'
 import { isIP } from 'is-ip'
@@ -133,6 +138,10 @@ export const useNodeQuery = () => {
           return true
         }
       }
+
+      if (extendedSearch.selectedService && extendedSearch.selectedService.length > 0) {
+        return true
+      }
     }
 
     return false
@@ -181,20 +190,31 @@ export const useNodeQuery = () => {
    */
   const trackedNodeQueryStringProperties = new Set([
     'categories',
+    'category1',
+    'category2',
     'flows',
+    'foreignsource',
     'ipAddress',
     'iplike',
     'listInterfaces',
+    'maclike',
+    'mib2Parm',
+    'mib2ParmValue',
+    'mib2ParmMatchType',
     'monitoredService',
     'monitoringLocation',
     'nodeLabel',
     'nodename',
+    'service',
     'snmpifalias',
     'snmpifdescription',
     'snmpifindex',
     'snmpifname',
     'snmpMatchType',
     'snmpphysaddr',
+    'snmpParm',
+    'snmpParmValue',
+    'snmpParmMatchType',
     'foreignSource',
     'foreignId',
     'fsfid',
@@ -226,44 +246,70 @@ export const useNodeQuery = () => {
     filter.searchTerm = parseNodeLabel(queryObject)
 
     const { categoryMode, selectedCategories } = parseCategories(queryObject, categories)
-
     if (selectedCategories.length > 0) {
       filter.categoryMode = categoryMode
       filter.selectedCategories = selectedCategories
     }
 
     const location = parseMonitoringLocation(queryObject, monitoringLocations)
-
     if (location) {
       filter.selectedMonitoringLocations.push(location)
     }
 
     filter.selectedFlows = parseFlows(queryObject)
 
-    // TODO: Implement ipaddress or iplike filtering
     const ip = parseIplike(queryObject)
-
     if (ip) {
       filter.extendedSearch.ipAddress = ip
     }
 
+    // Individual SNMP params take priority over legacy snmpParm/snmpParmValue
     const snmpParams = parseSnmpParams(queryObject)
-
     if (snmpParams) {
       filter.extendedSearch.snmpParams = snmpParams
+    } else {
+      const snmpParmParams = parseSnmpParmParams(queryObject)
+      if (snmpParmParams) {
+        filter.extendedSearch.snmpParams = snmpParmParams
+      }
     }
 
+    // Individual sys params take priority over legacy mib2Parm/mib2ParmValue
     const sysParams = parseSysParams(queryObject)
-
     if (sysParams) {
       filter.extendedSearch.sysParams = sysParams
+    } else {
+      const mib2Params = parseMib2Params(queryObject)
+      if (mib2Params) {
+        filter.extendedSearch.sysParams = mib2Params
+      }
     }
 
     const fsParams = parseForeignSource(queryObject)
-
     if (fsParams) {
       filter.extendedSearch.foreignSourceParams = fsParams
     }
+
+    // physAddr (MAC address) — set independently of snmpParm/snmpParams blocks
+    const macAddr = parseMaclike(queryObject)
+    if (macAddr) {
+      if (!filter.extendedSearch.snmpParams) {
+        filter.extendedSearch.snmpParams = getDefaultNodeQuerySnmpParams()
+      }
+      filter.extendedSearch.snmpParams.physAddr = macAddr
+    }
+
+    const serviceName = parseMonitoredService(queryObject)
+    if (serviceName) {
+      filter.extendedSearch.selectedService = serviceName
+    }
+
+    // listInterfaces: intentionally not handled — the Vue node list page has no interface-listing mode,
+    // and already displays the primary interface in the node table.
+    // service=<id>: numeric service ID is not resolved here; PR 3 pages will send monitoredService=<name>.
+    // TODO topology: not supported in the v2 API, out of scope.
+    // NOTE nodeId: not handled here. Once Vue Node Details (/node/:id) has parity with element/node.jsp,
+    //   update quicksearch-box.jsp to link to the Vue route instead of element/node.jsp?node={id}.
 
     return filter
   }
@@ -297,10 +343,11 @@ const buildNodeStructureQuery = (filter: NodeQueryFilter) => {
   const foreignSourceQuery = buildForeignSourceQuery(filter.extendedSearch.foreignSourceParams)
   const snmpQuery = buildSnmpQuery(filter.extendedSearch.snmpParams)
   const sysQuery = buildSysQuery(filter.extendedSearch.sysParams)
+  const serviceQuery = buildServiceQuery(filter.extendedSearch.selectedService)
 
   // TODO: May need more search term sanitizing and/or restrict characters in the FeatherInput above
   const querySeparator = getFiqlSetOperator(SetOperator.Intersection)
-  const query = [searchQuery, ipAddressQuery, foreignSourceQuery, snmpQuery, sysQuery, categoryQuery, flowsQuery, locationQuery].filter(s => s.length > 0).join(querySeparator)
+  const query = [searchQuery, ipAddressQuery, foreignSourceQuery, snmpQuery, sysQuery, categoryQuery, flowsQuery, locationQuery, serviceQuery].filter(s => s.length > 0).join(querySeparator)
 
   // additional fields to search on for main searchTerm
   // these will be added as SetOperator.Union (i.e. 'or')
@@ -376,13 +423,13 @@ const buildLocationsQuery = (selectedLocations: MonitoringLocation[]) => {
   return ''
 }
 
-const getSnmpSearchTerm = (name: string, field: any) => {
+const getSnmpSearchTerm = (name: string, field: any, wildcard = false) => {
   const fieldStr = (field as string) || ''
-
-  return `snmpInterface.${name}==${fieldStr}`
+  const searchValue = wildcard ? makeWildcard(fieldStr) : fieldStr
+  return `snmpInterface.${name}==${searchValue}`
 }
 
-const isValidParam = (value: string) => {
+const isValidParam = (value: string | undefined) => {
   return !!value && !!value.trim()
 }
 
@@ -423,20 +470,24 @@ const buildForeignSourceQuery = (fsParams?: NodeQueryForeignSourceParams) => {
   return ''
 }
 
-/**
- * Note, FIQL / SNMP search does not currently support 'like' or 'contains' matches, so we always
- * do an 'equals' (exact match) search.
- */
+const buildServiceQuery = (selectedService?: string) => {
+  if (isValidParam(selectedService)) {
+    return `serviceType.name==${selectedService!}`
+  }
+  return ''
+}
+
 const buildSnmpQuery = (snmpParams?: NodeQuerySnmpParams) => {
   if (snmpParams) {
     const arr: string[] = []
+    const wildcard = snmpParams.snmpMatchType === MatchType.Contains
 
     if (isValidParam(snmpParams.snmpIfAlias)) {
-      arr.push(getSnmpSearchTerm('ifAlias', snmpParams.snmpIfAlias))
+      arr.push(getSnmpSearchTerm('ifAlias', snmpParams.snmpIfAlias, wildcard))
     }
 
     if (isValidParam(snmpParams.snmpIfDescription)) {
-      arr.push(getSnmpSearchTerm('ifDescr', snmpParams.snmpIfDescription))
+      arr.push(getSnmpSearchTerm('ifDescr', snmpParams.snmpIfDescription, wildcard))
     }
 
     if (isValidIntegerParam('' + snmpParams.snmpIfIndex)) {
@@ -444,18 +495,22 @@ const buildSnmpQuery = (snmpParams?: NodeQuerySnmpParams) => {
     }
 
     if (isValidParam(snmpParams.snmpIfName)) {
-      arr.push(getSnmpSearchTerm('ifName', snmpParams.snmpIfName))
+      arr.push(getSnmpSearchTerm('ifName', snmpParams.snmpIfName, wildcard))
     }
 
     if (isValidIntegerParam(snmpParams.snmpIfType)) {
       arr.push(getSnmpSearchTerm('ifType', snmpParams.snmpIfType))
     }
 
+    if (isValidParam(snmpParams.physAddr)) {
+      arr.push(`snmpInterface.physAddr==*${snmpParams.physAddr!}*`)
+    }
+
     if (arr.length > 0) {
       return arr.join(';')
     }
   }
-  
+
   return ''
 }
 
@@ -467,7 +522,8 @@ const buildSysQuery = (sysParams?: NodeQuerySysParams) => {
     props.forEach(p => {
       const value = (sysParams as any)[p]
       if (isValidParam(value)) {
-        arr.push(`node.${p}==${makeWildcard(value)}`)
+        const searchValue = sysParams.sysMatchType === MatchType.Equals ? value : makeWildcard(value)
+        arr.push(`node.${p}==${searchValue}`)
       }
     })
 

--- a/ui/src/components/Nodes/utils.ts
+++ b/ui/src/components/Nodes/utils.ts
@@ -60,7 +60,7 @@ export const defaultColumns: NodeColumnSelectionItem[] = [
   { id: 'id', label: 'ID', selected: false, order: 0 },
   { id: 'label', label: 'Node Label', selected: true, order: 1 },
   { id: 'ipaddress', label: 'IP Address', selected: true, order: 2 },
-  { id: 'location', label: 'Location', selected: true, order: 3 },
+  { id: 'location', label: 'Monitoring Location', selected: true, order: 3 },
   { id: 'foreignSource', label: 'Foreign Source', selected: true, order: 4 },
   { id: 'foreignId', label: 'Foreign ID', selected: true, order: 5 },
   { id: 'sysContact', label: 'Sys Contact', selected: true, order: 6 },

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -57,8 +57,8 @@ const applyQueryFilter = (query: LocationQuery, prefs: NodePreferences | null) =
 
 const handleQuery = (prefs: NodePreferences | null) => {
   if (queryStringHasTrackedValues(route.query)) {
-    if (nodeStructureStore.categories.length === 0 || nodeStructureStore.monitoringLocations.length === 0) {
-      // Categories or locations not loaded yet — save and defer.
+    if (!nodeStructureStore.categoriesLoaded || !nodeStructureStore.monitoringLocationsLoaded) {
+      // Lists not finished loading yet — save and defer.
       pendingRouteQuery.value = { ...route.query }
     } else {
       applyQueryFilter(route.query, prefs)
@@ -70,13 +70,14 @@ const handleQuery = (prefs: NodePreferences | null) => {
   return false
 }
 
-// Re-apply any deferred query once categories and locations are both populated.
-// This handles the race between App.vue's async getCategories/getMonitoringLocations
+// Re-apply any deferred query once both lists have finished loading.
+// Handles the race between App.vue's async getCategories/getMonitoringLocations
 // and Nodes.vue mounting with query params already in the URL.
+// Note: lists may be empty (e.g. no categories configured) — loaded flags handle this correctly.
 watch(
-  [() => nodeStructureStore.categories.length, () => nodeStructureStore.monitoringLocations.length],
-  ([catLen, locLen]) => {
-    if (pendingRouteQuery.value && catLen > 0 && locLen > 0) {
+  [() => nodeStructureStore.categoriesLoaded, () => nodeStructureStore.monitoringLocationsLoaded],
+  ([catsLoaded, locsLoaded]) => {
+    if (pendingRouteQuery.value && catsLoaded && locsLoaded) {
       applyQueryFilter(pendingRouteQuery.value, loadNodePreferences())
       pendingRouteQuery.value = null
     }

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -46,7 +46,8 @@ const applyQueryFilter = (query: LocationQuery, prefs: NodePreferences | null) =
   const nodeFilter = buildNodeQueryFilterFromQueryString(
     query,
     nodeStructureStore.categories,
-    nodeStructureStore.monitoringLocations
+    nodeStructureStore.monitoringLocations,
+    nodeStructureStore.allServiceTypes
   )
   const newPrefs = {
     nodeColumns: prefs?.nodeColumns || [],
@@ -57,7 +58,7 @@ const applyQueryFilter = (query: LocationQuery, prefs: NodePreferences | null) =
 
 const handleQuery = (prefs: NodePreferences | null) => {
   if (queryStringHasTrackedValues(route.query)) {
-    if (!nodeStructureStore.categoriesLoaded || !nodeStructureStore.monitoringLocationsLoaded) {
+    if (!nodeStructureStore.categoriesLoaded || !nodeStructureStore.monitoringLocationsLoaded || !nodeStructureStore.serviceTypesLoaded) {
       // Lists not finished loading yet — save and defer.
       pendingRouteQuery.value = { ...route.query }
     } else {
@@ -75,9 +76,9 @@ const handleQuery = (prefs: NodePreferences | null) => {
 // and Nodes.vue mounting with query params already in the URL.
 // Note: lists may be empty (e.g. no categories configured) — loaded flags handle this correctly.
 watch(
-  [() => nodeStructureStore.categoriesLoaded, () => nodeStructureStore.monitoringLocationsLoaded],
-  ([catsLoaded, locsLoaded]) => {
-    if (pendingRouteQuery.value && catsLoaded && locsLoaded) {
+  [() => nodeStructureStore.categoriesLoaded, () => nodeStructureStore.monitoringLocationsLoaded, () => nodeStructureStore.serviceTypesLoaded],
+  ([catsLoaded, locsLoaded, svcTypesLoaded]) => {
+    if (pendingRouteQuery.value && catsLoaded && locsLoaded && svcTypesLoaded) {
       applyQueryFilter(pendingRouteQuery.value, loadNodePreferences())
       pendingRouteQuery.value = null
     }

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -21,7 +21,7 @@ import { loadNodePreferences } from '@/services/localStorageService'
 import { useMenuStore } from '@/stores/menuStore'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 import { BreadCrumb, NodePreferences } from '@/types'
-import { useRoute, useRouter } from 'vue-router'
+import { LocationQuery, useRoute, useRouter } from 'vue-router'
 
 const menuStore = useMenuStore()
 const nodeStructureStore = useNodeStructureStore()
@@ -38,41 +38,59 @@ const breadcrumbs = computed<BreadCrumb[]>(() => {
   ]
 })
 
+// Holds query params that arrived before categories/locations had loaded.
+// Cleared once the deferred filter is applied.
+const pendingRouteQuery = ref<LocationQuery | null>(null)
+
+const applyQueryFilter = (query: LocationQuery, prefs: NodePreferences | null) => {
+  const nodeFilter = buildNodeQueryFilterFromQueryString(
+    query,
+    nodeStructureStore.categories,
+    nodeStructureStore.monitoringLocations
+  )
+  const newPrefs = {
+    nodeColumns: prefs?.nodeColumns || [],
+    nodeFilter
+  } as NodePreferences
+  nodeStructureStore.setFromNodePreferences(newPrefs)
+}
+
 const handleQuery = (prefs: NodePreferences | null) => {
   if (queryStringHasTrackedValues(route.query)) {
-    const nodeFilter = buildNodeQueryFilterFromQueryString(route.query, nodeStructureStore.categories, nodeStructureStore.monitoringLocations)
-
-    const newPrefs = {
-      nodeColumns: prefs?.nodeColumns || [],
-      nodeFilter
-    } as NodePreferences
-
-    nodeStructureStore.setFromNodePreferences(newPrefs)
-
-    // TODO: Save prefs???
+    if (nodeStructureStore.categories.length === 0 || nodeStructureStore.monitoringLocations.length === 0) {
+      // Categories or locations not loaded yet — save and defer.
+      pendingRouteQuery.value = { ...route.query }
+    } else {
+      applyQueryFilter(route.query, prefs)
+    }
+    // Always clear the URL regardless of whether we deferred.
     router.replace({ name: 'Nodes' })
     return true
   }
-
   return false
 }
 
+// Re-apply any deferred query once categories and locations are both populated.
+// This handles the race between App.vue's async getCategories/getMonitoringLocations
+// and Nodes.vue mounting with query params already in the URL.
+watch(
+  [() => nodeStructureStore.categories.length, () => nodeStructureStore.monitoringLocations.length],
+  ([catLen, locLen]) => {
+    if (pendingRouteQuery.value && catLen > 0 && locLen > 0) {
+      applyQueryFilter(pendingRouteQuery.value, loadNodePreferences())
+      pendingRouteQuery.value = null
+    }
+  }
+)
+
 onMounted(() => {
-  // load any saved preferences
   const prefs = loadNodePreferences()
-
-  if (handleQuery(prefs)) {
-    return
-  }
-
-  if (prefs) {
-    nodeStructureStore.setFromNodePreferences(prefs)
-  }
+  if (handleQuery(prefs)) return
+  if (prefs) nodeStructureStore.setFromNodePreferences(prefs)
 })
 
-watch (() => route.query, () => {
-  const prefs = loadNodePreferences()
-  handleQuery(prefs)
+watch(() => route.query, () => {
+  handleQuery(loadNodePreferences())
 })
 </script>
   

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -55,6 +55,7 @@ onMounted(() => {
   monitoringSystemStore.getMainMonitoringSystem()
   nodeStructureStore.getCategories()
   nodeStructureStore.getMonitoringLocations()
+  nodeStructureStore.getServiceTypes()
   pluginStore.getPlugins()
 })
 </script>

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -30,6 +30,7 @@ import {
 } from './nodeService'
 import { getCategories } from './categoryService'
 import { getMonitoringLocations } from './monitoringLocationService'
+import { getServiceTypes } from './serviceTypes'
 import { getProvisionDService, putProvisionDService } from './configurationService'
 import {
   getGraphNodesNodes,
@@ -116,6 +117,7 @@ export default {
   getResourceForNode,
   getGraphDefinitionsByResourceId,
   getPlugins,
+  getServiceTypes,
   getDeviceConfigBackups,
   backupDeviceConfig,
   downloadDeviceConfigs,

--- a/ui/src/services/serviceTypes.ts
+++ b/ui/src/services/serviceTypes.ts
@@ -1,0 +1,35 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { v2 } from './axiosInstances'
+import { ServiceType } from '@/types'
+
+const getServiceTypes = async (): Promise<ServiceType[]> => {
+  try {
+    const resp = await v2.get('/nodes/service-types')
+    return resp.data as ServiceType[]
+  } catch {
+    return []
+  }
+}
+
+export { getServiceTypes }

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -256,18 +256,26 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
       if (prefs.nodeFilter.selectedCategories?.length) {
         filter.selectedCategories = [...prefs.nodeFilter.selectedCategories]
+        selectedCategories.value = prefs.nodeFilter.selectedCategories
+          .map(cat => ({ _value: cat.id, _text: cat.name } as IAutocompleteItemType))
       }
 
       if (prefs.nodeFilter.selectedCategories2?.length) {
         filter.selectedCategories2 = [...prefs.nodeFilter.selectedCategories2]
+        selectedCategories2.value = prefs.nodeFilter.selectedCategories2
+          .map(cat => ({ _value: cat.id, _text: cat.name } as IAutocompleteItemType))
       }
 
       if (prefs.nodeFilter.selectedFlows?.length) {
         filter.selectedFlows = [...prefs.nodeFilter.selectedFlows]
+        selectedFlows.value = prefs.nodeFilter.selectedFlows
+          .map(name => ({ _text: name, _value: name } as IAutocompleteItemType))
       }
 
       if (prefs.nodeFilter.selectedMonitoringLocations?.length) {
         filter.selectedMonitoringLocations = [...prefs.nodeFilter.selectedMonitoringLocations]
+        selectedMonitoringLocations.value = prefs.nodeFilter.selectedMonitoringLocations
+          .map(loc => ({ _text: loc.name, _value: loc.name, name: loc.name } as IAutocompleteItemType))
       }
 
       if (prefs.nodeFilter.extendedSearch) {

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -31,6 +31,7 @@ import {
   NodeColumnSelectionItem,
   NodePreferences,
   NodeQueryFilter,
+  ServiceType,
   SetOperator
 } from '@/types'
 import { IAutocompleteItemType } from '@featherds/autocomplete'
@@ -65,6 +66,9 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   const selectedCategories2 = ref<IAutocompleteItemType[]>([])
   const selectedFlows = ref<IAutocompleteItemType[]>([])
   const selectedMonitoringLocations = ref<IAutocompleteItemType[]>([])
+  const allServiceTypes = ref<ServiceType[]>([])
+  const serviceTypesLoaded = ref(false)
+  const selectedServices = ref<IAutocompleteItemType[]>([])
 
   const fetchCategories = async () => {
     const resp = await API.getCategories()
@@ -84,6 +88,11 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     monitoringLocationsLoaded.value = true
   }
 
+  const fetchServiceTypes = async () => {
+    allServiceTypes.value = await API.getServiceTypes()
+    serviceTypesLoaded.value = true
+  }
+
   const isAnyFilterSelected = () => {
     return (
       queryFilter.value.searchTerm?.length > 0 ||
@@ -91,6 +100,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
       (queryFilter.value.selectedCategories2?.length ?? 0) > 0 ||
       queryFilter.value.selectedFlows.length > 0 ||
       queryFilter.value.selectedMonitoringLocations.length > 0 ||
+      (queryFilter.value.selectedServices?.length ?? 0) > 0 ||
       !!queryFilter.value.extendedSearch?.ipAddress?.length ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.foreignSourceParams) ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.snmpParams) ||
@@ -213,10 +223,12 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     selectedCategories2.value = []
     selectedFlows.value = []
     selectedMonitoringLocations.value = []
+    selectedServices.value = []
 
     queryFilter.value = {
       ...filter,
-      searchTerm
+      searchTerm,
+      selectedServices: []
     }
   }
 
@@ -260,6 +272,21 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
       if (prefs.nodeFilter.extendedSearch) {
         filter.extendedSearch = { ...prefs.nodeFilter.extendedSearch }
+      }
+
+      if (prefs.nodeFilter.selectedServices?.length) {
+        // Always restore string names so the FIQL filter works regardless of load order.
+        // Building IAutocompleteItemType chip items requires allServiceTypes to be populated
+        // first; App.vue must call getServiceTypes() before setFromNodePreferences().
+        // If allServiceTypes is empty the chips won't render, but filtering still works.
+        filter.selectedServices = [...prefs.nodeFilter.selectedServices]
+        const items = prefs.nodeFilter.selectedServices
+          .map(name => {
+            const st = allServiceTypes.value.find(s => s.name === name)
+            return st ? { _value: st.id, _text: st.name } as IAutocompleteItemType : null
+          })
+          .filter((i): i is IAutocompleteItemType => i !== null)
+        selectedServices.value = items
       }
     }
 
@@ -334,6 +361,18 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value.selectedFlows = items.map((item) => item._text as string)
   }
 
+  const updateSelectedServices = (items: IAutocompleteItemType[]) => {
+    selectedServices.value = items
+    queryFilter.value.selectedServices = items.map(i => i._text as string)
+  }
+
+  const removeService = (item: IAutocompleteItemType) => {
+    selectedServices.value = selectedServices.value.filter(i => i._value !== item._value)
+    queryFilter.value.selectedServices = (queryFilter.value.selectedServices ?? []).filter(
+      n => n !== item._text
+    )
+  }
+
   const updateSelectedMonitoringLocations = async (locations: IAutocompleteItemType[]) => {
     selectedMonitoringLocations.value = locations
 
@@ -357,6 +396,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     clearAllFiltersAndSelections,
     getCategories: fetchCategories,
     getMonitoringLocations: fetchMonitoringLocations,
+    getServiceTypes: fetchServiceTypes,
     getNodePreferences,
     isAnyFilterSelected,
     resetColumnSelectionToDefault,
@@ -376,14 +416,19 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     selectedCategories2,
     selectedFlows,
     selectedMonitoringLocations,
+    allServiceTypes,
+    serviceTypesLoaded,
+    selectedServices,
     removeCategory,
     removeCategory2,
     removeExtendedSearch,
     removeFlow,
     removeMonitoringLocation,
+    removeService,
     updateSelectedCategories,
     updateSelectedCategories2,
     updateSelectedFlows,
+    updateSelectedServices,
     openColumnsDrawerModal,
     closeColumnsDrawerModal
   }

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -54,7 +54,9 @@ const getDefaultDrawerState = (): DrawerState => {
 export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   const categories = ref<Category[]>([])
   const categoryCount = computed(() => categories.value.length)
+  const categoriesLoaded = ref(false)
   const monitoringLocations = ref<MonitoringLocation[]>([])
+  const monitoringLocationsLoaded = ref(false)
   const columns = ref<NodeColumnSelectionItem[]>(defaultColumns)
   const queryFilter = ref<NodeQueryFilter>(getDefaultNodeQueryFilter())
   const drawerState = ref<DrawerState>(getDefaultDrawerState())
@@ -69,6 +71,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     if (resp) {
       categories.value = resp.category
     }
+    categoriesLoaded.value = true
   }
 
   const fetchMonitoringLocations = async () => {
@@ -77,6 +80,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     if (resp) {
       monitoringLocations.value = resp.location
     }
+    monitoringLocationsLoaded.value = true
   }
 
   const isAnyFilterSelected = () => {
@@ -320,9 +324,11 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
   return {
     categories,
+    categoriesLoaded,
     categoryCount,
     columns,
     monitoringLocations,
+    monitoringLocationsLoaded,
     queryFilter,
     drawerState,
     columnsDrawerState,

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -62,6 +62,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
   const drawerState = ref<DrawerState>(getDefaultDrawerState())
   const columnsDrawerState = ref<DrawerState>(getDefaultDrawerState())
   const selectedCategories = ref<IAutocompleteItemType[]>([])
+  const selectedCategories2 = ref<IAutocompleteItemType[]>([])
   const selectedFlows = ref<IAutocompleteItemType[]>([])
   const selectedMonitoringLocations = ref<IAutocompleteItemType[]>([])
 
@@ -87,6 +88,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     return (
       queryFilter.value.searchTerm?.length > 0 ||
       queryFilter.value.selectedCategories.length > 0 ||
+      (queryFilter.value.selectedCategories2?.length ?? 0) > 0 ||
       queryFilter.value.selectedFlows.length > 0 ||
       queryFilter.value.selectedMonitoringLocations.length > 0 ||
       !!queryFilter.value.extendedSearch?.ipAddress?.length ||
@@ -208,6 +210,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     const filter = getDefaultNodeQueryFilter()
 
     selectedCategories.value = []
+    selectedCategories2.value = []
     selectedFlows.value = []
     selectedMonitoringLocations.value = []
 
@@ -241,6 +244,10 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
       if (prefs.nodeFilter.selectedCategories?.length) {
         filter.selectedCategories = [...prefs.nodeFilter.selectedCategories]
+      }
+
+      if (prefs.nodeFilter.selectedCategories2?.length) {
+        filter.selectedCategories2 = [...prefs.nodeFilter.selectedCategories2]
       }
 
       if (prefs.nodeFilter.selectedFlows?.length) {
@@ -280,6 +287,11 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value.selectedCategories = queryFilter.value.selectedCategories.filter((c) => c.id !== item._value)
   }
 
+  const removeCategory2 = (item: IAutocompleteItemType) => {
+    selectedCategories2.value = selectedCategories2.value.filter((i) => i._value !== item._value)
+    queryFilter.value.selectedCategories2 = (queryFilter.value.selectedCategories2 ?? []).filter((c) => c.id !== item._value)
+  }
+
   const removeFlow = (item: IAutocompleteItemType) => {
     selectedFlows.value = selectedFlows.value.filter((i) => i._text !== item._text)
     queryFilter.value.selectedFlows = queryFilter.value.selectedFlows.filter((f) => f !== item._text)
@@ -301,6 +313,16 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
 
     // Also update the query filter
     queryFilter.value.selectedCategories = items.map((item) => ({
+      id: item._value as number,
+      name: item._text as string,
+      authorizedGroups: [] as string[]
+    }))
+  }
+
+  const updateSelectedCategories2 = (items: IAutocompleteItemType[]) => {
+    selectedCategories2.value = items
+
+    queryFilter.value.selectedCategories2 = items.map((item) => ({
       id: item._value as number,
       name: item._text as string,
       authorizedGroups: [] as string[]
@@ -351,13 +373,16 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     openInstancesDrawerModal,
     closeInstancesDrawerModal,
     selectedCategories,
+    selectedCategories2,
     selectedFlows,
     selectedMonitoringLocations,
     removeCategory,
+    removeCategory2,
     removeExtendedSearch,
     removeFlow,
     removeMonitoringLocation,
     updateSelectedCategories,
+    updateSelectedCategories2,
     updateSelectedFlows,
     openColumnsDrawerModal,
     closeColumnsDrawerModal

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -232,6 +232,11 @@ export interface SnmpInterface {
   poll: boolean
 }
 
+export interface ServiceType {
+  id: number
+  name: string
+}
+
 export interface IpInterface {
   ifIndex: string
   isManaged: null | string
@@ -571,7 +576,6 @@ export interface NodeQueryExtendedSearchParams {
   foreignSourceParams?: NodeQueryForeignSourceParams
   snmpParams?: NodeQuerySnmpParams
   sysParams?: NodeQuerySysParams
-  selectedService?: string
 }
 
 /** All components of a node structure query */
@@ -580,6 +584,7 @@ export interface NodeQueryFilter {
   categoryMode: SetOperator
   selectedCategories: Category[]
   selectedCategories2?: Category[]
+  selectedServices?: string[]
   selectedFlows: string[]
   selectedMonitoringLocations: MonitoringLocation[]
   extendedSearch: NodeQueryExtendedSearchParams
@@ -606,7 +611,8 @@ export enum FilterTypeEnum {
   Category = 'category',
   Category2 = 'category2',
   Flow = 'flow',
-  MonitoringLocation = 'location'
+  MonitoringLocation = 'location',
+  MonitoredService = 'monitoredService'
 }
 
 export enum Direction {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -554,6 +554,7 @@ export interface NodeQuerySnmpParams {
   snmpIfName: string
   snmpIfType: string
   snmpMatchType: MatchType
+  physAddr?: string
 }
 
 export interface NodeQuerySysParams {
@@ -562,6 +563,7 @@ export interface NodeQuerySysParams {
   sysLocation: string
   sysName: string
   sysObjectId: string
+  sysMatchType?: MatchType
 }
 
 export interface NodeQueryExtendedSearchParams {
@@ -569,6 +571,7 @@ export interface NodeQueryExtendedSearchParams {
   foreignSourceParams?: NodeQueryForeignSourceParams
   snmpParams?: NodeQuerySnmpParams
   sysParams?: NodeQuerySysParams
+  selectedService?: string
 }
 
 /** All components of a node structure query */

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -579,6 +579,7 @@ export interface NodeQueryFilter {
   searchTerm: string
   categoryMode: SetOperator
   selectedCategories: Category[]
+  selectedCategories2?: Category[]
   selectedFlows: string[]
   selectedMonitoringLocations: MonitoringLocation[]
   extendedSearch: NodeQueryExtendedSearchParams
@@ -603,6 +604,7 @@ export interface IpInterfaceInfo {
 
 export enum FilterTypeEnum {
   Category = 'category',
+  Category2 = 'category2',
   Flow = 'flow',
   MonitoringLocation = 'location'
 }

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -74,7 +74,7 @@ describe('Nodes queryStringParser test', () => {
       'parseCategories: %s',
       (title, queryObject, expectedCategoryMode, expectedCategories) => {
         const result = parseCategories(queryObject, categories)
-        expect(result).toEqual({ categoryMode: expectedCategoryMode, selectedCategories: expectedCategories })
+        expect(result).toEqual({ categoryMode: expectedCategoryMode, selectedCategories: expectedCategories, selectedCategories2: [] })
       }
     )
   })
@@ -292,32 +292,52 @@ describe('Nodes queryStringParser test', () => {
   })
 
   describe('parseCategories: category1/category2 aliases', () => {
-    test('category1 alone maps as union', () => {
+    test('category1 alone maps as union in group 1', () => {
       const result = parseCategories({ category1: 'Routers' }, categories)
       expect(result.categoryMode).toBe(SetOperator.Union)
       expect(result.selectedCategories).toEqual([categories[0]])
+      expect(result.selectedCategories2).toEqual([])
     })
 
-    test('category2 alone maps as union', () => {
+    test('category2 alone maps as union in group 1 (backwards compat)', () => {
       const result = parseCategories({ category2: 'Switches' }, categories)
       expect(result.categoryMode).toBe(SetOperator.Union)
       expect(result.selectedCategories).toEqual([categories[1]])
+      expect(result.selectedCategories2).toEqual([])
     })
 
-    test('category1 and category2 combined as intersection', () => {
+    test('category1 and category2 populate separate groups', () => {
       const result = parseCategories({ category1: 'Routers', category2: 'Switches' }, categories)
-      expect(result.categoryMode).toBe(SetOperator.Intersection)
+      expect(result.categoryMode).toBe(SetOperator.Union)
+      expect(result.selectedCategories).toEqual([categories[0]])
+      expect(result.selectedCategories2).toEqual([categories[1]])
+    })
+
+    test('category1 array and category2 array populate two groups with union within each', () => {
+      const result = parseCategories(
+        { category1: ['Routers', 'Switches'], category2: ['Production', 'Servers'] },
+        categories
+      )
       expect(result.selectedCategories).toEqual([categories[0], categories[1]])
+      expect(result.selectedCategories2).toEqual([categories[3], categories[2]])
+    })
+
+    test('category1 array alone (no category2) puts all in group 1', () => {
+      const result = parseCategories({ category1: ['Routers', 'Switches'] }, categories)
+      expect(result.selectedCategories).toEqual([categories[0], categories[1]])
+      expect(result.selectedCategories2).toEqual([])
     })
 
     test('categories param takes precedence over category1/category2', () => {
       const result = parseCategories({ categories: 'Servers', category1: 'Routers', category2: 'Switches' }, categories)
       expect(result.selectedCategories).toEqual([categories[2]])
+      expect(result.selectedCategories2).toEqual([])
     })
 
     test('unknown category1 value returns empty', () => {
       const result = parseCategories({ category1: 'NonExistent' }, categories)
       expect(result.selectedCategories).toEqual([])
+      expect(result.selectedCategories2).toEqual([])
     })
   })
 

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -28,14 +28,14 @@ import {
   parseIplike,
   parseMaclike,
   parseMib2Params,
-  parseMonitoredService,
+  parseMonitoredServices,
   parseMonitoringLocation,
   parseNodeLabel,
   parseSnmpParams,
   parseSnmpParmParams,
   parseSysParams
 } from '@/components/Nodes/hooks/queryStringParser'
-import { categories, monitoringLocations } from './utils'
+import { categories, monitoringLocations, serviceTypes } from './utils'
 import { MatchType, SetOperator } from '@/types'
 import { DEFAULT_MONITORING_LOCATION } from '@/lib/constants'
 
@@ -374,16 +374,37 @@ describe('Nodes queryStringParser test', () => {
     })
   })
 
-  describe('parseMonitoredService', () => {
-    test.each([
-      ['empty', {}, null],
-      ['monitoredService=HTTP', { monitoredService: 'HTTP' }, 'HTTP'],
-      ['monitoredService=ICMP', { monitoredService: 'ICMP' }, 'ICMP'],
-      ['empty monitoredService string', { monitoredService: '' }, null],
-      ['service numeric ID alone is not handled', { service: '1' }, null],
-      ['service and monitoredService: monitoredService wins', { monitoredService: 'HTTP', service: '1' }, 'HTTP'],
-    ]) ('parseMonitoredService: %s', (title, queryObject, expected) => {
-      expect(parseMonitoredService(queryObject)).toEqual(expected)
+  describe('parseMonitoredServices', () => {
+    test('returns [] when no service param present', () => {
+      expect(parseMonitoredServices({}, serviceTypes)).toEqual([])
+    })
+
+    test('resolves monitoredService by exact name', () => {
+      expect(parseMonitoredServices({ monitoredService: 'HTTPS' }, serviceTypes)).toEqual(['HTTPS'])
+    })
+
+    test('resolves monitoredService case-insensitively', () => {
+      expect(parseMonitoredServices({ monitoredService: 'https' }, serviceTypes)).toEqual(['HTTPS'])
+    })
+
+    test('resolves service param by exact name', () => {
+      expect(parseMonitoredServices({ service: 'HTTPS' }, serviceTypes)).toEqual(['HTTPS'])
+    })
+
+    test('resolves service param by numeric ID', () => {
+      expect(parseMonitoredServices({ service: '8' }, serviceTypes)).toEqual(['HTTPS'])
+    })
+
+    test('returns [] for unknown name', () => {
+      expect(parseMonitoredServices({ monitoredService: 'UNKNOWN' }, serviceTypes)).toEqual([])
+    })
+
+    test('returns [] for unknown numeric ID', () => {
+      expect(parseMonitoredServices({ service: '999' }, serviceTypes)).toEqual([])
+    })
+
+    test('monitoredService takes precedence over service when both present', () => {
+      expect(parseMonitoredServices({ monitoredService: 'HTTP', service: 'ICMP' }, serviceTypes)).toEqual(['HTTP'])
     })
   })
 })

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -26,9 +26,13 @@ import {
   parseFlows,
   parseForeignSource,
   parseIplike,
+  parseMaclike,
+  parseMib2Params,
+  parseMonitoredService,
   parseMonitoringLocation,
   parseNodeLabel,
   parseSnmpParams,
+  parseSnmpParmParams,
   parseSysParams
 } from '@/components/Nodes/hooks/queryStringParser'
 import { categories, monitoringLocations } from './utils'
@@ -236,5 +240,130 @@ describe('Nodes queryStringParser test', () => {
         }
       }
     )
+  })
+
+  describe('parseMib2Params', () => {
+    test.each([
+      ['sysDescription contains', { mib2Parm: 'sysDescription', mib2ParmValue: 'Linux', mib2ParmMatchType: 'contains' },
+        { sysContact: '', sysDescription: 'Linux', sysLocation: '', sysName: '', sysObjectId: '', sysMatchType: MatchType.Contains }],
+      ['sysContact equals', { mib2Parm: 'sysContact', mib2ParmValue: 'admin', mib2ParmMatchType: 'equals' },
+        { sysContact: 'admin', sysDescription: '', sysLocation: '', sysName: '', sysObjectId: '', sysMatchType: MatchType.Equals }],
+      ['sysName, match type defaults to Contains when omitted', { mib2Parm: 'sysName', mib2ParmValue: 'router' },
+        { sysContact: '', sysDescription: '', sysLocation: '', sysName: 'router', sysObjectId: '', sysMatchType: MatchType.Contains }],
+      ['sysLocation', { mib2Parm: 'sysLocation', mib2ParmValue: 'datacenter', mib2ParmMatchType: 'contains' },
+        { sysContact: '', sysDescription: '', sysLocation: 'datacenter', sysName: '', sysObjectId: '', sysMatchType: MatchType.Contains }],
+      ['sysObjectId', { mib2Parm: 'sysObjectId', mib2ParmValue: '.1.3.6.1', mib2ParmMatchType: 'equals' },
+        { sysContact: '', sysDescription: '', sysLocation: '', sysName: '', sysObjectId: '.1.3.6.1', sysMatchType: MatchType.Equals }],
+    ]) ('parseMib2Params: %s', (title, queryObject, expected) => {
+      expect(parseMib2Params(queryObject)).toEqual(expected)
+    })
+
+    test.each([
+      ['empty parm', { mib2Parm: '', mib2ParmValue: 'Linux' }],
+      ['empty value', { mib2Parm: 'sysDescription', mib2ParmValue: '' }],
+      ['invalid parm name', { mib2Parm: 'badField', mib2ParmValue: 'Linux' }],
+      ['both empty', {}],
+    ]) ('parseMib2Params: returns null for invalid input: %s', (title, queryObject) => {
+      expect(parseMib2Params(queryObject)).toBeNull()
+    })
+  })
+
+  describe('parseSnmpParmParams', () => {
+    test.each([
+      ['ifAlias equals', { snmpParm: 'ifAlias', snmpParmValue: 'Uplink', snmpParmMatchType: 'equals' },
+        { snmpIfAlias: 'Uplink', snmpIfDescription: '', snmpIfIndex: '', snmpIfName: '', snmpIfType: '', snmpMatchType: MatchType.Equals }],
+      ['ifName contains', { snmpParm: 'ifName', snmpParmValue: 'eth', snmpParmMatchType: 'contains' },
+        { snmpIfAlias: '', snmpIfDescription: '', snmpIfIndex: '', snmpIfName: 'eth', snmpIfType: '', snmpMatchType: MatchType.Contains }],
+      ['ifDescr, match type defaults to Equals when omitted', { snmpParm: 'ifDescr', snmpParmValue: 'GigabitEthernet' },
+        { snmpIfAlias: '', snmpIfDescription: 'GigabitEthernet', snmpIfIndex: '', snmpIfName: '', snmpIfType: '', snmpMatchType: MatchType.Equals }],
+    ]) ('parseSnmpParmParams: %s', (title, queryObject, expected) => {
+      expect(parseSnmpParmParams(queryObject)).toEqual(expected)
+    })
+
+    test.each([
+      ['empty parm', { snmpParm: '', snmpParmValue: 'value' }],
+      ['empty value', { snmpParm: 'ifAlias', snmpParmValue: '' }],
+      ['unsupported parm (ifIndex)', { snmpParm: 'ifIndex', snmpParmValue: '1' }],
+      ['unknown parm', { snmpParm: 'badField', snmpParmValue: 'value' }],
+      ['both empty', {}],
+    ]) ('parseSnmpParmParams: returns null for invalid input: %s', (title, queryObject) => {
+      expect(parseSnmpParmParams(queryObject)).toBeNull()
+    })
+  })
+
+  describe('parseCategories: category1/category2 aliases', () => {
+    test('category1 alone maps as union', () => {
+      const result = parseCategories({ category1: 'Routers' }, categories)
+      expect(result.categoryMode).toBe(SetOperator.Union)
+      expect(result.selectedCategories).toEqual([categories[0]])
+    })
+
+    test('category2 alone maps as union', () => {
+      const result = parseCategories({ category2: 'Switches' }, categories)
+      expect(result.categoryMode).toBe(SetOperator.Union)
+      expect(result.selectedCategories).toEqual([categories[1]])
+    })
+
+    test('category1 and category2 combined as union', () => {
+      const result = parseCategories({ category1: 'Routers', category2: 'Switches' }, categories)
+      expect(result.categoryMode).toBe(SetOperator.Union)
+      expect(result.selectedCategories).toEqual([categories[0], categories[1]])
+    })
+
+    test('categories param takes precedence over category1/category2', () => {
+      const result = parseCategories({ categories: 'Servers', category1: 'Routers', category2: 'Switches' }, categories)
+      expect(result.selectedCategories).toEqual([categories[2]])
+    })
+
+    test('unknown category1 value returns empty', () => {
+      const result = parseCategories({ category1: 'NonExistent' }, categories)
+      expect(result.selectedCategories).toEqual([])
+    })
+  })
+
+  describe('parseForeignSource: lowercase alias', () => {
+    test('foreignsource (lowercase) maps to foreignSource', () => {
+      const result = parseForeignSource({ foreignsource: 'MyFS' })
+      expect(result).toEqual({ foreignSource: 'MyFS', foreignId: '', foreignSourceId: '' })
+    })
+
+    test('foreignSource (camelCase) still works', () => {
+      const result = parseForeignSource({ foreignSource: 'MyFS' })
+      expect(result).toEqual({ foreignSource: 'MyFS', foreignId: '', foreignSourceId: '' })
+    })
+
+    test('foreignSource takes precedence over foreignsource', () => {
+      const result = parseForeignSource({ foreignSource: 'CamelFS', foreignsource: 'LowerFS' })
+      expect(result).toEqual({ foreignSource: 'CamelFS', foreignId: '', foreignSourceId: '' })
+    })
+  })
+
+  describe('parseMaclike', () => {
+    test.each([
+      ['empty', {}, null],
+      ['maclike with colons', { maclike: 'AA:BB:CC:DD:EE:FF' }, 'aabbccddeeff'],
+      ['maclike with dashes', { maclike: 'AA-BB-CC-DD-EE-FF' }, 'aabbccddeeff'],
+      ['maclike no separators', { maclike: 'AABBCCDDEEFF' }, 'aabbccddeeff'],
+      ['maclike already lowercase', { maclike: 'aabbccddeeff' }, 'aabbccddeeff'],
+      ['snmpphysaddr', { snmpphysaddr: 'AA:BB:CC:DD:EE:FF' }, 'aabbccddeeff'],
+      ['maclike takes precedence over snmpphysaddr', { maclike: '112233445566', snmpphysaddr: 'aabbccddeeff' }, '112233445566'],
+      ['partial MAC still stripped', { maclike: 'AA:BB:CC' }, 'aabbcc'],
+      ['empty maclike', { maclike: '' }, null]
+    ]) ('parseMaclike: %s', (title, queryObject, expected) => {
+      expect(parseMaclike(queryObject)).toEqual(expected)
+    })
+  })
+
+  describe('parseMonitoredService', () => {
+    test.each([
+      ['empty', {}, null],
+      ['monitoredService=HTTP', { monitoredService: 'HTTP' }, 'HTTP'],
+      ['monitoredService=ICMP', { monitoredService: 'ICMP' }, 'ICMP'],
+      ['empty monitoredService string', { monitoredService: '' }, null],
+      ['service numeric ID alone is not handled', { service: '1' }, null],
+      ['service and monitoredService: monitoredService wins', { monitoredService: 'HTTP', service: '1' }, 'HTTP'],
+    ]) ('parseMonitoredService: %s', (title, queryObject, expected) => {
+      expect(parseMonitoredService(queryObject)).toEqual(expected)
+    })
   })
 })

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -304,9 +304,9 @@ describe('Nodes queryStringParser test', () => {
       expect(result.selectedCategories).toEqual([categories[1]])
     })
 
-    test('category1 and category2 combined as union', () => {
+    test('category1 and category2 combined as intersection', () => {
       const result = parseCategories({ category1: 'Routers', category2: 'Switches' }, categories)
-      expect(result.categoryMode).toBe(SetOperator.Union)
+      expect(result.categoryMode).toBe(SetOperator.Intersection)
       expect(result.selectedCategories).toEqual([categories[0], categories[1]])
     })
 

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -595,6 +595,7 @@ describe('Nodes useNodeQuery test', () => {
       'snmpifdescription',
       'snmpifindex',
       'snmpifname',
+      'snmpiftype',
       'snmpMatchType',
       'snmpphysaddr',
       'snmpParm',

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -21,7 +21,7 @@
 ///
 
 import { describe, expect, test } from 'vitest'
-import { categories, monitoringLocations } from './utils'
+import { categories, monitoringLocations, serviceTypes } from './utils'
 import { useNodeQuery } from '@/components/Nodes/hooks/useNodeQuery'
 import { MatchType, NodeQueryFilter, SetOperator } from '@/types'
 import { DEFAULT_MONITORING_LOCATION } from '@/lib/constants'
@@ -375,10 +375,23 @@ describe('Nodes useNodeQuery test', () => {
       expect(filter.extendedSearch.snmpParams?.physAddr).toBe('aabbcc')
     })
 
-    test('monitoredService maps to extendedSearch.selectedService', () => {
-      const filter = buildNodeQueryFilterFromQueryString({ monitoredService: 'HTTP' }, categories, monitoringLocations)
+    test('monitoredService maps to selectedServices (by name)', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ monitoredService: 'HTTP' }, categories, monitoringLocations, serviceTypes)
       const expected = getDefaultNodeQueryFilter()
-      expected.extendedSearch.selectedService = 'HTTP'
+      expected.selectedServices = ['HTTP']
+      expect(filter).toEqual(expected)
+    })
+
+    test('monitoredService by numeric id maps to selectedServices', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ monitoredService: '8' }, categories, monitoringLocations, serviceTypes)
+      const expected = getDefaultNodeQueryFilter()
+      expected.selectedServices = ['HTTPS']
+      expect(filter).toEqual(expected)
+    })
+
+    test('monitoredService unknown name returns no selectedServices', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ monitoredService: 'UNKNOWN' }, categories, monitoringLocations, serviceTypes)
+      const expected = getDefaultNodeQueryFilter()
       expect(filter).toEqual(expected)
     })
   })
@@ -536,12 +549,26 @@ describe('Nodes useNodeQuery test', () => {
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: selectedService', () => {
-    test('selectedService generates serviceType.name FIQL query', () => {
+  describe('buildUpdatedNodeStructureQueryParameters: selectedServices', () => {
+    test('single selectedService generates serviceType.name FIQL query', () => {
       const filter = getDefaultNodeQueryFilter()
-      filter.extendedSearch.selectedService = 'HTTP'
+      filter.selectedServices = ['HTTP']
       const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('serviceType.name==HTTP')
+    })
+
+    test('two selectedServices generates OR FIQL query', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.selectedServices = ['HTTP', 'HTTPS']
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('(serviceType.name==HTTP,serviceType.name==HTTPS)')
+    })
+
+    test('empty selectedServices produces no FIQL query', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.selectedServices = []
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBeUndefined()
     })
   })
 

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -30,6 +30,7 @@ const {
   buildNodeQueryFilterFromQueryString,
   buildUpdatedNodeStructureQueryParameters,
   getDefaultNodeQueryFilter,
+  getDefaultNodeQuerySnmpParams,
   queryStringHasTrackedValues
 } = useNodeQuery()
 
@@ -290,6 +291,96 @@ describe('Nodes useNodeQuery test', () => {
         expect(filter).toEqual(expected)
       }
     )
+
+    test('category1 alias maps to selectedCategories', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ category1: 'Routers' }, categories, monitoringLocations)
+      const expected = getDefaultNodeQueryFilter()
+      expected.selectedCategories = [categories[0]]
+      expect(filter).toEqual(expected)
+    })
+
+    test('category2 alias maps to selectedCategories', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ category2: 'Switches' }, categories, monitoringLocations)
+      const expected = getDefaultNodeQueryFilter()
+      expected.selectedCategories = [categories[1]]
+      expect(filter).toEqual(expected)
+    })
+
+    test('foreignsource lowercase maps to foreignSourceParams', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ foreignsource: 'MyFS' }, categories, monitoringLocations)
+      const expected = getDefaultNodeQueryFilter()
+      expected.extendedSearch.foreignSourceParams = { foreignSource: 'MyFS', foreignId: '', foreignSourceId: '' }
+      expect(filter).toEqual(expected)
+    })
+
+    test('mib2Parm/mib2ParmValue maps to extendedSearch.sysParams', () => {
+      const filter = buildNodeQueryFilterFromQueryString(
+        { mib2Parm: 'sysDescription', mib2ParmValue: 'Linux', mib2ParmMatchType: 'contains' },
+        categories, monitoringLocations
+      )
+      const expected = getDefaultNodeQueryFilter()
+      expected.extendedSearch.sysParams = {
+        sysContact: '', sysDescription: 'Linux', sysLocation: '', sysName: '', sysObjectId: '',
+        sysMatchType: MatchType.Contains
+      }
+      expect(filter).toEqual(expected)
+    })
+
+    test('mib2Parm does not override explicit sysParams if both present', () => {
+      const filter = buildNodeQueryFilterFromQueryString(
+        { sysContact: 'admin', mib2Parm: 'sysDescription', mib2ParmValue: 'Linux' },
+        categories, monitoringLocations
+      )
+      // explicit sysContact should be set; mib2Parm should be ignored since sysParams already present
+      expect(filter.extendedSearch.sysParams?.sysContact).toBe('admin')
+      expect(filter.extendedSearch.sysParams?.sysDescription).toBe('')
+    })
+
+    test('snmpParm/snmpParmValue maps to extendedSearch.snmpParams', () => {
+      const filter = buildNodeQueryFilterFromQueryString(
+        { snmpParm: 'ifAlias', snmpParmValue: 'Uplink', snmpParmMatchType: 'equals' },
+        categories, monitoringLocations
+      )
+      const expected = getDefaultNodeQueryFilter()
+      expected.extendedSearch.snmpParams = {
+        snmpIfAlias: 'Uplink', snmpIfDescription: '', snmpIfIndex: '', snmpIfName: '', snmpIfType: '',
+        snmpMatchType: MatchType.Equals
+      }
+      expect(filter).toEqual(expected)
+    })
+
+    test('snmpParm does not override explicit snmpParams if both present', () => {
+      const filter = buildNodeQueryFilterFromQueryString(
+        { snmpifalias: 'existing', snmpParm: 'ifName', snmpParmValue: 'eth0' },
+        categories, monitoringLocations
+      )
+      // explicit snmpifalias should be preserved; snmpParm should be ignored
+      expect(filter.extendedSearch.snmpParams?.snmpIfAlias).toBe('existing')
+      expect(filter.extendedSearch.snmpParams?.snmpIfName).toBe('')
+    })
+
+    test('maclike maps to snmpParams.physAddr (stripped, lowercase)', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ maclike: 'AA:BB:CC:DD:EE:FF' }, categories, monitoringLocations)
+      const expected = getDefaultNodeQueryFilter()
+      expected.extendedSearch.snmpParams = { ...getDefaultNodeQuerySnmpParams(), physAddr: 'aabbccddeeff' }
+      expect(filter).toEqual(expected)
+    })
+
+    test('maclike coexists with explicit snmpParams', () => {
+      const filter = buildNodeQueryFilterFromQueryString(
+        { snmpifalias: 'Uplink', maclike: 'AA:BB:CC' },
+        categories, monitoringLocations
+      )
+      expect(filter.extendedSearch.snmpParams?.snmpIfAlias).toBe('Uplink')
+      expect(filter.extendedSearch.snmpParams?.physAddr).toBe('aabbcc')
+    })
+
+    test('monitoredService maps to extendedSearch.selectedService', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ monitoredService: 'HTTP' }, categories, monitoringLocations)
+      const expected = getDefaultNodeQueryFilter()
+      expected.extendedSearch.selectedService = 'HTTP'
+      expect(filter).toEqual(expected)
+    })
   })
 
   describe('test buildUpdatedNodeStructureQueryParameters', () => {
@@ -335,23 +426,153 @@ describe('Nodes useNodeQuery test', () => {
     )
   })
  
+  describe('buildUpdatedNodeStructureQueryParameters: sysParams match type', () => {
+    test('sysMatchType Contains uses wildcards', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.sysParams = {
+        sysContact: '',
+        sysDescription: 'Linux',
+        sysLocation: '',
+        sysName: '',
+        sysObjectId: '',
+        sysMatchType: MatchType.Contains
+      }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('node.sysDescription==*Linux*')
+    })
+
+    test('sysMatchType Equals uses no wildcards', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.sysParams = {
+        sysContact: '',
+        sysDescription: 'Linux',
+        sysLocation: '',
+        sysName: '',
+        sysObjectId: '',
+        sysMatchType: MatchType.Equals
+      }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('node.sysDescription==Linux')
+    })
+
+    test('sysMatchType undefined defaults to wildcard (Contains)', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.sysParams = {
+        sysContact: '',
+        sysDescription: 'Linux',
+        sysLocation: '',
+        sysName: '',
+        sysObjectId: ''
+      }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('node.sysDescription==*Linux*')
+    })
+  })
+
+  describe('buildUpdatedNodeStructureQueryParameters: snmpParams match type', () => {
+    test('snmpMatchType Contains uses wildcards on string fields', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.snmpParams = {
+        snmpIfAlias: 'Uplink',
+        snmpIfDescription: '',
+        snmpIfIndex: '',
+        snmpIfName: '',
+        snmpIfType: '',
+        snmpMatchType: MatchType.Contains
+      }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('snmpInterface.ifAlias==*Uplink*')
+    })
+
+    test('snmpMatchType Equals uses no wildcards', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.snmpParams = {
+        snmpIfAlias: 'Uplink',
+        snmpIfDescription: '',
+        snmpIfIndex: '',
+        snmpIfName: '',
+        snmpIfType: '',
+        snmpMatchType: MatchType.Equals
+      }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('snmpInterface.ifAlias==Uplink')
+    })
+
+    test('snmpMatchType undefined defaults to Equals (no wildcards)', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.snmpParams = {
+        snmpIfAlias: 'Uplink',
+        snmpIfDescription: '',
+        snmpIfIndex: '',
+        snmpIfName: '',
+        snmpIfType: ''
+      } as any
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('snmpInterface.ifAlias==Uplink')
+    })
+  })
+
+  describe('buildUpdatedNodeStructureQueryParameters: physAddr', () => {
+    test('physAddr generates snmpInterface.physAddr wildcard FIQL query', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.snmpParams = { ...getDefaultNodeQuerySnmpParams(), physAddr: 'aabbccddeeff' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('snmpInterface.physAddr==*aabbccddeeff*')
+    })
+
+    test('physAddr combined with ifAlias produces semicolon-joined query', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.snmpParams = {
+        snmpIfAlias: 'Uplink',
+        snmpIfDescription: '',
+        snmpIfIndex: '',
+        snmpIfName: '',
+        snmpIfType: '',
+        snmpMatchType: MatchType.Equals,
+        physAddr: 'aabbcc'
+      }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('snmpInterface.ifAlias==Uplink;snmpInterface.physAddr==*aabbcc*')
+    })
+  })
+
+  describe('buildUpdatedNodeStructureQueryParameters: selectedService', () => {
+    test('selectedService generates serviceType.name FIQL query', () => {
+      const filter = getDefaultNodeQueryFilter()
+      filter.extendedSearch.selectedService = 'HTTP'
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('serviceType.name==HTTP')
+    })
+  })
+
   describe('queryStringHasTrackedValues', () => {
     const trackedValues = [
       'categories',
+      'category1',
+      'category2',
       'flows',
+      'foreignsource',
       'ipAddress',
       'iplike',
       'listInterfaces',
+      'maclike',
+      'mib2Parm',
+      'mib2ParmValue',
+      'mib2ParmMatchType',
       'monitoredService',
       'monitoringLocation',
       'nodeLabel',
       'nodename',
+      'service',
       'snmpifalias',
       'snmpifdescription',
       'snmpifindex',
       'snmpifname',
       'snmpMatchType',
       'snmpphysaddr',
+      'snmpParm',
+      'snmpParmValue',
+      'snmpParmMatchType',
       'foreignSource',
       'foreignId',
       'fsfid',

--- a/ui/tests/components/Nodes/hooks/utils.ts
+++ b/ui/tests/components/Nodes/hooks/utils.ts
@@ -31,6 +31,12 @@ export const categories = [
   { authorizedGroups: [] as any[], id: 6, name: 'Development' }
 ]
 
+export const serviceTypes = [
+  { id: 1, name: 'HTTP' },
+  { id: 8, name: 'HTTPS' },
+  { id: 3, name: 'ICMP' }
+]
+
 export const monitoringLocations = [
   {
     geolocation: null,

--- a/ui/tests/stores/nodeStructureStore.test.ts
+++ b/ui/tests/stores/nodeStructureStore.test.ts
@@ -1,0 +1,496 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { defaultColumns } from '@/components/Nodes/utils'
+import API from '@/services'
+import { SetOperator } from '@/types'
+import { categories, monitoringLocations } from '../components/Nodes/hooks/utils'
+
+vi.mock('@/services', () => ({
+  default: {
+    getCategories: vi.fn(),
+    getMonitoringLocations: vi.fn()
+  }
+}))
+
+describe('useNodeStructureStore', () => {
+  let store: ReturnType<typeof useNodeStructureStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useNodeStructureStore()
+    vi.clearAllMocks()
+  })
+
+  // ─── Initial state ──────────────────────────────────────────────────────────
+
+  describe('initial state', () => {
+    it('has empty categories and locations', () => {
+      expect(store.categories).toEqual([])
+      expect(store.monitoringLocations).toEqual([])
+    })
+
+    it('has categoriesLoaded and monitoringLocationsLoaded false', () => {
+      expect(store.categoriesLoaded).toBe(false)
+      expect(store.monitoringLocationsLoaded).toBe(false)
+    })
+
+    it('has default columns', () => {
+      expect(store.columns).toEqual(defaultColumns)
+    })
+
+    it('has empty queryFilter', () => {
+      expect(store.queryFilter.searchTerm).toBe('')
+      expect(store.queryFilter.selectedCategories).toEqual([])
+      expect(store.queryFilter.selectedFlows).toEqual([])
+      expect(store.queryFilter.selectedMonitoringLocations).toEqual([])
+    })
+
+    it('has closed drawer states', () => {
+      expect(store.drawerState.visible).toBe(false)
+      expect(store.columnsDrawerState.visible).toBe(false)
+    })
+  })
+
+  // ─── getCategories ──────────────────────────────────────────────────────────
+
+  describe('getCategories', () => {
+    it('populates categories and sets categoriesLoaded on success', async () => {
+      vi.mocked(API.getCategories).mockResolvedValue({ category: categories, count: categories.length, offset: 0, totalCount: categories.length })
+
+      await store.getCategories()
+
+      expect(store.categories).toEqual(categories)
+      expect(store.categoriesLoaded).toBe(true)
+    })
+
+    it('sets categoriesLoaded true even when list is empty', async () => {
+      vi.mocked(API.getCategories).mockResolvedValue({ category: [], count: 0, offset: 0, totalCount: 0 })
+
+      await store.getCategories()
+
+      expect(store.categories).toEqual([])
+      expect(store.categoriesLoaded).toBe(true)
+    })
+
+    it('sets categoriesLoaded true even when API call fails', async () => {
+      vi.mocked(API.getCategories).mockResolvedValue(false)
+
+      await store.getCategories()
+
+      expect(store.categories).toEqual([])
+      expect(store.categoriesLoaded).toBe(true)
+    })
+  })
+
+  // ─── getMonitoringLocations ─────────────────────────────────────────────────
+
+  describe('getMonitoringLocations', () => {
+    it('populates locations and sets monitoringLocationsLoaded on success', async () => {
+      vi.mocked(API.getMonitoringLocations).mockResolvedValue({ location: monitoringLocations, count: monitoringLocations.length, offset: 0, totalCount: monitoringLocations.length })
+
+      await store.getMonitoringLocations()
+
+      expect(store.monitoringLocations).toEqual(monitoringLocations)
+      expect(store.monitoringLocationsLoaded).toBe(true)
+    })
+
+    it('sets monitoringLocationsLoaded true even when list is empty', async () => {
+      vi.mocked(API.getMonitoringLocations).mockResolvedValue({ location: [], count: 0, offset: 0, totalCount: 0 })
+
+      await store.getMonitoringLocations()
+
+      expect(store.monitoringLocations).toEqual([])
+      expect(store.monitoringLocationsLoaded).toBe(true)
+    })
+
+    it('sets monitoringLocationsLoaded true even when API call fails', async () => {
+      vi.mocked(API.getMonitoringLocations).mockResolvedValue(false)
+
+      await store.getMonitoringLocations()
+
+      expect(store.monitoringLocations).toEqual([])
+      expect(store.monitoringLocationsLoaded).toBe(true)
+    })
+  })
+
+  // ─── setSearchTerm ──────────────────────────────────────────────────────────
+
+  describe('setSearchTerm', () => {
+    it('updates searchTerm', async () => {
+      await store.setSearchTerm('mynode')
+
+      expect(store.queryFilter.searchTerm).toBe('mynode')
+    })
+
+    it('preserves other filter fields', async () => {
+      await store.setCategoryMode(SetOperator.Intersection)
+      await store.setSearchTerm('mynode')
+
+      expect(store.queryFilter.categoryMode).toBe(SetOperator.Intersection)
+    })
+  })
+
+  // ─── setCategoryMode ────────────────────────────────────────────────────────
+
+  describe('setCategoryMode', () => {
+    it('updates categoryMode', async () => {
+      await store.setCategoryMode(SetOperator.Intersection)
+
+      expect(store.queryFilter.categoryMode).toBe(SetOperator.Intersection)
+    })
+  })
+
+  // ─── isAnyFilterSelected ────────────────────────────────────────────────────
+
+  describe('isAnyFilterSelected', () => {
+    it('returns false on default state', () => {
+      expect(store.isAnyFilterSelected()).toBe(false)
+    })
+
+    it('returns true when searchTerm is set', async () => {
+      await store.setSearchTerm('test')
+
+      expect(store.isAnyFilterSelected()).toBe(true)
+    })
+
+    it('returns true when categories are selected', () => {
+      store.queryFilter.selectedCategories = [categories[0]]
+
+      expect(store.isAnyFilterSelected()).toBe(true)
+    })
+
+    it('returns true when flows are selected', () => {
+      store.queryFilter.selectedFlows = ['Ingress']
+
+      expect(store.isAnyFilterSelected()).toBe(true)
+    })
+
+    it('returns true when monitoring locations are selected', () => {
+      store.queryFilter.selectedMonitoringLocations = [monitoringLocations[0]]
+
+      expect(store.isAnyFilterSelected()).toBe(true)
+    })
+
+    it('returns true when ipAddress is set', async () => {
+      await store.setFilterWithIpAddress('192.168.1.1')
+
+      expect(store.isAnyFilterSelected()).toBe(true)
+    })
+
+    it('returns true when foreignSourceParams are set', async () => {
+      await store.setFilterWithForeignSourceParams('foreignSource', 'MyFS')
+
+      expect(store.isAnyFilterSelected()).toBe(true)
+    })
+
+    it('returns true when snmpParams are set', async () => {
+      await store.setFilterWithSnmpParams('snmpIfAlias', 'uplink')
+
+      expect(store.isAnyFilterSelected()).toBe(true)
+    })
+
+    it('returns true when sysParams are set', async () => {
+      await store.setFilterWithSysParams('sysName', 'router1')
+
+      expect(store.isAnyFilterSelected()).toBe(true)
+    })
+  })
+
+  // ─── clearAllFiltersAndSelections ────────────────────────────────────────────
+
+  describe('clearAllFiltersAndSelections', () => {
+    it('clears categories, flows, and locations', async () => {
+      store.selectedCategories = [{ _value: 1, _text: 'Routers' }]
+      store.selectedFlows = [{ _text: 'Ingress' }]
+      store.queryFilter.selectedCategories = [categories[0]]
+
+      await store.clearAllFiltersAndSelections()
+
+      expect(store.selectedCategories).toEqual([])
+      expect(store.selectedFlows).toEqual([])
+      expect(store.queryFilter.selectedCategories).toEqual([])
+    })
+
+    it('retains searchTerm', async () => {
+      await store.setSearchTerm('keep-me')
+      await store.clearAllFiltersAndSelections()
+
+      expect(store.queryFilter.searchTerm).toBe('keep-me')
+    })
+  })
+
+  // ─── extended search setters ─────────────────────────────────────────────────
+
+  describe('setFilterWithIpAddress', () => {
+    it('sets ipAddress', async () => {
+      await store.setFilterWithIpAddress('10.0.0.1')
+
+      expect(store.queryFilter.extendedSearch.ipAddress).toBe('10.0.0.1')
+    })
+
+    it('clears other extended search params', async () => {
+      await store.setFilterWithSnmpParams('snmpIfAlias', 'uplink')
+      await store.setFilterWithIpAddress('10.0.0.1')
+
+      expect(store.queryFilter.extendedSearch.snmpParams?.snmpIfAlias).toBe('')
+    })
+  })
+
+  describe('setFilterWithSnmpParams', () => {
+    it('sets the given snmp field', async () => {
+      await store.setFilterWithSnmpParams('snmpIfAlias', 'uplink')
+
+      expect(store.queryFilter.extendedSearch.snmpParams?.snmpIfAlias).toBe('uplink')
+    })
+
+    it('clears other extended search params', async () => {
+      await store.setFilterWithIpAddress('1.2.3.4')
+      await store.setFilterWithSnmpParams('snmpIfAlias', 'uplink')
+
+      expect(store.queryFilter.extendedSearch.ipAddress).toBe('')
+    })
+  })
+
+  describe('setFilterWithSysParams', () => {
+    it('sets the given sys field', async () => {
+      await store.setFilterWithSysParams('sysName', 'router1')
+
+      expect(store.queryFilter.extendedSearch.sysParams?.sysName).toBe('router1')
+    })
+  })
+
+  describe('setFilterWithForeignSourceParams', () => {
+    it('sets the given foreign source field', async () => {
+      await store.setFilterWithForeignSourceParams('foreignSource', 'MyFS')
+
+      expect(store.queryFilter.extendedSearch.foreignSourceParams?.foreignSource).toBe('MyFS')
+    })
+  })
+
+  describe('removeExtendedSearch', () => {
+    it('resets extendedSearch to defaults', async () => {
+      await store.setFilterWithIpAddress('1.2.3.4')
+      store.removeExtendedSearch()
+
+      expect(store.queryFilter.extendedSearch.ipAddress).toBe('')
+    })
+  })
+
+  // ─── selected item removal ───────────────────────────────────────────────────
+
+  describe('removeCategory', () => {
+    it('removes from selectedCategories and queryFilter', () => {
+      store.selectedCategories = [{ _value: 1, _text: 'Routers' }, { _value: 2, _text: 'Switches' }]
+      store.queryFilter.selectedCategories = [categories[0], categories[1]]
+
+      store.removeCategory({ _value: 1, _text: 'Routers' })
+
+      expect(store.selectedCategories).toHaveLength(1)
+      expect(store.selectedCategories[0]._value).toBe(2)
+      expect(store.queryFilter.selectedCategories).toHaveLength(1)
+      expect(store.queryFilter.selectedCategories[0].id).toBe(2)
+    })
+  })
+
+  describe('removeFlow', () => {
+    it('removes from selectedFlows and queryFilter', () => {
+      store.selectedFlows = [{ _text: 'Ingress' }, { _text: 'Egress' }]
+      store.queryFilter.selectedFlows = ['Ingress', 'Egress']
+
+      store.removeFlow({ _text: 'Ingress' })
+
+      expect(store.selectedFlows).toHaveLength(1)
+      expect(store.selectedFlows[0]._text).toBe('Egress')
+      expect(store.queryFilter.selectedFlows).toEqual(['Egress'])
+    })
+  })
+
+  describe('removeMonitoringLocation', () => {
+    it('removes from queryFilter by name', () => {
+      store.queryFilter.selectedMonitoringLocations = [monitoringLocations[0], monitoringLocations[1]]
+
+      store.removeMonitoringLocation({ _value: 'Default', name: monitoringLocations[0].name })
+
+      expect(store.queryFilter.selectedMonitoringLocations).toHaveLength(1)
+      expect(store.queryFilter.selectedMonitoringLocations[0].name).toBe(monitoringLocations[1].name)
+    })
+  })
+
+  // ─── updateSelected* ────────────────────────────────────────────────────────
+
+  describe('updateSelectedCategories', () => {
+    it('syncs selectedCategories and queryFilter.selectedCategories', () => {
+      store.updateSelectedCategories([
+        { _value: 1, _text: 'Routers' },
+        { _value: 2, _text: 'Switches' }
+      ])
+
+      expect(store.selectedCategories).toHaveLength(2)
+      expect(store.queryFilter.selectedCategories).toHaveLength(2)
+      expect(store.queryFilter.selectedCategories[0]).toMatchObject({ id: 1, name: 'Routers' })
+    })
+  })
+
+  describe('updateSelectedFlows', () => {
+    it('syncs selectedFlows and queryFilter.selectedFlows', () => {
+      store.updateSelectedFlows([{ _text: 'Ingress' }, { _text: 'Egress' }])
+
+      expect(store.selectedFlows).toHaveLength(2)
+      expect(store.queryFilter.selectedFlows).toEqual(['Ingress', 'Egress'])
+    })
+  })
+
+  describe('updateSelectedMonitoringLocations', () => {
+    beforeEach(async () => {
+      vi.mocked(API.getMonitoringLocations).mockResolvedValue({ location: monitoringLocations, count: monitoringLocations.length, offset: 0, totalCount: monitoringLocations.length })
+      await store.getMonitoringLocations()
+    })
+
+    it('maps autocomplete items to full MonitoringLocation objects', async () => {
+      await store.updateSelectedMonitoringLocations([
+        { _value: monitoringLocations[1].name, _text: monitoringLocations[1].name }
+      ])
+
+      expect(store.queryFilter.selectedMonitoringLocations).toHaveLength(1)
+      expect(store.queryFilter.selectedMonitoringLocations[0]).toEqual(monitoringLocations[1])
+    })
+
+    it('excludes items not found in the store locations list', async () => {
+      await store.updateSelectedMonitoringLocations([
+        { _value: 'NonExistent', _text: 'NonExistent' }
+      ])
+
+      expect(store.queryFilter.selectedMonitoringLocations).toHaveLength(0)
+    })
+  })
+
+  // ─── setFromNodePreferences ──────────────────────────────────────────────────
+
+  describe('setFromNodePreferences', () => {
+    it('applies columns from preferences', async () => {
+      const customColumns = [defaultColumns[0]]
+      await store.setFromNodePreferences({ nodeColumns: customColumns, nodeFilter: null as any })
+
+      expect(store.columns).toEqual(customColumns)
+    })
+
+    it('does not replace columns when preference columns are empty', async () => {
+      await store.setFromNodePreferences({ nodeColumns: [], nodeFilter: null as any })
+
+      expect(store.columns).toEqual(defaultColumns)
+    })
+
+    it('applies searchTerm from filter', async () => {
+      await store.setFromNodePreferences({
+        nodeColumns: [],
+        nodeFilter: { searchTerm: 'hello', selectedCategories: [], selectedFlows: [], selectedMonitoringLocations: [], categoryMode: SetOperator.Union, extendedSearch: { ipAddress: '', foreignSourceParams: null as any, snmpParams: null as any, sysParams: null as any } }
+      })
+
+      expect(store.queryFilter.searchTerm).toBe('hello')
+    })
+
+    it('applies selectedCategories from filter', async () => {
+      await store.setFromNodePreferences({
+        nodeColumns: [],
+        nodeFilter: { searchTerm: '', selectedCategories: [categories[0]], selectedFlows: [], selectedMonitoringLocations: [], categoryMode: SetOperator.Union, extendedSearch: { ipAddress: '', foreignSourceParams: null as any, snmpParams: null as any, sysParams: null as any } }
+      })
+
+      expect(store.queryFilter.selectedCategories).toEqual([categories[0]])
+    })
+  })
+
+  // ─── getNodePreferences ──────────────────────────────────────────────────────
+
+  describe('getNodePreferences', () => {
+    it('returns current columns and filter', async () => {
+      await store.setSearchTerm('test')
+      const prefs = await store.getNodePreferences()
+
+      expect(prefs.nodeColumns).toEqual(defaultColumns)
+      expect(prefs.nodeFilter?.searchTerm).toBe('test')
+    })
+  })
+
+  // ─── drawer state ────────────────────────────────────────────────────────────
+
+  describe('drawer state', () => {
+    it('openInstancesDrawerModal sets drawerState.visible true', () => {
+      store.openInstancesDrawerModal()
+
+      expect(store.drawerState.visible).toBe(true)
+    })
+
+    it('closeInstancesDrawerModal sets drawerState.visible false', () => {
+      store.openInstancesDrawerModal()
+      store.closeInstancesDrawerModal()
+
+      expect(store.drawerState.visible).toBe(false)
+    })
+
+    it('openColumnsDrawerModal sets columnsDrawerState.visible true', () => {
+      store.openColumnsDrawerModal()
+
+      expect(store.columnsDrawerState.visible).toBe(true)
+    })
+
+    it('closeColumnsDrawerModal sets columnsDrawerState.visible false', () => {
+      store.openColumnsDrawerModal()
+      store.closeColumnsDrawerModal()
+
+      expect(store.columnsDrawerState.visible).toBe(false)
+    })
+  })
+
+  // ─── column management ───────────────────────────────────────────────────────
+
+  describe('setNodeColumnSelection', () => {
+    it('replaces columns with provided list', async () => {
+      const subset = [defaultColumns[0]]
+      await store.setNodeColumnSelection(subset)
+
+      expect(store.columns).toEqual(subset)
+    })
+  })
+
+  describe('updateNodeColumnSelection', () => {
+    it('toggles selected state of a column by id', async () => {
+      const col = { ...defaultColumns[0], selected: false }
+      await store.updateNodeColumnSelection(col)
+
+      const updated = store.columns.find(c => c.id === col.id)
+      expect(updated?.selected).toBe(false)
+    })
+  })
+
+  describe('resetColumnSelectionToDefault', () => {
+    it('restores defaultColumns', async () => {
+      await store.setNodeColumnSelection([defaultColumns[0]])
+      await store.resetColumnSelectionToDefault()
+
+      expect(store.columns).toEqual(defaultColumns)
+    })
+  })
+})

--- a/ui/tests/stores/nodeStructureStore.test.ts
+++ b/ui/tests/stores/nodeStructureStore.test.ts
@@ -31,7 +31,8 @@ import { categories, monitoringLocations } from '../components/Nodes/hooks/utils
 vi.mock('@/services', () => ({
   default: {
     getCategories: vi.fn(),
-    getMonitoringLocations: vi.fn()
+    getMonitoringLocations: vi.fn(),
+    getServiceTypes: vi.fn()
   }
 }))
 
@@ -520,6 +521,65 @@ describe('useNodeStructureStore', () => {
       await store.resetColumnSelectionToDefault()
 
       expect(store.columns).toEqual(defaultColumns)
+    })
+  })
+
+  // ─── service types ───────────────────────────────────────────────────────────
+
+  describe('service types', () => {
+    it('loads service types on init', async () => {
+      const store = useNodeStructureStore()
+      vi.mocked(API.getServiceTypes).mockResolvedValue([{ id: 1, name: 'HTTP' }, { id: 8, name: 'HTTPS' }])
+      await store.getServiceTypes()
+      expect(store.allServiceTypes).toEqual([{ id: 1, name: 'HTTP' }, { id: 8, name: 'HTTPS' }])
+    })
+
+    it('updateSelectedServices updates selectedServices and queryFilter', () => {
+      const store = useNodeStructureStore()
+      store.updateSelectedServices([{ _value: 8, _text: 'HTTPS' }])
+      expect(store.selectedServices).toEqual([{ _value: 8, _text: 'HTTPS' }])
+      expect(store.queryFilter.selectedServices).toEqual(['HTTPS'])
+    })
+
+    it('removeService removes from selectedServices and queryFilter', () => {
+      const store = useNodeStructureStore()
+      store.updateSelectedServices([{ _value: 1, _text: 'HTTP' }, { _value: 8, _text: 'HTTPS' }])
+      store.removeService({ _value: 8, _text: 'HTTPS' })
+      expect(store.selectedServices).toEqual([{ _value: 1, _text: 'HTTP' }])
+      expect(store.queryFilter.selectedServices).toEqual(['HTTP'])
+    })
+
+    it('clearAllFiltersAndSelections clears selectedServices', async () => {
+      const store = useNodeStructureStore()
+      store.updateSelectedServices([{ _value: 8, _text: 'HTTPS' }])
+      await store.clearAllFiltersAndSelections()
+      expect(store.selectedServices).toEqual([])
+      expect(store.queryFilter.selectedServices).toEqual([])
+    })
+
+    it('setFromNodePreferences restores selectedServices after getServiceTypes', async () => {
+      const store = useNodeStructureStore()
+      vi.mocked(API.getServiceTypes).mockResolvedValue([
+        { id: 1, name: 'HTTP' },
+        { id: 8, name: 'HTTPS' }
+      ])
+      await store.getServiceTypes()
+
+      await store.setFromNodePreferences({
+        nodeColumns: [],
+        nodeFilter: {
+          searchTerm: '',
+          selectedCategories: [],
+          selectedFlows: [],
+          selectedMonitoringLocations: [],
+          categoryMode: SetOperator.Union,
+          selectedServices: ['HTTPS'],
+          extendedSearch: { ipAddress: '', foreignSourceParams: null as any, snmpParams: null as any, sysParams: null as any }
+        }
+      })
+
+      expect(store.selectedServices).toEqual([{ _value: 8, _text: 'HTTPS' }])
+      expect(store.queryFilter.selectedServices).toEqual(['HTTPS'])
     })
   })
 })

--- a/ui/tests/stores/nodeStructureStore.test.ts
+++ b/ui/tests/stores/nodeStructureStore.test.ts
@@ -224,12 +224,14 @@ describe('useNodeStructureStore', () => {
   describe('clearAllFiltersAndSelections', () => {
     it('clears categories, flows, and locations', async () => {
       store.selectedCategories = [{ _value: 1, _text: 'Routers' }]
+      store.selectedCategories2 = [{ _value: 2, _text: 'Switches' }]
       store.selectedFlows = [{ _text: 'Ingress' }]
       store.queryFilter.selectedCategories = [categories[0]]
 
       await store.clearAllFiltersAndSelections()
 
       expect(store.selectedCategories).toEqual([])
+      expect(store.selectedCategories2).toEqual([])
       expect(store.selectedFlows).toEqual([])
       expect(store.queryFilter.selectedCategories).toEqual([])
     })
@@ -315,6 +317,20 @@ describe('useNodeStructureStore', () => {
     })
   })
 
+  describe('removeCategory2', () => {
+    it('removes from selectedCategories2 and queryFilter', () => {
+      store.selectedCategories2 = [{ _value: 1, _text: 'Routers' }, { _value: 2, _text: 'Switches' }]
+      store.queryFilter.selectedCategories2 = [categories[0], categories[1]]
+
+      store.removeCategory2({ _value: 1, _text: 'Routers' })
+
+      expect(store.selectedCategories2).toHaveLength(1)
+      expect(store.selectedCategories2[0]._value).toBe(2)
+      expect(store.queryFilter.selectedCategories2).toHaveLength(1)
+      expect(store.queryFilter.selectedCategories2![0].id).toBe(2)
+    })
+  })
+
   describe('removeFlow', () => {
     it('removes from selectedFlows and queryFilter', () => {
       store.selectedFlows = [{ _text: 'Ingress' }, { _text: 'Egress' }]
@@ -351,6 +367,19 @@ describe('useNodeStructureStore', () => {
       expect(store.selectedCategories).toHaveLength(2)
       expect(store.queryFilter.selectedCategories).toHaveLength(2)
       expect(store.queryFilter.selectedCategories[0]).toMatchObject({ id: 1, name: 'Routers' })
+    })
+  })
+
+  describe('updateSelectedCategories2', () => {
+    it('syncs selectedCategories2 and queryFilter.selectedCategories2', () => {
+      store.updateSelectedCategories2([
+        { _value: 3, _text: 'Servers' },
+        { _value: 4, _text: 'Production' }
+      ])
+
+      expect(store.selectedCategories2).toHaveLength(2)
+      expect(store.queryFilter.selectedCategories2).toHaveLength(2)
+      expect(store.queryFilter.selectedCategories2![0]).toMatchObject({ id: 3, name: 'Servers' })
     })
   })
 


### PR DESCRIPTION
We are replacing the legacy JSP Node List (`element/nodeList.htm`) page with a new Vue UI page, currently known as the `Structured Node List` page.

One final thing we've needed to do is to make sure links from other pages back to the node list page will work correctly with the new page. Those links can contains query string filter parameters to filter the node list.

We previously did work to handle some of these. This PR does the rest of the work to handle all of them. Some work in the Nodes v2 Rest API was also needed to handle some cases which were not fully handled by the FIQL -> Criteria processing.

Once this PR is merged, a 2nd PR will be done which actually relinks all existing links to the legacy node list page to the new Vue page, and will also remove the legacy page.

We handle the `category1/category2` filtering from the Surveillance View. The filter will be union within category sets, then intersection between category sets. I.e.:

`(category1Item || category1Item || category1Item) && (category2Item || category2Item || category2Item)`

The UI has been updated to allow an optional 2nd category. If needed we could add more category sets.

Added full support for monitored service filtering, including accepting different query params and adding to the UI filters.

Fixed various issues re case-insensitive filtering and various other things.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-16118
