### PR TITLE
NMS-19849: Add Vmware Datastore Collections for vCenter datastore capacity

### DIFF
--- a/docs/modules/reference/nav.adoc
+++ b/docs/modules/reference/nav.adoc
@@ -32,6 +32,7 @@
 ** xref:performance-data-collection/collectors/tca.adoc[]
 ** xref:performance-data-collection/collectors/vmware.adoc[]
 ** xref:performance-data-collection/collectors/vmware-cim.adoc[]
+** xref:performance-data-collection/collectors/vmware-datastore.adoc[]
 ** xref:performance-data-collection/collectors/wsman.adoc[]
 ** xref:performance-data-collection/collectors/xml.adoc[]
 ** xref:performance-data-collection/collectors/xml-examples.adoc[]

--- a/docs/modules/reference/pages/performance-data-collection/collectors/vmware-datastore.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/vmware-datastore.adoc
@@ -72,9 +72,8 @@ Graphs are defined in `$\{OPENNMS_HOME}/etc/snmp-graph.properties.d/vmware-datas
 | Attribute
 | Description
 
-| name
-| Display name of the datastore (also used as the resource label).
-
+| vmwareDatastoreCapacityName
+| Display name of the datastore (used as the resource label).
 | type
 | Datastore type: `VMFS`, `NFS`, `NFS41`, `vsan`, `VVOL`, etc.
 

--- a/docs/modules/reference/pages/performance-data-collection/collectors/vmware-datastore.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/vmware-datastore.adoc
@@ -1,0 +1,98 @@
+
+= VMware datastore capacity
+:description: Reference for the datastore capacity attributes that VmwareCollector emits for each VMware HostSystem in OpenNMS {page-component-title}.
+
+The xref:performance-data-collection/collectors/vmware.adoc[VmwareCollector] emits a multi-instance resource for each datastore a HostSystem mounts, alongside the performance counters it already collects.
+The values come from `Datastore.summary`, a property on the managed object, rather than from vCenter's PerformanceManager — so capacity numbers reflect what vCenter reports at collection time, not a 5-minute averaged sample.
+
+Datastore data is collected automatically for every host imported by the VMware requisition handler, scoped to the datastores that host mounts.
+A datastore mounted by multiple hosts is collected once per host, under each host's resource tree.
+No additional operator setup is required.
+
+== When this group runs
+
+The shipped `default-HostSystem6` and `default-HostSystem7` collections include a `<vmware-group>` with `resourceType="vmwareDatastoreCapacity"`.
+When VmwareCollector iterates a host's configured groups, that resource type triggers the datastore dispatch instead of a PerformanceManager query.
+Removing the group from a custom collection disables datastore collection for hosts using that collection.
+
+The group is only valid inside HostSystem collections.
+If it appears in a VirtualMachine collection (or any non-HostSystem managed entity), the collector logs a warning and skips it.
+
+== Resource layout
+
+Per host:
+
+[source]
+----
+share/rrd/snmp/{nodeId}/vmwareDatastoreCapacity/{datastoreMoid}/
+  DsCapacity.rrd  DsFreeSpace.rrd  DsUsed.rrd  DsUsedPct.rrd
+  DsUncommitted.rrd  DsOvercommitted.rrd  DsAccessible.rrd  DsMultiHost.rrd
+  strings.properties   (DsType, DsUrl, vmwareDatastoreCapacityName)
+----
+
+The resource type is registered globally via `$\{OPENNMS_HOME}/etc/resource-types.d/vmware-datastore-resource.xml`.
+Graphs are defined in `$\{OPENNMS_HOME}/etc/snmp-graph.properties.d/vmware-datastore-graph.properties`.
+
+== Numeric attributes (gauges)
+
+[options="header"]
+[cols="2,4"]
+|===
+| Attribute
+| Description
+
+| capacity
+| Total size of the datastore in bytes, as reported by vCenter.
+
+| freeSpace
+| Free space in bytes.
+
+| used
+| Computed as `capacity - freeSpace`.
+
+| usedPct
+| Integer percent of capacity in use (0-100).
+  Returns `0` if `capacity` is `0`.
+
+| uncommitted
+| Bytes promised by thin-provisioned virtual disks but not yet written.
+  Coerced to `0` when vCenter does not report a value.
+
+| overcommittedBytes
+| Computed as `max(0, used + uncommitted - capacity)`.
+  Non-zero values indicate the datastore is at risk if thin-provisioned VMs grow into their full provisioned size.
+
+| accessible
+| `1` if vCenter reports the datastore as accessible at collection time, `0` otherwise.
+
+| multipleHostAccess
+| `1` if the datastore is mounted by more than one host, `0` otherwise.
+  Coerced to `0` if vCenter does not report a value.
+|===
+
+== String attributes
+
+[options="header"]
+[cols="2,4"]
+|===
+| Attribute
+| Description
+
+| name
+| Display name of the datastore (also used as the resource label).
+
+| type
+| Datastore type: `VMFS`, `NFS`, `NFS41`, `vsan`, `VVOL`, etc.
+
+| url
+| Datastore URL (for example, `ds:///vmfs/volumes/<uuid>/`).
+|===
+
+== Notes on behavior
+
+A datastore mounted by multiple hosts is collected once per host that mounts it.
+The data lands under each host's resource tree, so the same datastore appears as multiple resources across the UI.
+This is intentional — datastore data follows the same node-centric layout as every other VMware metric in OpenNMS — but it can produce noticeable duplication on large clusters with heavily shared SAN or NFS storage.
+
+A non-numeric `type` on any of the numeric attributes (for example, configuring `<attrib name="capacity" alias="DsCapacity" type="string"/>`) results in a warning and the value is not persisted.
+Configure the numeric attributes as `Gauge` or `Counter`.

--- a/docs/modules/reference/pages/performance-data-collection/collectors/vmware-datastore.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/vmware-datastore.adoc
@@ -2,21 +2,15 @@
 = VMware datastore capacity
 :description: Reference for the datastore capacity attributes that VmwareCollector emits for each VMware HostSystem in OpenNMS {page-component-title}.
 
-The xref:performance-data-collection/collectors/vmware.adoc[VmwareCollector] emits a multi-instance resource for each datastore a HostSystem mounts, alongside the performance counters it already collects.
-The values come from `Datastore.summary`, a property on the managed object, rather than from vCenter's PerformanceManager — so capacity numbers reflect what vCenter reports at collection time, not a 5-minute averaged sample.
+The xref:performance-data-collection/collectors/vmware.adoc[VmwareCollector] emits a multi-instance resource for each datastore a HostSystem mounts, alongside the performance counters it already collects. The values come from `Datastore.summary`, a property on the managed object, rather than from vCenter's PerformanceManager — so capacity numbers reflect what vCenter reports at collection time, not a 5-minute averaged sample.
 
-Datastore data is collected automatically for every host imported by the VMware requisition handler, scoped to the datastores that host mounts.
-A datastore mounted by multiple hosts is collected once per host, under each host's resource tree.
-No additional operator setup is required.
+Datastore data is collected automatically for every host imported by the VMware requisition handler, scoped to the datastores that host mounts. A datastore mounted by multiple hosts is collected once per host, under each host's resource tree.
 
 == When this group runs
 
-The shipped `default-HostSystem6` and `default-HostSystem7` collections include a `<vmware-group>` with `resourceType="vmwareDatastoreCapacity"`.
-When VmwareCollector iterates a host's configured groups, that resource type triggers the datastore dispatch instead of a PerformanceManager query.
-Removing the group from a custom collection disables datastore collection for hosts using that collection.
+The shipped `default-HostSystem6` and `default-HostSystem7` collections include a `<vmware-group>` with `resourceType="vmwareDatastoreCapacity"`. When VmwareCollector iterates a host's configured groups, that resource type triggers the datastore dispatch instead of a PerformanceManager query. Removing the group from a custom collection disables datastore collection for hosts using that collection.
 
-The group is only valid inside HostSystem collections.
-If it appears in a VirtualMachine collection (or any non-HostSystem managed entity), the collector logs a warning and skips it.
+The group is only valid inside HostSystem collections. If it appears in a VirtualMachine collection (or any non-HostSystem managed entity), the collector logs a warning and skips it.
 
 == Resource layout
 
@@ -88,11 +82,3 @@ Graphs are defined in `$\{OPENNMS_HOME}/etc/snmp-graph.properties.d/vmware-datas
 | Datastore URL (for example, `ds:///vmfs/volumes/<uuid>/`).
 |===
 
-== Notes on behavior
-
-A datastore mounted by multiple hosts is collected once per host that mounts it.
-The data lands under each host's resource tree, so the same datastore appears as multiple resources across the UI.
-This is intentional — datastore data follows the same node-centric layout as every other VMware metric in OpenNMS — but it can produce noticeable duplication on large clusters with heavily shared SAN or NFS storage.
-
-A non-numeric `type` on any of the numeric attributes (for example, configuring `<attrib name="capacity" alias="DsCapacity" type="string"/>`) results in a warning and the value is not persisted.
-Configure the numeric attributes as `Gauge` or `Counter`.

--- a/docs/modules/reference/pages/performance-data-collection/collectors/vmware-datastore.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/vmware-datastore.adoc
@@ -72,8 +72,9 @@ Graphs are defined in `$\{OPENNMS_HOME}/etc/snmp-graph.properties.d/vmware-datas
 | Attribute
 | Description
 
-| vmwareDatastoreCapacityName
-| Display name of the datastore (used as the resource label).
+| name
+| Display name of the datastore (also used as the resource label).
+
 | type
 | Datastore type: `VMFS`, `NFS`, `NFS41`, `vsan`, `VVOL`, etc.
 

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,6 +67,9 @@ import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import com.google.common.base.Strings;
+import com.vmware.vim25.DatastoreSummary;
+import com.vmware.vim25.mo.Datastore;
+import com.vmware.vim25.mo.HostSystem;
 import com.vmware.vim25.mo.ManagedEntity;
 
 /**
@@ -84,6 +89,47 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
             new SimpleEntry<>(VmwareImporter.VMWARE_COLLECTION_KEY, VmwareCollection.class),
             new SimpleEntry<>(VmwareImporter.VMWARE_SERVER_KEY, VmwareServer.class))
             .collect(Collectors.toMap((e) -> e.getKey(), (e) -> e.getValue())));
+
+    /** Resource type that triggers datastore-capacity dispatch instead of the PerformanceManager path. */
+    static final String DATASTORE_RESOURCE_TYPE = "vmwareDatastoreCapacity";
+
+    // Per-attribute extractors against Datastore.summary. Package-private for tests.
+    static final Map<String, ToLongFunction<DatastoreSummary>> DATASTORE_NUMERIC_EXTRACTORS;
+    static final Map<String, Function<DatastoreSummary, String>> DATASTORE_STRING_EXTRACTORS;
+
+    static {
+        final Map<String, ToLongFunction<DatastoreSummary>> numeric = new HashMap<>();
+        numeric.put("capacity", DatastoreSummary::getCapacity);
+        numeric.put("freeSpace", DatastoreSummary::getFreeSpace);
+        numeric.put("used", s -> s.getCapacity() - s.getFreeSpace());
+        numeric.put("usedPct", s -> {
+            final long cap = s.getCapacity();
+            return cap > 0L ? ((cap - s.getFreeSpace()) * 100L) / cap : 0L;
+        });
+        numeric.put("uncommitted", s -> {
+            final Long u = s.getUncommitted();
+            return u == null ? 0L : u.longValue();
+        });
+        numeric.put("overcommittedBytes", s -> {
+            final long cap = s.getCapacity();
+            final long used = cap - s.getFreeSpace();
+            final Long u = s.getUncommitted();
+            final long unc = u == null ? 0L : u.longValue();
+            return Math.max(0L, used + unc - cap);
+        });
+        numeric.put("accessible", s -> s.isAccessible() ? 1L : 0L);
+        numeric.put("multipleHostAccess", s -> {
+            final Boolean b = s.getMultipleHostAccess();
+            return b != null && b ? 1L : 0L;
+        });
+        DATASTORE_NUMERIC_EXTRACTORS = Collections.unmodifiableMap(numeric);
+
+        final Map<String, Function<DatastoreSummary, String>> string = new HashMap<>();
+        string.put("name", DatastoreSummary::getName);
+        string.put("type", DatastoreSummary::getType);
+        string.put("url", DatastoreSummary::getUrl);
+        DATASTORE_STRING_EXTRACTORS = Collections.unmodifiableMap(string);
+    }
 
     /**
      * the node dao object for retrieving assets
@@ -214,7 +260,7 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
             return builder.build();
         }
 
-        try (final VmwareViJavaAccess vmwareViJavaAccess = new VmwareViJavaAccess(vmwareServer)) {
+        try (final VmwareViJavaAccess vmwareViJavaAccess = createVmwareViJavaAccess(vmwareServer)) {
             vmwareViJavaAccess.connect(ParameterMap.getKeyedInteger(parameters, "timeout", VmwareViJavaAccess.DEFAULT_TIMEOUT));
             final ManagedEntity managedEntity = vmwareViJavaAccess.getManagedEntityByManagedObjectId(vmwareManagedObjectId);
             VmwarePerformanceValues vmwarePerformanceValues = null;
@@ -226,6 +272,10 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
             }
             for (final VmwareGroup vmwareGroup : collection.getVmwareGroup()) {
                 final NodeLevelResource nodeResource = new NodeLevelResource(agent.getNodeId());
+                if (DATASTORE_RESOURCE_TYPE.equals(vmwareGroup.getResourceType())) {
+                    collectDatastoreCapacity(agent, builder, nodeResource, vmwareViJavaAccess, vmwareManagedObjectId, vmwareGroup);
+                    continue;
+                }
                 if ("node".equalsIgnoreCase(vmwareGroup.getResourceType())) {
                     // single instance value
                     for (final Attrib attrib : vmwareGroup.getAttrib()) {
@@ -290,6 +340,108 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
     }
 
     /**
+     * Walks the datastores this HostSystem mounts and emits a multi-instance resource
+     * per datastore keyed by managed object id. Attribute names recognized in the
+     * configured group map directly to fields on {@code Datastore.summary}:
+     *
+     * Numeric: {@code capacity}, {@code freeSpace}, {@code used}, {@code usedPct},
+     *          {@code uncommitted}, {@code overcommittedBytes}, {@code accessible},
+     *          {@code multipleHostAccess}.
+     *
+     * String:  {@code name}, {@code type}, {@code url}.
+     *
+     * Looks the HostSystem up explicitly by moid because {@link
+     * VmwareViJavaAccess#getManagedEntityByManagedObjectId(String)} returns the
+     * abstract base class. If the moid does not refer to a HostSystem on the
+     * server, getDatastores() will fail and the per-datastore loop is skipped.
+     */
+    private void collectDatastoreCapacity(final CollectionAgent agent,
+                                          final CollectionSetBuilder builder,
+                                          final NodeLevelResource nodeResource,
+                                          final VmwareViJavaAccess vmwareViJavaAccess,
+                                          final String vmwareManagedObjectId,
+                                          final VmwareGroup vmwareGroup) {
+        final HostSystem hostSystem = vmwareViJavaAccess.getHostSystemByManagedObjectId(vmwareManagedObjectId);
+        if (hostSystem == null) {
+            logger.warn("VmwareCollector: could not resolve HostSystem for managed object id '{}'; skipping datastore group '{}'.",
+                    vmwareManagedObjectId, vmwareGroup.getName());
+            return;
+        }
+
+        final Datastore[] datastores;
+        try {
+            datastores = hostSystem.getDatastores();
+        } catch (final Exception e) {
+            logger.warn("VmwareCollector: error enumerating datastores for host '{}': {}",
+                    hostSystem.getName(), e.getMessage());
+            return;
+        }
+        if (datastores == null || datastores.length == 0) {
+            logger.debug("VmwareCollector: host '{}' has no mounted datastores; skipping group '{}'.",
+                    hostSystem.getName(), vmwareGroup.getName());
+            return;
+        }
+
+        for (final Datastore ds : datastores) {
+            final String moid = ds.getMOR().getVal();
+
+            final DatastoreSummary summary;
+            try {
+                summary = ds.getSummary();
+            } catch (final Exception e) {
+                logger.warn("VmwareCollector: error reading summary for datastore '{}' ({}): {}",
+                        ds.getName(), moid, e.getMessage());
+                continue;
+            }
+            if (summary == null) {
+                logger.debug("VmwareCollector: null summary for datastore '{}' ({}); skipping.",
+                        ds.getName(), moid);
+                continue;
+            }
+
+            final Resource resource = new DeferredGenericTypeResource(nodeResource,
+                    vmwareGroup.getResourceType(), moid);
+
+            // Resource label property — UI uses this via resourceLabel="${<resourceType>Name}".
+            final String label = summary.getName() == null ? moid : summary.getName();
+            builder.withStringAttribute(resource, vmwareGroup.getName(),
+                    vmwareGroup.getResourceType() + "Name", label);
+
+            for (final Attrib attrib : vmwareGroup.getAttrib()) {
+                final String name = attrib.getName();
+                if (DATASTORE_NUMERIC_EXTRACTORS.containsKey(name)) {
+                    try {
+                        final long value = DATASTORE_NUMERIC_EXTRACTORS.get(name).applyAsLong(summary);
+                        final AttributeType type = attrib.getType();
+                        if (type.isNumeric()) {
+                            builder.withNumericAttribute(resource, vmwareGroup.getName(),
+                                    attrib.getAlias(), value, type);
+                        } else {
+                            logger.warn("VmwareCollector: numeric attribute '{}' (alias '{}') in group '{}' is configured with non-numeric type '{}'; skipping. Configure type as Gauge or Counter.",
+                                    name, attrib.getAlias(), vmwareGroup.getName(), type);
+                        }
+                    } catch (final Exception e) {
+                        logger.debug("VmwareCollector: failed to extract '{}' from datastore '{}' ({}): {}",
+                                name, ds.getName(), moid, e.getMessage());
+                    }
+                } else if (DATASTORE_STRING_EXTRACTORS.containsKey(name)) {
+                    try {
+                        final String value = DATASTORE_STRING_EXTRACTORS.get(name).apply(summary);
+                        builder.withStringAttribute(resource, vmwareGroup.getName(),
+                                attrib.getAlias(), value == null ? "" : value);
+                    } catch (final Exception e) {
+                        logger.debug("VmwareCollector: failed to extract '{}' from datastore '{}' ({}): {}",
+                                name, ds.getName(), moid, e.getMessage());
+                    }
+                } else {
+                    logger.warn("VmwareCollector: unknown datastore attribute '{}' configured in group '{}'; ignoring.",
+                            name, vmwareGroup.getName());
+                }
+            }
+        }
+    }
+
+    /**
      * Returns the Rrd repository for this object.
      *
      * @param collectionName the collection's name
@@ -307,5 +459,11 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
      */
     public void setNodeDao(NodeDao nodeDao) {
         m_nodeDao = nodeDao;
+    }
+
+    // Factory seam to allow tests to substitute a mocked VmwareViJavaAccess
+    // without pulling in mockito-inline for constructor mocking.
+    protected VmwareViJavaAccess createVmwareViJavaAccess(final VmwareServer vmwareServer) {
+        return new VmwareViJavaAccess(vmwareServer);
     }
 }

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
@@ -372,9 +372,9 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
         try {
             datastores = hostSystem.getDatastores();
         } catch (final Exception e) {
-            logger.warn("VmwareCollector: error enumerating datastores for host '{}': {}",
-                    hostSystem.getName(), e.getMessage());
+            logger.warn("VmwareCollector: error enumerating datastores for host '{}'.", hostSystem.getName(), e);
             return;
+        }
         }
         if (datastores == null || datastores.length == 0) {
             logger.debug("VmwareCollector: host '{}' has no mounted datastores; skipping group '{}'.",

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
@@ -375,7 +375,6 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
             logger.warn("VmwareCollector: error enumerating datastores for host '{}'.", hostSystem.getName(), e);
             return;
         }
-        }
         if (datastores == null || datastores.length == 0) {
             logger.debug("VmwareCollector: host '{}' has no mounted datastores; skipping group '{}'.",
                     hostSystem.getName(), vmwareGroup.getName());
@@ -391,7 +390,6 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
             } catch (final Exception e) {
                 logger.warn("VmwareCollector: error reading summary for datastore '{}' ({}).", ds.getName(), moid, e);
                 continue;
-            }
             }
             if (summary == null) {
                 logger.debug("VmwareCollector: null summary for datastore '{}' ({}); skipping.",

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
@@ -350,10 +350,10 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
      *
      * String:  {@code name}, {@code type}, {@code url}.
      *
-     * Looks the HostSystem up explicitly by moid because {@link
-     * VmwareViJavaAccess#getManagedEntityByManagedObjectId(String)} returns the
-     * abstract base class. If the moid does not refer to a HostSystem on the
-     * server, getDatastores() will fail and the per-datastore loop is skipped.
+     * Looks the HostSystem up explicitly by moid because
+     * VmwareViJavaAccess.getManagedEntityByManagedObjectId returns the abstract
+     * base class. If the moid does not refer to a HostSystem on the server,
+     * getDatastores() will fail and the per-datastore loop is skipped.
      */
     private void collectDatastoreCapacity(final CollectionAgent agent,
                                           final CollectionSetBuilder builder,

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCollector.java
@@ -389,9 +389,9 @@ public class VmwareCollector extends AbstractRemoteServiceCollector {
             try {
                 summary = ds.getSummary();
             } catch (final Exception e) {
-                logger.warn("VmwareCollector: error reading summary for datastore '{}' ({}): {}",
-                        ds.getName(), moid, e.getMessage());
+                logger.warn("VmwareCollector: error reading summary for datastore '{}' ({}).", ds.getName(), moid, e);
                 continue;
+            }
             }
             if (summary == null) {
                 logger.debug("VmwareCollector: null summary for datastore '{}' ({}); skipping.",

--- a/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/collectd/VmwareCollectorDatastoreCollectTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/collectd/VmwareCollectorDatastoreCollectTest.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.collectd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.rmi.RemoteException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.netmgt.collectd.vmware.vijava.VmwarePerformanceValues;
+import org.opennms.netmgt.collection.api.AttributeType;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+import org.opennms.netmgt.collection.api.ResourceTypeMapper;
+import org.opennms.netmgt.collection.support.AbstractCollectionSetVisitor;
+import org.opennms.netmgt.collection.support.IndexStorageStrategy;
+import org.opennms.netmgt.collection.support.PersistAllSelectorStrategy;
+import org.opennms.netmgt.config.datacollection.PersistenceSelectorStrategy;
+import org.opennms.netmgt.config.datacollection.ResourceType;
+import org.opennms.netmgt.config.datacollection.StorageStrategy;
+import org.opennms.netmgt.config.vmware.VmwareServer;
+import org.opennms.netmgt.config.vmware.vijava.Attrib;
+import org.opennms.netmgt.config.vmware.vijava.VmwareCollection;
+import org.opennms.netmgt.config.vmware.vijava.VmwareGroup;
+import org.opennms.netmgt.provision.service.vmware.VmwareImporter;
+import org.opennms.protocols.vmware.VmwareViJavaAccess;
+
+import com.vmware.vim25.DatastoreSummary;
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.mo.Datastore;
+import com.vmware.vim25.mo.HostSystem;
+
+/**
+ * Exercises {@link VmwareCollector#collect}'s datastore-capacity dispatch
+ * against a mocked {@link VmwareViJavaAccess} and a mock HostSystem. Datastore
+ * sizes mirror the test vCenter (vcsa0.dagonships.com): one small NFS volume,
+ * one mid VMFS volume, one large VMFS volume modeled on
+ * {@code ArkhamHost1Datastore} (4 TB capacity, ~27.7% used).
+ *
+ * Only the datastore branch is exercised here. The performance-counter path
+ * is mocked with an empty {@link VmwarePerformanceValues}, so the perf-group
+ * branch contributes nothing.
+ */
+public class VmwareCollectorDatastoreCollectTest {
+
+    private static final String HOST_MOID = "host-104";
+
+    private VmwareViJavaAccess mockAccess;
+    private VmwareCollector collector;
+    private CollectionAgent agent;
+    private VmwareServer server;
+    private VmwareCollection collection;
+    private HostSystem hostSystem;
+
+    @Before
+    public void setUp() throws Exception {
+        ResourceTypeMapper.getInstance().setResourceTypeMapper(VmwareCollectorDatastoreCollectTest::resourceTypeFor);
+
+        mockAccess = mock(VmwareViJavaAccess.class);
+        collector = new VmwareCollector() {
+            @Override
+            protected VmwareViJavaAccess createVmwareViJavaAccess(final VmwareServer ignored) {
+                return mockAccess;
+            }
+        };
+
+        agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(42);
+
+        server = new VmwareServer();
+        server.setHostname("vcsa0.example.com");
+        server.setUsername("user");
+        server.setPassword("pass");
+
+        // Empty perf values so the performance-counter group branch is a no-op
+        // even if the test collection includes such groups.
+        final VmwarePerformanceValues emptyPerf = mock(VmwarePerformanceValues.class);
+        when(mockAccess.queryPerformanceValues(any())).thenReturn(emptyPerf);
+
+        // HostSystem the collector resolves via the runtime-attributes managed object id.
+        hostSystem = mock(HostSystem.class);
+        when(hostSystem.getName()).thenReturn("esxi-mgmt-01");
+        // Both lookups: the perf-counter path uses the generic ManagedEntity lookup
+        // (queryPerformanceValues works against any entity), and the datastore path
+        // re-resolves the typed HostSystem to access HostSystem.getDatastores().
+        when(mockAccess.getManagedEntityByManagedObjectId(HOST_MOID)).thenReturn(hostSystem);
+        when(mockAccess.getHostSystemByManagedObjectId(HOST_MOID)).thenReturn(hostSystem);
+
+        collection = buildDatastoreOnlyCollection();
+    }
+
+    private static ResourceType resourceTypeFor(final String name) {
+        final ResourceType rt = new ResourceType();
+        rt.setName(name);
+        final StorageStrategy ss = new StorageStrategy();
+        ss.setClazz(IndexStorageStrategy.class.getName());
+        rt.setStorageStrategy(ss);
+        final PersistenceSelectorStrategy pss = new PersistenceSelectorStrategy();
+        pss.setClazz(PersistAllSelectorStrategy.class.getName());
+        rt.setPersistenceSelectorStrategy(pss);
+        return rt;
+    }
+
+    @Test
+    public void hostWithNoMountedDatastoresProducesSucceededEmptyCollectionSet() throws Exception {
+        when(hostSystem.getDatastores()).thenReturn(new Datastore[0]);
+
+        final CollectionSet result = collector.collect(agent, buildParameters());
+
+        assertEquals(CollectionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(0, collect(result).resources.size());
+    }
+
+    @Test
+    public void hostGetDatastoresThrowsLeavesCollectionSucceededWithNoDatastoreData() throws Exception {
+        when(hostSystem.getDatastores()).thenThrow(new RemoteException("boom"));
+
+        final CollectionSet result = collector.collect(agent, buildParameters());
+
+        // The datastore group fails but the overall collection still completes;
+        // performance-counter groups (none here) would still have run.
+        assertEquals(CollectionStatus.SUCCEEDED, result.getStatus());
+        assertEquals(0, collect(result).resources.size());
+    }
+
+    @Test
+    public void happyPathCollectsAllHostMountedDatastoresWithExpectedAttributes() throws Exception {
+        final Datastore small = mockDatastore("datastore-1003", "iso-library",
+                250_000_000_000L, 50_000_000_000L, null, "NFS", "nfs://nas/iso/", true, Boolean.TRUE);
+        final Datastore medium = mockDatastore("datastore-1002", "production-vol",
+                2_198_000_000_000L, 1_100_000_000_000L, 200_000_000_000L, "VMFS",
+                "ds:///vmfs/volumes/def/", true, Boolean.TRUE);
+        // ArkhamHost1Datastore: 4TB / 2.891TB free → 1.109TB used → 27% (integer truncation).
+        final Datastore large = mockDatastore("datastore-1001", "ArkhamHost1Datastore",
+                4_000_000_000_000L, 2_891_000_000_000L, 0L, "VMFS",
+                "ds:///vmfs/volumes/abc/", true, Boolean.FALSE);
+
+        when(hostSystem.getDatastores()).thenReturn(new Datastore[]{small, medium, large});
+
+        final CollectionSet result = collector.collect(agent, buildParameters());
+
+        assertEquals(CollectionStatus.SUCCEEDED, result.getStatus());
+        final Captured captured = collect(result);
+        assertEquals(3, captured.resources.size());
+        assertTrue(captured.resources.contains("datastore-1001"));
+        assertTrue(captured.resources.contains("datastore-1002"));
+        assertTrue(captured.resources.contains("datastore-1003"));
+
+        // Spot-check the large datastore (ArkhamHost1Datastore-shaped).
+        assertEquals(4_000_000_000_000L, captured.numericFor("datastore-1001", "DsCapacity"));
+        assertEquals(2_891_000_000_000L, captured.numericFor("datastore-1001", "DsFreeSpace"));
+        assertEquals(1_109_000_000_000L, captured.numericFor("datastore-1001", "DsUsed"));
+        assertEquals(27L, captured.numericFor("datastore-1001", "DsUsedPct"));
+        assertEquals(0L, captured.numericFor("datastore-1001", "DsUncommitted"));
+        assertEquals(0L, captured.numericFor("datastore-1001", "DsOvercommitted"));
+        assertEquals(1L, captured.numericFor("datastore-1001", "DsAccessible"));
+        assertEquals(0L, captured.numericFor("datastore-1001", "DsMultiHost"));
+        assertEquals("VMFS", captured.stringFor("datastore-1001", "DsType"));
+        assertEquals("ds:///vmfs/volumes/abc/", captured.stringFor("datastore-1001", "DsUrl"));
+        assertEquals("ArkhamHost1Datastore",
+                captured.stringFor("datastore-1001", "vmwareDatastoreCapacityName"));
+
+        // Medium: uncommitted non-null; used + unc < capacity so overcommit floors at 0.
+        assertEquals(200_000_000_000L, captured.numericFor("datastore-1002", "DsUncommitted"));
+        assertEquals(0L, captured.numericFor("datastore-1002", "DsOvercommitted"));
+        assertEquals(1L, captured.numericFor("datastore-1002", "DsMultiHost"));
+
+        // Small: null uncommitted → 0; 250G / 50G free = 80% used.
+        assertEquals(0L, captured.numericFor("datastore-1003", "DsUncommitted"));
+        assertEquals(80L, captured.numericFor("datastore-1003", "DsUsedPct"));
+        assertEquals("NFS", captured.stringFor("datastore-1003", "DsType"));
+    }
+
+    @Test
+    public void perDatastoreSummaryFailureIsIsolated() throws Exception {
+        final Datastore good = mockDatastore("datastore-2001", "good",
+                1_000_000L, 250_000L, 0L, "VMFS", "ds:///good/", true, Boolean.FALSE);
+        final Datastore bad = mockDatastoreWithSummaryThrow("datastore-2002", "bad");
+        final Datastore alsoGood = mockDatastore("datastore-2003", "also-good",
+                500_000L, 100_000L, 0L, "VMFS", "ds:///also/", true, Boolean.FALSE);
+
+        when(hostSystem.getDatastores()).thenReturn(new Datastore[]{good, bad, alsoGood});
+
+        final CollectionSet result = collector.collect(agent, buildParameters());
+
+        assertEquals(CollectionStatus.SUCCEEDED, result.getStatus());
+        final Captured captured = collect(result);
+        assertEquals(2, captured.resources.size());
+        assertTrue(captured.resources.contains("datastore-2001"));
+        assertTrue(captured.resources.contains("datastore-2003"));
+        assertNull(captured.numerics.get("datastore-2002"));
+    }
+
+    // -------- helpers --------
+
+    private Map<String, Object> buildParameters() {
+        final Map<String, Object> p = new HashMap<>();
+        p.put(VmwareImporter.VMWARE_COLLECTION_KEY, collection);
+        p.put(VmwareImporter.METADATA_MANAGEMENT_SERVER, "vcsa0.example.com");
+        p.put(VmwareImporter.METADATA_MANAGED_OBJECT_ID, HOST_MOID);
+        p.put(VmwareImporter.VMWARE_SERVER_KEY, server);
+        return p;
+    }
+
+    private VmwareCollection buildDatastoreOnlyCollection() {
+        final VmwareCollection c = new VmwareCollection();
+        final VmwareGroup g = new VmwareGroup();
+        g.setName("vmwareDatastoreCapacity");
+        g.setResourceType("vmwareDatastoreCapacity");
+        g.setAttrib(new Attrib[]{
+                attrib("capacity", "DsCapacity", AttributeType.GAUGE),
+                attrib("freeSpace", "DsFreeSpace", AttributeType.GAUGE),
+                attrib("used", "DsUsed", AttributeType.GAUGE),
+                attrib("usedPct", "DsUsedPct", AttributeType.GAUGE),
+                attrib("uncommitted", "DsUncommitted", AttributeType.GAUGE),
+                attrib("overcommittedBytes", "DsOvercommitted", AttributeType.GAUGE),
+                attrib("accessible", "DsAccessible", AttributeType.GAUGE),
+                attrib("multipleHostAccess", "DsMultiHost", AttributeType.GAUGE),
+                attrib("type", "DsType", AttributeType.STRING),
+                attrib("url", "DsUrl", AttributeType.STRING),
+        });
+        c.setVmwareGroup(new VmwareGroup[]{g});
+        return c;
+    }
+
+    private static Attrib attrib(final String name, final String alias, final AttributeType type) {
+        final Attrib a = new Attrib();
+        a.setName(name);
+        a.setAlias(alias);
+        a.setType(type);
+        return a;
+    }
+
+    private static Datastore mockDatastore(final String moid, final String name,
+                                            final long capacity, final long freeSpace,
+                                            final Long uncommitted, final String type,
+                                            final String url, final boolean accessible,
+                                            final Boolean multipleHostAccess) {
+        final Datastore ds = mock(Datastore.class);
+        final ManagedObjectReference mor = mock(ManagedObjectReference.class);
+        when(mor.getVal()).thenReturn(moid);
+        when(ds.getMOR()).thenReturn(mor);
+        when(ds.getName()).thenReturn(name);
+
+        final DatastoreSummary summary = mock(DatastoreSummary.class);
+        when(summary.getCapacity()).thenReturn(capacity);
+        when(summary.getFreeSpace()).thenReturn(freeSpace);
+        when(summary.getUncommitted()).thenReturn(uncommitted);
+        when(summary.getName()).thenReturn(name);
+        when(summary.getType()).thenReturn(type);
+        when(summary.getUrl()).thenReturn(url);
+        when(summary.isAccessible()).thenReturn(accessible);
+        when(summary.getMultipleHostAccess()).thenReturn(multipleHostAccess);
+        when(ds.getSummary()).thenReturn(summary);
+        return ds;
+    }
+
+    private static Datastore mockDatastoreWithSummaryThrow(final String moid, final String name) {
+        final Datastore ds = mock(Datastore.class);
+        final ManagedObjectReference mor = mock(ManagedObjectReference.class);
+        when(mor.getVal()).thenReturn(moid);
+        when(ds.getMOR()).thenReturn(mor);
+        when(ds.getName()).thenReturn(name);
+        when(ds.getSummary()).thenThrow(new RuntimeException("summary unavailable"));
+        return ds;
+    }
+
+    private static Captured collect(final CollectionSet set) {
+        final Captured c = new Captured();
+        set.visit(new AbstractCollectionSetVisitor() {
+            private String current;
+
+            @Override
+            public void visitResource(final CollectionResource resource) {
+                current = resource.getInstance();
+                if (current != null) {
+                    c.resources.add(current);
+                    c.numerics.computeIfAbsent(current, k -> new HashMap<>());
+                    c.strings.computeIfAbsent(current, k -> new HashMap<>());
+                }
+            }
+
+            @Override
+            public void visitAttribute(final CollectionAttribute attribute) {
+                if (current == null) {
+                    return;
+                }
+                if (attribute.getType() != null && attribute.getType().isNumeric()) {
+                    c.numerics.get(current).put(attribute.getName(),
+                            attribute.getNumericValue() == null ? null : attribute.getNumericValue().longValue());
+                } else {
+                    c.strings.get(current).put(attribute.getName(), attribute.getStringValue());
+                }
+            }
+        });
+        return c;
+    }
+
+    private static class Captured {
+        final Set<String> resources = new HashSet<>();
+        final Map<String, Map<String, Long>> numerics = new HashMap<>();
+        final Map<String, Map<String, String>> strings = new HashMap<>();
+
+        long numericFor(final String resource, final String attr) {
+            return numerics.get(resource).get(attr);
+        }
+
+        String stringFor(final String resource, final String attr) {
+            return strings.get(resource).get(attr);
+        }
+    }
+}

--- a/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/collectd/VmwareCollectorDatastoreExtractorTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/collectd/VmwareCollectorDatastoreExtractorTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.collectd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.vmware.vim25.DatastoreSummary;
+
+/**
+ * Unit tests for {@link VmwareCollector}'s datastore extractor maps.
+ *
+ * These are the per-attribute extraction lambdas that convert a
+ * {@link DatastoreSummary} into the numeric and string values the collector
+ * persists when a {@code <vmware-group>} has
+ * {@code resourceType="vmwareDatastoreCapacity"}. Edge cases worth pinning:
+ *
+ * - {@code usedPct} when {@code capacity == 0} (avoid divide-by-zero).
+ * - {@code uncommitted} when {@code summary.getUncommitted()} returns null
+ *   (some datastores don't report it; we coerce to 0).
+ * - {@code overcommittedBytes} when used + uncommitted does not exceed
+ *   capacity (must floor at 0, never negative).
+ * - {@code multipleHostAccess} when the boxed Boolean is null.
+ * - String extractors when the underlying field is null (returned as null;
+ *   the collect path is what coerces to ""). This test verifies the
+ *   extractor itself doesn't fabricate a value.
+ */
+public class VmwareCollectorDatastoreExtractorTest {
+
+    private static DatastoreSummary summaryOf(final long capacity,
+                                              final long freeSpace,
+                                              final Long uncommitted,
+                                              final boolean accessible,
+                                              final Boolean multipleHostAccess) {
+        final DatastoreSummary s = mock(DatastoreSummary.class);
+        when(s.getCapacity()).thenReturn(capacity);
+        when(s.getFreeSpace()).thenReturn(freeSpace);
+        when(s.getUncommitted()).thenReturn(uncommitted);
+        when(s.isAccessible()).thenReturn(accessible);
+        when(s.getMultipleHostAccess()).thenReturn(multipleHostAccess);
+        return s;
+    }
+
+    @Test
+    public void capacityAndFreeSpaceArePassedThrough() {
+        final DatastoreSummary s = summaryOf(1000L, 250L, 0L, true, Boolean.FALSE);
+        assertEquals(1000L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("capacity").applyAsLong(s));
+        assertEquals(250L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("freeSpace").applyAsLong(s));
+    }
+
+    @Test
+    public void usedIsCapacityMinusFreeSpace() {
+        final DatastoreSummary s = summaryOf(1000L, 250L, 0L, true, Boolean.FALSE);
+        assertEquals(750L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("used").applyAsLong(s));
+    }
+
+    @Test
+    public void usedPctIsIntegerPercent() {
+        final DatastoreSummary s = summaryOf(1000L, 250L, 0L, true, Boolean.FALSE);
+        assertEquals(75L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("usedPct").applyAsLong(s));
+    }
+
+    @Test
+    public void usedPctHandlesZeroCapacity() {
+        // Empty/uninitialised datastore — avoid divide-by-zero.
+        final DatastoreSummary s = summaryOf(0L, 0L, 0L, false, Boolean.FALSE);
+        assertEquals(0L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("usedPct").applyAsLong(s));
+    }
+
+    @Test
+    public void uncommittedNonNull() {
+        final DatastoreSummary s = summaryOf(1000L, 250L, 100L, true, Boolean.FALSE);
+        assertEquals(100L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("uncommitted").applyAsLong(s));
+    }
+
+    @Test
+    public void uncommittedNullCoercesToZero() {
+        final DatastoreSummary s = summaryOf(1000L, 250L, null, true, Boolean.FALSE);
+        assertEquals(0L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("uncommitted").applyAsLong(s));
+    }
+
+    @Test
+    public void overcommittedFloorsAtZeroWhenUsedPlusUncommittedFitsCapacity() {
+        // capacity 1000, free 500 → used 500, uncommitted 200 → used+unc=700, < 1000.
+        final DatastoreSummary s = summaryOf(1000L, 500L, 200L, true, Boolean.FALSE);
+        assertEquals(0L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("overcommittedBytes").applyAsLong(s));
+    }
+
+    @Test
+    public void overcommittedReportsExcessWhenUsedPlusUncommittedExceedsCapacity() {
+        // capacity 1000, free 100 → used 900, uncommitted 300 → used+unc=1200, excess 200.
+        final DatastoreSummary s = summaryOf(1000L, 100L, 300L, true, Boolean.FALSE);
+        assertEquals(200L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("overcommittedBytes").applyAsLong(s));
+    }
+
+    @Test
+    public void overcommittedNullUncommittedFloorsAtUsedMinusCapacity() {
+        // uncommitted null → 0 → used 900, capacity 1000 → max(0, 900 - 1000) = 0
+        final DatastoreSummary s = summaryOf(1000L, 100L, null, true, Boolean.FALSE);
+        assertEquals(0L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("overcommittedBytes").applyAsLong(s));
+    }
+
+    @Test
+    public void accessibleBooleanMapsToOneOrZero() {
+        assertEquals(1L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("accessible")
+                .applyAsLong(summaryOf(1L, 1L, 0L, true, Boolean.FALSE)));
+        assertEquals(0L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("accessible")
+                .applyAsLong(summaryOf(1L, 1L, 0L, false, Boolean.FALSE)));
+    }
+
+    @Test
+    public void multipleHostAccessBooleanMapsToOneOrZero() {
+        assertEquals(1L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("multipleHostAccess")
+                .applyAsLong(summaryOf(1L, 1L, 0L, true, Boolean.TRUE)));
+        assertEquals(0L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("multipleHostAccess")
+                .applyAsLong(summaryOf(1L, 1L, 0L, true, Boolean.FALSE)));
+    }
+
+    @Test
+    public void multipleHostAccessNullCoercesToZero() {
+        assertEquals(0L, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.get("multipleHostAccess")
+                .applyAsLong(summaryOf(1L, 1L, 0L, true, null)));
+    }
+
+    @Test
+    public void stringExtractorsPassThroughNonNull() {
+        final DatastoreSummary s = mock(DatastoreSummary.class);
+        when(s.getName()).thenReturn("ArkhamHost1Datastore");
+        when(s.getType()).thenReturn("VMFS");
+        when(s.getUrl()).thenReturn("ds:///vmfs/volumes/abc/");
+        assertEquals("ArkhamHost1Datastore", VmwareCollector.DATASTORE_STRING_EXTRACTORS.get("name").apply(s));
+        assertEquals("VMFS", VmwareCollector.DATASTORE_STRING_EXTRACTORS.get("type").apply(s));
+        assertEquals("ds:///vmfs/volumes/abc/", VmwareCollector.DATASTORE_STRING_EXTRACTORS.get("url").apply(s));
+    }
+
+    @Test
+    public void stringExtractorsReturnNullWithoutFabricating() {
+        final DatastoreSummary s = mock(DatastoreSummary.class);
+        // Mockito returns null by default for non-stubbed methods on object-returning calls.
+        assertNull(VmwareCollector.DATASTORE_STRING_EXTRACTORS.get("name").apply(s));
+        assertNull(VmwareCollector.DATASTORE_STRING_EXTRACTORS.get("type").apply(s));
+        assertNull(VmwareCollector.DATASTORE_STRING_EXTRACTORS.get("url").apply(s));
+    }
+
+    @Test
+    public void numericExtractorMapContainsAllExpectedKeys() {
+        assertTrue(VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.containsKey("capacity"));
+        assertTrue(VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.containsKey("freeSpace"));
+        assertTrue(VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.containsKey("used"));
+        assertTrue(VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.containsKey("usedPct"));
+        assertTrue(VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.containsKey("uncommitted"));
+        assertTrue(VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.containsKey("overcommittedBytes"));
+        assertTrue(VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.containsKey("accessible"));
+        assertTrue(VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.containsKey("multipleHostAccess"));
+        assertEquals(8, VmwareCollector.DATASTORE_NUMERIC_EXTRACTORS.size());
+    }
+
+    @Test
+    public void stringExtractorMapContainsAllExpectedKeys() {
+        assertTrue(VmwareCollector.DATASTORE_STRING_EXTRACTORS.containsKey("name"));
+        assertTrue(VmwareCollector.DATASTORE_STRING_EXTRACTORS.containsKey("type"));
+        assertTrue(VmwareCollector.DATASTORE_STRING_EXTRACTORS.containsKey("url"));
+        assertEquals(3, VmwareCollector.DATASTORE_STRING_EXTRACTORS.size());
+    }
+}

--- a/opennms-base-assembly/src/main/filtered/etc/resource-types.d/vmware-datastore-resource.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/resource-types.d/vmware-datastore-resource.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
 
 <!--
-  Resource type for the VmwareDatastoreCollector.
+  Resource type for the VmwareCollector.
 
+  Datastore properties retrieved via Datastore.summary do not vary across
   Datastore properties retrieved via Datastore.summary do not vary across
   vCenter API versions, so this resource type is intentionally not
   version-prefixed (unlike the vmware6*/vmware7* per-counter groups).

--- a/opennms-base-assembly/src/main/filtered/etc/resource-types.d/vmware-datastore-resource.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/resource-types.d/vmware-datastore-resource.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<!--
+  Resource type for the VmwareDatastoreCollector.
+
+  Datastore properties retrieved via Datastore.summary do not vary across
+  vCenter API versions, so this resource type is intentionally not
+  version-prefixed (unlike the vmware6*/vmware7* per-counter groups).
+-->
+
+<resource-types>
+
+  <resourceType name="vmwareDatastoreCapacity"
+                label="VMware Datastore Capacity"
+                resourceLabel="${vmwareDatastoreCapacityName}">
+    <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+    <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+  </resourceType>
+
+</resource-types>

--- a/opennms-base-assembly/src/main/filtered/etc/resource-types.d/vmware-datastore-resource.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/resource-types.d/vmware-datastore-resource.xml
@@ -4,7 +4,6 @@
   Resource type for the VmwareCollector.
 
   Datastore properties retrieved via Datastore.summary do not vary across
-  Datastore properties retrieved via Datastore.summary do not vary across
   vCenter API versions, so this resource type is intentionally not
   version-prefixed (unlike the vmware6*/vmware7* per-counter groups).
 -->

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware-datastore-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware-datastore-graph.properties
@@ -1,7 +1,7 @@
 reports=vmware.datastoreCapacity
 
 # Single combined "is this datastore healthy" graph rendered once per datastore
-# resource collected by the VmwareDatastoreCollector.  Stacks used + uncommitted
+# resource collected by the VmwareCollector.  Stacks used + uncommitted
 # bytes against a capacity reference line; over-commit shown as a separate line
 # when nonzero; numeric usedPct / accessible / multipleHostAccess values are
 # emitted as legend annotations rather than separate curves.

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware-datastore-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware-datastore-graph.properties
@@ -1,0 +1,41 @@
+reports=vmware.datastoreCapacity
+
+# Single combined "is this datastore healthy" graph rendered once per datastore
+# resource collected by the VmwareDatastoreCollector.  Stacks used + uncommitted
+# bytes against a capacity reference line; over-commit shown as a separate line
+# when nonzero; numeric usedPct / accessible / multipleHostAccess values are
+# emitted as legend annotations rather than separate curves.
+report.vmware.datastoreCapacity.name=VMware Datastore Capacity
+report.vmware.datastoreCapacity.columns=DsCapacity, DsUsed, DsFreeSpace, DsUncommitted, DsOvercommitted, DsUsedPct, DsAccessible, DsMultiHost
+report.vmware.datastoreCapacity.propertiesValues=vmwareDatastoreCapacityName
+report.vmware.datastoreCapacity.type=vmwareDatastoreCapacity
+report.vmware.datastoreCapacity.command=--title="VMware Datastore: {vmwareDatastoreCapacityName}" \
+ --vertical-label="Bytes" \
+ --base=1024 \
+ DEF:cap={rrd1}:DsCapacity:AVERAGE \
+ DEF:used={rrd2}:DsUsed:AVERAGE \
+ DEF:free={rrd3}:DsFreeSpace:AVERAGE \
+ DEF:unc={rrd4}:DsUncommitted:AVERAGE \
+ DEF:over={rrd5}:DsOvercommitted:AVERAGE \
+ DEF:pct={rrd6}:DsUsedPct:AVERAGE \
+ DEF:acc={rrd7}:DsAccessible:AVERAGE \
+ DEF:mh={rrd8}:DsMultiHost:AVERAGE \
+ AREA:used#3a78c2:"Used        " \
+ GPRINT:used:LAST:"Cur\\: %8.2lf%s" \
+ GPRINT:used:AVERAGE:"Avg\\: %8.2lf%s" \
+ GPRINT:used:MAX:"Max\\: %8.2lf%s\\n" \
+ STACK:unc#f6b352:"Uncommitted " \
+ GPRINT:unc:LAST:"Cur\\: %8.2lf%s" \
+ GPRINT:unc:AVERAGE:"Avg\\: %8.2lf%s" \
+ GPRINT:unc:MAX:"Max\\: %8.2lf%s\\n" \
+ LINE2:cap#d62728:"Capacity    " \
+ GPRINT:cap:LAST:"Cur\\: %8.2lf%s\\n" \
+ LINE2:over#8e44ad:"Overcommit  " \
+ GPRINT:over:LAST:"Cur\\: %8.2lf%s" \
+ GPRINT:over:MAX:"Max\\: %8.2lf%s\\n" \
+ COMMENT:"\\n" \
+ GPRINT:pct:LAST:"Used %%       Cur\\: %5.1lf %%" \
+ GPRINT:pct:AVERAGE:" Avg\\: %5.1lf %%" \
+ GPRINT:pct:MAX:" Max\\: %5.1lf %%\\n" \
+ GPRINT:acc:LAST:"Accessible\\: %1.0lf" \
+ GPRINT:mh:LAST:"   MultiHost\\: %1.0lf\\n"

--- a/opennms-base-assembly/src/main/filtered/etc/vmware-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/vmware-datacollection-config.xml
@@ -380,6 +380,24 @@
         <attrib name="datastore.totalWriteLatency.average" alias="DaStTlWeLyAvg" type="Gauge"/>
         <attrib name="datastore.write.average" alias="DaStWeAvg" type="Gauge"/>
       </vmware-group>
+      <!--
+        Datastore capacity, free space, and provisioning state for the
+        datastores this host mounts. Dispatched by VmwareCollector when
+        resourceType="vmwareDatastoreCapacity"; values come from
+        Datastore.summary rather than PerformanceManager.
+      -->
+      <vmware-group name="vmwareDatastoreCapacity" resourceType="vmwareDatastoreCapacity">
+        <attrib name="capacity"           alias="DsCapacity"      type="Gauge"/>
+        <attrib name="freeSpace"          alias="DsFreeSpace"     type="Gauge"/>
+        <attrib name="used"               alias="DsUsed"          type="Gauge"/>
+        <attrib name="usedPct"            alias="DsUsedPct"       type="Gauge"/>
+        <attrib name="uncommitted"        alias="DsUncommitted"   type="Gauge"/>
+        <attrib name="overcommittedBytes" alias="DsOvercommitted" type="Gauge"/>
+        <attrib name="accessible"         alias="DsAccessible"    type="Gauge"/>
+        <attrib name="multipleHostAccess" alias="DsMultiHost"     type="Gauge"/>
+        <attrib name="type"               alias="DsType"          type="string"/>
+        <attrib name="url"                alias="DsUrl"           type="string"/>
+      </vmware-group>
     </vmware-groups>
   </vmware-collection>
 
@@ -743,6 +761,25 @@
         <attrib name="datastore.unmapSize.summation" alias="DaStUnmapSeSum" type="Gauge"/>
         <attrib name="datastore.write.average" alias="DaStWeAvg" type="Gauge"/>
       </vmware-group>
+      <!--
+        Datastore capacity, free space, and provisioning state for the
+        datastores this host mounts. Dispatched by VmwareCollector when
+        resourceType="vmwareDatastoreCapacity"; values come from
+        Datastore.summary rather than PerformanceManager.
+      -->
+      <vmware-group name="vmwareDatastoreCapacity" resourceType="vmwareDatastoreCapacity">
+        <attrib name="capacity"           alias="DsCapacity"      type="Gauge"/>
+        <attrib name="freeSpace"          alias="DsFreeSpace"     type="Gauge"/>
+        <attrib name="used"               alias="DsUsed"          type="Gauge"/>
+        <attrib name="usedPct"            alias="DsUsedPct"       type="Gauge"/>
+        <attrib name="uncommitted"        alias="DsUncommitted"   type="Gauge"/>
+        <attrib name="overcommittedBytes" alias="DsOvercommitted" type="Gauge"/>
+        <attrib name="accessible"         alias="DsAccessible"    type="Gauge"/>
+        <attrib name="multipleHostAccess" alias="DsMultiHost"     type="Gauge"/>
+        <attrib name="type"               alias="DsType"          type="string"/>
+        <attrib name="url"                alias="DsUrl"           type="string"/>
+      </vmware-group>
     </vmware-groups>
   </vmware-collection>
+
 </vmware-datacollection-config>


### PR DESCRIPTION
Attempt number two to add VMware Datastore stats for collection for [NMS-19849](https://opennms.atlassian.net/browse/NMS-19849).  Refactored to keep this as part of the VMware collector instead of adding another collector for it.  It does mean that data is duplicated for each host but honestly, I think that's a worthy tradeoff for this to be simpler.

This includes:

* New vmwareDatastoreCapacity resource type (version-agnostic)
* Works with default Vmware collections (no new service needed)
* Combined datastore-capacity graph definition under snmp-graph.properties.d
* Extractor unit tests covering null/zero edge cases
* Reference documentation page and nav entry

Assisted-by: Claude Code:Opus 4.7/4.8

[NMS-19849]: https://opennms.atlassian.net/browse/NMS-19849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ