### PR TITLE
NMS-19852: Fix filter icons on Alarm List page

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
@@ -95,15 +95,15 @@
   // optional bookmark
   final OnmsFilterFavorite favorite = (OnmsFilterFavorite) req.getAttribute("favorite");
 
-    pageContext.setAttribute("addPositiveFilter", "<i class=\"fa fa-plus-square-o\"></i>");
-    pageContext.setAttribute("addNegativeFilter", "<i class=\"fa fa-minus-square-o\"></i>");
-    pageContext.setAttribute("addBeforeFilter", "<i class=\"fa fa-toggle-right\"></i>");
-    pageContext.setAttribute("addAfterFilter", "<i class=\"fa fa-toggle-left\"></i>");
-    pageContext.setAttribute("filterFavoriteSelectTagHandler", new FilterFavoriteSelectTagHandler("All Alarms"));
-    
-    // get sound constants from session, request or opennms.properties
-	  String soundEnabledStr = System.getProperty("opennms.alarmlist.sound.enable");
-	  boolean soundEnabled = (soundEnabledStr == null) ? false : "true".equals(soundEnabledStr.trim());
+  pageContext.setAttribute("addPositiveFilter", "<i class=\"far fa-square-plus\"></i>");
+  pageContext.setAttribute("addNegativeFilter", "<i class=\"far fa-square-minus\"></i>");
+  pageContext.setAttribute("addBeforeFilter", "<i class=\"fas fa-square-caret-right\"></i>");
+  pageContext.setAttribute("addAfterFilter", "<i class=\"fas fa-square-caret-left\"></i>");
+  pageContext.setAttribute("filterFavoriteSelectTagHandler", new FilterFavoriteSelectTagHandler("All Alarms"));
+
+  // get sound constants from session, request or opennms.properties
+  String soundEnabledStr = System.getProperty("opennms.alarmlist.sound.enable");
+  boolean soundEnabled = (soundEnabledStr == null) ? false : "true".equals(soundEnabledStr.trim());
 
   boolean soundOn = false;
   boolean soundOnEvent = false;


### PR DESCRIPTION
Fix the icon CSS classes for the filter icons that display next to items in the rows of the Alarm List.

The Alarm List fixes had been applied to `foundation-2024` which had a different version of `font-awesome` and the CSS classes for the `+` and `-` icons we used had changed.

The functionality was still there, you just could not see the icons.

This fixes it for `release-36.x`.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19852

