### PR TITLE
NMS-19853: note Ops Board / Wallboard removal in What's New

### DIFF
--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -105,3 +105,11 @@ IMPORTANT: If you previously configured the plugin via `$\{OPENNMS_HOME}/etc/org
 The Karaf feature is now `opennms-plugins-prometheus-remotewrite` (previously `opennms-plugins-cortex-tss`), and the KAR file is `opennms-prometheus-remotewrite-plugin` (previously `opennms-cortex-tss-plugin`).
 See xref:deployment:time-series-storage/timeseries/prometheus-remotewrite.adoc[the Prometheus RemoteWrite plugin documentation] for details.
 
+=== Ops Board and Wallboard removed
+
+The Vaadin-based Ops Board (operator board) and Wallboard, their dashlets, and the *Wallboard Configuration* admin page have been removed.
+These provided auto-rotating, dashlet-composed displays intended for wall-mounted operations screens.
+
+The *Ops Board* and *Wallboard* main-menu entries and the `admin/wallboardConfig.jsp` page no longer exist, and any existing Ops Board configuration is no longer used.
+There is no drop-in replacement.
+


### PR DESCRIPTION
Add a Breaking changes entry to the release notes recording that the Vaadin Ops Board and Wallboard (and the Wallboard Configuration admin page) were removed.