### PR TITLE
NMS-19855: Remaining issues for Vue Nodes Page

### DIFF
--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.netutils/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.netutils/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,7 @@ http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0 http://aries.apache
         <cm:default-properties>
             <cm:property name="eventsURL" value="event/list"/>
             <cm:property name="alarmsURL" value="alarm/list.htm"/>
-        	<cm:property name="nodeListURL" value="element/nodeList.htm"/>
+        	<cm:property name="nodeListURL" value="ui/#/nodes"/>
         	<cm:property name="nodePageURL" value="element/node.jsp?node="/>
         	<cm:property name="resourceGraphListURL" value="graph/index.jsp"/>
         	<cm:property name="resourceGraphNodeURL" value="graph/chooseresource.jsp?reports=all&amp;parentResourceId=node"/> 

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/InterfaceSnmpResourceType.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/InterfaceSnmpResourceType.java
@@ -21,7 +21,6 @@
  */
 package org.opennms.netmgt.dao.support;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -297,12 +296,8 @@ public class InterfaceSnmpResourceType implements OnmsResourceType {
     private List<OnmsResource> getDomainResources(ResourcePath parent, Set<String> intfNames) {
         final List<OnmsResource> resources = Lists.newLinkedList();
         for (String intfName : intfNames) {
-            OnmsResource resource = getResourceByParentPathAndInterface(parent, intfName); 
-            try {
-                resource.setLink("element/nodeList.htm?listInterfaces=true&snmpParm=ifAlias&snmpParmMatchType=contains&snmpParmValue=" + URLEncoder.encode(intfName, StandardCharsets.UTF_8.name()));
-            } catch (UnsupportedEncodingException e) {
-                throw new IllegalStateException("URLEncoder.encode complained about UTF-8. " + e, e);
-            }
+            OnmsResource resource = getResourceByParentPathAndInterface(parent, intfName);
+            resource.setLink("ui/#/nodes?snmpifalias=" + URLEncoder.encode(intfName, StandardCharsets.UTF_8) + "&snmpMatchType=contains");
             resources.add(resource);
         }
         return resources;

--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultSiteStatusViewService.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultSiteStatusViewService.java
@@ -207,39 +207,45 @@ public class DefaultSiteStatusViewService implements SiteStatusViewService {
     }
     
     private String createNodePageUrl(AggregateStatusView statusView, AggregateStatus status) {
-        
-        if (status.getDownEntityCount() == 0) {
-            final StringBuilder buf = new StringBuilder("element/nodeList.htm?");
-            buf.append("statusViewName=");
-            buf.append(Util.encode(statusView.getName()));
-            buf.append('&');
-            buf.append("statusSite=");
-            buf.append(Util.encode(statusView.getColumnValue()));
-            buf.append('&');
-            buf.append("statusRowLabel=");
-            buf.append(Util.encode(status.getLabel()));
-            return buf.toString();
-        } else if (status.getDownEntityCount() == 1) {
+
+        // A single down node links straight to the (unconverted) node detail page.
+        if (status.getDownEntityCount() == 1) {
             OnmsNode node = status.getDownNodes().iterator().next();
-            StringBuffer buf = new StringBuffer("element/node.jsp?");
-            buf.append("node=");
-            buf.append(node.getId());
-            return buf.toString();
-        } else {
-            StringBuffer buf = new StringBuffer("element/nodeList.htm?");
-            buf.append("statusViewName=");
-            buf.append(Util.encode(statusView.getName()));
-            buf.append('&');
-            buf.append("statusSite=");
-            buf.append(Util.encode(statusView.getColumnValue()));
-            buf.append('&');
-            buf.append("statusRowLabel=");
-            buf.append(Util.encode(status.getLabel()));
-            buf.append('&');
-            buf.append("nodesWithDownAggregateStatus=true");
-            return buf.toString();
+            return "element/node.jsp?node=" + node.getId();
         }
-        
+
+        // Otherwise link to the Vue Nodes page. The legacy statusViewName/statusSite/statusRowLabel
+        // params are resolved here (server-side) into the concrete filters the Vue page understands:
+        // the row's categories (category1, unioned) and the view's asset column/value (assetColumn/assetValue).
+        final List<String> params = new ArrayList<>();
+
+        for (OnmsCategory category : getCategoriesForStatusLabel(statusView, status.getLabel())) {
+            params.add("category1=" + Util.encode(category.getName()));
+        }
+
+        if (statusView.getColumnName() != null && statusView.getColumnValue() != null) {
+            params.add("assetColumn=" + Util.encode(statusView.getColumnName()));
+            params.add("assetValue=" + Util.encode(statusView.getColumnValue()));
+        }
+
+        // More than one down node: restrict to nodes with a down aggregate status.
+        if (status.getDownEntityCount() > 1) {
+            params.add("nodesWithDownAggregateStatus=true");
+        }
+
+        return "ui/#/nodes?" + String.join("&", params);
+    }
+
+    /**
+     * Resolves the categories configured for the status row whose label matches the given status label.
+     */
+    private Set<OnmsCategory> getCategoriesForStatusLabel(AggregateStatusView statusView, String statusLabel) {
+        for (AggregateStatusDefinition def : statusView.getStatusDefinitions()) {
+            if (def.getName().equals(statusLabel)) {
+                return def.getCategories();
+            }
+        }
+        return java.util.Collections.emptySet();
     }
     
     /**

--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultSurveillanceService.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultSurveillanceService.java
@@ -407,7 +407,7 @@ public class DefaultSurveillanceService implements SurveillanceService {
             params.add("category2=" + Util.encode(category.getName()));
         }
         params.add("nodesWithDownAggregateStatus=true");
-        return "element/nodeList.htm?" + StringUtils.collectionToDelimitedString(params, "&");
+        return "ui/#/nodes?" + StringUtils.collectionToDelimitedString(params, "&");
     }
 
     /**

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
@@ -21,7 +21,6 @@
  */
 package org.opennms.web.rest.support;
 
-import static org.opennms.web.rest.support.CriteriaValueConverters.BOOLEAN_CONVERTER;
 import static org.opennms.web.rest.support.CriteriaValueConverters.CHARACTER_CONVERTER;
 import static org.opennms.web.rest.support.CriteriaValueConverters.DATE_CONVERTER;
 import static org.opennms.web.rest.support.CriteriaValueConverters.FLOAT_CONVERTER;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -363,6 +363,44 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         downStatusBehavior.setSkipPropertyByDefault(true);
         map.put("nodesWithDownAggregateStatus", downStatusBehavior);
 
+        // nodesWithAssets: nodes whose asset record has at least one non-empty field.
+        // Mirrors the legacy AssetModel.searchNodesWithAssets() query ("All nodes with asset info").
+        final String[] assetColumns = {
+            "manufacturer", "vendor", "modelNumber", "serialNumber", "description", "circuitId",
+            "assetNumber", "operatingSystem", "rack", "slot", "port", "region", "division", "department",
+            "address1", "address2", "city", "state", "zip", "building", "floor", "room", "vendorPhone",
+            "vendorFax", "dateInstalled", "lease", "leaseExpires", "supportPhone", "maintContract",
+            "vendorAssetNumber", "maintContractExpires", "displayCategory", "notifyCategory",
+            "pollerCategory", "thresholdCategory", "comment", "username", "password", "enable",
+            "connection", "autoenable", "cpu", "ram", "storagectrl", "hdd1", "hdd2", "hdd3", "hdd4",
+            "hdd5", "hdd6", "numpowersupplies", "inputpower", "additionalhardware", "admin",
+            "snmpcommunity", "rackunitheight"
+        };
+        final String nonEmptyAssets = java.util.Arrays.stream(assetColumns)
+                .map(col -> "coalesce(" + col + ",'') != ''")
+                .collect(java.util.stream.Collectors.joining(" or "));
+        final String assetsSubquery = "(select nodeid from assets where " + nonEmptyAssets + ")";
+        CriteriaBehavior<?> withAssetsBehavior = new CriteriaBehavior<>((String)null, String::new, (b, v, c, w) -> {
+            if (v == null) {
+                return;
+            }
+            final boolean wantAssets = Boolean.parseBoolean((String)v);
+            boolean hasAssets;
+            switch (c) {
+            case EQUALS:
+                hasAssets = wantAssets;
+                break;
+            case NOT_EQUALS:
+                hasAssets = !wantAssets;
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal condition type for nodesWithAssets expression: " + c);
+            }
+            b.sql("{alias}.nodeid " + (hasAssets ? "in " : "not in ") + assetsSubquery);
+        });
+        withAssetsBehavior.setSkipPropertyByDefault(true);
+        map.put("nodesWithAssets", withAssetsBehavior);
+
         return map;
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -310,6 +310,29 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         iplikeBehavior.setSkipPropertyByDefault(true);
         map.put("iplike", iplikeBehavior);
 
+        // maclike: case-insensitive partial match on SNMP interface physical (MAC) address.
+        // Mirrors DefaultNodeListService.addCriteriaForMaclike — colons and dashes are stripped,
+        // then an ANYWHERE ilike is applied. Uses a SQL subquery because snmpinterface is a child
+        // association and cannot be aliased against the root criteria here.
+        CriteriaBehavior<?> maclikeBehavior = new CriteriaBehavior<>((String)null, String::new, (b, v, c, w) -> {
+            if (v == null) {
+                return;
+            }
+            final String pattern = "%" + ((String)v).replaceAll("[:-]", "") + "%";
+            switch (c) {
+            case EQUALS:
+                b.sql("{alias}.nodeid in (select nodeid from snmpinterface where snmpphysaddr ilike ?)", pattern, Type.STRING);
+                break;
+            case NOT_EQUALS:
+                b.sql("{alias}.nodeid not in (select nodeid from snmpinterface where snmpphysaddr ilike ?)", pattern, Type.STRING);
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal condition type for maclike expression: " + c);
+            }
+        });
+        maclikeBehavior.setSkipPropertyByDefault(true);
+        map.put("maclike", maclikeBehavior);
+
         return map;
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -333,6 +333,36 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         maclikeBehavior.setSkipPropertyByDefault(true);
         map.put("maclike", maclikeBehavior);
 
+        // nodesWithDownAggregateStatus: nodes whose aggregate status is "down", i.e. that have at
+        // least one active (status='A') monitored service currently in outage (ifRegainedService is null).
+        // Mirrors the post-query AggregateStatus.getDownNodes() filter the legacy node list applies.
+        // Uses a SQL subquery because the outage/ifservice tables are not aliased on the node criteria.
+        final String downStatusSubquery = "(select ip.nodeid from outages o " +
+                "join ifservices s on o.ifserviceid = s.id " +
+                "join ipinterface ip on s.ipinterfaceid = ip.id " +
+                "where o.ifregainedservice is null and s.status = 'A')";
+        CriteriaBehavior<?> downStatusBehavior = new CriteriaBehavior<>((String)null, String::new, (b, v, c, w) -> {
+            if (v == null) {
+                return;
+            }
+            final boolean wantDown = Boolean.parseBoolean((String)v);
+            // (==true) and (!=false) both mean "down nodes only"; (==false)/(!=true) mean "exclude down nodes".
+            boolean downOnly;
+            switch (c) {
+            case EQUALS:
+                downOnly = wantDown;
+                break;
+            case NOT_EQUALS:
+                downOnly = !wantDown;
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal condition type for nodesWithDownAggregateStatus expression: " + c);
+            }
+            b.sql("{alias}.nodeid " + (downOnly ? "in " : "not in ") + downStatusSubquery);
+        });
+        downStatusBehavior.setSkipPropertyByDefault(true);
+        map.put("nodesWithDownAggregateStatus", downStatusBehavior);
+
         return map;
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -287,6 +287,29 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
 
         // TODO: Figure out if it makes sense to search/orderBy on 2nd-level and greater JOINed properties
 
+        // iplike: PostgreSQL iplike() pattern filter over all IP interfaces of the node.
+        // Uses a SQL subquery because IpLikeCriteriaBehavior.b.iplike() only works against the
+        // root alias; the ipinterface table is a child association and cannot be aliased there.
+        // FIQL delivers '*' wildcards as '%' by the time the lambda fires — reverse with replaceAll().
+        CriteriaBehavior<?> iplikeBehavior = new CriteriaBehavior<>((String)null, String::new, (b, v, c, w) -> {
+            if (v == null) {
+                return;
+            }
+            final String pattern = ((String)v).replaceAll("%", "*");
+            switch (c) {
+            case EQUALS:
+                b.sql("{alias}.nodeid in (select nodeid from ipinterface where iplike(ipaddr, ?))", pattern, Type.STRING);
+                break;
+            case NOT_EQUALS:
+                b.sql("{alias}.nodeid not in (select nodeid from ipinterface where iplike(ipaddr, ?))", pattern, Type.STRING);
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal condition type for iplike expression: " + c);
+            }
+        });
+        iplikeBehavior.setSkipPropertyByDefault(true);
+        map.put("iplike", iplikeBehavior);
+
         return map;
     }
 

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
@@ -80,8 +80,8 @@
       "roles": null,
       "items": [
         {
-          "id": "nodeList",
-          "name": "Node List",
+          "id": "nodes",
+          "name": "Nodes",
           "url": "ui/index.html#/nodes",
           "locationMatch": "configurationManagement",
           "roles": null

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -87,8 +87,8 @@
       "roles": null,
       "items": [
         {
-          "id": "nodeList",
-          "name": "Node List",
+          "id": "nodes",
+          "name": "Nodes",
           "url": "ui/index.html#/nodes",
           "locationMatch": "configurationManagement",
           "roles": null

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
@@ -45,8 +45,8 @@
       "roles": null,
       "items": [
         {
-          "id": "nodeList",
-          "name": "Node List",
+          "id": "nodes",
+          "name": "Nodes",
           "url": "ui/index.html#/nodes",
           "locationMatch": "configurationManagement",
           "roles": null

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -87,8 +87,8 @@
       "roles": null,
       "items": [
         {
-          "id": "nodeList",
-          "name": "Node List",
+          "id": "nodes",
+          "name": "Nodes",
           "url": "ui/index.html#/nodes",
           "locationMatch": "configurationManagement",
           "roles": null

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/menu/MenuProviderTest.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/menu/MenuProviderTest.java
@@ -90,7 +90,7 @@ public class MenuProviderTest {
         MenuEntry infoMenu = getMenuEntry(mainMenu.menus, "Info");
 
         final String[] expectedNames = new String[] {
-                "Node List", "Nodes (Legacy)", "Assets", "Path Outages", "Device Configs", "External Requisitions",
+                "Nodes", "Nodes (Legacy)", "Assets", "Path Outages", "Device Configs", "External Requisitions",
                 "Logs", "Secure Credentials Vault", "Connect to Zenith"
         };
         List<String> actualNames = getMenuNames(infoMenu);
@@ -117,7 +117,7 @@ public class MenuProviderTest {
         MenuEntry infoMenu = getMenuEntry(mainMenu.menus, "Info");
 
         final String[] expectedNames = new String[] {
-                "Node List", "Nodes (Legacy)", "Assets", "Path Outages", "Device Configs", "External Requisitions",
+                "Nodes", "Nodes (Legacy)", "Assets", "Path Outages", "Device Configs", "External Requisitions",
                 "Logs", "Secure Credentials Vault"
         };
 
@@ -136,7 +136,7 @@ public class MenuProviderTest {
 
         // Should not have any admin-only roles
         final String[] expectedNames = new String[] {
-            "Node List", "Nodes (Legacy)", "Assets", "Path Outages"
+            "Nodes", "Nodes (Legacy)", "Assets", "Path Outages"
         };
 
         List<String> actualNames = getMenuNames(infoMenu);
@@ -154,7 +154,7 @@ public class MenuProviderTest {
 
         // Should not have any admin-only roles, but should have file system manager roles
         final String[] expectedNames = new String[] {
-            "Node List", "Nodes (Legacy)", "Assets", "Path Outages", "File Editor"
+            "Nodes", "Nodes (Legacy)", "Assets", "Path Outages", "File Editor"
         };
 
         List<String> actualNames = getMenuNames(infoMenu);

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -321,6 +321,41 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
+    public void testMaclikeSearch() throws Exception {
+        // Create a node with a known SNMP interface MAC (physical) address via the REST API
+        String node = "<node type=\"A\" label=\"MaclikeTestNode\" foreignSource=\"JUnit\" foreignId=\"MaclikeTestNode\">" +
+                "<location>Default</location>" +
+                "<labelSource>H</labelSource>" +
+                "</node>";
+        sendPost("/nodes", node, 201);
+
+        // physAddr is stored stripped of separators and (typically) upper-cased
+        String snmpInterface = "<snmpInterface ifIndex=\"1\">" +
+                "<ifType>6</ifType>" +
+                "<physAddr>AABBCCDDEEFF</physAddr>" +
+                "</snmpInterface>";
+        sendPost("/nodes/1/snmpinterfaces", snmpInterface, 201);
+
+        String url = "/nodes";
+
+        // Exact MAC match via maclike (case-insensitive)
+        sendRequest(GET, url, parseParamData("_s=maclike==aabbccddeeff"), 200);
+
+        // Separators in the search term are stripped before matching
+        sendRequest(GET, url, parseParamData("_s=maclike==AA:BB:CC:DD:EE:FF"), 200);
+        sendRequest(GET, url, parseParamData("_s=maclike==aa-bb-cc-dd-ee-ff"), 200);
+
+        // Partial (manufacturer prefix) match
+        sendRequest(GET, url, parseParamData("_s=maclike==aabbcc"), 200);
+
+        // Non-matching MAC — no match, expect 204 No Content
+        sendRequest(GET, url, parseParamData("_s=maclike==112233445566"), 204);
+
+        // NOT_EQUALS: the node does NOT have this MAC, so it appears in results
+        sendRequest(GET, url, parseParamData("_s=maclike!=112233445566"), 200);
+    }
+
+    @Test
     public void createNodeWithParent() throws Exception{
 
         final NetworkBuilder builder = new NetworkBuilder();

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -27,13 +27,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import javax.ws.rs.core.MediaType;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -269,6 +266,58 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
         // Negative: unknown MAC returns no results
         sendRequest(GET, "/nodes", parseParamData("_s=snmpInterface.physAddr==*000000000000*"), 204);
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void testIplikeSearch() throws Exception {
+        // Create a node with a known IP address via the REST API
+        String node = "<node type=\"A\" label=\"IplikeTestNode\" foreignSource=\"JUnit\" foreignId=\"IplikeTestNode\">" +
+                "<location>Default</location>" +
+                "<labelSource>H</labelSource>" +
+                "</node>";
+        sendPost("/nodes", node, 201);
+
+        String ipInterface = "<ipInterface snmpPrimary=\"P\">" +
+                "<ipAddress>192.168.1.100</ipAddress>" +
+                "<hostName>iplike-host</hostName>" +
+                "</ipInterface>";
+        sendPost("/nodes/1/ipinterfaces", ipInterface, 201);
+
+        String url = "/nodes";
+
+        // Exact IP match via iplike
+        sendRequest(GET, url, parseParamData("_s=iplike==192.168.1.100"), 200);
+
+        // Wildcard subnet match (* in URL becomes % by FIQL; the behavior reverses it)
+        sendRequest(GET, url, parseParamData("_s=iplike==192.168.1.*"), 200);
+
+        // Wrong subnet — no match, expect 204 No Content
+        sendRequest(GET, url, parseParamData("_s=iplike==10.0.0.*"), 204);
+
+        // NOT_EQUALS: the node is NOT in the 10.x range, so it appears in results
+        sendRequest(GET, url, parseParamData("_s=iplike!=10.0.0.*"), 200);
+
+        // --- IPv6 iplike coverage ---
+        // Add a second node with an IPv6 address
+        String node2 = "<node type=\"A\" label=\"IplikeTestNodeV6\" foreignSource=\"JUnit\" foreignId=\"IplikeTestNodeV6\">" +
+                "<location>Default</location>" +
+                "<labelSource>H</labelSource>" +
+                "</node>";
+        sendPost("/nodes", node2, 201);
+
+        String ipv6Interface = "<ipInterface snmpPrimary=\"P\">" +
+                "<ipAddress>2001:db8::1</ipAddress>" +
+                "<hostName>iplike-v6-host</hostName>" +
+                "</ipInterface>";
+        // The second node gets id=2 in a fresh @JUnitTemporaryDatabase
+        sendPost("/nodes/2/ipinterfaces", ipv6Interface, 201);
+
+        // IPv6 wildcard pattern matches the 2001:db8:: range
+        sendRequest(GET, url, parseParamData("_s=iplike==2001:db8:*:*:*:*:*:*"), 200);
+
+        // Wrong IPv6 prefix — no match
+        sendRequest(GET, url, parseParamData("_s=iplike==fe80:*:*:*:*:*:*:*"), 204);
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -321,6 +321,30 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
+    @JUnitTemporaryDatabase
+    public void testNodesWithDownAggregateStatusSearch() throws Exception {
+        // DatabasePopulator seeds node1 with an unresolved (open) outage on its active SNMP service,
+        // so node1 has a "down" aggregate status; the other nodes do not.
+        m_databasePopulator.populateDatabase();
+
+        String url = "/nodes";
+
+        // Down-only: at least node1 matches
+        sendRequest(GET, url, parseParamData("_s=nodesWithDownAggregateStatus==true"), 200);
+
+        // Precise: node1 IS down, node2 is NOT
+        sendRequest(GET, url, parseParamData("_s=nodesWithDownAggregateStatus==true;node.label==node1"), 200);
+        sendRequest(GET, url, parseParamData("_s=nodesWithDownAggregateStatus==true;node.label==node2"), 204);
+
+        // Excluding down nodes: node1 drops out, node2 remains
+        sendRequest(GET, url, parseParamData("_s=nodesWithDownAggregateStatus==false;node.label==node1"), 204);
+        sendRequest(GET, url, parseParamData("_s=nodesWithDownAggregateStatus==false;node.label==node2"), 200);
+
+        // NOT_EQUALS true is equivalent to ==false (exclude down nodes)
+        sendRequest(GET, url, parseParamData("_s=nodesWithDownAggregateStatus!=true;node.label==node1"), 204);
+    }
+
+    @Test
     public void testMaclikeSearch() throws Exception {
         // Create a node with a known SNMP interface MAC (physical) address via the REST API
         String node = "<node type=\"A\" label=\"MaclikeTestNode\" foreignSource=\"JUnit\" foreignId=\"MaclikeTestNode\">" +

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -370,6 +370,29 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
+    @JUnitTemporaryDatabase
+    public void testAssetFilterValueWithFiqlCharacters() throws Exception {
+        // A node whose asset 'building' contains FIQL-structural characters (comma + semicolon).
+        // The Vue UI double-encodes such values (',' -> %252C, ';' -> %253B); the servlet container
+        // and CXF (search.decode.values=true) then decode them back to the exact literal before the
+        // value reaches the criteria, so an exact match must still work.
+        final NetworkBuilder builder = new NetworkBuilder();
+        builder.addNode("AssetCommaNode").setForeignSource("JUnit").setForeignId("AssetComma").setType(OnmsNode.NodeType.ACTIVE);
+        builder.setBuilding("A,B;C");
+        final OnmsNode node = builder.getCurrentNode();
+        m_databasePopulator.getNodeDao().save(node);
+        m_databasePopulator.getNodeDao().flush();
+
+        String url = "/nodes";
+
+        // Exact match via the double-encoded value the UI emits
+        sendRequest(GET, url, parseParamData("_s=assetRecord.building==A%252CB%253BC"), 200);
+
+        // A different (also double-encoded) value must not match
+        sendRequest(GET, url, parseParamData("_s=assetRecord.building==A%252CX"), 204);
+    }
+
+    @Test
     public void testMaclikeSearch() throws Exception {
         // Create a node with a known SNMP interface MAC (physical) address via the REST API
         String node = "<node type=\"A\" label=\"MaclikeTestNode\" foreignSource=\"JUnit\" foreignId=\"MaclikeTestNode\">" +

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -345,6 +345,31 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
+    @JUnitTemporaryDatabase
+    public void testNodesWithAssetsSearch() throws Exception {
+        // DatabasePopulator seeds alternate-node1 with asset info (assetNumber, plus building "HQ"
+        // carried over by NetworkBuilder). A bare node created via REST has no asset fields set
+        // (its asset 'category' defaults to "Unspecified", which is intentionally NOT in the query).
+        m_databasePopulator.populateDatabase();
+
+        String bareNode = "<node type=\"A\" label=\"AssetEmptyNode\" foreignSource=\"JUnit\" foreignId=\"AssetEmptyNode\">" +
+                "<location>Default</location>" +
+                "<labelSource>H</labelSource>" +
+                "</node>";
+        sendPost("/nodes", bareNode, 201);
+
+        String url = "/nodes";
+
+        // Has-asset-info: alternate-node1 matches, the bare node does not
+        sendRequest(GET, url, parseParamData("_s=nodesWithAssets==true;node.label==alternate-node1"), 200);
+        sendRequest(GET, url, parseParamData("_s=nodesWithAssets==true;node.label==AssetEmptyNode"), 204);
+
+        // Inverse: alternate-node1 drops out, the bare node remains
+        sendRequest(GET, url, parseParamData("_s=nodesWithAssets==false;node.label==alternate-node1"), 204);
+        sendRequest(GET, url, parseParamData("_s=nodesWithAssets==false;node.label==AssetEmptyNode"), 200);
+    }
+
+    @Test
     public void testMaclikeSearch() throws Exception {
         // Create a node with a known SNMP interface MAC (physical) address via the REST API
         String node = "<node type=\"A\" label=\"MaclikeTestNode\" foreignSource=\"JUnit\" foreignId=\"MaclikeTestNode\">" +

--- a/opennms-webapp-rest/src/test/resources/menu/menu-template.json
+++ b/opennms-webapp-rest/src/test/resources/menu/menu-template.json
@@ -40,8 +40,8 @@
       "roles": null,
       "items": [
         {
-          "id": "nodeList",
-          "name": "Node List",
+          "id": "nodes",
+          "name": "Nodes",
           "url": "ui/index.html#/nodes",
           "locationMatch": "configurationManagement",
           "roles": null

--- a/opennms-webapp/src/main/java/org/opennms/web/element/ElementUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/ElementUtil.java
@@ -601,14 +601,14 @@ public abstract class ElementUtil {
             } catch (NumberFormatException e) {
                 throw new ElementIdNotFoundException("Wrong data type for \""
                         + nodeLookupString + "\", should be integer", nodeLookupString, 
-                        "node", "element/node.jsp", "node", "element/nodeList.htm");
+                        "node", "element/node.jsp", "node", "ui/#/nodes");
             }
         }
 
         OnmsNode node = NetworkElementFactory.getInstance(servletContext).getNode(nodeLookupString);
 
         if (node == null) {
-            throw new ElementNotFoundException("No such node in database", "node", "element/node.jsp", "node", "element/nodeList.htm");
+            throw new ElementNotFoundException("No such node in database", "node", "element/node.jsp", "node", "ui/#/nodes");
         }
         
         return node;
@@ -690,7 +690,7 @@ public abstract class ElementUtil {
                 if (node != null) {
                     nodeId = node.getId();
                 } else {
-                    throw new ElementNotFoundException("No such node in database", "node", "element/node.jsp", "node", "element/nodeList.htm");
+                    throw new ElementNotFoundException("No such node in database", "node", "element/node.jsp", "node", "ui/#/nodes");
                 }
             } else {
                 try {

--- a/opennms-webapp/src/main/java/org/opennms/web/element/ElementUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/ElementUtil.java
@@ -917,7 +917,7 @@ public abstract class ElementUtil {
     		nodeId = Integer.parseInt(request.getParameter("node"));
     	} catch (NumberFormatException nfe) {
     		throw new ElementIdNotFoundException("Wrong type for parameter \"node\" (should be integer)",
-    					request.getParameter("node"), "node", "element/node.jsp", "node", "element/nodeList.jsp");
+    					request.getParameter("node"), "node", "element/node.jsp", "node", "element/NodeList.jsp");
     	}
     	services = NetworkElementFactory.getInstance(servletContext).getServicesOnNode(nodeId, serviceId);
     	return services;

--- a/opennms-webapp/src/main/java/org/opennms/web/element/ElementUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/ElementUtil.java
@@ -917,7 +917,7 @@ public abstract class ElementUtil {
     		nodeId = Integer.parseInt(request.getParameter("node"));
     	} catch (NumberFormatException nfe) {
     		throw new ElementIdNotFoundException("Wrong type for parameter \"node\" (should be integer)",
-    					request.getParameter("node"), "node", "element/node.jsp", "node", "element/NodeList.jsp");
+    					request.getParameter("node"), "node", "element/node.jsp", "node", "element/nodeList.jsp");
     	}
     	services = NetworkElementFactory.getInstance(servletContext).getServicesOnNode(nodeId, serviceId);
     	return services;

--- a/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -339,14 +339,9 @@
                     <property name="entries">
                         <list>
                             <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
-                                <property name="name" value="Nodes (Legacy)"/>
-                                <property name="url" value="element/nodeList.htm"/>
-                                <property name="locationMatch" value="nodelist"/>
-                            </bean>
-                            <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
                                 <property name="name" value="Node List"/>
                                 <property name="url" value="ui/index.html#/nodes"/>
-                                <property name="locationMatch" value="configurationManagement"/>
+                                <property name="locationMatch" value="nodeList"/>
                             </bean>
                             <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
                                 <property name="name" value="Assets"/>

--- a/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -339,7 +339,7 @@
                     <property name="entries">
                         <list>
                             <bean class="org.opennms.web.navigate.LocationBasedNavBarEntry">
-                                <property name="name" value="Node List"/>
+                                <property name="name" value="Nodes"/>
                                 <property name="url" value="ui/index.html#/nodes"/>
                                 <property name="locationMatch" value="nodeList"/>
                             </bean>

--- a/opennms-webapp/src/main/webapp/admin/nodemanagement/managenode.jsp
+++ b/opennms-webapp/src/main/webapp/admin/nodemanagement/managenode.jsp
@@ -55,7 +55,7 @@
 	throw new ServletException("Session attribute "
 				   + "interfaces.nodemanagement is null");
     } else if (interfaces.size() < 1) {
-    	throw new NoManagedInterfacesException("element/nodeList.htm");
+    	throw new NoManagedInterfacesException("ui/#/nodes");
     }
     lineItems = (Integer) userSession.getAttribute("lineItems.nodemanagement");
     if (lineItems == null) {

--- a/opennms-webapp/src/main/webapp/element/index.jsp
+++ b/opennms-webapp/src/main/webapp/element/index.jsp
@@ -236,7 +236,8 @@ function submitNodeSearch(params) {
       <div class="card-body">
         <div>
             <ul class="list-unstyled">
-              <li><a href="asset/nodelist.jsp?column=_allNonEmpty">All nodes with asset info</a></li>
+              <li><a href="ui/#/nodes?nodesWithAssets=true">All nodes with asset info (Nodes page)</a></li>
+              <li><a href="asset/nodelist.jsp?column=_allNonEmpty">All nodes with asset info (Assets page)</a></li>
             </ul>
         </div>
 

--- a/opennms-webapp/src/main/webapp/element/linkednode.jsp
+++ b/opennms-webapp/src/main/webapp/element/linkednode.jsp
@@ -58,7 +58,7 @@
     //get the database node info
     final OnmsNode node_db = factory.getNode( nodeId );
     if( node_db == null ) {
-		throw new ElementNotFoundException("No such node in database", "node", "element/linkednode.jsp", "node", "element/nodeList.htm");
+		throw new ElementNotFoundException("No such node in database", "node", "element/linkednode.jsp", "node", "ui/#/nodes");
     }
 
 	pageContext.setAttribute("nodeId", nodeId);

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -90,7 +90,7 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         // Inventory Menu
         // Note, some items are below under Vue UI checks
-        clickMenuItem("inventoryMenu", "Node List");
+        clickMenuItem("inventoryMenu", "Nodes (Legacy)");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[contains(@class, 'card')]//span[@class='title' and text()='Node List']")));
 
         clickMenuItem("inventoryMenu", "Assets");
@@ -283,8 +283,8 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         // Navigation on Vue UI pages
         frontPage();
-        clickMenuItem("inventoryMenu", "Node List");
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='card']//span[text()='Node List']")));
+        clickMenuItem("inventoryMenu", "Nodes");
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='card']//span[text()='Nodes']")));
 
         clickMenuItem("inventoryMenu", "Device Configs");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='Device Config Backup']")));

--- a/smoke-test/src/test/java/org/opennms/smoketest/UIRefreshIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/UIRefreshIT.java
@@ -61,7 +61,7 @@ public class UIRefreshIT extends OpenNMSSeleniumIT {
         assertEquals("ItsRainingItsPouring", node.getLabel());
 
         // Switch to the new UI
-        clickMenuItem("inventoryMenu", "Node List");
+        clickMenuItem("inventoryMenu", "Nodes");
     }
 
     @After

--- a/smoke-test/src/test/java/org/opennms/smoketest/ui/NodeListIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ui/NodeListIT.java
@@ -38,7 +38,7 @@ import org.opennms.smoketest.OpenNMSSeleniumIT;
 import org.opennms.smoketest.utils.RestClient;
 
 /**
- * Basic validation of the Vue Node List page.
+ * Basic validation of the Vue Nodes page.
  */
 public class NodeListIT extends OpenNMSSeleniumIT {
     protected int savedNodeId;
@@ -67,7 +67,7 @@ public class NodeListIT extends OpenNMSSeleniumIT {
 
         savedNodeId = node.getId();
 
-        // Navigate to the Node List page
+        // Navigate to the Nodes page
         getDriver().get(getBaseUrlInternal() + "opennms/ui/index.html#/nodes");
     }
 
@@ -78,8 +78,8 @@ public class NodeListIT extends OpenNMSSeleniumIT {
 
     @Test
     public void canRender() {
-        // Ensure we are on the Node List page and the test node is displayed
-        wait.until(pageContainsText("Node List"));
+        // Ensure we are on the Nodes page and the test node is displayed
+        wait.until(pageContainsText("Nodes"));
         wait.until(pageContainsText("Test_Node1"));
 
         // find the Actions menu for this node

--- a/ui/src/components/Nodes/AssetFilterPanel.vue
+++ b/ui/src/components/Nodes/AssetFilterPanel.vue
@@ -1,0 +1,199 @@
+<template>
+  <div class="asset-filter-container">
+    <div class="feather-row add-row">
+      <div class="feather-col-5">
+        <FeatherSelect
+          label="Asset Field"
+          :options="assetOptions"
+          :textProp="'title'"
+          v-model="currentSelection"
+        />
+      </div>
+      <div class="feather-col-5">
+        <FeatherInput
+          v-model="assetValue"
+          label="Value"
+        />
+      </div>
+      <div class="feather-col-2 add-btn-col">
+        <FeatherButton
+          secondary
+          icon="Add"
+          data-test="add-asset-filter-button"
+          class="add-asset-filter-button"
+          @click="onAddAssetFilter"
+        >
+          <FeatherIcon :icon="Add" />
+          Add
+        </FeatherButton>
+      </div>
+    </div>
+
+    <PDataTable
+      v-if="gridItems.length > 0"
+      :value="gridItems"
+      dataKey="column"
+      class="asset-filter-table"
+    >
+      <PColumn field="label" header="Asset Field" style="width: 40%" />
+      <PColumn field="value" header="Value">
+        <template #body="{ data }">
+          <PInputText
+            v-model="data.value"
+            class="asset-filter-input"
+          />
+        </template>
+      </PColumn>
+      <PColumn header="" style="width: 3.5rem">
+        <template #body="{ data }">
+          <FeatherButton
+            icon="Delete"
+            data-test="delete-asset-filter-button"
+            @click="removeGridItem(data.column)"
+          >
+            <FeatherIcon :icon="DeleteIcon" />
+          </FeatherButton>
+        </template>
+      </PColumn>
+    </PDataTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+import DataTableComponent from 'primevue/datatable'
+import ColumnComponent from 'primevue/column'
+import InputTextComponent from 'primevue/inputtext'
+import { FeatherButton } from '@featherds/button'
+import { FeatherIcon } from '@featherds/icon'
+import Add from '@featherds/icon/action/Add'
+import DeleteIcon from '@featherds/icon/action/Delete'
+import { FeatherInput } from '@featherds/input'
+import { FeatherSelect, ISelectItemType } from '@featherds/select'
+import { ASSET_COLUMN_OPTIONS } from '@/components/Nodes/hooks/queryStringParser'
+import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+
+const PDataTable = DataTableComponent
+const PColumn = ColumnComponent
+const PInputText = InputTextComponent
+
+interface GridItem {
+  column: string
+  label: string
+  value: string
+}
+
+const assetOptions: ISelectItemType[] = ASSET_COLUMN_OPTIONS.map(o => ({ title: o.label, value: o.value }))
+
+const nodeStructureStore = useNodeStructureStore()
+const assetValue = ref('')
+const currentSelection = ref<ISelectItemType | undefined>(undefined)
+const gridItems = ref<GridItem[]>([])
+
+const onAddAssetFilter = () => {
+  if (!currentSelection.value || !assetValue.value.trim()) {
+    return
+  }
+  const column = currentSelection.value.value as string
+  const label = currentSelection.value.title as string
+  const existing = gridItems.value.findIndex(i => i.column === column)
+  if (existing >= 0) {
+    gridItems.value[existing].value = assetValue.value.trim()
+  } else {
+    gridItems.value.push({ column, label, value: assetValue.value.trim() })
+  }
+  assetValue.value = ''
+  currentSelection.value = undefined
+}
+
+const removeGridItem = (column: string) => {
+  gridItems.value = gridItems.value.filter(i => i.column !== column)
+}
+
+const applyToStore = () => {
+  const assetFilters = gridItems.value
+    .filter(i => i.value.trim())
+    .map(i => ({ column: i.column, value: i.value.trim() }))
+  nodeStructureStore.setFilterWithAssetFilters(assetFilters)
+}
+
+const resetFromStore = () => {
+  gridItems.value = (nodeStructureStore.queryFilter.assetFilters ?? []).map(f => ({
+    column: f.column,
+    label: assetOptions.find(o => o.value === f.column)?.title as string ?? f.column,
+    value: f.value
+  }))
+  assetValue.value = ''
+  currentSelection.value = undefined
+}
+
+defineExpose({ applyToStore, resetFromStore })
+
+onMounted(() => {
+  resetFromStore()
+})
+</script>
+
+<style lang="scss" scoped>
+@use '@featherds/styles/mixins/typography';
+@use '@featherds/styles/themes/variables';
+
+.asset-filter-container {
+  .add-asset-filter-button {
+    border-radius: 0;
+    border: 1px solid var(--feather-primary);
+    width: auto;
+    padding: 0.5em 1em;
+  }
+
+  .add-btn-col {
+    display: flex;
+    padding-bottom: 0.25rem;
+  }
+
+  .asset-filter-table {
+    margin-top: 1rem;
+
+    .asset-filter-input {
+      width: 100%;
+    }
+
+    :deep(.p-datatable-tbody > tr > td) {
+      padding: 0.25rem 0.5rem;
+      vertical-align: middle;
+      border-color: var(--feather-border-on-surface);
+      color: var(--feather-primary-text-on-surface);
+    }
+
+    :deep(.p-datatable-thead > tr > th) {
+      padding: 0.4rem 0.5rem;
+      background-color: var(--feather-background);
+      border-bottom: 1px solid var(--feather-border-on-surface);
+      color: var(--feather-secondary-text-on-surface);
+      text-transform: uppercase;
+    }
+
+    :deep(.p-datatable-tbody > tr) {
+      background-color: var(--feather-elevation-background-8);
+      color: var(--feather-primary-text-on-surface);
+    }
+
+    :deep(.p-select) {
+      background-color: var(--feather-surface);
+      border-color: var(--feather-border-on-surface);
+      color: var(--feather-primary-text-on-surface);
+    }
+
+    :deep(.p-inputtext) {
+      background-color: var(--feather-elevation-background-8);
+      border-color: var(--feather-border-on-surface);
+      color: var(--feather-primary-text-on-surface);
+    }
+
+    :deep(.p-select-label) {
+      color: var(--feather-primary-text-on-surface);
+    }
+  }
+}
+</style>

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -17,7 +17,7 @@
           :icon="InfoIcon"
           class="info-icon"
           @click="isMessageDialogVisible = true"
-          data-test="snmp-config-lookup-info-icon"
+          data-test="advanced-filters-info-icon"
         />
       </div>
       <h4 class="title">Categories</h4>
@@ -120,6 +120,7 @@
           />
         </div>
       </div>
+      <div class="spacer-large"></div>
       <FeatherAutocomplete
         class="filter-autocomplete"
         label="Flows"
@@ -140,6 +141,23 @@
             Down nodes only (nodes with a down aggregate status)
           </FeatherCheckbox>
         </div>
+      </div>
+      <div class="feather-row">
+        <div class="feather-col-12">
+          <FeatherCheckbox
+            v-model="selectedFilters.nodesWithAssets"
+          >
+            Nodes with asset info only
+          </FeatherCheckbox>
+        </div>
+      </div>
+      <div class="spacer-medium"></div>
+      <hr />
+      <div class="spacer-medium"></div>
+      <div>
+        <h4 class="title">Asset Fields</h4>
+        <div class="spacer-medium"></div>
+        <AssetFilterPanel ref="assetFilterPanelRef" />
       </div>
       <div class="spacer-medium"></div>
       <hr />
@@ -181,7 +199,7 @@
         <template #content>
           <div>
             <p>Use the advanced filters to find nodes that match specific criteria.</p>
-            <p>You can filter by categories, monitoring locations, monitored services, IP address, topology, flow type and multiple extended search parameters.</p>
+            <p>You can filter by categories, monitoring locations, monitored services, IP address, MAC address, topology, flow type, down status, asset fields and multiple extended search parameters.</p>
             <br />
             <p><strong>Categories</strong></p>
             <p>You may select up to two category groups to filter nodes by. Each category group can contain multiple categories "unioned" together.</p>
@@ -216,19 +234,19 @@
             <p><strong>Flows</strong></p>
             <p>Filtering by Flows allows you to find nodes which have ingress flows, egress flows or no flows.</p>
             <br />
+            <p><strong>Down nodes only</strong></p>
+            <p>Limits results to nodes with a down aggregate status, i.e. nodes that have at least one active monitored service currently in outage.</p>
+            <br />
+            <p><strong>Nodes with asset info only</strong></p>
+            <p>Limits results to nodes that have at least one non-empty asset-record field.</p>
+            <br />
+            <p><strong>Asset Fields</strong></p>
+            <p>Filter by one or more node asset-record fields (such as Building, Region, or Rack). Choose an asset field, enter a value, and click Add. Each added field is an exact match, and multiple asset fields are intersected (a node must match all of them).</p>
+            <br />
             <p><strong>Extended Search</strong></p>
             <p>Extended search allows you to perform more complex queries across multiple fields and criteria, including requisition, asset, and SNMP fields.</p>
             <p>Choose a search type, then a search term and click Add to add it as a filter. You may add multiple filters.</p>
             <p>This is a case-insensitive partial string match against the selected field.</p>
-            <br />
-            <br />
-            <p><strong>TODO</strong></p>
-            <br />
-            <p><strong>TODO: Move to main page</strong></p>
-            <p>Searching by name is a case-insensitive, inclusive search. For example, searching on serv would find any of serv, Service, Reserved, NTSERV, UserVortex, etc. The underscore character acts as a single character wildcard. The percent character acts as a multiple character wildcard.</p>
-            <br />
-            <p><strong>TODO: Need to implement</strong></p>
-            <p>Also note that you can quickly search for all nodes which have asset information assigned by clicking the List all nodes with asset info link.</p>
           </div>
         </template>
       </MessageDialog>
@@ -251,6 +269,7 @@ import DeleteIcon from '@featherds/icon/action/Delete'
 import InfoIcon from '@featherds/icon/action/Info'
 import MessageDialog from '../Common/MessageDialog.vue'
 import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
+import AssetFilterPanel from './AssetFilterPanel.vue'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 
 interface DrawerErrors {
@@ -258,6 +277,7 @@ interface DrawerErrors {
 }
 
 type ExtendedSearchPanelInstance = InstanceType<typeof ExtendedSearchPanel>
+type AssetFilterPanelInstance = InstanceType<typeof AssetFilterPanel>
 
 const searchTimeout = ref<number>(-1)
 const category2SearchTimeout = ref<number>(-1)
@@ -279,6 +299,7 @@ const TIMEOUT = 5
 
 const nodeStructureStore = useNodeStructureStore()
 const extendedSearchPanelRef = ref<ExtendedSearchPanelInstance | null>(null)
+const assetFilterPanelRef = ref<AssetFilterPanelInstance | null>(null)
 const showSecondCategories = ref(false)
 const selectedFilters = reactive({
   categories: [] as IAutocompleteItemType[],
@@ -289,7 +310,8 @@ const selectedFilters = reactive({
   ipAddress: '',
   macAddress: '',
   topology: '',
-  nodesWithDownAggregateStatus: false
+  nodesWithDownAggregateStatus: false,
+  nodesWithAssets: false
 })
 
 const filterCategoryItems = (query: string): IAutocompleteItemType[] => {
@@ -389,7 +411,9 @@ const applySelectedFilters = () => {
   nodeStructureStore.setFilterWithIpAddress(selectedFilters.ipAddress)
   nodeStructureStore.setFilterWithMacAddress(selectedFilters.macAddress)
   nodeStructureStore.setFilterWithDownAggregateStatus(selectedFilters.nodesWithDownAggregateStatus)
+  nodeStructureStore.setFilterWithNodesWithAssets(selectedFilters.nodesWithAssets)
   nodeStructureStore.setFilterWithTopology(selectedFilters.topology)
+  assetFilterPanelRef.value?.applyToStore()
   extendedSearchPanelRef.value?.applyToStore()
   nodeStructureStore.closeInstancesDrawerModal()
 }
@@ -405,7 +429,9 @@ const clearDrawerFilters = async () => {
   selectedFilters.macAddress = ''
   selectedFilters.topology = ''
   selectedFilters.nodesWithDownAggregateStatus = false
+  selectedFilters.nodesWithAssets = false
   showSecondCategories.value = false
+  assetFilterPanelRef.value?.resetFromStore()
   extendedSearchPanelRef.value?.resetFromStore()
 }
 
@@ -421,7 +447,9 @@ watch(() => nodeStructureStore.drawerState.visible, (visible) => {
     selectedFilters.macAddress = nodeStructureStore.queryFilter.macAddress ?? ''
     selectedFilters.topology = nodeStructureStore.queryFilter.topology ?? ''
     selectedFilters.nodesWithDownAggregateStatus = nodeStructureStore.queryFilter.nodesWithDownAggregateStatus ?? false
+    selectedFilters.nodesWithAssets = nodeStructureStore.queryFilter.nodesWithAssets ?? false
     serviceResults.value = nodeStructureStore.allServiceTypes.map(s => ({ _value: s.id, _text: s.name } as IAutocompleteItemType))
+    assetFilterPanelRef.value?.resetFromStore()
     extendedSearchPanelRef.value?.resetFromStore()
   }
 })

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -106,6 +106,15 @@
         <div class="feather-col-6">
           <FeatherInput
             class="filter-input last-filter-input"
+            label="MAC Address"
+            v-model="selectedFilters.macAddress"
+          />
+        </div>
+      </div>
+      <div class="feather-row">
+        <div class="feather-col-6">
+          <FeatherInput
+            class="filter-input last-filter-input"
             label="Topology (CDP/LLDP)"
             v-model="selectedFilters.topology"
           />
@@ -267,6 +276,7 @@ const selectedFilters = reactive({
   locations: [] as IAutocompleteItemType[],
   services: [] as IAutocompleteItemType[],
   ipAddress: '',
+  macAddress: '',
   topology: ''
 })
 
@@ -365,6 +375,7 @@ const applySelectedFilters = () => {
   nodeStructureStore.updateSelectedMonitoringLocations(selectedFilters.locations)
   nodeStructureStore.updateSelectedServices(selectedFilters.services)
   nodeStructureStore.setFilterWithIpAddress(selectedFilters.ipAddress)
+  nodeStructureStore.setFilterWithMacAddress(selectedFilters.macAddress)
   nodeStructureStore.setFilterWithTopology(selectedFilters.topology)
   extendedSearchPanelRef.value?.applyToStore()
   nodeStructureStore.closeInstancesDrawerModal()
@@ -378,6 +389,7 @@ const clearDrawerFilters = async () => {
   selectedFilters.locations = []
   selectedFilters.services = []
   selectedFilters.ipAddress = ''
+  selectedFilters.macAddress = ''
   selectedFilters.topology = ''
   showSecondCategories.value = false
   extendedSearchPanelRef.value?.resetFromStore()
@@ -392,6 +404,7 @@ watch(() => nodeStructureStore.drawerState.visible, (visible) => {
     selectedFilters.locations = [...nodeStructureStore.selectedMonitoringLocations]
     selectedFilters.services = [...nodeStructureStore.selectedServices]
     selectedFilters.ipAddress = nodeStructureStore.queryFilter.ipAddress ?? ''
+    selectedFilters.macAddress = nodeStructureStore.queryFilter.macAddress ?? ''
     selectedFilters.topology = nodeStructureStore.queryFilter.topology ?? ''
     serviceResults.value = nodeStructureStore.allServiceTypes.map(s => ({ _value: s.id, _text: s.name } as IAutocompleteItemType))
     extendedSearchPanelRef.value?.resetFromStore()

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -98,7 +98,7 @@
         <div class="feather-col-6">
           <FeatherInput
             class="filter-input"
-            label="IP Address"
+            label="IP Address / Pattern"
             v-model="selectedFilters.ipAddress"
             :error="errors.ipAddress"
           />
@@ -163,8 +163,53 @@
           <div>
             <p>Use the advanced filters to find nodes that match specific criteria.</p>
             <p>You can filter by categories, monitoring locations, monitored services, IP address, topology, flow type and multiple extended search parameters.</p>
-            <p><strong>Categories.</strong> You may select up to two category groups to filter nodes by. Each category group can contain multiple categories "unioned" together.</p>
+            <br />
+            <p><strong>Categories</strong></p>
+            <p>You may select up to two category groups to filter nodes by. Each category group can contain multiple categories "unioned" together.</p>
             <p>Category groups are then "intersected" with each other to refine the search results.</p>
+            <br />
+            <p><strong>Monitoring Location / Monitored Service</strong></p>
+            <p>To search by Monitoring Location or Monitored Service, click the down arrow and select the location or service you would like to search for.</p>
+            <br />
+            <p><strong>IP Address / IPLIKE</strong></p>
+            <p>Searching by TCP/IP address uses a very flexible search format, allowing you to separate the four or eight (in case of IPv6) fields of a TCP/IP address into specific searches.</p>
+            <p>An asterisk (*) in place of any octet matches any value for that octet.</p>
+            <p>Ranges are indicated by two numbers separated by a dash (-), and commas (,) are used for list demarcation.</p>
+            <br />
+            <p>For example, the following search fields are all valid:</p>
+            <ul>
+              <li><code>10.0.*.*</code> (multiple wildcards)</li>
+              <li><code>10.0.0.1-255</code> (range in last octet)</li>
+              <li><code>10.0.0-255.1-255</code> (range in third and fourth octets)</li>
+              <li><code>10.9.1-3.*</code> (range in third octet with wildcard in last octet)</li>
+              <li><code>192.168.0,1.*</code> (comma list in third octet, wildcard in last octet)</li>
+              <li><code>192.168.1,2,3-255.*</code> (comma + range combination, with wildcard in last octet)</li>
+              <li><code>2001:0-ffff:*:*:*:*:*:*</code> (IPv6 range and wildcards)</li>
+              <li><code>fc00,fe80:*:*:*:*:*:*:*</code> (IPv6 comma and wildcards)</li>
+            </ul>
+            <br />
+            <p><strong>MAC Address</strong></p>
+            <p>Searching by MAC Address allows you to find interfaces with hardware (MAC) addresses matching the search string. This is a case-insensitive partial string match. For example, you can find all interfaces with a specified manufacturer's code by entering the first 6 characters of the mac address. Octet separators (dash or colon) are optional.</p>
+            <br />
+            <p><strong>Topology</strong></p>
+            <p>Searching by Topology allows you to find nodes which have CDP or LLDP neighbors matching the search string. This is a case-insensitive partial string match against the neighbor's system name, system description, and interface name.</p>
+            <br />
+            <p><strong>Flows</strong></p>
+            <p>Filtering by Flows allows you to find nodes which have ingress flows, egress flows or no flows.</p>
+            <br />
+            <p><strong>Extended Search</strong></p>
+            <p>Extended search allows you to perform more complex queries across multiple fields and criteria, including requisition, asset, and SNMP fields.</p>
+            <p>Choose a search type, then a search term and click Add to add it as a filter. You may add multiple filters.</p>
+            <p>This is a case-insensitive partial string match against the selected field.</p>
+            <br />
+            <br />
+            <p><strong>TODO</strong></p>
+            <br />
+            <p><strong>TODO: Move to main page</strong></p>
+            <p>Searching by name is a case-insensitive, inclusive search. For example, searching on serv would find any of serv, Service, Reserved, NTSERV, UserVortex, etc. The underscore character acts as a single character wildcard. The percent character acts as a multiple character wildcard.</p>
+            <br />
+            <p><strong>TODO: Need to implement</strong></p>
+            <p>Also note that you can quickly search for all nodes which have asset information assigned by clicking the List all nodes with asset info link.</p>
           </div>
         </template>
       </MessageDialog>
@@ -175,6 +220,7 @@
 <script lang="ts" setup>
 import { ref, reactive, watch, watchEffect } from 'vue'
 import { isIP } from 'is-ip'
+import { isIplikePattern } from '@/components/Nodes/hooks/queryStringParser'
 import { FeatherAutocomplete, IAutocompleteItemType } from '@featherds/autocomplete'
 import { FeatherDrawer } from '@featherds/drawer'
 import { FeatherButton } from '@featherds/button'
@@ -301,8 +347,8 @@ const removeSecondCategories = () => {
 const validate = (): DrawerErrors => {
   const errs: DrawerErrors = {}
   const ip = selectedFilters.ipAddress
-  if (ip && !isIP(ip)) {
-    errs.ipAddress = 'Must be a valid IPv4 or IPv6 address'
+  if (ip && !isIP(ip) && !isIplikePattern(ip)) {
+    errs.ipAddress = 'Enter a valid IPv4/IPv6 address or iplike pattern (e.g. 192.168.1.*, 10.0.0.1-255, 10.9.1-3.*, 192.168.0,1.*, 2001:db8:*:*:*:*:*:*)'
   }
   return errs
 }

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -132,6 +132,16 @@
         text-prop="_text"
       ></FeatherAutocomplete>
       <div class="spacer-medium"></div>
+      <div class="feather-row">
+        <div class="feather-col-12">
+          <FeatherCheckbox
+            v-model="selectedFilters.nodesWithDownAggregateStatus"
+          >
+            Down nodes only (nodes with a down aggregate status)
+          </FeatherCheckbox>
+        </div>
+      </div>
+      <div class="spacer-medium"></div>
       <hr />
       <div class="spacer-medium"></div>
       <div>
@@ -233,6 +243,7 @@ import { isIplikePattern } from '@/components/Nodes/hooks/queryStringParser'
 import { FeatherAutocomplete, IAutocompleteItemType } from '@featherds/autocomplete'
 import { FeatherDrawer } from '@featherds/drawer'
 import { FeatherButton } from '@featherds/button'
+import { FeatherCheckbox } from '@featherds/checkbox'
 import { FeatherIcon } from '@featherds/icon'
 import { FeatherInput } from '@featherds/input'
 import AddIcon from '@featherds/icon/action/Add'
@@ -277,7 +288,8 @@ const selectedFilters = reactive({
   services: [] as IAutocompleteItemType[],
   ipAddress: '',
   macAddress: '',
-  topology: ''
+  topology: '',
+  nodesWithDownAggregateStatus: false
 })
 
 const filterCategoryItems = (query: string): IAutocompleteItemType[] => {
@@ -376,6 +388,7 @@ const applySelectedFilters = () => {
   nodeStructureStore.updateSelectedServices(selectedFilters.services)
   nodeStructureStore.setFilterWithIpAddress(selectedFilters.ipAddress)
   nodeStructureStore.setFilterWithMacAddress(selectedFilters.macAddress)
+  nodeStructureStore.setFilterWithDownAggregateStatus(selectedFilters.nodesWithDownAggregateStatus)
   nodeStructureStore.setFilterWithTopology(selectedFilters.topology)
   extendedSearchPanelRef.value?.applyToStore()
   nodeStructureStore.closeInstancesDrawerModal()
@@ -391,6 +404,7 @@ const clearDrawerFilters = async () => {
   selectedFilters.ipAddress = ''
   selectedFilters.macAddress = ''
   selectedFilters.topology = ''
+  selectedFilters.nodesWithDownAggregateStatus = false
   showSecondCategories.value = false
   extendedSearchPanelRef.value?.resetFromStore()
 }
@@ -406,6 +420,7 @@ watch(() => nodeStructureStore.drawerState.visible, (visible) => {
     selectedFilters.ipAddress = nodeStructureStore.queryFilter.ipAddress ?? ''
     selectedFilters.macAddress = nodeStructureStore.queryFilter.macAddress ?? ''
     selectedFilters.topology = nodeStructureStore.queryFilter.topology ?? ''
+    selectedFilters.nodesWithDownAggregateStatus = nodeStructureStore.queryFilter.nodesWithDownAggregateStatus ?? false
     serviceResults.value = nodeStructureStore.allServiceTypes.map(s => ({ _value: s.id, _text: s.name } as IAutocompleteItemType))
     extendedSearchPanelRef.value?.resetFromStore()
   }

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -39,8 +39,17 @@
               </FeatherInput>
             </div>
             <div>
+              <FeatherIcon
+                :icon="InfoIcon"
+                class="info-icon"
+                title="Node Search Help"
+                @click="isHelpMessageDialogVisible = true"
+                data-test="nodes-info-icon"
+              />
+            </div>
+            <div>
               <FeatherButton
-                icon="FilterAlt"
+                icon="Advanced Filters"
                 @click="() => nodeStructureStore.openInstancesDrawerModal()"
               >
                 <FeatherIcon :icon="FilterAlt" />
@@ -183,16 +192,30 @@
               </FeatherChip>
 
               <FeatherChip
-                v-if="nodeStructureStore.queryFilter.assetValue"
+                v-if="nodeStructureStore.queryFilter.nodesWithAssets"
               >
                 <template #icon>
                   <FeatherIcon
                     :icon="cancelIcon"
                     class="icon"
-                    @click="nodeStructureStore.removeAsset()"
+                    @click="nodeStructureStore.removeNodesWithAssets()"
                   />
                 </template>
-                {{ `Asset ${nodeStructureStore.queryFilter.assetColumn}: ${nodeStructureStore.queryFilter.assetValue}` }}
+                Nodes with asset info
+              </FeatherChip>
+
+              <FeatherChip
+                v-for="assetFilter in (nodeStructureStore.queryFilter.assetFilters ?? [])"
+                :key="assetFilter.column"
+              >
+                <template #icon>
+                  <FeatherIcon
+                    :icon="cancelIcon"
+                    class="icon"
+                    @click="nodeStructureStore.removeAssetFilter(assetFilter.column)"
+                  />
+                </template>
+                {{ `Asset ${getAssetColumnLabel(assetFilter.column)}: ${assetFilter.value}` }}
               </FeatherChip>
             </FeatherChipList>
           </div>
@@ -381,6 +404,24 @@
   </NodeDetailsDialog>
   <NodeAdvancedFiltersDrawer />
   <ColumnSelectionDrawer />
+
+  <MessageDialog
+    :visible="isHelpMessageDialogVisible"
+    :relative="true"
+    maxHeight="22em"
+    maxWidth="50em"
+    title="Node Search"
+    @close="isHelpMessageDialogVisible = false"
+  >
+    <template #content>
+      <div>
+        <p>You may search by node name or exact IP address here.</p>
+        <p>Searching by name is a case-insensitive, inclusive search.</p>
+        <p>For example, searching on serv would find any of serv, Service, Reserved, NTSERV, UserVortex, etc. The underscore character acts as a single character wildcard. The percent character acts as a multiple character wildcard.</p>
+        <p>For more advanced search options, please open the Advanced Filters drawer.</p>
+      </div>
+    </template>
+  </MessageDialog>
 </template>
 
 <script setup lang="ts">
@@ -409,9 +450,11 @@ import ViewDetails from '@featherds/icon/action/ViewDetails'
 import Cancel from '@featherds/icon/navigation/Cancel'
 import ChevronLeft from '@featherds/icon/navigation/ChevronLeft'
 import ChevronRight from '@featherds/icon/navigation/ChevronRight'
+import InfoIcon from '@featherds/icon/action/Info'
 import { FeatherInput } from '@featherds/input'
 import { FeatherPagination } from '@featherds/pagination'
 import { FeatherSortHeader, SORT } from '@featherds/table'
+import MessageDialog from '../Common/MessageDialog.vue'
 import { computed, nextTick, reactive, ref, watch } from 'vue'
 import ColumnSelectionDrawer from './ColumnSelectionDrawer.vue'
 import FlowTooltipCell from './FlowTooltipCell.vue'
@@ -423,6 +466,7 @@ import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
 import NodeTooltipCell from './NodeTooltipCell.vue'
 import { useNodeExport } from './hooks/useNodeExport'
 import { useNodeQuery } from './hooks/useNodeQuery'
+import { getAssetColumnLabel } from './hooks/queryStringParser'
 import { getTableCssClasses } from './utils'
 import EmptyList from '../Common/EmptyList.vue'
 
@@ -434,6 +478,7 @@ const { generateBlob, generateDownload, getExportData } = useNodeExport()
 const { buildUpdatedNodeStructureQueryParameters, getExtendedSearchValues } = useNodeQuery()
 const visibleColumnStart = ref(0)
 const visibleColumnsCount = 5
+const isHelpMessageDialogVisible = ref(false)
 
 const visibleColumns = computed(() => {
   return nodeStructureStore.columns
@@ -747,11 +792,23 @@ table {
 }
 
 .title-bar {
-  display: flex;
   justify-content: space-between;
   align-items: center;
   padding-right: 1rem;
   padding-left: 1rem;
+}
+
+.search-container {
+  .info-icon {
+    cursor: pointer;
+    font-size: 1.5em;
+    margin-left: 0.5em;
+    color: var(variables.$primary);
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
 }
 
 .action-buttons-container {

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -2,7 +2,7 @@
   <div class="card">
     <div>
       <div class="feather-row title-bar">
-        <span class="title">Node List</span>
+        <span class="title">Nodes</span>
         <div class="action-buttons-container">
           <NodeDownloadDropdown
             :onCsvDownload="onCsvDownload"

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -168,6 +168,32 @@
                 </template>
                 {{ `Topology: ${topologyTerm}` }}
               </FeatherChip>
+
+              <FeatherChip
+                v-if="nodeStructureStore.queryFilter.nodesWithDownAggregateStatus"
+              >
+                <template #icon>
+                  <FeatherIcon
+                    :icon="cancelIcon"
+                    class="icon"
+                    @click="nodeStructureStore.removeDownAggregateStatus()"
+                  />
+                </template>
+                Down nodes only
+              </FeatherChip>
+
+              <FeatherChip
+                v-if="nodeStructureStore.queryFilter.assetValue"
+              >
+                <template #icon>
+                  <FeatherIcon
+                    :icon="cancelIcon"
+                    class="icon"
+                    @click="nodeStructureStore.removeAsset()"
+                  />
+                </template>
+                {{ `Asset ${nodeStructureStore.queryFilter.assetColumn}: ${nodeStructureStore.queryFilter.assetValue}` }}
+              </FeatherChip>
             </FeatherChipList>
           </div>
         </div>

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -144,6 +144,19 @@
               </FeatherChip>
 
               <FeatherChip
+                v-if="nodeStructureStore.queryFilter.macAddress"
+              >
+                <template #icon>
+                  <FeatherIcon
+                    :icon="cancelIcon"
+                    class="icon"
+                    @click="nodeStructureStore.removeMacAddress()"
+                  />
+                </template>
+                {{ `MAC Address: ${nodeStructureStore.queryFilter.macAddress}` }}
+              </FeatherChip>
+
+              <FeatherChip
                 v-if="hasTopologySearch"
               >
                 <template #icon>

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -136,7 +136,7 @@
                     @click="removeExtendedSearchItem(value)"
                   />
                 </template>
-                {{ `Extended Search: ${value.name} ${value.value}` }}
+                {{ `${value.name} ${value.value}` }}
               </FeatherChip>
 
               <FeatherChip
@@ -149,7 +149,7 @@
                     @click="nodeStructureStore.removeIpAddress()"
                   />
                 </template>
-                {{ `IP Address: ${nodeStructureStore.queryFilter.ipAddress}` }}
+                {{ `IP Pattern: ${nodeStructureStore.queryFilter.ipAddress}` }}
               </FeatherChip>
 
               <FeatherChip
@@ -215,7 +215,7 @@
                     @click="nodeStructureStore.removeAssetFilter(assetFilter.column)"
                   />
                 </template>
-                {{ `Asset ${getAssetColumnLabel(assetFilter.column)}: ${assetFilter.value}` }}
+                {{ `Asset: ${getAssetColumnLabel(assetFilter.column)}: ${assetFilter.value}` }}
               </FeatherChip>
             </FeatherChipList>
           </div>

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -139,13 +139,48 @@ export const parseFlows = (queryObject: any) => {
 }
 
 /**
- * Currently this accepts anything in any valid IPv4 or IPv6 format (see `is-ip`), but
- * some formats may not actually be supported by our FIQL search.
+ * Returns true if value looks like an IPv4 or IPv6 iplike pattern (wildcard, range, or list).
+ *
+ * IPv4: 1-4 dot-separated segments, each being * | N | N-M | N,M | N-M,P-Q,...
+ *   Examples: 192.168.1.*, 10.9.1-3.*, 10.0.0.1-255, 192.168.0,1,2.*
+ * IPv6: 1-8 colon-separated hextets, each being * | H | H-H | H,H,...  (hex values)
+ *   Examples: 2001:db8:*:*:*:*:*:*, fe80:*:*:*:*:*:*:*, 2001:0-ffff:*:*:*:*:*:*
+ *
+ * Returns false for plain exact IPs (use isIP() for those) and for garbage.
+ * Compressed IPv6 notation (::) is not supported in patterns — only in exact addresses.
+ * Ranges are per-segment only; cross-segment notation like 10.0.0.1-10.0.0.255 is invalid.
+ */
+export const isIplikePattern = (value: string): boolean => {
+  // Must contain at least one pattern character to be an iplike pattern (not a plain IP)
+  if (!value.includes('*') && !value.includes('-') && !value.includes(',')) {
+    return false
+  }
+  if (value.includes('.')) {
+    // IPv4: each octet is * | N | N-M | list of those
+    const seg = '(\\*|\\d+(?:-\\d+)?(?:,\\d+(?:-\\d+)?)*)'
+    return new RegExp(`^${seg}(\\.${seg}){0,3}$`).test(value)
+  }
+  if (value.includes(':')) {
+    // IPv6: each hextet is * | H | H-H | list of those (hex digits only)
+    const seg = '(\\*|[0-9a-fA-F]{1,4}(?:-[0-9a-fA-F]{1,4})?(?:,[0-9a-fA-F]{1,4}(?:-[0-9a-fA-F]{1,4})?)*)'
+    return new RegExp(`^${seg}(:${seg}){0,7}$`).test(value)
+  }
+  return false
+}
+
+/**
+ * Parses an IP address or iplike pattern from a URL query object.
+ * Accepts exact IPv4/IPv6 addresses and IPv4 iplike wildcard patterns like 192.168.1.*.
+ * Priority: `iplike` param over `ipAddress` param.
  */
 export const parseIplike = (queryObject: any) => {
   const ip = queryObject.iplike as string || queryObject.ipAddress as string || ''
 
-  if (ip && isIP(ip)) {
+  if (!ip) {
+    return null
+  }
+
+  if (isIP(ip) || isIplikePattern(ip)) {
     return ip
   }
 

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -326,6 +326,39 @@ export const parseMaclike = (queryObject: any): string | null => {
 }
 
 /**
+ * OnmsAssetRecord string columns that can be filtered directly via `assetRecord.<col>` FIQL.
+ * Used to validate the `assetColumn` query param (sourced from site-status-views config) so a
+ * stray/unsupported column never produces an invalid FIQL query. Geolocation-backed fields
+ * (city/state/zip/country) are intentionally excluded — they are not direct assetRecord properties.
+ */
+export const ALLOWED_ASSET_COLUMNS = new Set([
+  'building', 'floor', 'room', 'rack', 'region', 'division', 'department',
+  'category', 'displayCategory', 'circuitId'
+])
+
+/**
+ * Returns true if the `nodesWithDownAggregateStatus` query param requests down-only nodes.
+ */
+export const parseDownAggregateStatus = (queryObject: any): boolean => {
+  return String(queryObject.nodesWithDownAggregateStatus ?? '').toLowerCase() === 'true'
+}
+
+/**
+ * Parses an asset-field filter (`assetColumn` + `assetValue`) from a query object.
+ * Both must be present and the column must be in ALLOWED_ASSET_COLUMNS, otherwise null.
+ */
+export const parseAssetFilter = (queryObject: any): { column: string, value: string } | null => {
+  const column = (queryObject.assetColumn as string) || ''
+  const value = (queryObject.assetValue as string) || ''
+
+  if (!column || !value || !ALLOWED_ASSET_COLUMNS.has(column)) {
+    return null
+  }
+
+  return { column, value }
+}
+
+/**
  * Maps monitoredService or service query params to canonical service names for FIQL filtering.
  * Resolves by exact or case-insensitive name match, or by numeric ID lookup via serviceTypes.
  * monitoredService takes precedence over service when both are present.

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -313,8 +313,10 @@ export const parseMib2Params = (queryObject: any): NodeQuerySysParams | null => 
 
 /**
  * Maps legacy maclike/snmpphysaddr params to a stripped, lowercase MAC address string
- * suitable for wildcard FIQL matching against snmpInterface.physAddr.
- * Colons and dashes are stripped to match the format stored in the database.
+ * suitable for matching against snmpInterface.physAddr.
+ * All non-hex characters (separators like ':' and '-', plus any stray FIQL characters such as
+ * ',' or ';') are stripped, both to match the format stored in the database and to keep the value
+ * safe for the FIQL expression.
  */
 export const parseMaclike = (queryObject: any): string | null => {
   const mac = queryObject.maclike as string || queryObject.snmpphysaddr as string || ''
@@ -323,7 +325,7 @@ export const parseMaclike = (queryObject: any): string | null => {
     return null
   }
 
-  return mac.replace(/[:-]/g, '').toLowerCase()
+  return mac.replace(/[^0-9a-fA-F]/g, '').toLowerCase()
 }
 
 /**

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -151,19 +151,21 @@ export const parseFlows = (queryObject: any) => {
  * Ranges are per-segment only; cross-segment notation like 10.0.0.1-10.0.0.255 is invalid.
  */
 export const isIplikePattern = (value: string): boolean => {
+  // Normalize spaces around commas so "1, 2, 3" is treated the same as "1,2,3"
+  const v = value.replace(/\s*,\s*/g, ',')
   // Must contain at least one pattern character to be an iplike pattern (not a plain IP)
-  if (!value.includes('*') && !value.includes('-') && !value.includes(',')) {
+  if (!v.includes('*') && !v.includes('-') && !v.includes(',')) {
     return false
   }
-  if (value.includes('.')) {
+  if (v.includes('.')) {
     // IPv4: each octet is * | N | N-M | list of those
     const seg = '(\\*|\\d+(?:-\\d+)?(?:,\\d+(?:-\\d+)?)*)'
-    return new RegExp(`^${seg}(\\.${seg}){0,3}$`).test(value)
+    return new RegExp(`^${seg}(\\.${seg}){0,3}$`).test(v)
   }
-  if (value.includes(':')) {
+  if (v.includes(':')) {
     // IPv6: each hextet is * | H | H-H | list of those (hex digits only)
     const seg = '(\\*|[0-9a-fA-F]{1,4}(?:-[0-9a-fA-F]{1,4})?(?:,[0-9a-fA-F]{1,4}(?:-[0-9a-fA-F]{1,4})?)*)'
-    return new RegExp(`^${seg}(:${seg}){0,7}$`).test(value)
+    return new RegExp(`^${seg}(:${seg}){0,7}$`).test(v)
   }
   return false
 }

--- a/ui/src/components/Nodes/hooks/queryStringParser.ts
+++ b/ui/src/components/Nodes/hooks/queryStringParser.ts
@@ -21,6 +21,7 @@
 ///
 
 import {
+  AssetFilter,
   Category,
   MatchType,
   MonitoringLocation,
@@ -326,15 +327,30 @@ export const parseMaclike = (queryObject: any): string | null => {
 }
 
 /**
- * OnmsAssetRecord string columns that can be filtered directly via `assetRecord.<col>` FIQL.
- * Used to validate the `assetColumn` query param (sourced from site-status-views config) so a
- * stray/unsupported column never produces an invalid FIQL query. Geolocation-backed fields
- * (city/state/zip/country) are intentionally excluded — they are not direct assetRecord properties.
+ * OnmsAssetRecord string columns that can be filtered directly via `assetRecord.<col>` FIQL,
+ * with human-readable labels for the asset-filter dropdown. Geolocation-backed fields
+ * (city/state/zip/country) are intentionally excluded — they are not direct assetRecord properties,
+ * so an `assetRecord.city` query would be invalid.
  */
-export const ALLOWED_ASSET_COLUMNS = new Set([
-  'building', 'floor', 'room', 'rack', 'region', 'division', 'department',
-  'category', 'displayCategory', 'circuitId'
-])
+export const ASSET_COLUMN_OPTIONS: { value: string, label: string }[] = [
+  { value: 'building', label: 'Building' },
+  { value: 'floor', label: 'Floor' },
+  { value: 'room', label: 'Room' },
+  { value: 'rack', label: 'Rack' },
+  { value: 'region', label: 'Region' },
+  { value: 'division', label: 'Division' },
+  { value: 'department', label: 'Department' },
+  { value: 'category', label: 'Category' },
+  { value: 'displayCategory', label: 'Display Category' },
+  { value: 'circuitId', label: 'Circuit ID' }
+]
+
+/** Set of allowed asset column keys, used to validate inbound `assetColumn` params. */
+export const ALLOWED_ASSET_COLUMNS = new Set(ASSET_COLUMN_OPTIONS.map(o => o.value))
+
+/** Display label for an asset column key (falls back to the key itself). */
+export const getAssetColumnLabel = (column: string): string =>
+  ASSET_COLUMN_OPTIONS.find(o => o.value === column)?.label ?? column
 
 /**
  * Returns true if the `nodesWithDownAggregateStatus` query param requests down-only nodes.
@@ -344,18 +360,36 @@ export const parseDownAggregateStatus = (queryObject: any): boolean => {
 }
 
 /**
- * Parses an asset-field filter (`assetColumn` + `assetValue`) from a query object.
- * Both must be present and the column must be in ALLOWED_ASSET_COLUMNS, otherwise null.
+ * Returns true if the `nodesWithAssets` query param requests only nodes that have asset info.
  */
-export const parseAssetFilter = (queryObject: any): { column: string, value: string } | null => {
-  const column = (queryObject.assetColumn as string) || ''
-  const value = (queryObject.assetValue as string) || ''
+export const parseNodesWithAssets = (queryObject: any): boolean => {
+  return String(queryObject.nodesWithAssets ?? '').toLowerCase() === 'true'
+}
 
-  if (!column || !value || !ALLOWED_ASSET_COLUMNS.has(column)) {
-    return null
+/**
+ * Parses asset-field filters from `assetColumn` + `assetValue` query params.
+ * Each param may be a single value (vue-router string) or repeated (array); the two are paired
+ * by index. Pairs with an empty value or a column not in ALLOWED_ASSET_COLUMNS are skipped, and
+ * duplicate columns keep the last value. Returns [] when none are valid.
+ */
+export const parseAssetFilters = (queryObject: any): AssetFilter[] => {
+  const toArray = (v: any): string[] =>
+    Array.isArray(v) ? (v as string[]) : v ? [v as string] : []
+
+  const columns = toArray(queryObject.assetColumn)
+  const values = toArray(queryObject.assetValue)
+
+  const byColumn = new Map<string, string>()
+  const count = Math.min(columns.length, values.length)
+  for (let i = 0; i < count; i++) {
+    const column = columns[i]
+    const value = values[i]
+    if (column && value && ALLOWED_ASSET_COLUMNS.has(column)) {
+      byColumn.set(column, value)
+    }
   }
 
-  return { column, value }
+  return Array.from(byColumn, ([column, value]) => ({ column, value }))
 }
 
 /**

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -631,9 +631,10 @@ const buildMaclikeQuery = (macAddress?: string) => {
     return ''
   }
 
-  // Strip separators and lowercase to match the format stored in snmpinterface.snmpphysaddr.
+  // Strip separators/whitespace and lowercase to match the format stored in snmpinterface.snmpphysaddr.
   // The backend maclike behavior does a case-insensitive ANYWHERE match, so a partial MAC is fine.
-  const stripped = macAddress.replace(/[:-]/g, '').toLowerCase()
+  const stripped = macAddress.replace(/[^0-9a-fA-F]/g, '').toLowerCase()
+
   if (stripped.length === 0) {
     return ''
   }

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -99,6 +99,7 @@ export const useNodeQuery = () => {
       selectedFlows: [] as string[],
       selectedMonitoringLocations: [] as MonitoringLocation[],
       ipAddress: '',
+      macAddress: '',
       topology: '',
       extendedSearch: getDefaultNodeQueryExtendedSearchParams()
     } as NodeQueryFilter
@@ -292,13 +293,10 @@ export const useNodeQuery = () => {
       filter.extendedSearch.foreignSourceParams = fsParams
     }
 
-    // physAddr (MAC address) — set independently of snmpParm/snmpParams blocks
+    // maclike (MAC address) — dedicated top-level filter, emitted as a maclike== FIQL query
     const macAddr = parseMaclike(queryObject)
     if (macAddr) {
-      if (!filter.extendedSearch.snmpParams) {
-        filter.extendedSearch.snmpParams = getDefaultNodeQuerySnmpParams()
-      }
-      filter.extendedSearch.snmpParams.physAddr = macAddr
+      filter.macAddress = macAddr
     }
 
     const serviceNames = parseMonitoredServices(queryObject, serviceTypes)
@@ -351,11 +349,12 @@ const buildNodeStructureQuery = (filter: NodeQueryFilter) => {
   const snmpQuery = buildSnmpQuery(filter.extendedSearch.snmpParams)
   const sysQuery = buildSysQuery(filter.extendedSearch.sysParams)
   const serviceQuery = buildServiceQuery(filter.selectedServices ?? [])
+  const maclikeQuery = buildMaclikeQuery(filter.macAddress)
   const topologyQuery = buildTopologyQuery(filter.topology)
 
   // TODO: May need more search term sanitizing and/or restrict characters in the FeatherInput above
   const querySeparator = getFiqlSetOperator(SetOperator.Intersection)
-  const query = [searchQuery, ipAddressQuery, foreignSourceQuery, snmpQuery, sysQuery, categoryQuery, flowsQuery, locationQuery, serviceQuery, topologyQuery].filter(s => s.length > 0).join(querySeparator)
+  const query = [searchQuery, ipAddressQuery, foreignSourceQuery, snmpQuery, sysQuery, categoryQuery, flowsQuery, locationQuery, serviceQuery, maclikeQuery, topologyQuery].filter(s => s.length > 0).join(querySeparator)
 
   // additional fields to search on for main searchTerm
   // these will be added as SetOperator.Union (i.e. 'or')
@@ -594,6 +593,21 @@ const buildSysQuery = (sysParams?: NodeQuerySysParams) => {
   }
 
   return ''
+}
+
+const buildMaclikeQuery = (macAddress?: string) => {
+  if (!macAddress) {
+    return ''
+  }
+
+  // Strip separators and lowercase to match the format stored in snmpinterface.snmpphysaddr.
+  // The backend maclike behavior does a case-insensitive ANYWHERE match, so a partial MAC is fine.
+  const stripped = macAddress.replace(/[:-]/g, '').toLowerCase()
+  if (stripped.length === 0) {
+    return ''
+  }
+
+  return `maclike==${stripped}`
 }
 
 const buildTopologyQuery = (topology?: string) => {

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -338,7 +338,9 @@ export const useNodeQuery = () => {
  */
 const buildNodeStructureQuery = (filter: NodeQueryFilter) => {
   const searchTerm = sanitizeSearchTerm(filter.searchTerm)
-  const ipAddress = sanitizeSearchTerm(filter.ipAddress)
+  // don't sanitize IP address — allow users to enter commas and other FIQL characters, since buildIpAddressQuery will handle them appropriately
+  // (commas are valid in iplike patterns, and users may naturally enter comma-separated lists of IPs or CIDRs)
+  const ipAddress = filter.ipAddress
 
   const searchQuery = buildSearchQuery(searchTerm)
   const ipAddressQuery = buildIpAddressQuery(ipAddress)
@@ -382,8 +384,10 @@ const buildIpAddressQuery = (ipAddress?: string) => {
   if (!ipAddress) {
     return ''
   }
+
   // Normalize spaces around commas (users naturally type "1, 2, 3" but iplike has no spaces)
   const normalized = ipAddress.replace(/\s*,\s*/g, ',')
+
   if (isIplikePattern(normalized)) {
     // Commas in iplike patterns must survive HTTP URL-decoding intact so that FIQL's parser
     // does not treat them as OR operators.  queryParametersHandler emits the URL verbatim
@@ -394,7 +398,13 @@ const buildIpAddressQuery = (ipAddress?: string) => {
     const encoded = normalized.replace(/,/g, '%252C')
     return `iplike==${encoded}`
   }
-  return `ipInterface.ipAddress==${ipAddress}`
+
+  if (isIP(normalized)) {
+    return `ipInterface.ipAddress==${normalized}`
+  }
+
+  // if it's not a valid IP or iplike pattern, don't include it in the query at all
+  return ''
 }
 
 const buildCategoryQuery = (selectedCategories: Category[], categoryMode: SetOperator, selectedCategories2?: Category[]) => {

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -36,7 +36,10 @@ import {
   SetOperator
 } from '@/types'
 import {
+  ALLOWED_ASSET_COLUMNS,
+  parseAssetFilter,
   parseCategories,
+  parseDownAggregateStatus,
   parseFlows,
   parseForeignSource,
   isIplikePattern,
@@ -101,6 +104,9 @@ export const useNodeQuery = () => {
       ipAddress: '',
       macAddress: '',
       topology: '',
+      nodesWithDownAggregateStatus: false,
+      assetColumn: '',
+      assetValue: '',
       extendedSearch: getDefaultNodeQueryExtendedSearchParams()
     } as NodeQueryFilter
   }
@@ -189,6 +195,8 @@ export const useNodeQuery = () => {
    * Query string search parameters tracked/accepted by the Node Structure page.
    */
   const trackedNodeQueryStringProperties = new Set([
+    'assetColumn',
+    'assetValue',
     'categories',
     'category1',
     'category2',
@@ -196,6 +204,7 @@ export const useNodeQuery = () => {
     'foreignsource',
     'ipAddress',
     'iplike',
+    'nodesWithDownAggregateStatus',
     'listInterfaces',
     'maclike',
     'mib2Parm',
@@ -299,6 +308,18 @@ export const useNodeQuery = () => {
       filter.macAddress = macAddr
     }
 
+    // nodesWithDownAggregateStatus — limit to nodes with a down aggregate status
+    if (parseDownAggregateStatus(queryObject)) {
+      filter.nodesWithDownAggregateStatus = true
+    }
+
+    // asset-field filter (e.g. from site-status-view drill-down links)
+    const assetFilter = parseAssetFilter(queryObject)
+    if (assetFilter) {
+      filter.assetColumn = assetFilter.column
+      filter.assetValue = assetFilter.value
+    }
+
     const serviceNames = parseMonitoredServices(queryObject, serviceTypes)
     if (serviceNames.length > 0) {
       filter.selectedServices = serviceNames
@@ -350,11 +371,13 @@ const buildNodeStructureQuery = (filter: NodeQueryFilter) => {
   const sysQuery = buildSysQuery(filter.extendedSearch.sysParams)
   const serviceQuery = buildServiceQuery(filter.selectedServices ?? [])
   const maclikeQuery = buildMaclikeQuery(filter.macAddress)
+  const downStatusQuery = buildDownStatusQuery(filter.nodesWithDownAggregateStatus)
+  const assetQuery = buildAssetQuery(filter.assetColumn, filter.assetValue)
   const topologyQuery = buildTopologyQuery(filter.topology)
 
   // TODO: May need more search term sanitizing and/or restrict characters in the FeatherInput above
   const querySeparator = getFiqlSetOperator(SetOperator.Intersection)
-  const query = [searchQuery, ipAddressQuery, foreignSourceQuery, snmpQuery, sysQuery, categoryQuery, flowsQuery, locationQuery, serviceQuery, maclikeQuery, topologyQuery].filter(s => s.length > 0).join(querySeparator)
+  const query = [searchQuery, ipAddressQuery, foreignSourceQuery, snmpQuery, sysQuery, categoryQuery, flowsQuery, locationQuery, serviceQuery, maclikeQuery, downStatusQuery, assetQuery, topologyQuery].filter(s => s.length > 0).join(querySeparator)
 
   // additional fields to search on for main searchTerm
   // these will be added as SetOperator.Union (i.e. 'or')
@@ -608,6 +631,19 @@ const buildMaclikeQuery = (macAddress?: string) => {
   }
 
   return `maclike==${stripped}`
+}
+
+const buildDownStatusQuery = (nodesWithDownAggregateStatus?: boolean) => {
+  return nodesWithDownAggregateStatus ? 'nodesWithDownAggregateStatus==true' : ''
+}
+
+const buildAssetQuery = (assetColumn?: string, assetValue?: string) => {
+  if (!assetColumn || !assetValue || !ALLOWED_ASSET_COLUMNS.has(assetColumn)) {
+    return ''
+  }
+
+  // Exact match against the asset record column (mirrors the legacy site-status-view asset filter).
+  return `assetRecord.${assetColumn}==${assetValue}`
 }
 
 const buildTopologyQuery = (topology?: string) => {

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -39,6 +39,7 @@ import {
   parseCategories,
   parseFlows,
   parseForeignSource,
+  isIplikePattern,
   parseIplike,
   parseMaclike,
   parseMib2Params,
@@ -153,7 +154,7 @@ export const useNodeQuery = () => {
   }
 
   const addIpAddressToQueryFilter = (filter: NodeQueryFilter, ipAddress: string) => {
-    const ip = parseIplike(ipAddress)
+    const ip = parseIplike({ ipAddress })
 
     if (ip) {
       return {
@@ -378,11 +379,20 @@ const buildSearchQuery = (searchTerm: string) => {
 }
 
 const buildIpAddressQuery = (ipAddress?: string) => {
-  if (ipAddress) {
-    return `ipInterface.ipAddress==${ipAddress}`
+  if (!ipAddress) {
+    return ''
   }
-
-  return ''
+  if (isIplikePattern(ipAddress)) {
+    // Commas in iplike patterns must survive HTTP URL-decoding intact so that FIQL's parser
+    // does not treat them as OR operators.  queryParametersHandler emits the URL verbatim
+    // (no encoding), so the servlet container performs exactly one URL-decode on the query
+    // string.  Double-encoding (%252C) means the server receives %2C after that decode;
+    // CXF's FIQL parser sees %2C as a literal (not a comma), and search.decode.values=true
+    // then decodes %2C → , before the value reaches our CriteriaBehavior lambda.
+    const encoded = ipAddress.replace(/,/g, '%252C')
+    return `iplike==${encoded}`
+  }
+  return `ipInterface.ipAddress==${ipAddress}`
 }
 
 const buildCategoryQuery = (selectedCategories: Category[], categoryMode: SetOperator, selectedCategories2?: Category[]) => {

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -650,6 +650,27 @@ const buildWithAssetsQuery = (nodesWithAssets?: boolean) => {
   return nodesWithAssets ? 'nodesWithAssets==true' : ''
 }
 
+/**
+ * Encode a FIQL value so it survives intact to the backend CriteriaBehavior as an exact literal.
+ *
+ * Asset values are free text and may contain FIQL-structural characters (',' ';' '(' ')') or
+ * URL-structural characters ('&' '#' '%' space). We can neither sanitize them away (the match must
+ * be exact) nor pass them raw (they corrupt the FIQL expression or the URL).
+ *
+ * The value is URL-decoded twice on the way in — once by the servlet container, once by CXF
+ * (search.decode.values=true on the v2 endpoints) — so we double-encode it here. This generalizes
+ * the comma double-encoding in buildIpAddressQuery to every reserved character. A strict encoder is
+ * used because encodeURIComponent leaves ! ' ( ) * unescaped, and ( ) * are meaningful to FIQL.
+ *
+ * After two decodes the backend receives the exact original string (and '*' is matched literally,
+ * preserving exact-match rather than being treated as a wildcard).
+ */
+const encodeFiqlValue = (value: string): string => {
+  const strictEncode = (s: string): string =>
+    encodeURIComponent(s).replace(/[!'()*]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase())
+  return strictEncode(strictEncode(value))
+}
+
 const buildAssetQuery = (assetFilters?: AssetFilter[]) => {
   if (!assetFilters || assetFilters.length === 0) {
     return ''
@@ -659,7 +680,7 @@ const buildAssetQuery = (assetFilters?: AssetFilter[]) => {
   // Multiple filters are intersected (a node must match every one).
   return assetFilters
     .filter(f => f.column && f.value && ALLOWED_ASSET_COLUMNS.has(f.column))
-    .map(f => `assetRecord.${f.column}==${f.value}`)
+    .map(f => `assetRecord.${f.column}==${encodeFiqlValue(f.value)}`)
     .join(getFiqlSetOperator(SetOperator.Intersection))
 }
 

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -382,14 +382,16 @@ const buildIpAddressQuery = (ipAddress?: string) => {
   if (!ipAddress) {
     return ''
   }
-  if (isIplikePattern(ipAddress)) {
+  // Normalize spaces around commas (users naturally type "1, 2, 3" but iplike has no spaces)
+  const normalized = ipAddress.replace(/\s*,\s*/g, ',')
+  if (isIplikePattern(normalized)) {
     // Commas in iplike patterns must survive HTTP URL-decoding intact so that FIQL's parser
     // does not treat them as OR operators.  queryParametersHandler emits the URL verbatim
     // (no encoding), so the servlet container performs exactly one URL-decode on the query
     // string.  Double-encoding (%252C) means the server receives %2C after that decode;
     // CXF's FIQL parser sees %2C as a literal (not a comma), and search.decode.values=true
     // then decodes %2C → , before the value reaches our CriteriaBehavior lambda.
-    const encoded = ipAddress.replace(/,/g, '%252C')
+    const encoded = normalized.replace(/,/g, '%252C')
     return `iplike==${encoded}`
   }
   return `ipInterface.ipAddress==${ipAddress}`

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -22,6 +22,7 @@
 
 import { isConvertibleToInteger } from '@/lib/utils'
 import {
+  AssetFilter,
   Category,
   ExtendedSearchValue,
   MatchType,
@@ -37,7 +38,7 @@ import {
 } from '@/types'
 import {
   ALLOWED_ASSET_COLUMNS,
-  parseAssetFilter,
+  parseAssetFilters,
   parseCategories,
   parseDownAggregateStatus,
   parseFlows,
@@ -49,6 +50,7 @@ import {
   parseMonitoredServices,
   parseMonitoringLocation,
   parseNodeLabel,
+  parseNodesWithAssets,
   parseSnmpParams,
   parseSnmpParmParams,
   parseSysParams
@@ -105,8 +107,8 @@ export const useNodeQuery = () => {
       macAddress: '',
       topology: '',
       nodesWithDownAggregateStatus: false,
-      assetColumn: '',
-      assetValue: '',
+      nodesWithAssets: false,
+      assetFilters: [] as AssetFilter[],
       extendedSearch: getDefaultNodeQueryExtendedSearchParams()
     } as NodeQueryFilter
   }
@@ -204,6 +206,7 @@ export const useNodeQuery = () => {
     'foreignsource',
     'ipAddress',
     'iplike',
+    'nodesWithAssets',
     'nodesWithDownAggregateStatus',
     'listInterfaces',
     'maclike',
@@ -313,11 +316,15 @@ export const useNodeQuery = () => {
       filter.nodesWithDownAggregateStatus = true
     }
 
-    // asset-field filter (e.g. from site-status-view drill-down links)
-    const assetFilter = parseAssetFilter(queryObject)
-    if (assetFilter) {
-      filter.assetColumn = assetFilter.column
-      filter.assetValue = assetFilter.value
+    // nodesWithAssets — limit to nodes that have asset info (legacy "All nodes with asset info")
+    if (parseNodesWithAssets(queryObject)) {
+      filter.nodesWithAssets = true
+    }
+
+    // asset-field filters (e.g. from site-status-view drill-down links)
+    const assetFilters = parseAssetFilters(queryObject)
+    if (assetFilters.length > 0) {
+      filter.assetFilters = assetFilters
     }
 
     const serviceNames = parseMonitoredServices(queryObject, serviceTypes)
@@ -372,12 +379,13 @@ const buildNodeStructureQuery = (filter: NodeQueryFilter) => {
   const serviceQuery = buildServiceQuery(filter.selectedServices ?? [])
   const maclikeQuery = buildMaclikeQuery(filter.macAddress)
   const downStatusQuery = buildDownStatusQuery(filter.nodesWithDownAggregateStatus)
-  const assetQuery = buildAssetQuery(filter.assetColumn, filter.assetValue)
+  const withAssetsQuery = buildWithAssetsQuery(filter.nodesWithAssets)
+  const assetQuery = buildAssetQuery(filter.assetFilters)
   const topologyQuery = buildTopologyQuery(filter.topology)
 
   // TODO: May need more search term sanitizing and/or restrict characters in the FeatherInput above
   const querySeparator = getFiqlSetOperator(SetOperator.Intersection)
-  const query = [searchQuery, ipAddressQuery, foreignSourceQuery, snmpQuery, sysQuery, categoryQuery, flowsQuery, locationQuery, serviceQuery, maclikeQuery, downStatusQuery, assetQuery, topologyQuery].filter(s => s.length > 0).join(querySeparator)
+  const query = [searchQuery, ipAddressQuery, foreignSourceQuery, snmpQuery, sysQuery, categoryQuery, flowsQuery, locationQuery, serviceQuery, maclikeQuery, downStatusQuery, withAssetsQuery, assetQuery, topologyQuery].filter(s => s.length > 0).join(querySeparator)
 
   // additional fields to search on for main searchTerm
   // these will be added as SetOperator.Union (i.e. 'or')
@@ -637,13 +645,21 @@ const buildDownStatusQuery = (nodesWithDownAggregateStatus?: boolean) => {
   return nodesWithDownAggregateStatus ? 'nodesWithDownAggregateStatus==true' : ''
 }
 
-const buildAssetQuery = (assetColumn?: string, assetValue?: string) => {
-  if (!assetColumn || !assetValue || !ALLOWED_ASSET_COLUMNS.has(assetColumn)) {
+const buildWithAssetsQuery = (nodesWithAssets?: boolean) => {
+  return nodesWithAssets ? 'nodesWithAssets==true' : ''
+}
+
+const buildAssetQuery = (assetFilters?: AssetFilter[]) => {
+  if (!assetFilters || assetFilters.length === 0) {
     return ''
   }
 
-  // Exact match against the asset record column (mirrors the legacy site-status-view asset filter).
-  return `assetRecord.${assetColumn}==${assetValue}`
+  // Exact match against each asset record column (mirrors the legacy site-status-view asset filter).
+  // Multiple filters are intersected (a node must match every one).
+  return assetFilters
+    .filter(f => f.column && f.value && ALLOWED_ASSET_COLUMNS.has(f.column))
+    .map(f => `assetRecord.${f.column}==${f.value}`)
+    .join(getFiqlSetOperator(SetOperator.Intersection))
 }
 
 const buildTopologyQuery = (topology?: string) => {

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -449,12 +449,12 @@ const buildCategoryQuery = (selectedCategories: Category[], categoryMode: SetOpe
       if (items.length === 1) {
         return items[0]
       }
-      return `(${items.join(',')})`
+      return `(${items.join(getFiqlSetOperator(SetOperator.Union))})`
     }
     const group1 = buildGroup(selectedCategories)
     const group2 = buildGroup(selectedCategories2)
     if (group1 && group2) {
-      return `${group1};${group2}`
+      return `${group1}${getFiqlSetOperator(SetOperator.Intersection)}${group2}`
     }
     return group1 || group2
   }
@@ -487,7 +487,7 @@ const buildFlowsQuery = (selectedFlows: string[]) => {
   if (flowItems.length === 1) {
     return `${flowItems[0]}`
   } else if (flowItems.length > 1) {
-    return `(${flowItems.join(',')})`
+    return `(${flowItems.join(getFiqlSetOperator(SetOperator.Union))})`
   }
 
   return ''
@@ -499,7 +499,7 @@ const buildLocationsQuery = (selectedLocations: MonitoringLocation[]) => {
   if (locationItems.length === 1) {
     return `${locationItems[0]}`
   } else if (locationItems.length > 1) {
-    return `(${locationItems.join(',')})`
+    return `(${locationItems.join(getFiqlSetOperator(SetOperator.Union))})`
   }
 
   return ''
@@ -565,7 +565,7 @@ const buildServiceQuery = (selectedServices: string[]) => {
     return items[0]
   }
 
-  return `(${items.join(',')})`
+  return `(${items.join(getFiqlSetOperator(SetOperator.Union))})`
 }
 
 const buildSnmpQuery = (snmpParams?: NodeQuerySnmpParams) => {
@@ -598,7 +598,7 @@ const buildSnmpQuery = (snmpParams?: NodeQuerySnmpParams) => {
     }
 
     if (arr.length > 0) {
-      return arr.join(';')
+      return arr.join(getFiqlSetOperator(SetOperator.Intersection))
     }
   }
 
@@ -619,7 +619,7 @@ const buildSysQuery = (sysParams?: NodeQuerySysParams) => {
     })
 
     if (arr.length > 0) {
-      return arr.join(';')
+      return arr.join(getFiqlSetOperator(SetOperator.Intersection))
     }
   }
 

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -36,7 +36,7 @@ const homeUrl = computed<string>(() => menuStore.mainMenu?.homeUrl)
 const breadcrumbs = computed<BreadCrumb[]>(() => {
   return [
     { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
-    { label: 'Node List', to: '#', position: 'last' }
+    { label: 'Nodes', to: '#', position: 'last' }
   ]
 })
 

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -393,6 +393,11 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value.selectedMonitoringLocations = queryFilter.value.selectedMonitoringLocations.filter(
       loc => loc.name !== locationName
     )
+    // Also update the autocomplete-backed ref (read by the drawer on reopen); otherwise a removed
+    // location chip would reappear in the drawer's selection. Mirrors removeCategory/removeService.
+    selectedMonitoringLocations.value = selectedMonitoringLocations.value.filter(
+      loc => loc.name !== locationName
+    )
   }
 
   const removeExtendedSearch = (item: ExtendedSearchValue) => {

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -105,6 +105,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
       (queryFilter.value.selectedServices?.length ?? 0) > 0 ||
       !!queryFilter.value.ipAddress?.length ||
       !!queryFilter.value.macAddress?.length ||
+      !!queryFilter.value.nodesWithDownAggregateStatus ||
+      !!queryFilter.value.assetValue?.length ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.foreignSourceParams) ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.snmpParams) ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.sysParams) ||
@@ -145,6 +147,21 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value = {
       ...queryFilter.value,
       macAddress
+    }
+  }
+
+  const setFilterWithDownAggregateStatus = async (nodesWithDownAggregateStatus: boolean) => {
+    queryFilter.value = {
+      ...queryFilter.value,
+      nodesWithDownAggregateStatus
+    }
+  }
+
+  const setFilterWithAsset = async (assetColumn: string, assetValue: string) => {
+    queryFilter.value = {
+      ...queryFilter.value,
+      assetColumn,
+      assetValue
     }
   }
 
@@ -293,6 +310,15 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
         filter.macAddress = prefs.nodeFilter.macAddress
       }
 
+      if (prefs.nodeFilter.nodesWithDownAggregateStatus) {
+        filter.nodesWithDownAggregateStatus = true
+      }
+
+      if (prefs.nodeFilter.assetColumn && prefs.nodeFilter.assetValue) {
+        filter.assetColumn = prefs.nodeFilter.assetColumn
+        filter.assetValue = prefs.nodeFilter.assetValue
+      }
+
       if (prefs.nodeFilter.topology) {
         filter.topology = prefs.nodeFilter.topology
       }
@@ -379,6 +405,14 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value = { ...queryFilter.value, macAddress: '' }
   }
 
+  const removeDownAggregateStatus = () => {
+    queryFilter.value = { ...queryFilter.value, nodesWithDownAggregateStatus: false }
+  }
+
+  const removeAsset = () => {
+    queryFilter.value = { ...queryFilter.value, assetColumn: '', assetValue: '' }
+  }
+
   const removeTopology = () => {
     queryFilter.value = { ...queryFilter.value, topology: '' }
   }
@@ -455,6 +489,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     setCategoryMode,
     setFilterWithIpAddress,
     setFilterWithMacAddress,
+    setFilterWithDownAggregateStatus,
+    setFilterWithAsset,
     setFilterWithSnmpParams,
     setFilterWithForeignSourceParams,
     setFilterWithSysParams,
@@ -478,6 +514,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     removeExtendedSearch,
     removeIpAddress,
     removeMacAddress,
+    removeDownAggregateStatus,
+    removeAsset,
     removeTopology,
     setExtendedSearchParams,
     removeFlow,

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -25,6 +25,7 @@ import { defaultColumns } from '@/components/Nodes/utils'
 import { hasNonEmptyProperty } from '@/lib/utils'
 import API from '@/services'
 import {
+  AssetFilter,
   Category,
   DrawerState,
   ExtendedSearchValue,
@@ -106,7 +107,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
       !!queryFilter.value.ipAddress?.length ||
       !!queryFilter.value.macAddress?.length ||
       !!queryFilter.value.nodesWithDownAggregateStatus ||
-      !!queryFilter.value.assetValue?.length ||
+      !!queryFilter.value.nodesWithAssets ||
+      (queryFilter.value.assetFilters?.length ?? 0) > 0 ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.foreignSourceParams) ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.snmpParams) ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.sysParams) ||
@@ -157,11 +159,17 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     }
   }
 
-  const setFilterWithAsset = async (assetColumn: string, assetValue: string) => {
+  const setFilterWithNodesWithAssets = async (nodesWithAssets: boolean) => {
     queryFilter.value = {
       ...queryFilter.value,
-      assetColumn,
-      assetValue
+      nodesWithAssets
+    }
+  }
+
+  const setFilterWithAssetFilters = async (assetFilters: AssetFilter[]) => {
+    queryFilter.value = {
+      ...queryFilter.value,
+      assetFilters: [...assetFilters]
     }
   }
 
@@ -314,9 +322,12 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
         filter.nodesWithDownAggregateStatus = true
       }
 
-      if (prefs.nodeFilter.assetColumn && prefs.nodeFilter.assetValue) {
-        filter.assetColumn = prefs.nodeFilter.assetColumn
-        filter.assetValue = prefs.nodeFilter.assetValue
+      if (prefs.nodeFilter.nodesWithAssets) {
+        filter.nodesWithAssets = true
+      }
+
+      if (prefs.nodeFilter.assetFilters?.length) {
+        filter.assetFilters = [...prefs.nodeFilter.assetFilters]
       }
 
       if (prefs.nodeFilter.topology) {
@@ -409,8 +420,15 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value = { ...queryFilter.value, nodesWithDownAggregateStatus: false }
   }
 
-  const removeAsset = () => {
-    queryFilter.value = { ...queryFilter.value, assetColumn: '', assetValue: '' }
+  const removeNodesWithAssets = () => {
+    queryFilter.value = { ...queryFilter.value, nodesWithAssets: false }
+  }
+
+  const removeAssetFilter = (column: string) => {
+    queryFilter.value = {
+      ...queryFilter.value,
+      assetFilters: (queryFilter.value.assetFilters ?? []).filter(f => f.column !== column)
+    }
   }
 
   const removeTopology = () => {
@@ -490,7 +508,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     setFilterWithIpAddress,
     setFilterWithMacAddress,
     setFilterWithDownAggregateStatus,
-    setFilterWithAsset,
+    setFilterWithNodesWithAssets,
+    setFilterWithAssetFilters,
     setFilterWithSnmpParams,
     setFilterWithForeignSourceParams,
     setFilterWithSysParams,
@@ -515,7 +534,8 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     removeIpAddress,
     removeMacAddress,
     removeDownAggregateStatus,
-    removeAsset,
+    removeNodesWithAssets,
+    removeAssetFilter,
     removeTopology,
     setExtendedSearchParams,
     removeFlow,

--- a/ui/src/stores/nodeStructureStore.ts
+++ b/ui/src/stores/nodeStructureStore.ts
@@ -104,6 +104,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
       queryFilter.value.selectedMonitoringLocations.length > 0 ||
       (queryFilter.value.selectedServices?.length ?? 0) > 0 ||
       !!queryFilter.value.ipAddress?.length ||
+      !!queryFilter.value.macAddress?.length ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.foreignSourceParams) ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.snmpParams) ||
       hasNonEmptyProperty(queryFilter.value.extendedSearch.sysParams) ||
@@ -137,6 +138,13 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value = {
       ...queryFilter.value,
       ipAddress
+    }
+  }
+
+  const setFilterWithMacAddress = async (macAddress: string) => {
+    queryFilter.value = {
+      ...queryFilter.value,
+      macAddress
     }
   }
 
@@ -281,6 +289,10 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
         filter.ipAddress = prefs.nodeFilter.ipAddress
       }
 
+      if (prefs.nodeFilter.macAddress) {
+        filter.macAddress = prefs.nodeFilter.macAddress
+      }
+
       if (prefs.nodeFilter.topology) {
         filter.topology = prefs.nodeFilter.topology
       }
@@ -363,6 +375,10 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     queryFilter.value = { ...queryFilter.value, ipAddress: '' }
   }
 
+  const removeMacAddress = () => {
+    queryFilter.value = { ...queryFilter.value, macAddress: '' }
+  }
+
   const removeTopology = () => {
     queryFilter.value = { ...queryFilter.value, topology: '' }
   }
@@ -438,6 +454,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     resetColumnSelectionToDefault,
     setCategoryMode,
     setFilterWithIpAddress,
+    setFilterWithMacAddress,
     setFilterWithSnmpParams,
     setFilterWithForeignSourceParams,
     setFilterWithSysParams,
@@ -460,6 +477,7 @@ export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
     removeCategory2,
     removeExtendedSearch,
     removeIpAddress,
+    removeMacAddress,
     removeTopology,
     setExtendedSearchParams,
     removeFlow,

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -594,6 +594,7 @@ export interface NodeQueryFilter {
   selectedFlows: string[]
   selectedMonitoringLocations: MonitoringLocation[]
   ipAddress?: string
+  macAddress?: string
   topology?: string
   extendedSearch: NodeQueryExtendedSearchParams
 }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -596,6 +596,9 @@ export interface NodeQueryFilter {
   ipAddress?: string
   macAddress?: string
   topology?: string
+  nodesWithDownAggregateStatus?: boolean
+  assetColumn?: string
+  assetValue?: string
   extendedSearch: NodeQueryExtendedSearchParams
 }
 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -584,6 +584,12 @@ export interface ExtendedSearchValue {
   key: string
 }
 
+/** A single asset-record field filter (column + exact-match value). */
+export interface AssetFilter {
+  column: string
+  value: string
+}
+
 /** All components of a node structure query */
 export interface NodeQueryFilter {
   searchTerm: string
@@ -597,8 +603,8 @@ export interface NodeQueryFilter {
   macAddress?: string
   topology?: string
   nodesWithDownAggregateStatus?: boolean
-  assetColumn?: string
-  assetValue?: string
+  nodesWithAssets?: boolean
+  assetFilters?: AssetFilter[]
   extendedSearch: NodeQueryExtendedSearchParams
 }
 

--- a/ui/tests/components/Menu/menu-template-test.json
+++ b/ui/tests/components/Menu/menu-template-test.json
@@ -30,8 +30,8 @@
       "roles": null,
       "items": [
         {
-          "id": "nodeList",
-          "name": "Node List",
+          "id": "nodes",
+          "name": "Nodes",
           "url": "ui/index.html#/nodes",
           "locationMatch": "configurationManagement",
           "roles": null

--- a/ui/tests/components/Menu/utils.test.ts
+++ b/ui/tests/components/Menu/utils.test.ts
@@ -79,7 +79,7 @@ describe('Menu utils', () => {
       const inventoryItems = childItems(inventory)
       expect(inventoryItems).toHaveLength(3)
       expect(inventoryItems[0]).toMatchObject({
-        id: 'nodeList',
+        id: 'nodes',
         type: 'item',
         title: 'Nodes',
         href: `${baseHref}ui/index.html#/nodes`,

--- a/ui/tests/components/Menu/utils.test.ts
+++ b/ui/tests/components/Menu/utils.test.ts
@@ -81,7 +81,7 @@ describe('Menu utils', () => {
       expect(inventoryItems[0]).toMatchObject({
         id: 'nodeList',
         type: 'item',
-        title: 'Node List',
+        title: 'Nodes',
         href: `${baseHref}ui/index.html#/nodes`,
         target: '_self'
       })

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -22,7 +22,9 @@
 
 import { describe, expect, test } from 'vitest'
 import {
+  parseAssetFilter,
   parseCategories,
+  parseDownAggregateStatus,
   parseFlows,
   parseForeignSource,
   parseIplike,
@@ -419,6 +421,33 @@ describe('Nodes queryStringParser test', () => {
       ['empty maclike', { maclike: '' }, null]
     ]) ('parseMaclike: %s', (title, queryObject, expected) => {
       expect(parseMaclike(queryObject)).toEqual(expected)
+    })
+  })
+
+  describe('parseDownAggregateStatus', () => {
+    test.each([
+      ['empty', {}, false],
+      ['true', { nodesWithDownAggregateStatus: 'true' }, true],
+      ['TRUE (case-insensitive)', { nodesWithDownAggregateStatus: 'TRUE' }, true],
+      ['boolean true', { nodesWithDownAggregateStatus: true }, true],
+      ['false', { nodesWithDownAggregateStatus: 'false' }, false],
+      ['garbage', { nodesWithDownAggregateStatus: 'yes' }, false]
+    ]) ('parseDownAggregateStatus: %s', (title, queryObject, expected) => {
+      expect(parseDownAggregateStatus(queryObject)).toBe(expected)
+    })
+  })
+
+  describe('parseAssetFilter', () => {
+    test.each([
+      ['empty', {}, null],
+      ['column only', { assetColumn: 'building' }, null],
+      ['value only', { assetValue: 'HQ' }, null],
+      ['valid building', { assetColumn: 'building', assetValue: 'HQ' }, { column: 'building', value: 'HQ' }],
+      ['valid region', { assetColumn: 'region', assetValue: 'East' }, { column: 'region', value: 'East' }],
+      ['disallowed column (geolocation) returns null', { assetColumn: 'city', assetValue: 'Pittsburgh' }, null],
+      ['unknown column returns null', { assetColumn: 'bogus', assetValue: 'X' }, null]
+    ]) ('parseAssetFilter: %s', (title, queryObject, expected) => {
+      expect(parseAssetFilter(queryObject)).toEqual(expected)
     })
   })
 

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -26,6 +26,7 @@ import {
   parseFlows,
   parseForeignSource,
   parseIplike,
+  isIplikePattern,
   parseMaclike,
   parseMib2Params,
   parseMonitoredServices,
@@ -131,12 +132,55 @@ describe('Nodes queryStringParser test', () => {
       ['invalid iplike', { iplike: 'abc' }, null],
       ['invalid iplike localhost', { iplike: 'localhost' }, null],
       ['invalid partial iplike', { iplike: '192.168.' }, null],
-      ['invalid iplike', { iplike: 'A.B.C.D' }, null]
+      ['invalid iplike', { iplike: 'A.B.C.D' }, null],
+
+      ['iplike wildcard pattern from iplike param', { iplike: '192.168.1.*'}, '192.168.1.*'],
+      ['iplike wildcard pattern from ipAddress param', { ipAddress: '10.*.*.*'}, '10.*.*.*'],
+      ['iplike prefers iplike param over ipAddress', { iplike: '10.*.*.*', ipAddress: '192.168.1.1'}, '10.*.*.*'],
+      ['iplike all wildcards', { iplike: '*.*.*.*'}, '*.*.*.*'],
+      ['iplike IPv6 wildcard from iplike param', { iplike: '2001:db8:*:*:*:*:*:*' }, '2001:db8:*:*:*:*:*:*'],
+      ['iplike IPv6 wildcard from ipAddress param', { ipAddress: 'fe80:*:*:*:*:*:*:*' }, 'fe80:*:*:*:*:*:*:*']
     ]) (
       'parseIpLike: %s',
       (title, queryObject, expected) => {
         const result = parseIplike(queryObject)
         expect(result).toEqual(expected)
+      }
+    )
+  })
+
+  describe('isIplikePattern', () => {
+    test.each([
+      // wildcard patterns
+      ['accepts 192.168.1.*', '192.168.1.*', true],
+      ['accepts *.*.*.*', '*.*.*.*', true],
+      ['accepts 10.*.*.*', '10.*.*.*', true],
+      ['accepts 2001:db8:*:*:*:*:*:*', '2001:db8:*:*:*:*:*:*', true],
+      ['accepts *:*:*:*:*:*:*:*', '*:*:*:*:*:*:*:*', true],
+      ['accepts fe80:*:*:*:*:*:*:*', 'fe80:*:*:*:*:*:*:*', true],
+      ['accepts 2001:db8:85a3:*:*:8a2e:*:7334', '2001:db8:85a3:*:*:8a2e:*:7334', true],
+      // IPv4 range patterns (hyphen per-octet)
+      ['accepts 10.0.0.1-255 — range in last octet', '10.0.0.1-255', true],
+      ['accepts 10.9.1-3.* — range in third octet with wildcard', '10.9.1-3.*', true],
+      ['accepts 10.0-255.0-255.0-255 — ranges in multiple octets', '10.0-255.0-255.0-255', true],
+      // IPv4 comma list patterns
+      ['accepts 192.168.0,1.* — list in third octet', '192.168.0,1.*', true],
+      ['accepts 192.168.1,2,3-255.* — list with ranges', '192.168.1,2,3-255.*', true],
+      ['accepts 10.0.0.1,5,10-20 — comma list without wildcard', '10.0.0.1,5,10-20', true],
+      // IPv6 range patterns
+      ['accepts 2001:0-ffff:*:*:*:*:*:* — range in second hextet', '2001:0-ffff:*:*:*:*:*:*', true],
+      // rejection cases
+      ['rejects plain text', 'notanip', false],
+      ['rejects exact IP without wildcard', '192.168.1.100', false],
+      ['rejects empty string', '', false],
+      ['rejects exact IPv6, no * — handled by isIP() not isIplikePattern', '2001:db8::1', false],
+      ['rejects invalid hex group gggg (g is not hex)', '2001:db8:gggg:*:*:*:*:*', false],
+      ['rejects 9 groups (too many)', '2001:db8:*:*:*:*:*:*:extra', false],
+      ['rejects cross-octet range notation (not valid iplike)', '10.0.0.1-10.0.0.255', false]
+    ]) (
+      'isIplikePattern: %s',
+      (title, value, expected) => {
+        expect(isIplikePattern(value)).toBe(expected)
       }
     )
   })

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -22,9 +22,10 @@
 
 import { describe, expect, test } from 'vitest'
 import {
-  parseAssetFilter,
+  parseAssetFilters,
   parseCategories,
   parseDownAggregateStatus,
+  parseNodesWithAssets,
   parseFlows,
   parseForeignSource,
   parseIplike,
@@ -437,17 +438,60 @@ describe('Nodes queryStringParser test', () => {
     })
   })
 
-  describe('parseAssetFilter', () => {
+  describe('parseNodesWithAssets', () => {
     test.each([
-      ['empty', {}, null],
-      ['column only', { assetColumn: 'building' }, null],
-      ['value only', { assetValue: 'HQ' }, null],
-      ['valid building', { assetColumn: 'building', assetValue: 'HQ' }, { column: 'building', value: 'HQ' }],
-      ['valid region', { assetColumn: 'region', assetValue: 'East' }, { column: 'region', value: 'East' }],
-      ['disallowed column (geolocation) returns null', { assetColumn: 'city', assetValue: 'Pittsburgh' }, null],
-      ['unknown column returns null', { assetColumn: 'bogus', assetValue: 'X' }, null]
-    ]) ('parseAssetFilter: %s', (title, queryObject, expected) => {
-      expect(parseAssetFilter(queryObject)).toEqual(expected)
+      ['empty', {}, false],
+      ['true', { nodesWithAssets: 'true' }, true],
+      ['TRUE (case-insensitive)', { nodesWithAssets: 'TRUE' }, true],
+      ['boolean true', { nodesWithAssets: true }, true],
+      ['false', { nodesWithAssets: 'false' }, false],
+      ['garbage', { nodesWithAssets: 'yes' }, false]
+    ]) ('parseNodesWithAssets: %s', (title, queryObject, expected) => {
+      expect(parseNodesWithAssets(queryObject)).toBe(expected)
+    })
+  })
+
+  describe('parseAssetFilters', () => {
+    test.each([
+      ['empty', {}, []],
+      ['column only', { assetColumn: 'building' }, []],
+      ['value only', { assetValue: 'HQ' }, []],
+      ['single valid building', { assetColumn: 'building', assetValue: 'HQ' }, [{ column: 'building', value: 'HQ' }]],
+      ['single valid region', { assetColumn: 'region', assetValue: 'East' }, [{ column: 'region', value: 'East' }]],
+      ['disallowed column (geolocation) skipped', { assetColumn: 'city', assetValue: 'Pittsburgh' }, []],
+      ['unknown column skipped', { assetColumn: 'bogus', assetValue: 'X' }, []]
+    ]) ('parseAssetFilters: %s', (title, queryObject, expected) => {
+      expect(parseAssetFilters(queryObject)).toEqual(expected)
+    })
+
+    test('pairs repeated column/value params by index', () => {
+      const result = parseAssetFilters({
+        assetColumn: ['building', 'region'],
+        assetValue: ['HQ', 'East']
+      })
+      expect(result).toEqual([
+        { column: 'building', value: 'HQ' },
+        { column: 'region', value: 'East' }
+      ])
+    })
+
+    test('skips disallowed columns within a repeated set', () => {
+      const result = parseAssetFilters({
+        assetColumn: ['building', 'city', 'rack'],
+        assetValue: ['HQ', 'Pittsburgh', 'R1']
+      })
+      expect(result).toEqual([
+        { column: 'building', value: 'HQ' },
+        { column: 'rack', value: 'R1' }
+      ])
+    })
+
+    test('duplicate columns keep the last value', () => {
+      const result = parseAssetFilters({
+        assetColumn: ['building', 'building'],
+        assetValue: ['HQ', 'DC2']
+      })
+      expect(result).toEqual([{ column: 'building', value: 'DC2' }])
     })
   })
 

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -167,6 +167,9 @@ describe('Nodes queryStringParser test', () => {
       ['accepts 192.168.0,1.* — list in third octet', '192.168.0,1.*', true],
       ['accepts 192.168.1,2,3-255.* — list with ranges', '192.168.1,2,3-255.*', true],
       ['accepts 10.0.0.1,5,10-20 — comma list without wildcard', '10.0.0.1,5,10-20', true],
+      // space normalization: spaces around commas are stripped before matching
+      ['accepts 192.168.0, 1.* — space after comma is normalized', '192.168.0, 1.*', true],
+      ['accepts 192.168.1, 2, 3-255.* — spaces after commas normalized', '192.168.1, 2, 3-255.*', true],
       // IPv6 range patterns
       ['accepts 2001:0-ffff:*:*:*:*:*:* — range in second hextet', '2001:0-ffff:*:*:*:*:*:*', true],
       // rejection cases

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -137,10 +137,10 @@ describe('Nodes queryStringParser test', () => {
       ['invalid partial iplike', { iplike: '192.168.' }, null],
       ['invalid iplike', { iplike: 'A.B.C.D' }, null],
 
-      ['iplike wildcard pattern from iplike param', { iplike: '192.168.1.*'}, '192.168.1.*'],
-      ['iplike wildcard pattern from ipAddress param', { ipAddress: '10.*.*.*'}, '10.*.*.*'],
-      ['iplike prefers iplike param over ipAddress', { iplike: '10.*.*.*', ipAddress: '192.168.1.1'}, '10.*.*.*'],
-      ['iplike all wildcards', { iplike: '*.*.*.*'}, '*.*.*.*'],
+      ['iplike wildcard pattern from iplike param', { iplike: '192.168.1.*' }, '192.168.1.*'],
+      ['iplike wildcard pattern from ipAddress param', { ipAddress: '10.*.*.*' }, '10.*.*.*'],
+      ['iplike prefers iplike param over ipAddress', { iplike: '10.*.*.*', ipAddress: '192.168.1.1' }, '10.*.*.*'],
+      ['iplike all wildcards', { iplike: '*.*.*.*' }, '*.*.*.*'],
       ['iplike IPv6 wildcard from iplike param', { iplike: '2001:db8:*:*:*:*:*:*' }, '2001:db8:*:*:*:*:*:*'],
       ['iplike IPv6 wildcard from ipAddress param', { ipAddress: 'fe80:*:*:*:*:*:*:*' }, 'fe80:*:*:*:*:*:*:*']
     ]) (

--- a/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
+++ b/ui/tests/components/Nodes/hooks/queryStringParser.test.ts
@@ -167,6 +167,7 @@ describe('Nodes queryStringParser test', () => {
       ['accepts 192.168.0,1.* — list in third octet', '192.168.0,1.*', true],
       ['accepts 192.168.1,2,3-255.* — list with ranges', '192.168.1,2,3-255.*', true],
       ['accepts 10.0.0.1,5,10-20 — comma list without wildcard', '10.0.0.1,5,10-20', true],
+      ['accepts 192.168.1,2,3-255.* — list with ranges and wildcard in last octet', '192.168.1,2,3-255.*', true],
       // space normalization: spaces around commas are stripped before matching
       ['accepts 192.168.0, 1.* — space after comma is normalized', '192.168.0, 1.*', true],
       ['accepts 192.168.1, 2, 3-255.* — spaces after commas normalized', '192.168.1, 2, 3-255.*', true],

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -662,6 +662,33 @@ describe('Nodes useNodeQuery test', () => {
       expect(params._s).toContain('nodesWithDownAggregateStatus==true')
       expect(params._s).toContain(';')
     })
+
+    // Asset values are free text; FIQL/URL-structural characters are double-encoded so they survive
+    // the two URL-decodes (servlet container + CXF search.decode.values) and reach the backend as the
+    // exact literal, without corrupting the FIQL expression. See encodeFiqlValue.
+    test.each([
+      ['comma', 'A,B', 'assetRecord.building==A%252CB'],
+      ['semicolon', 'A;B', 'assetRecord.building==A%253BB'],
+      ['parentheses', '(A)', 'assetRecord.building==%2528A%2529'],
+      ['ampersand', 'A&B', 'assetRecord.building==A%2526B'],
+      ['percent', '50%', 'assetRecord.building==50%2525'],
+      ['asterisk (literal, not wildcard)', 'A*', 'assetRecord.building==A%252A'],
+      ['space', 'Data Center', 'assetRecord.building==Data%2520Center'],
+      ['mixed', 'Bldg 1, Floor (2)', 'assetRecord.building==Bldg%25201%252C%2520Floor%2520%25282%2529']
+    ])('double-encodes a value with %s', (title, value, expected) => {
+      const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'building', value }] }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe(expected)
+    })
+
+    test('round-trips back to the original value after two URL-decodes', () => {
+      const value = 'Bldg 1, Floor (2) & A;B 50%'
+      const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'building', value }] }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const encoded = (params._s as string).replace('assetRecord.building==', '')
+      // container decode, then CXF search.decode.values decode
+      expect(decodeURIComponent(decodeURIComponent(encoded))).toBe(value)
+    })
   })
 
   describe('buildNodeQueryFilterFromQueryString: down + asset params', () => {

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -593,6 +593,47 @@ describe('Nodes useNodeQuery test', () => {
       expect(params._s ?? '').not.toContain('ipInterface.ipAddress==')
       expect(params._s ?? '').not.toContain('iplike==')
     })
+
+    test('emits iplike== for a range-only pattern (no wildcard)', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '10.0.0.1-255' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s).toContain('iplike==10.0.0.1-255')
+      expect(params._s).not.toContain('ipInterface.ipAddress==')
+    })
+
+    test('emits iplike== with double-encoded commas for a comma-list pattern', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '192.168.1,2.*' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s).toContain('iplike==192.168.1%252C2.*')
+      expect(params._s).not.toContain('ipInterface.ipAddress==')
+    })
+
+    test('normalizes spaces around commas before encoding', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '192.168.1, 2, 3-255.*' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s).toContain('iplike==192.168.1%252C2%252C3-255.*')
+    })
+
+    test('omits IP query when ipAddress is not a valid IP or iplike pattern', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: 'notanip' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s ?? '').not.toContain('ipInterface.ipAddress==')
+      expect(params._s ?? '').not.toContain('iplike==')
+    })
+
+    test('emits iplike== for an IPv6 wildcard pattern', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '2001:db8:*:*:*:*:*:*' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s).toContain('iplike==2001:db8:*:*:*:*:*:*')
+      expect(params._s).not.toContain('ipInterface.ipAddress==')
+    })
+
+    test('emits ipInterface.ipAddress== for an exact IPv6 address', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s).toContain('ipInterface.ipAddress==FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+      expect(params._s).not.toContain('iplike==')
+    })
   })
 
   describe('queryStringHasTrackedValues', () => {

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -366,6 +366,13 @@ describe('Nodes useNodeQuery test', () => {
       expect(filter).toEqual(expected)
     })
 
+    test('maclike maps to macAddress (stripped, remove FIQL characters, lowercase)', () => {
+      const filter = buildNodeQueryFilterFromQueryString({ maclike: 'AA:B,B:CC:DD:E;E:FF' }, categories, monitoringLocations)
+      const expected = getDefaultNodeQueryFilter()
+      expected.macAddress = 'aabbccddeeff'
+      expect(filter).toEqual(expected)
+    })
+
     test('maclike coexists with explicit snmpParams', () => {
       const filter = buildNodeQueryFilterFromQueryString(
         { snmpifalias: 'Uplink', maclike: 'AA:BB:CC' },

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -572,6 +572,29 @@ describe('Nodes useNodeQuery test', () => {
     })
   })
 
+  describe('buildUpdatedNodeStructureQueryParameters: ipAddress / iplike', () => {
+    test('emits ipInterface.ipAddress== for an exact IP', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '192.168.1.100' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s).toContain('ipInterface.ipAddress==192.168.1.100')
+      expect(params._s).not.toContain('iplike==')
+    })
+
+    test('emits iplike== for a wildcard pattern', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '192.168.1.*' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s).toContain('iplike==192.168.1.*')
+      expect(params._s).not.toContain('ipInterface.ipAddress==')
+    })
+
+    test('omits IP query when ipAddress is empty', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      expect(params._s ?? '').not.toContain('ipInterface.ipAddress==')
+      expect(params._s ?? '').not.toContain('iplike==')
+    })
+  })
+
   describe('queryStringHasTrackedValues', () => {
     const trackedValues = [
       'categories',

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -595,21 +595,51 @@ describe('Nodes useNodeQuery test', () => {
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: asset filter', () => {
-    test('emits assetRecord.<col>== for an allowed column', () => {
-      const filter = { ...getDefaultNodeQueryFilter(), assetColumn: 'building', assetValue: 'HQ' }
+  describe('buildUpdatedNodeStructureQueryParameters: nodesWithAssets', () => {
+    test('emits nodesWithAssets==true when set', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), nodesWithAssets: true }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('nodesWithAssets==true')
+    })
+
+    test('omits the filter when false', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), nodesWithAssets: false }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s ?? '').not.toContain('nodesWithAssets')
+    })
+
+    test('parses nodesWithAssets from the query string', () => {
+      const filter = buildNodeQueryFilterFromQueryString(
+        { nodesWithAssets: 'true' }, categories, monitoringLocations
+      )
+      expect(filter.nodesWithAssets).toBe(true)
+    })
+  })
+
+  describe('buildUpdatedNodeStructureQueryParameters: asset filters', () => {
+    test('emits assetRecord.<col>== for a single allowed column', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'building', value: 'HQ' }] }
       const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('assetRecord.building==HQ')
     })
 
-    test('omits asset query for a disallowed column', () => {
-      const filter = { ...getDefaultNodeQueryFilter(), assetColumn: 'city', assetValue: 'Pittsburgh' }
+    test('intersects multiple asset filters', () => {
+      const filter = {
+        ...getDefaultNodeQueryFilter(),
+        assetFilters: [{ column: 'building', value: 'HQ' }, { column: 'region', value: 'East' }]
+      }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('assetRecord.building==HQ;assetRecord.region==East')
+    })
+
+    test('omits disallowed columns', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'city', value: 'Pittsburgh' }] }
       const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('assetRecord')
     })
 
-    test('omits asset query when value missing', () => {
-      const filter = { ...getDefaultNodeQueryFilter(), assetColumn: 'building', assetValue: '' }
+    test('omits entries with an empty value', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'building', value: '' }] }
       const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('assetRecord')
     })
@@ -617,8 +647,7 @@ describe('Nodes useNodeQuery test', () => {
     test('combines categories, asset and down filter with intersection', () => {
       const filter = {
         ...getDefaultNodeQueryFilter(),
-        assetColumn: 'building',
-        assetValue: 'HQ',
+        assetFilters: [{ column: 'building', value: 'HQ' }],
         nodesWithDownAggregateStatus: true
       }
       const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
@@ -629,14 +658,13 @@ describe('Nodes useNodeQuery test', () => {
   })
 
   describe('buildNodeQueryFilterFromQueryString: down + asset params', () => {
-    test('parses nodesWithDownAggregateStatus and asset filter', () => {
+    test('parses nodesWithDownAggregateStatus and asset filters', () => {
       const filter = buildNodeQueryFilterFromQueryString(
         { nodesWithDownAggregateStatus: 'true', assetColumn: 'building', assetValue: 'HQ' },
         categories, monitoringLocations
       )
       expect(filter.nodesWithDownAggregateStatus).toBe(true)
-      expect(filter.assetColumn).toBe('building')
-      expect(filter.assetValue).toBe('HQ')
+      expect(filter.assetFilters).toEqual([{ column: 'building', value: 'HQ' }])
     })
 
     test('ignores a disallowed asset column', () => {
@@ -644,8 +672,7 @@ describe('Nodes useNodeQuery test', () => {
         { assetColumn: 'city', assetValue: 'Pittsburgh' },
         categories, monitoringLocations
       )
-      expect(filter.assetColumn).toBe('')
-      expect(filter.assetValue).toBe('')
+      expect(filter.assetFilters).toEqual([])
     })
   })
 

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -359,10 +359,10 @@ describe('Nodes useNodeQuery test', () => {
       expect(filter.extendedSearch.snmpParams?.snmpIfName).toBe('')
     })
 
-    test('maclike maps to snmpParams.physAddr (stripped, lowercase)', () => {
+    test('maclike maps to macAddress (stripped, lowercase)', () => {
       const filter = buildNodeQueryFilterFromQueryString({ maclike: 'AA:BB:CC:DD:EE:FF' }, categories, monitoringLocations)
       const expected = getDefaultNodeQueryFilter()
-      expected.extendedSearch.snmpParams = { ...getDefaultNodeQuerySnmpParams(), physAddr: 'aabbccddeeff' }
+      expected.macAddress = 'aabbccddeeff'
       expect(filter).toEqual(expected)
     })
 
@@ -372,7 +372,7 @@ describe('Nodes useNodeQuery test', () => {
         categories, monitoringLocations
       )
       expect(filter.extendedSearch.snmpParams?.snmpIfAlias).toBe('Uplink')
-      expect(filter.extendedSearch.snmpParams?.physAddr).toBe('aabbcc')
+      expect(filter.macAddress).toBe('aabbcc')
     })
 
     test('monitoredService maps to selectedServices (by name)', () => {
@@ -546,6 +546,38 @@ describe('Nodes useNodeQuery test', () => {
       }
       const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('snmpInterface.ifAlias==Uplink;snmpInterface.physAddr==*aabbcc*')
+    })
+  })
+
+  describe('buildUpdatedNodeStructureQueryParameters: macAddress / maclike', () => {
+    test('emits maclike== for a MAC with colons (stripped, lowercase)', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), macAddress: 'AA:BB:CC:DD:EE:FF' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('maclike==aabbccddeeff')
+    })
+
+    test('emits maclike== for a MAC with dashes', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), macAddress: 'AA-BB-CC-DD-EE-FF' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('maclike==aabbccddeeff')
+    })
+
+    test('emits maclike== for a partial MAC (manufacturer prefix)', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), macAddress: 'AA:BB:CC' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('maclike==aabbcc')
+    })
+
+    test('omits maclike query when macAddress is empty', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), macAddress: '' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s ?? '').not.toContain('maclike==')
+    })
+
+    test('omits maclike query when macAddress is only separators', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), macAddress: '::--' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s ?? '').not.toContain('maclike==')
     })
   })
 

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -581,6 +581,74 @@ describe('Nodes useNodeQuery test', () => {
     })
   })
 
+  describe('buildUpdatedNodeStructureQueryParameters: nodesWithDownAggregateStatus', () => {
+    test('emits nodesWithDownAggregateStatus==true when set', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), nodesWithDownAggregateStatus: true }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('nodesWithDownAggregateStatus==true')
+    })
+
+    test('omits the down filter when false', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), nodesWithDownAggregateStatus: false }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s ?? '').not.toContain('nodesWithDownAggregateStatus')
+    })
+  })
+
+  describe('buildUpdatedNodeStructureQueryParameters: asset filter', () => {
+    test('emits assetRecord.<col>== for an allowed column', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), assetColumn: 'building', assetValue: 'HQ' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toBe('assetRecord.building==HQ')
+    })
+
+    test('omits asset query for a disallowed column', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), assetColumn: 'city', assetValue: 'Pittsburgh' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s ?? '').not.toContain('assetRecord')
+    })
+
+    test('omits asset query when value missing', () => {
+      const filter = { ...getDefaultNodeQueryFilter(), assetColumn: 'building', assetValue: '' }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s ?? '').not.toContain('assetRecord')
+    })
+
+    test('combines categories, asset and down filter with intersection', () => {
+      const filter = {
+        ...getDefaultNodeQueryFilter(),
+        assetColumn: 'building',
+        assetValue: 'HQ',
+        nodesWithDownAggregateStatus: true
+      }
+      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      expect(params._s).toContain('assetRecord.building==HQ')
+      expect(params._s).toContain('nodesWithDownAggregateStatus==true')
+      expect(params._s).toContain(';')
+    })
+  })
+
+  describe('buildNodeQueryFilterFromQueryString: down + asset params', () => {
+    test('parses nodesWithDownAggregateStatus and asset filter', () => {
+      const filter = buildNodeQueryFilterFromQueryString(
+        { nodesWithDownAggregateStatus: 'true', assetColumn: 'building', assetValue: 'HQ' },
+        categories, monitoringLocations
+      )
+      expect(filter.nodesWithDownAggregateStatus).toBe(true)
+      expect(filter.assetColumn).toBe('building')
+      expect(filter.assetValue).toBe('HQ')
+    })
+
+    test('ignores a disallowed asset column', () => {
+      const filter = buildNodeQueryFilterFromQueryString(
+        { assetColumn: 'city', assetValue: 'Pittsburgh' },
+        categories, monitoringLocations
+      )
+      expect(filter.assetColumn).toBe('')
+      expect(filter.assetValue).toBe('')
+    })
+  })
+
   describe('buildUpdatedNodeStructureQueryParameters: selectedServices', () => {
     test('single selectedService generates serviceType.name FIQL query', () => {
       const filter = getDefaultNodeQueryFilter()

--- a/ui/tests/stores/nodeStructureStore.test.ts
+++ b/ui/tests/stores/nodeStructureStore.test.ts
@@ -369,13 +369,21 @@ describe('useNodeStructureStore', () => {
   })
 
   describe('removeMonitoringLocation', () => {
-    it('removes from queryFilter by name', () => {
+    it('removes from queryFilter and the selectedMonitoringLocations ref by name', () => {
       store.queryFilter.selectedMonitoringLocations = [monitoringLocations[0], monitoringLocations[1]]
+      store.selectedMonitoringLocations = [
+        { _text: monitoringLocations[0].name, _value: monitoringLocations[0].name, name: monitoringLocations[0].name },
+        { _text: monitoringLocations[1].name, _value: monitoringLocations[1].name, name: monitoringLocations[1].name }
+      ]
 
       store.removeMonitoringLocation({ _value: 'Default', name: monitoringLocations[0].name })
 
       expect(store.queryFilter.selectedMonitoringLocations).toHaveLength(1)
       expect(store.queryFilter.selectedMonitoringLocations[0].name).toBe(monitoringLocations[1].name)
+
+      // the autocomplete-backed ref (read by the drawer on reopen) must also drop the removed location
+      expect(store.selectedMonitoringLocations).toHaveLength(1)
+      expect((store.selectedMonitoringLocations[0] as any).name).toBe(monitoringLocations[1].name)
     })
   })
 


### PR DESCRIPTION
Fix a number of remaining issues for the Vue Nodes page.

All links from other pages that had been going to the legacy Node List page have now been fixed to go to the new Vue Nodes page. This PR continues with fixing the remaining search/filter types, including query string param support, full UI support for all filters, and back end / Rest API support.

Just to reiterate, `GET` urls from other pages can be populated with query string params representing search filters. These had previously gone from various pages to the legacy Node List page. We had to make quite a few updates to handle all the different filters. The Vue Nodes page will read the query params and store them off in their `pinia` store as well as in `localStorage`. Then the page rewrites the URL to remove the query params, so they don't conflict with any changes a user could then make. All the filters are supported in the query string, in the UI itself (Advanced Filters drawer) and in the `NodeRestService` Rest API.

This PR gets parity with all of the searches possible on the Inventory Search page `element/index.jsp`. The searches from that page now redirect to the Vue Nodes page and should work as expected.

This does not actually delete the old node list page. We can do that once this page has been tested more. The legacy page is also still on the menu, will soon be removed.

- Renamed it to `Nodes` instead of `Node List`, to match `Alarms`, `Events`, etc.

- Added full `iplike` ipv4 and ipv6 support

- Added MAC address / `maclike` support

- Added Nodes with Assets filter

- Support for `nodesWithDownAggregateStatus`, `SiteStatusView` links.

- Support for Asset fields. Note this does not support geolocation-specific ones.

- Added some help in the UI

## Nodes Table

<img width="1793" height="418" alt="nodes-table" src="https://github.com/user-attachments/assets/5bcd77fc-7368-47b8-a968-fb532fa3bc9f" />


## Nodes Advanced Filters Drawer

<img width="919" height="1055" alt="node-advanced-filter-drawer" src="https://github.com/user-attachments/assets/fa380c09-8f8c-4109-8abb-f37ea8e54128" />

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19855
