### PR TITLE
NMS-19880: Bump netty to 4.2.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1915,7 +1915,7 @@
     <minaVersion>2.2.7</minaVersion>
     <mockitoVersion>3.12.4</mockitoVersion>
     <netty3Version>3.10.6.Final</netty3Version>
-    <netty4Version>4.2.13.Final</netty4Version>
+    <netty4Version>4.2.15.Final</netty4Version>
     <newtsVersion>3.0.0</newtsVersion>
     <newtsOsgiVersion>3.0.0</newtsOsgiVersion>
     <paxCdiVersion>1.1.4</paxCdiVersion>


### PR DESCRIPTION
Bumps netty4Version from 4.2.13.Final to 4.2.15.Final (one property; elasticsearchNettyVersion aliases it, and the Karaf features/overrides for OpenNMS, Minion, and Sentinel pick it up through build-time filtering).

Two upstream behavior changes to be aware of (both from 4.2.14): the HTTP/2 default MAX_CONCURRENT_STREAMS is now 100 instead of unlimited, and localhost lookups no longer query DNS servers. 4.2.15 additionally tightens MQTT packet validation and bounds compression-decoder memory allocation.

Verified locally: telemetry listener ITs (JTI, BMP, thresholding, listener/parser threading) and the OpenConfig gRPC-over-HTTP/2 ITs pass against 4.2.15; the assembled lib/ carries a single netty version set, and Trivy reports zero netty findings against the assembly (down from 13).

Assisted-by: Claude Code:Opus 4.8/Fable 5

Jira: https://opennms.atlassian.net/browse/NMS-19880