### PR TITLE
NMS-19882: guard HeartbeatConsumer against misconfigured Minions

### DIFF
--- a/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
+++ b/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
@@ -129,6 +129,11 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
         LOG.info("Received heartbeat for Minion with id: {} at location: {}",
                 minionHandle.getId(), minionHandle.getLocation());
 
+        if (minionHandle.getId() == null || minionHandle.getId().isEmpty()) {
+            LOG.warn("Refusing to process Minion heartbeat with null 'id' for location: '{}'", minionHandle.getLocation());
+            return;
+        }
+
         OnmsMinion minion = minionDao.findById(minionHandle.getId());
         if (minion == null) {
             minion = new OnmsMinion();
@@ -235,10 +240,6 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
 
         // Return if minion with this foreignId and location already exists.
         String foreignId = minion.getLabel() != null ? minion.getLabel() : minion.getId();
-        if (foreignId.isEmpty()) {
-            LOG.warn("Heartbeat received with null ID and label for location '{}', aborting this heartbeat!", minion.getLocation());
-            return;
-        }
         List<OnmsNode> nodes = nodeDao.findByForeignIdForLocation(foreignId, nextLocation);
         if (!nodes.isEmpty()) {
             //check for existing requisitions the policy and detectors are in place

--- a/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
+++ b/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
@@ -129,7 +129,7 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
         LOG.info("Received heartbeat for Minion with id: {} at location: {}",
                 minionHandle.getId(), minionHandle.getLocation());
 
-        if (minionHandle.getId() == null || minionHandle.getId().isEmpty()) {
+        if (minionHandle.getId() == null || minionHandle.getId().isBlank()) {
             LOG.warn("Refusing to process Minion heartbeat with invalid 'id' for location: '{}'", minionHandle.getLocation());
             return;
         }

--- a/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
+++ b/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
@@ -70,6 +70,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import javax.xml.bind.ValidationException;
+
 public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, MinionIdentityDTO>, InitializingBean {
 
     private static final Logger LOG = LoggerFactory.getLogger(HeartbeatConsumer.class);
@@ -172,9 +174,13 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
 
         executor.execute(() -> {
 
-            this.provision(onmsMinion,
-                    prevLocation,
-                    nextLocation);
+            try {
+                this.provision(onmsMinion,
+                        prevLocation,
+                        nextLocation) ;
+            } catch (ValidationException e) {
+                throw new RuntimeException("Heartbeat provisioner failed to validate: ", e);
+            }
 
             if (prevLocation == null) {
                 final EventBuilder eventBuilder = new EventBuilder(EventConstants.MONITORING_SYSTEM_ADDED_UEI,
@@ -202,14 +208,11 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
                 }
             }
         });
-
-
-
     }
 
     private void provision(final OnmsMinion minion,
                            final String prevLocation,
-                           final String nextLocation) {
+                           final String nextLocation) throws ValidationException {
         // Return fast if automatic provisioning is disabled
         if (!PROVISIONING) {
             return;
@@ -232,6 +235,10 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
 
         // Return if minion with this foreignId and location already exists.
         String foreignId = minion.getLabel() != null ? minion.getLabel() : minion.getId();
+        if (foreignId.isEmpty()) {
+            LOG.warn("Heartbeat received with null ID and label for location '{}', aborting this heartbeat!", minion.getLocation());
+            return;
+        }
         List<OnmsNode> nodes = nodeDao.findByForeignIdForLocation(foreignId, nextLocation);
         if (!nodes.isEmpty()) {
             //check for existing requisitions the policy and detectors are in place
@@ -302,6 +309,7 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
             requisitionNode.setForeignId(foreignId);
             requisitionNode.setLocation(minion.getLocation());
             requisitionNode.putInterface(requisitionInterface);
+            requisitionNode.validate();
 
             nextRequisition.putNode(requisitionNode);
             nextRequisition.setDate(new Date());

--- a/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
+++ b/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
@@ -184,7 +184,8 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
                         prevLocation,
                         nextLocation) ;
             } catch (ValidationException e) {
-                throw new RuntimeException("Heartbeat provisioner failed to validate: ", e);
+               LOG.error("Heartbeat provisioner failed to validate: ", e);
+               return;
             }
 
             if (prevLocation == null) {

--- a/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
+++ b/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
@@ -130,7 +130,7 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
                 minionHandle.getId(), minionHandle.getLocation());
 
         if (minionHandle.getId() == null || minionHandle.getId().isEmpty()) {
-            LOG.warn("Refusing to process Minion heartbeat with null 'id' for location: '{}'", minionHandle.getLocation());
+            LOG.warn("Refusing to process Minion heartbeat with invalid 'id' for location: '{}'", minionHandle.getLocation());
             return;
         }
 


### PR DESCRIPTION
HeartbeatConsumer will attempt to provision minions with missing IDs, fouling up the Minions requisition and causing it to be re-created empty, which then forces all the minions to be re-provisioned until the invalid minion(s) send its next heartbeat.  Repeat.

Check for and bail out on null / empty foreignId from the heartbeat message, and validate the node object before adding it to the req.

This one was _not_ assisted by Claude, believe it or not.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19882
* SUPPORT-3239

