### PR TITLE
NMS-19902: bound the VMware CIM connection and probe each host address

### DIFF
--- a/docs/modules/reference/pages/provisioning/handlers/vmware.adoc
+++ b/docs/modules/reference/pages/provisioning/handlers/vmware.adoc
@@ -98,8 +98,9 @@ Add additional parameters as key/value pairs in the *Advanced Options* area.
 | Default
 
 | cimTimeout
-| Timeout, in milliseconds, used to test interface addresses for a reachable CIM service.
-Increase this value only if you have problems discovering CIM services on host systems.
+| Timeout, in milliseconds, for the direct connection to a host system's CIM service (port 5989).
+A host whose CIM port is unreachable fails within this timeout instead of stalling the import.
+Increase this value only if reachable hosts are being missed during discovery.
 | 3000
 
 | hostSystemServices

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCimCollector.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/collectd/VmwareCimCollector.java
@@ -440,6 +440,7 @@ public class VmwareCimCollector extends AbstractRemoteServiceCollector {
 
         try (final VmwareViJavaAccess vmwareViJavaAccess = new VmwareViJavaAccess(vmwareServer)) {
             vmwareViJavaAccess.connect(ParameterMap.getKeyedInteger(parameters, "timeout", VmwareViJavaAccess.DEFAULT_TIMEOUT));
+            vmwareViJavaAccess.setCimTimeout(ParameterMap.getKeyedInteger(parameters, "timeout", VmwareViJavaAccess.DEFAULT_TIMEOUT));
             final HostSystem hostSystem = vmwareViJavaAccess.getHostSystemByManagedObjectId(vmwareManagedObjectId);
             String powerState = null;
             if (hostSystem == null) {

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/poller/monitors/VmwareCimMonitor.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/poller/monitors/VmwareCimMonitor.java
@@ -122,6 +122,7 @@ public class VmwareCimMonitor extends AbstractVmwareMonitor {
         for (tracker.reset(); tracker.shouldRetry() && !serviceStatus.isAvailable(); tracker.nextAttempt()) {
             try (final VmwareViJavaAccess vmwareViJavaAccess = new VmwareViJavaAccess(vmwareManagementServer, vmwareMangementServerUsername, vmwareMangementServerPassword)) {
                 vmwareViJavaAccess.connect(tracker.getConnectionTimeout());
+                vmwareViJavaAccess.setCimTimeout(tracker.getConnectionTimeout());
                 final HostSystem hostSystem = vmwareViJavaAccess.getHostSystemByManagedObjectId(vmwareManagedObjectId);
                 String powerState = null;
                 if (hostSystem == null) {

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImporter.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImporter.java
@@ -515,13 +515,19 @@ public class VmwareImporter {
         if (!vmwareViJavaAccess.setTimeout(request.getCimTimeout())) {
             logger.warn("Error setting CIM connection timeout");
         }
+        vmwareViJavaAccess.setCimTimeout(request.getCimTimeout());
 
         logger.debug("Probing address {} for Host System '{}'", ipAddress, hostSystem.getName());
 
         List<CIMObject> cimObjects = null;
         try {
             cimObjects = vmwareViJavaAccess.queryCimObjects(hostSystem, "CIM_NumericSensor", ipAddress);
-        } catch (ConnectException | RemoteException | CIMException e) {
+        } catch (ConnectException e) {
+            logger.warn("CIM service for Host System '{}' is not reachable at {} (within {} ms); "
+                    + "the VMwareCim-HostSystem service will not be assigned for this address. Reason: {}",
+                    hostSystem.getName(), ipAddress, request.getCimTimeout(), e.getMessage());
+            return false;
+        } catch (RemoteException | CIMException e) {
             logger.debug("Error while probing for address {} for Host System '{}'", ipAddress, hostSystem.getName());
             logger.debug("Exception thrown while probing IP address: {}", e);
             return false;

--- a/integrations/opennms-vmware/src/main/java/org/opennms/protocols/vmware/VmwareViJavaAccess.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/protocols/vmware/VmwareViJavaAccess.java
@@ -423,7 +423,7 @@ public class VmwareViJavaAccess implements AutoCloseable {
             // An explicit address was supplied (for example, the importer probing each of a
             // host's interface addresses in turn). Use it directly rather than a value cached
             // from an earlier call, so every candidate address is actually tried.
-            cimAgentAddress = "https://" + primaryIpAddress + ":5989";
+            cimAgentAddress = cimUrlFor(primaryIpAddress);
         } else {
             if (!m_hostSystemCimUrls.containsKey(hostSystem)) {
                 final String ipAddress = getPrimaryHostSystemIpAddress(hostSystem);
@@ -433,7 +433,7 @@ public class VmwareViJavaAccess implements AutoCloseable {
                     return cimObjects;
                 }
 
-                m_hostSystemCimUrls.put(hostSystem, "https://" + ipAddress + ":5989");
+                m_hostSystemCimUrls.put(hostSystem, cimUrlFor(ipAddress));
             }
 
             cimAgentAddress = m_hostSystemCimUrls.get(hostSystem);
@@ -452,7 +452,7 @@ public class VmwareViJavaAccess implements AutoCloseable {
         CIMNameSpace ns = new CIMNameSpace(cimAgentAddress, namespace);
         CIMClient cimClient = new CIMClient(ns, userPr, pwCred);
 
-        cimClient.getSessionProperties().setHttpTimeOut(m_cimTimeout);
+        cimClient.getSessionProperties().setHttpTimeOut(boundedTimeout(m_cimTimeout));
 
         // very important to query esx5 hosts
         cimClient.useMPost(false);
@@ -493,23 +493,57 @@ public class VmwareViJavaAccess implements AutoCloseable {
      * @throws ConnectException if the connection cannot be established within the timeout
      */
     protected void checkCimReachable(final String cimAgentAddress, final int timeout) throws ConnectException {
-        final URI uri = URI.create(cimAgentAddress);
-        final String host = uri.getHost();
-        final int port = uri.getPort();
+        final String host;
+        final int port;
+        try {
+            final URI uri = URI.create(cimAgentAddress);
+            host = uri.getHost();
+            port = uri.getPort();
+        } catch (IllegalArgumentException e) {
+            // Unparseable address; let the CIM client surface the problem.
+            return;
+        }
 
         if (host == null || port < 0) {
             // Malformed address; let the CIM client surface the problem.
             return;
         }
 
+        final int connectTimeout = boundedTimeout(timeout);
+
         try (Socket socket = new Socket()) {
-            socket.connect(new InetSocketAddress(host, port), timeout);
+            socket.connect(new InetSocketAddress(host, port), connectTimeout);
         } catch (IOException e) {
             final ConnectException connectException = new ConnectException("CIM service at " + host + ":" + port
-                    + " is not reachable within " + timeout + " ms (" + e.getMessage() + ")");
+                    + " could not be reached (timeout " + connectTimeout + " ms): " + e.getMessage());
             connectException.initCause(e);
             throw connectException;
         }
+    }
+
+    /**
+     * Bounds a CIM timeout to a usable value. {@code Socket.connect} treats 0 as an infinite
+     * timeout and rejects negatives with an {@code IllegalArgumentException}, and
+     * {@code setSoTimeout(0)} is likewise an infinite read timeout, so non-positive values are
+     * clamped to the default bound.
+     *
+     * @param timeout the requested timeout in milliseconds
+     * @return the timeout to use, never less than 1
+     */
+    static int boundedTimeout(final int timeout) {
+        return timeout > 0 ? timeout : DEFAULT_TIMEOUT;
+    }
+
+    /**
+     * Builds the CIM agent URL for an address, bracketing IPv6 literals so the result is a
+     * valid URI authority (for example {@code https://[fe80::1]:5989}).
+     *
+     * @param ipAddress the host address
+     * @return the CIM agent URL
+     */
+    private static String cimUrlFor(final String ipAddress) {
+        final boolean ipv6 = ipAddress.indexOf(':') >= 0 && !ipAddress.startsWith("[");
+        return "https://" + (ipv6 ? "[" + ipAddress + "]" : ipAddress) + ":5989";
     }
 
     /**

--- a/integrations/opennms-vmware/src/main/java/org/opennms/protocols/vmware/VmwareViJavaAccess.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/protocols/vmware/VmwareViJavaAccess.java
@@ -38,9 +38,13 @@
 
 package org.opennms.protocols.vmware;
 
+import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.Socket;
+import java.net.URI;
 import java.rmi.RemoteException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -134,6 +138,8 @@ public class VmwareViJavaAccess implements AutoCloseable {
 
     private int m_timeout = DEFAULT_TIMEOUT;
 
+    private int m_cimTimeout = DEFAULT_TIMEOUT;
+
     /**
      * Constructor for creating a instance for a given server and credentials.
      *
@@ -155,6 +161,23 @@ public class VmwareViJavaAccess implements AutoCloseable {
 
     public int getTimeout() {
         return m_timeout;
+    }
+
+    public int getCimTimeout() {
+        return m_cimTimeout;
+    }
+
+    /**
+     * Sets the timeout, in milliseconds, used for the direct connection to a
+     * host system's CIM service (port 5989). This bounds the TCP connect that
+     * the underlying CIM client would otherwise attempt without a timeout, so
+     * an unreachable or firewalled CIM port fails fast instead of blocking the
+     * calling thread until the operating system connect timeout elapses.
+     *
+     * @param timeout the CIM connection timeout in milliseconds
+     */
+    public void setCimTimeout(int timeout) {
+        m_cimTimeout = timeout;
     }
 
     /**
@@ -394,23 +417,32 @@ public class VmwareViJavaAccess implements AutoCloseable {
 
         HostServiceTicket hostServiceTicket = m_hostServiceTickets.get(hostSystem);
 
-        if (!m_hostSystemCimUrls.containsKey(hostSystem)) {
-            String ipAddress = primaryIpAddress;
+        final String cimAgentAddress;
 
-            if (ipAddress == null) {
-                ipAddress = getPrimaryHostSystemIpAddress(hostSystem);
+        if (primaryIpAddress != null) {
+            // An explicit address was supplied (for example, the importer probing each of a
+            // host's interface addresses in turn). Use it directly rather than a value cached
+            // from an earlier call, so every candidate address is actually tried.
+            cimAgentAddress = "https://" + primaryIpAddress + ":5989";
+        } else {
+            if (!m_hostSystemCimUrls.containsKey(hostSystem)) {
+                final String ipAddress = getPrimaryHostSystemIpAddress(hostSystem);
+
+                if (ipAddress == null) {
+                    logger.warn("Cannot determine ip address for host system '{}'", hostSystem.getMOR().getVal());
+                    return cimObjects;
+                }
+
+                m_hostSystemCimUrls.put(hostSystem, "https://" + ipAddress + ":5989");
             }
 
-
-            if (ipAddress == null) {
-                logger.warn("Cannot determine ip address for host system '{}'", hostSystem.getMOR().getVal());
-                return cimObjects;
-            }
-
-            m_hostSystemCimUrls.put(hostSystem, "https://" + ipAddress + ":5989");
+            cimAgentAddress = m_hostSystemCimUrls.get(hostSystem);
         }
 
-        String cimAgentAddress = m_hostSystemCimUrls.get(hostSystem);
+        // The underlying CIM client opens its connection to the host's CIM port (5989)
+        // without a connect timeout, so an unreachable or firewalled host would block this
+        // thread until the operating system connect timeout elapses. Bound the connect first.
+        checkCimReachable(cimAgentAddress, m_cimTimeout);
 
         String namespace = "root/cimv2";
 
@@ -420,7 +452,7 @@ public class VmwareViJavaAccess implements AutoCloseable {
         CIMNameSpace ns = new CIMNameSpace(cimAgentAddress, namespace);
         CIMClient cimClient = new CIMClient(ns, userPr, pwCred);
 
-        cimClient.getSessionProperties().setHttpTimeOut(3000);
+        cimClient.getSessionProperties().setHttpTimeOut(m_cimTimeout);
 
         // very important to query esx5 hosts
         cimClient.useMPost(false);
@@ -445,6 +477,39 @@ public class VmwareViJavaAccess implements AutoCloseable {
      */
     public List<CIMObject> queryCimObjects(HostSystem hostSystem, String cimClass) throws ConnectException, RemoteException, CIMException {
         return queryCimObjects(hostSystem, cimClass, null);
+    }
+
+    /**
+     * Verifies that the CIM service at the given agent address accepts a TCP connection
+     * within the specified timeout.
+     *
+     * <p>The SBLIM CIM client performs an unbounded connect when it opens its socket, so
+     * an unreachable host (for example, one whose CIM port is dropped by a firewall) would
+     * block the calling thread for the operating system connect timeout. Probing the
+     * connection here first bounds that wait by {@code timeout} milliseconds.</p>
+     *
+     * @param cimAgentAddress the CIM agent URL, for example {@code https://host:5989}
+     * @param timeout         the connect timeout in milliseconds
+     * @throws ConnectException if the connection cannot be established within the timeout
+     */
+    protected void checkCimReachable(final String cimAgentAddress, final int timeout) throws ConnectException {
+        final URI uri = URI.create(cimAgentAddress);
+        final String host = uri.getHost();
+        final int port = uri.getPort();
+
+        if (host == null || port < 0) {
+            // Malformed address; let the CIM client surface the problem.
+            return;
+        }
+
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), timeout);
+        } catch (IOException e) {
+            final ConnectException connectException = new ConnectException("CIM service at " + host + ":" + port
+                    + " is not reachable within " + timeout + " ms (" + e.getMessage() + ")");
+            connectException.initCause(e);
+            throw connectException;
+        }
     }
 
     /**

--- a/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/collectd/vmware/VmwareViJavaAccessTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/collectd/vmware/VmwareViJavaAccessTest.java
@@ -158,6 +158,11 @@ public class VmwareViJavaAccessTest {
             @Override
             protected void relax() {
             }
+
+            @Override
+            protected void checkCimReachable(String cimAgentAddress, int timeout) {
+                // Skip the real TCP reachability probe; the CIM client is mocked in this test.
+            }
         };
 
         // setup PerformanceManager

--- a/integrations/opennms-vmware/src/test/java/org/opennms/protocols/vmware/VmwareCimReachabilityTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/protocols/vmware/VmwareCimReachabilityTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.protocols.vmware;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.ConnectException;
+import java.net.ServerSocket;
+
+import org.junit.Test;
+
+import com.vmware.vim25.HostServiceTicket;
+import com.vmware.vim25.mo.HostSystem;
+
+/**
+ * Verifies that {@link VmwareViJavaAccess#checkCimReachable(String, int)} bounds the
+ * connection to a host's CIM service so that an unreachable or firewalled CIM port
+ * fails fast instead of blocking the calling thread.
+ */
+public class VmwareCimReachabilityTest {
+
+    private final VmwareViJavaAccess access = new VmwareViJavaAccess("host", "user", "pass");
+
+    /**
+     * A closed local port should be rejected (connection refused) promptly.
+     */
+    @Test
+    public void failsWhenConnectionRefused() throws Exception {
+        final int closedPort;
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            closedPort = serverSocket.getLocalPort();
+        }
+        // The server socket is now closed, so nothing is listening on closedPort.
+
+        final long start = System.currentTimeMillis();
+        try {
+            access.checkCimReachable("https://127.0.0.1:" + closedPort, 5000);
+            fail("expected a ConnectException for a closed CIM port");
+        } catch (ConnectException expected) {
+            final long elapsed = System.currentTimeMillis() - start;
+            assertTrue("connection refused should be reported promptly, took " + elapsed + " ms", elapsed < 5000);
+        }
+    }
+
+    /**
+     * An unroutable host (RFC 5737 TEST-NET-1) must not block longer than the configured
+     * timeout -- the SBLIM client would otherwise block for the OS connect timeout.
+     */
+    @Test
+    public void boundsConnectForUnreachableHost() {
+        final int timeout = 1000;
+        final long start = System.currentTimeMillis();
+        try {
+            access.checkCimReachable("https://192.0.2.1:5989", timeout);
+            fail("expected a ConnectException for an unreachable CIM host");
+        } catch (ConnectException expected) {
+            final long elapsed = System.currentTimeMillis() - start;
+            assertTrue("connect should be bounded by the timeout, took " + elapsed + " ms",
+                    elapsed < timeout + 4000);
+        }
+    }
+
+    /**
+     * A malformed agent address is left for the CIM client to surface (no exception here).
+     */
+    @Test
+    public void ignoresMalformedAddress() throws Exception {
+        access.checkCimReachable("not-a-url", 1000);
+    }
+
+    /**
+     * Exercises the full {@code queryCimObjects} path with a mocked vCenter ticket (as a real
+     * vCenter would mint) but an unreachable host CIM port. The query must fail within
+     * cimTimeout rather than blocking on the SBLIM client's unbounded connect, and it must
+     * not reach the CIM client at all.
+     */
+    @Test
+    public void queryCimObjectsBoundsUnreachableCimConnect() throws Exception {
+        access.setCimTimeout(800);
+
+        final HostServiceTicket ticket = new HostServiceTicket();
+        ticket.setSessionId("sessionId");
+        final HostSystem hostSystem = mock(HostSystem.class);
+        when(hostSystem.acquireCimServicesTicket()).thenReturn(ticket);
+
+        final long start = System.currentTimeMillis();
+        try {
+            // 192.0.2.1 is RFC 5737 TEST-NET-1 (unroutable).
+            access.queryCimObjects(hostSystem, "CIM_NumericSensor", "192.0.2.1");
+            fail("expected a ConnectException for an unreachable CIM host");
+        } catch (ConnectException expected) {
+            final long elapsed = System.currentTimeMillis() - start;
+            assertTrue("queryCimObjects should be bounded by cimTimeout, took " + elapsed + " ms",
+                    elapsed < 5000);
+        }
+    }
+
+    /**
+     * Each call with an explicit address must probe that address, not a value cached from an
+     * earlier call. The importer relies on this to try each of a host's interface addresses
+     * in turn; caching the first one would wrongly mark a host with a reachable secondary
+     * address as unreachable.
+     */
+    @Test
+    public void queryCimObjectsUsesEachExplicitAddress() throws Exception {
+        access.setCimTimeout(800);
+        final HostServiceTicket ticket = new HostServiceTicket();
+        ticket.setSessionId("sessionId");
+        final HostSystem hostSystem = mock(HostSystem.class);
+        when(hostSystem.acquireCimServicesTicket()).thenReturn(ticket);
+
+        try {
+            access.queryCimObjects(hostSystem, "CIM_NumericSensor", "192.0.2.1");
+            fail("expected a ConnectException");
+        } catch (ConnectException expected) {
+            assertTrue("first probe should report 192.0.2.1: " + expected.getMessage(),
+                    expected.getMessage().contains("192.0.2.1"));
+        }
+
+        try {
+            access.queryCimObjects(hostSystem, "CIM_NumericSensor", "192.0.2.2");
+            fail("expected a ConnectException");
+        } catch (ConnectException expected) {
+            assertTrue("second probe must use the supplied address, not a cached one: " + expected.getMessage(),
+                    expected.getMessage().contains("192.0.2.2"));
+        }
+    }
+}

--- a/integrations/opennms-vmware/src/test/java/org/opennms/protocols/vmware/VmwareCimReachabilityTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/protocols/vmware/VmwareCimReachabilityTest.java
@@ -21,6 +21,7 @@
  */
 package org.opennms.protocols.vmware;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -146,5 +147,80 @@ public class VmwareCimReachabilityTest {
             assertTrue("second probe must use the supplied address, not a cached one: " + expected.getMessage(),
                     expected.getMessage().contains("192.0.2.2"));
         }
+    }
+
+    /**
+     * An IPv6 host literal must be bracketed so the URL is a valid authority and the address is
+     * actually probed -- an unbracketed IPv6 URL parses to a null host, so the probe would
+     * silently no-op and leave the unbounded connect in place.
+     */
+    @Test
+    public void queryCimObjectsProbesIpv6Address() throws Exception {
+        access.setCimTimeout(800);
+        final HostServiceTicket ticket = new HostServiceTicket();
+        ticket.setSessionId("sessionId");
+        final HostSystem hostSystem = mock(HostSystem.class);
+        when(hostSystem.acquireCimServicesTicket()).thenReturn(ticket);
+
+        try {
+            // 2001:db8::5 is RFC 3849 documentation space (unroutable).
+            access.queryCimObjects(hostSystem, "CIM_NumericSensor", "2001:db8::5");
+            fail("expected a ConnectException for an unreachable IPv6 CIM host");
+        } catch (ConnectException expected) {
+            assertTrue("the IPv6 address must be probed, not skipped: " + expected.getMessage(),
+                    expected.getMessage().contains("2001:db8::5"));
+        }
+    }
+
+    /**
+     * A timeout of 0 is an infinite Socket.connect timeout; it must be clamped so the probe
+     * returns rather than blocking indefinitely.
+     */
+    @Test(timeout = 20000)
+    public void clampsZeroTimeout() throws Exception {
+        final long start = System.currentTimeMillis();
+        try {
+            access.checkCimReachable("https://192.0.2.1:5989", 0);
+            fail("expected a ConnectException");
+        } catch (ConnectException expected) {
+            final long elapsed = System.currentTimeMillis() - start;
+            assertTrue("a zero timeout must be clamped, took " + elapsed + " ms",
+                    elapsed < VmwareViJavaAccess.DEFAULT_TIMEOUT + 5000);
+        }
+    }
+
+    /**
+     * A negative timeout would make Socket.connect throw IllegalArgumentException; it must be
+     * clamped and surface as a normal connect failure instead.
+     */
+    @Test(timeout = 20000)
+    public void clampsNegativeTimeout() throws Exception {
+        try {
+            access.checkCimReachable("https://192.0.2.1:5989", -1);
+            fail("expected a ConnectException");
+        } catch (ConnectException expected) {
+            // ok: clamped to the default and reported as a connect failure, not IllegalArgumentException
+        }
+    }
+
+    /**
+     * An address that URI parsing rejects must be swallowed (left for the CIM client) rather
+     * than propagated as an IllegalArgumentException.
+     */
+    @Test
+    public void ignoresUnparseableAddress() throws Exception {
+        access.checkCimReachable("https://bad host:5989", 1000);
+    }
+
+    /**
+     * Non-positive timeouts must be clamped: this guards both the connect probe and the read
+     * timeout (setHttpTimeOut), since 0 is an infinite timeout in both and a negative value is
+     * rejected outright by Socket.connect.
+     */
+    @Test
+    public void boundedTimeoutClampsNonPositive() {
+        assertEquals(VmwareViJavaAccess.DEFAULT_TIMEOUT, VmwareViJavaAccess.boundedTimeout(0));
+        assertEquals(VmwareViJavaAccess.DEFAULT_TIMEOUT, VmwareViJavaAccess.boundedTimeout(-5));
+        assertEquals(800, VmwareViJavaAccess.boundedTimeout(800));
     }
 }


### PR DESCRIPTION
The VMware integration connects directly to a host system's CIM service (port 5989) through the SBLIM client, which opens its socket with no connection timeout. An unreachable CIM port therefore blocked the importer's single thread for the operating system connect timeout, stalling requisition imports (and likewise the VmwareCim monitor and collector).

- Add a bounded reachability check (checkCimReachable) in VmwareViJavaAccess.queryCimObjects, using a new cimTimeout that is wired from the cimTimeout/timeout parameters in the importer, monitor, and collector; setHttpTimeOut now uses it as well.
- Log a clear WARN when a host's CIM service is unreachable during import (previously DEBUG only, so the cause was invisible).
- Probe each interface address that is passed to queryCimObjects rather than reusing the first one cached per host, so a host with a reachable secondary address is no longer wrongly marked unreachable.
- Add VmwareCimReachabilityTest and document the cimTimeout parameter.

I validated this in my homelab.  Works as described above.

Assisted-by: Claude Code: Opus 4.7/4.8

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19902
