### PR TITLE
NMS-19843: Update PrimeVue presets to match Feather themes throughout app

### DIFF
--- a/ui/src/components/Nodes/AssetFilterPanel.vue
+++ b/ui/src/components/Nodes/AssetFilterPanel.vue
@@ -162,37 +162,10 @@ onMounted(() => {
     :deep(.p-datatable-tbody > tr > td) {
       padding: 0.25rem 0.5rem;
       vertical-align: middle;
-      border-color: var(--feather-border-on-surface);
-      color: var(--feather-primary-text-on-surface);
     }
 
     :deep(.p-datatable-thead > tr > th) {
       padding: 0.4rem 0.5rem;
-      background-color: var(--feather-background);
-      border-bottom: 1px solid var(--feather-border-on-surface);
-      color: var(--feather-secondary-text-on-surface);
-      text-transform: uppercase;
-    }
-
-    :deep(.p-datatable-tbody > tr) {
-      background-color: var(--feather-elevation-background-8);
-      color: var(--feather-primary-text-on-surface);
-    }
-
-    :deep(.p-select) {
-      background-color: var(--feather-surface);
-      border-color: var(--feather-border-on-surface);
-      color: var(--feather-primary-text-on-surface);
-    }
-
-    :deep(.p-inputtext) {
-      background-color: var(--feather-elevation-background-8);
-      border-color: var(--feather-border-on-surface);
-      color: var(--feather-primary-text-on-surface);
-    }
-
-    :deep(.p-select-label) {
-      color: var(--feather-primary-text-on-surface);
     }
   }
 }

--- a/ui/src/components/Nodes/ExtendedSearchPanel.vue
+++ b/ui/src/components/Nodes/ExtendedSearchPanel.vue
@@ -204,37 +204,10 @@ onMounted(() => {
     :deep(.p-datatable-tbody > tr > td) {
       padding: 0.25rem 0.5rem;
       vertical-align: middle;
-      border-color: var(--feather-border-on-surface);
-      color: var(--feather-primary-text-on-surface);
     }
 
     :deep(.p-datatable-thead > tr > th) {
       padding: 0.4rem 0.5rem;
-      background-color: var(--feather-background);
-      border-bottom: 1px solid var(--feather-border-on-surface);
-      color: var(--feather-secondary-text-on-surface);
-      text-transform: uppercase;
-    }
-
-    :deep(.p-datatable-tbody > tr) {
-      background-color: var(--feather-elevation-background-8);
-      color: var(--feather-primary-text-on-surface);
-    }
-
-    :deep(.p-select) {
-      background-color: var(--feather-surface);
-      border-color: var(--feather-border-on-surface);
-      color: var(--feather-primary-text-on-surface);
-    }
-
-    :deep(.p-inputtext) {
-      background-color: var(--feather-elevation-background-8);
-      border-color: var(--feather-border-on-surface);
-      color: var(--feather-primary-text-on-surface);
-    }
-
-    :deep(.p-select-label) {
-      color: var(--feather-primary-text-on-surface);
     }
   }
 }

--- a/ui/src/components/PrimeVueTest.vue
+++ b/ui/src/components/PrimeVueTest.vue
@@ -54,6 +54,19 @@ License.
     </section>
 
     <section>
+      <h3>PrimeVue DataTable &amp; Chips (theme token check)</h3>
+      <div class="component-row">
+        <PChip label="Chip One" />
+        <PChip label="Removable" removable />
+      </div>
+      <PDataTable :value="tableRows">
+        <PColumn field="name" header="Name" />
+        <PColumn field="type" header="Type" />
+        <PColumn field="status" header="Status" />
+      </PDataTable>
+    </section>
+
+    <section>
       <h3>FeatherDS Components (coexistence check)</h3>
       <div class="component-row">
         <FeatherButton primary>FeatherDS Button</FeatherButton>
@@ -86,6 +99,9 @@ import InputText from 'primevue/inputtext'
 import Checkbox from 'primevue/checkbox'
 import Select from 'primevue/select'
 import Dialog from 'primevue/dialog'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import Chip from 'primevue/chip'
 import { FeatherButton } from '@featherds/button'
 import { FeatherInput } from '@featherds/input'
 
@@ -94,6 +110,9 @@ const PInputText = InputText
 const PCheckbox = Checkbox
 const PSelect = Select
 const PDialog = Dialog
+const PDataTable = DataTable
+const PColumn = Column
+const PChip = Chip
 
 const inputValue = ref('')
 const featherInputValue = ref('')
@@ -104,6 +123,11 @@ const selectOptions = ref([
   { label: 'Option A', value: 'a' },
   { label: 'Option B', value: 'b' },
   { label: 'Option C', value: 'c' }
+])
+const tableRows = ref([
+  { name: 'router-01', type: 'Cisco', status: 'Up' },
+  { name: 'switch-02', type: 'Juniper', status: 'Down' },
+  { name: 'server-03', type: 'Linux', status: 'Up' }
 ])
 </script>
 

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileRrdSettingsTab.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileRrdSettingsTab.vue
@@ -231,33 +231,6 @@ const onRowEditSave = (event: DataTableRowEditSaveEvent) => {
 .rra-section {
   margin-top: 20px;
 
-  :deep(.p-datatable-thead > tr > th) {
-    background-color: var(--feather-background);
-    border-bottom: 1px solid var(--feather-border-on-surface);
-    color: var(--feather-secondary-text-on-surface);
-    text-transform: uppercase;
-  }
-
-  :deep(.p-datatable-tbody > tr) {
-    background-color: var(--feather-surface);
-    color: var(--feather-primary-text-on-surface);
-  }
-
-  :deep(.p-datatable-tbody > tr > td) {
-    border-color: var(--feather-border-on-surface);
-    color: var(--feather-primary-text-on-surface);
-  }
-
-  :deep(.p-select) {
-    background-color: var(--feather-surface);
-    border-color: var(--feather-border-on-surface);
-    color: var(--feather-primary-text-on-surface);
-  }
-
-  :deep(.p-select-label) {
-    color: var(--feather-primary-text-on-surface);
-  }
-
   .rra-header {
     display: flex;
     align-items: center;

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileSourcesTab.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileSourcesTab.vue
@@ -122,15 +122,5 @@ const removeSource = (name: string) => {
   :deep(.p-datatable-thead) {
     display: none;
   }
-
-  :deep(.p-datatable-tbody > tr) {
-    background-color: var(--feather-surface);
-    color: var(--feather-primary-text-on-surface);
-  }
-
-  :deep(.p-datatable-tbody > tr > td) {
-    border-color: var(--feather-border-on-surface);
-    color: var(--feather-primary-text-on-surface);
-  }
 }
 </style>

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/SnmpDataCollectionSourceProfilesDrawer.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/SnmpDataCollectionSourceProfilesDrawer.vue
@@ -159,11 +159,6 @@ watch(() => props.visible, async (visible) => {
   flex-wrap: wrap;
   gap: 8px;
   min-height: 40px;
-
-  :deep(.p-chip-label),
-  :deep(.p-chip-remove-icon) {
-    color: var(--feather-primary-text-on-surface);
-  }
 }
 
 .empty-text {
@@ -183,40 +178,6 @@ watch(() => props.visible, async (visible) => {
 
   :deep(.btn + .btn) {
     margin-left: 0 !important;
-  }
-}
-
-:deep(.p-autocomplete-input) {
-  font-family: var(--feather-font-family);
-  background: var(--feather-background);
-  color: var(--feather-primary-text-on-surface);
-  border-color: var(--feather-border-on-surface);
-}
-</style>
-
-<style lang="scss">
-@use '@featherds/styles/themes/variables';
-
-// Overlay is teleported to body; :deep() can't reach it.
-// Un-layered global CSS wins over PrimeVue's @layer primevue styles.
-.p-autocomplete-overlay {
-  font-family: var(--feather-font-family);
-}
-
-.open-dark {
-  .p-autocomplete-overlay {
-    background: var(variables.$surface);
-    color: var(variables.$primary-text-on-surface);
-    border-color: var(variables.$border-on-surface);
-  }
-
-  .p-autocomplete-option {
-    color: var(variables.$primary-text-on-surface);
-
-    &.p-autocomplete-option-selected,
-    &:not(.p-disabled):hover {
-      background: rgba(255, 255, 255, 0.06);
-    }
   }
 }
 </style>

--- a/ui/src/containers/SnmpDataCollectionSourceDetail.vue
+++ b/ui/src/containers/SnmpDataCollectionSourceDetail.vue
@@ -549,10 +549,6 @@ watch(() => route.params.id, (id: string | string[]) => {
             display: flex;
             flex-wrap: wrap;
             gap: 6px;
-
-            :deep(.p-chip-label) {
-              color: var(--feather-primary-text-on-surface);
-            }
           }
 
           .no-profiles-text {

--- a/ui/src/services/themeService.ts
+++ b/ui/src/services/themeService.ts
@@ -41,7 +41,15 @@ export const saveTheme = (theme: Theme): void => {
 }
 
 export const applyThemeClass = (theme: Theme): void => {
-  const body = document.body
-  body.classList.remove(LIGHT_THEME, DARK_THEME)
-  body.classList.add(theme)
+  // Apply to both <html> and <body>. PrimeVue declares its component CSS
+  // variables on `:root` (<html>) as references to the semantic theme variables
+  // (e.g. `--p-inputtext-background: var(--p-form-field-background)`). Those
+  // references are substituted at the element where they are declared (<html>),
+  // so the dark-mode class must be present on <html> for component variables to
+  // resolve to their dark values. FeatherDS reads the same class and is
+  // unaffected by it also being on <html>.
+  for (const el of [document.documentElement, document.body]) {
+    el.classList.remove(LIGHT_THEME, DARK_THEME)
+    el.classList.add(theme)
+  }
 }

--- a/ui/src/styles/primevue-overrides.scss
+++ b/ui/src/styles/primevue-overrides.scss
@@ -1,0 +1,48 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Global PrimeVue tweaks that match the FeatherDS look but cannot be expressed
+// as theme tokens. Colors/backgrounds/borders are handled by the preset
+// (opennms-preset.ts) — keep this file for non-token, structural rules only.
+//
+// Rules are intentionally unlayered so they win over PrimeVue's `@layer primevue`
+// styles. Remove this file when FeatherDS is dropped (migration Phase 6) if the
+// PrimeVue defaults are acceptable at that point.
+
+// FeatherDS data tables render column headers in uppercase.
+.p-datatable-thead > tr > th {
+  text-transform: uppercase;
+}
+
+// FeatherDS buttons use uppercase, bold, slightly spaced label text. Match it
+// (these are FeatherDS button typography token values; text-transform and
+// letter-spacing are not expressible as PrimeVue theme tokens).
+.p-button {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08929em;
+  font-weight: 700;
+
+  .p-button-label {
+    font-weight: 700;
+  }
+}

--- a/ui/src/theme/opennms-preset.ts
+++ b/ui/src/theme/opennms-preset.ts
@@ -23,6 +23,31 @@
 import { definePreset } from '@primevue/themes'
 import Aura from '@primevue/themes/aura'
 
+/**
+ * OpenNMS PrimeVue preset (based on Aura).
+ *
+ * Goal: PrimeVue components match the existing FeatherDS look in BOTH light and
+ * dark mode out-of-the-box, so individual components do not need per-component
+ * `:deep(.p-*)` overrides.
+ *
+ * The surface / content / text / form-field / overlay token values below are the
+ * literal FeatherDS theme colors (from @featherds/styles/themes/open-light.css and
+ * open-dark.css). They are intentionally NOT expressed as `var(--feather-*)`:
+ * PrimeVue declares its `--p-*` variables on `:root` (html), whereas FeatherDS
+ * declares `--feather-*` on the `body.open-light` / `body.open-dark` class. A
+ * `var(--feather-*)` referenced from a `:root` declaration cannot resolve (the
+ * variable is defined on a descendant), so the token would compute to empty.
+ * Literal values avoid that and let PrimeVue's `darkModeSelector` switch schemes.
+ *
+ * When FeatherDS is removed (migration Phase 6) these values become the canonical
+ * OpenNMS palette — no further change required here.
+ */
+
+// FeatherDS primary brand color, referenced for form-field focus rings etc.
+// (PrimeVue token refs like `{primary.color}` resolve within PrimeVue's own
+// :root variables, so they are safe to use here.)
+const PRIMARY_FOCUS = '{primary.color}'
+
 const OpenNMSPreset = definePreset(Aura, {
   semantic: {
     primary: {
@@ -50,6 +75,35 @@ const OpenNMSPreset = definePreset(Aura, {
           100: '#f4f7fc',
           200: '#e8edf5',
           300: '#d1d5e0'
+        },
+        text: {
+          color: 'rgba(10, 12, 27, 0.9)',
+          hoverColor: 'rgba(10, 12, 27, 0.9)',
+          mutedColor: 'rgba(10, 12, 27, 0.7)',
+          hoverMutedColor: 'rgba(10, 12, 27, 0.7)'
+        },
+        content: {
+          background: '#ffffff',
+          hoverBackground: '#f4f7fc',
+          borderColor: 'rgba(10, 12, 27, 0.12)',
+          color: 'rgba(10, 12, 27, 0.9)',
+          hoverColor: 'rgba(10, 12, 27, 0.9)'
+        },
+        formField: {
+          background: '#ffffff',
+          borderColor: 'rgba(10, 12, 27, 0.12)',
+          hoverBorderColor: 'rgba(10, 12, 27, 0.12)',
+          focusBorderColor: PRIMARY_FOCUS,
+          color: 'rgba(10, 12, 27, 0.9)',
+          placeholderColor: 'rgba(10, 12, 27, 0.7)',
+          iconColor: 'rgba(10, 12, 27, 0.7)',
+          disabledBackground: '#f4f7fc',
+          disabledColor: 'rgba(10, 12, 27, 0.4)'
+        },
+        overlay: {
+          select: { background: '#ffffff', borderColor: 'rgba(10, 12, 27, 0.12)', color: 'rgba(10, 12, 27, 0.9)' },
+          popover: { background: '#ffffff', borderColor: 'rgba(10, 12, 27, 0.12)', color: 'rgba(10, 12, 27, 0.9)' },
+          modal: { background: '#ffffff', borderColor: 'rgba(10, 12, 27, 0.12)', color: 'rgba(10, 12, 27, 0.9)' }
         }
       },
       dark: {
@@ -62,49 +116,67 @@ const OpenNMSPreset = definePreset(Aura, {
         surface: {
           0: '#15182B'
         },
-        // Aura dark uses {surface.0} as white for text.color, but we set surface.0
-        // to our dark navy. Override text tokens here to keep text legible in dark mode.
         text: {
-          color: 'rgba(255, 255, 255, 0.87)',
-          hoverColor: 'rgba(255, 255, 255, 0.87)',
-          mutedColor: 'rgba(255, 255, 255, 0.6)',
+          color: 'rgb(255, 255, 255)',
+          hoverColor: 'rgb(255, 255, 255)',
+          mutedColor: 'rgba(255, 255, 255, 0.78)',
           hoverMutedColor: 'rgba(255, 255, 255, 0.78)'
         },
-        // DataTable body rows and other content areas use {content.background}.
-        // Aura dark maps that to {surface.900} (zinc.900 = #18181b), a neutral gray
-        // that doesn't match the OpenNMS navy palette. Map it to surface.0 instead.
         content: {
-          background: '{surface.0}',
+          background: '#15182B',
           hoverBackground: 'rgba(255, 255, 255, 0.06)',
-          borderColor: 'rgba(255, 255, 255, 0.12)',
-          color: '{text.color}',
-          hoverColor: '{text.hover.color}'
+          borderColor: 'rgba(255, 255, 255, 0.24)',
+          color: 'rgb(255, 255, 255)',
+          hoverColor: 'rgb(255, 255, 255)'
         },
-        // Aura dark sets formField.color to {surface.0}, which is our dark navy (#15182B) —
-        // unreadable text. Also align the form field background to the OpenNMS navy palette.
         formField: {
-          background: '{surface.0}',
-          color: '{text.color}',
-          borderColor: 'rgba(255, 255, 255, 0.2)',
+          background: '#15182B',
+          borderColor: 'rgba(255, 255, 255, 0.24)',
           hoverBorderColor: 'rgba(255, 255, 255, 0.38)',
+          focusBorderColor: PRIMARY_FOCUS,
+          color: 'rgb(255, 255, 255)',
           placeholderColor: 'rgba(255, 255, 255, 0.5)',
           iconColor: 'rgba(255, 255, 255, 0.5)',
-          disabledBackground: 'rgba(255, 255, 255, 0.05)',
-          disabledColor: 'rgba(255, 255, 255, 0.38)'
+          disabledBackground: '#0a0c1b',
+          disabledColor: 'rgba(255, 255, 255, 0.5)'
         },
-        // Select/popover overlays are teleported to body; still set their tokens so the
-        // CSS variables carry the right dark values everywhere they're inherited.
         overlay: {
-          select: {
-            background: '{surface.0}',
-            borderColor: 'rgba(255, 255, 255, 0.12)',
-            color: '{text.color}'
-          },
-          popover: {
-            background: '{surface.0}',
-            borderColor: 'rgba(255, 255, 255, 0.12)',
-            color: '{text.color}'
-          }
+          select: { background: '#15182B', borderColor: 'rgba(255, 255, 255, 0.24)', color: 'rgb(255, 255, 255)' },
+          popover: { background: '#15182B', borderColor: 'rgba(255, 255, 255, 0.24)', color: 'rgb(255, 255, 255)' },
+          modal: { background: '#15182B', borderColor: 'rgba(255, 255, 255, 0.24)', color: 'rgb(255, 255, 255)' }
+        }
+      }
+    }
+  },
+  components: {
+    // DataTable rows/body inherit the bridged `content.*` tokens. Headers in the
+    // FeatherDS look use the (muted) background + secondary text, and the border
+    // color is set explicitly because Aura's dark scheme hardcodes it to a
+    // neutral surface shade.
+    datatable: {
+      colorScheme: {
+        light: {
+          root: { borderColor: 'rgba(10, 12, 27, 0.12)' },
+          headerCell: { background: '#f4f7fc', color: 'rgba(10, 12, 27, 0.7)' }
+        },
+        dark: {
+          root: { borderColor: 'rgba(255, 255, 255, 0.24)' },
+          headerCell: { background: '#0a0c1b', color: 'rgba(255, 255, 255, 0.78)' }
+        }
+      }
+    },
+    // Chip label/icon default to a surface-scale color; align with body text.
+    chip: {
+      colorScheme: {
+        light: {
+          root: { color: 'rgba(10, 12, 27, 0.9)' },
+          icon: { color: 'rgba(10, 12, 27, 0.9)' },
+          removeIcon: { color: 'rgba(10, 12, 27, 0.9)' }
+        },
+        dark: {
+          root: { color: 'rgb(255, 255, 255)' },
+          icon: { color: 'rgb(255, 255, 255)' },
+          removeIcon: { color: 'rgb(255, 255, 255)' }
         }
       }
     }

--- a/ui/src/theme/primevue-setup.ts
+++ b/ui/src/theme/primevue-setup.ts
@@ -23,6 +23,7 @@
 import PrimeVue from 'primevue/config'
 import OpenNMSPreset from './opennms-preset'
 import 'primeicons/primeicons.css'
+import '@/styles/primevue-overrides.scss'
 
 import type { App } from 'vue'
 


### PR DESCRIPTION
Part of converting Feather -> PrimeVue. Update app-wide themes to have more-or-less FeatherDS themes applied to PrimeVue components going forward, including both light/dark modes, without needing component-specific `:deep()` or other overrides.

This also gives us a central place to globally update any PrimeVue styles as desired.

Note that `PrimeVueTest.vue` is a temporary test file to view Feather and PrimeVue side-by-side to visually confirm themes are correct. Will eventually delete it once the conversion is complete.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19843

