### PR TITLE
NMS-19905: Fix reflected XSS in application base-URL helper

### DIFF
--- a/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
@@ -141,7 +141,11 @@ public abstract class Util extends Object {
                 out.append(c);
             }
         }
-        return out.toString();
+        // The scheme, host, and context path are derived from the request (e.g. the Host
+        // or X-Forwarded-Host header) and are emitted unescaped into HTML/JS by callers,
+        // so HTML-encode here to neutralize reflected XSS. Legitimate URL characters
+        // (':', '/', '.', '-') pass through unchanged; only HTML metacharacters are escaped.
+        return WebSecurityUtils.sanitizeString(out.toString());
     }
 
     protected static final String[] hostHeaders = {

--- a/opennms-web-api/src/test/java/org/opennms/web/api/UtilTest.java
+++ b/opennms-web-api/src/test/java/org/opennms/web/api/UtilTest.java
@@ -94,4 +94,31 @@ public class UtilTest {
 
         Assert.assertEquals("first.example.org", host);
     }
+
+    @Test
+    public void testSubstituteUrlLeavesLegitimateUrlUnchanged() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("https");
+        request.addHeader("X-Forwarded-Host", "nms.example.org:8443");
+        request.setContextPath("/opennms");
+
+        // A legitimate URL contains no HTML metacharacters, so sanitization is a no-op.
+        Assert.assertEquals("https://nms.example.org:8443/opennms/",
+                Util.substituteUrl(request, "%s://%x%c/"));
+    }
+
+    @Test
+    public void testSubstituteUrlEscapesMaliciousForwardedHost() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("https");
+        request.addHeader("X-Forwarded-Host", "evil\"><script>alert(1)</script>");
+        request.setContextPath("/opennms");
+
+        final String url = Util.substituteUrl(request, "%s://%x%c/");
+
+        // The reflected-XSS payload must not survive as raw HTML/JS metacharacters.
+        Assert.assertFalse("must not contain raw <", url.contains("<"));
+        Assert.assertFalse("must not contain raw >", url.contains(">"));
+        Assert.assertFalse("must not contain raw \"", url.contains("\""));
+    }
 }


### PR DESCRIPTION
Util.calculateUrlBase/substituteUrl build the app base URL from request-derived values (scheme, Host/X-Forwarded-Host header, context path), and callers emit it unescaped into HTML/JS — most notably __baseHref in bootstrap.jsp. Because the default template resolves the host from X-Forwarded-Host (no HTTP host-char validation), a poisoned header reflects into the response: reflected XSS. SonarQube flags 142 instances of this (javasecurity:S5131, High).

Fix: HTML-encode the assembled URL once in substituteUrl — the single chokepoint both calculateUrlBase overloads pass through — via the existing WebSecurityUtils.sanitizeString (OWASP Encode.forHtml). Legitimate URL characters pass through unchanged; HTML metacharacters are escaped. This clears every calculateUrlBase-rooted alert at the source, with no per-sink JSP edits and no new dependency.

Testing: Added two UtilTest regression cases (legitimate URL unchanged; malicious X-Forwarded-Host neutralized). opennms-web-api builds; UtilTest passes 8/8. Branch is -smoke to run the smoke suite.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19905

