### PR TITLE
NMS-19771: Rename KSC Reports to Graph Collections in UI and docs

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/add-to-ksc/add-to-ksc.html
+++ b/core/web-assets/src/main/assets/js/apps/add-to-ksc/add-to-ksc.html
@@ -25,14 +25,14 @@
       <p class="invalid-feedback">Time range is required.</p>
     </div>
     <div class="form-group">
-      <label class="col-form-label" for="kscReport">Target KSC Report</label>
+      <label class="col-form-label" for="kscReport">Target Graph Collection</label>
       <input required class="form-control" type="text" id="kscReport" name="kscReport" ng-model="kscReport" 
-        placeholder="Choose the target KSC Report by typing the name here..."
+        placeholder="Choose the target Graph Collection by typing the name here..."
         uib-typeahead="ksc as ksc.label for ksc in kscReports | filter:$viewValue"
         typeahead-editable="false"
         typeahead-min-length="0"
         ng-class="{ 'is-invalid' : kscForm.kscReport.$invalid }">
-      <p class="invalid-feedback">Target KSC Report is required.</p>
+      <p class="invalid-feedback">Target Graph Collection is required.</p>
     </div>
   </div>
   <div class="modal-footer">

--- a/core/web-assets/src/main/assets/js/apps/add-to-ksc/add-to-ksc.html
+++ b/core/web-assets/src/main/assets/js/apps/add-to-ksc/add-to-ksc.html
@@ -1,6 +1,6 @@
 <ng-form name="kscForm">
   <div class="modal-header">
-    <h3 class="modal-title">Add {{ graphTitle }} to KSC</h3>
+    <h3 class="modal-title">Add {{ graphTitle }} to Graph Collection</h3>
   </div>
   <div class="modal-body">
     <div class="form-group">

--- a/core/web-assets/src/main/assets/js/apps/ksc-wizard/index.js
+++ b/core/web-assets/src/main/assets/js/apps/ksc-wizard/index.js
@@ -167,7 +167,7 @@ angular.module('onms-ksc-wizard', [
   $scope.reloadConfig = function() {
     bootbox.dialog({
       message: 'Are you sure you want to do this?<br/>',
-      title: 'Reload KSC Configuration',
+      title: 'Reload Graph Collections Configuration',
       buttons: {
         reload: {
           label: 'Yes',

--- a/core/web-assets/src/main/assets/js/apps/search/template.ksc.html
+++ b/core/web-assets/src/main/assets/js/apps/search/template.ksc.html
@@ -1,6 +1,6 @@
 <div class="form-group">
   <div class="input-group">
-    <input type="text" class="form-control" ng-model="asyncKsc" placeholder="Type the KSC report name"
+    <input type="text" class="form-control" ng-model="asyncKsc" placeholder="Type the Graph Collection name"
       uib-typeahead="ksc as ksc.label for ksc in getKscReports($viewValue)"
       typeahead-editable="false"
       typeahead-loading="kscLoadingNodes"

--- a/docs/modules/operation/pages/deep-dive/visualizations/ksc-reports.adoc
+++ b/docs/modules/operation/pages/deep-dive/visualizations/ksc-reports.adoc
@@ -1,15 +1,15 @@
 
 [[ksc-reports]]
-= KSC Reports
-:description: Learn about KSC reports in {page-component-title}, which display prefabricated graphical views of collected data.
+= Graph Collections
+:description: Learn about graph collections in {page-component-title}, which display prefabricated graphical views of collected data.
 
-KSC reports provide a way to generate prefabricated graphical views of collected data.
-A report displays its data in its defined order (columns, rows, and so on).
+Graph collections (formerly KSC reports) provide a way to generate prefabricated graphical views of collected data.
+A graph collection displays its data in its defined order (columns, rows, and so on).
 
 == Configuration
 
-You can configure KSC reports in the {page-component-title} web UI.
-To do so, click menu:Reports[KSC Reports] in the top menu bar.
+You can configure graph collections in the {page-component-title} web UI.
+To do so, click menu:Reports[Graph Collections] in the top menu bar.
 
 The following is an example report entry that uses a custom index and graphs:
 
@@ -44,6 +44,6 @@ For more information, see `org.opennms.netmgt.config.KSC_PerformanceReportFactor
 
 NOTE: Make sure that each report's `id` is unique.
 
-== Use KSC reports
+== Use graph collections
 
-The KSC Reports section on the {page-component-title} home page includes a drop-down list from which you can select configured KSC reports.
+The Graph Collections section on the {page-component-title} home page includes a drop-down list from which you can select configured graph collections.

--- a/docs/modules/operation/pages/quick-start/visualize-data.adoc
+++ b/docs/modules/operation/pages/quick-start/visualize-data.adoc
@@ -11,7 +11,7 @@ The {page-component-title} home page presents an overview of important network s
 By default, it displays pending situations and problems, ongoing outages, 24-hour availability statistics, and a map showing real-time regional status data.
 
 By default, the visualizations on the home page are not filtered.
-You can apply filters to the data using the sections on the right side of the screen (Resource Graphs, KSC Reports, and Quick Search).
+You can apply filters to the data using the sections on the right side of the screen (Resource Graphs, Graph Collections, and Quick Search).
 For more information, see xref:deep-dive/visualizations/grafana-dashboard-box.adoc[] in the Deep Dive section.
 
 [[qs-visualize-dashboard]]

--- a/docs/modules/reference/pages/glossary.adoc
+++ b/docs/modules/reference/pages/glossary.adoc
@@ -89,6 +89,9 @@ Nodes can be manually assigned a location, or the location can be automatically 
 https://grafana.com/[Grafana]:: An open-source analysis and visualization web application.
 It connects to data sources and generates dashboards with charts, graphs, and alerts.
 
+Graph collections:: Formerly known as KSC (Key SNMP customized) reports, graph collections provide a way to generate prefabricated graphical views of collected data.
+They let you display data from different devices and sources (SNMP, ICMP, HTTP) on one page (see xref:operation:deep-dive/visualizations/ksc-reports.adoc[]).
+
 https://www.opennms.com/horizon/[Horizon]:: An open-source solution from The OpenNMS Group that lets you visualize and monitor everything on your local and remote networks.
 The free, community-driven project includes the latest technology and features and is delivered through a rapid release cycle.
 
@@ -122,8 +125,7 @@ Originally developed at LinkedIn, it is now supported by the Apache community (s
 https://www.elastic.co/kibana/[Kibana]:: A component of the Elastic Stack (comprised of Elasticsearch, Logstash, and Kibana).
 It enables visualizations for data indexed in an Elasticsearch cluster.
 
-KSC reports:: Key SNMP customized (KSC) reports provide a way to generate prefabricated graphical views of collected data.
-They let you display data from different devices and sources (SNMP, ICMP, HTTP) on one page (see xref:operation:deep-dive/visualizations/ksc-reports.adoc[]).
+KSC reports:: See *Graph collections*.
 
 https://kubernetes.io/[Kubernetes]:: An open-source container orchestration system for automating software deployments, scaling, and management.
 Originally designed by Google, the Cloud Native Computing Foundation now maintains it.

--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -113,3 +113,13 @@ These provided auto-rotating, dashlet-composed displays intended for wall-mounte
 The *Ops Board* and *Wallboard* main-menu entries and the `admin/wallboardConfig.jsp` page no longer exist, and any existing Ops Board configuration is no longer used.
 There is no drop-in replacement.
 
+=== KSC Reports renamed to Graph Collections
+
+The feature formerly labeled *KSC Reports* is now *Graph Collections* throughout the web UI (the main-menu entry, page titles, breadcrumbs, the *Add to Graph Collection* dialog, and the home-page section) and the documentation.
+The global search category formerly named *KSC Report* is now *Graph Collection*.
+
+This is a user-facing label change only.
+The underlying configuration file (`etc/ksc-performance-reports.xml`), the REST endpoints under `/rest/ksc`, the `KSC/*.jsp` page URLs, and the internal identifiers are unchanged, so existing reports, saved bookmarks, and API integrations continue to work without modification.
+
+NOTE: Update any of your own documentation, runbooks, training material, or UI automation that refers to *KSC Reports* by name — including tests that match on the old menu label or the *KSC Report* search category — to use *Graph Collections*.
+

--- a/features/search/providers/src/main/java/org/opennms/netmgt/search/providers/action/KscReportSearchProvider.java
+++ b/features/search/providers/src/main/java/org/opennms/netmgt/search/providers/action/KscReportSearchProvider.java
@@ -38,7 +38,7 @@ import org.opennms.web.svclayer.api.KscReportService;
 
 public class KscReportSearchProvider implements SearchProvider {
 
-    private final SearchContext CONTEXT = new SearchContext("KSC Report");
+    private final SearchContext CONTEXT = new SearchContext("Graph Collection");
 
     private final KscReportService kscReportService;
 

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
@@ -241,7 +241,7 @@
         },
         {
           "id": "kscReports",
-          "name": "Metrics Dashboard (KSC Reports)",
+          "name": "Graph Collections",
           "url": "KSC/index.jsp",
           "locationMatch": "ksc",
           "roles": null

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -71,7 +71,7 @@
         },
         {
           "id": "kscReports",
-          "name": "Metrics Dashboard (KSC Reports)",
+          "name": "Graph Collections",
           "url": "KSC/index.jsp",
           "locationMatch": "ksc",
           "roles": null

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
@@ -219,7 +219,7 @@
         },
         {
           "id": "kscReports",
-          "name": "KSC Reports",
+          "name": "Graph Collections",
           "url": "KSC/index.jsp",
           "locationMatch": "ksc",
           "roles": null

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -71,7 +71,7 @@
         },
         {
           "id": "kscReports",
-          "name": "Metrics Dashboard (KSC Reports)",
+          "name": "Graph Collections",
           "url": "KSC/index.jsp",
           "locationMatch": "ksc",
           "roles": null

--- a/opennms-webapp-rest/src/test/resources/menu/menu-template.json
+++ b/opennms-webapp-rest/src/test/resources/menu/menu-template.json
@@ -214,7 +214,7 @@
         },
         {
           "id": "kscReports",
-          "name": "KSC Reports",
+          "name": "Graph Collections",
           "url": "KSC/index.jsp",
           "locationMatch": "ksc",
           "roles": null

--- a/opennms-webapp/src/main/webapp/KSC/customGraphChooseResource.jsp
+++ b/opennms-webapp/src/main/webapp/KSC/customGraphChooseResource.jsp
@@ -29,10 +29,10 @@
 <%@ page import="org.opennms.web.utils.Bootstrap" %>
 <% Bootstrap.with(pageContext)
           .headTitle("Choose Resource")
-          .headTitle("KSC")
+          .headTitle("Graph Collections")
           .headTitle("Reports")
           .breadcrumb("Reports", "report/index.jsp")
-          .breadcrumb("KSC Reports", "KSC/index.jsp")
+          .breadcrumb("Graph Collections", "KSC/index.jsp")
           .breadcrumb("Custom Graph")
           .ngApp("onms-ksc-wizard")
           .build(request);

--- a/opennms-webapp/src/main/webapp/KSC/index.jsp
+++ b/opennms-webapp/src/main/webapp/KSC/index.jsp
@@ -47,9 +47,9 @@
 <% Bootstrap.with(pageContext)
           .headTitle("Performance")
           .headTitle("Reports")
-          .headTitle("KSC")
+          .headTitle("Graph Collections")
           .breadcrumb("Reports", "report/index.jsp")
-          .breadcrumb("KSC Reports")
+          .breadcrumb("Graph Collections")
           .ngApp("onms-ksc-wizard")
           .build(request);
 %>
@@ -206,7 +206,7 @@
       </div>
       <c:choose>
         <c:when test="${isReadOnly == false}">
-        <button class="btn btn-secondary" type="button" ng-click="reloadConfig()">Request a Reload of KSC Reports Configuration</button>
+        <button class="btn btn-secondary" type="button" ng-click="reloadConfig()">Request a Reload of Graph Collections Configuration</button>
         </c:when>
       </c:choose>
     </div>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customGraphEditDetails.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customGraphEditDetails.jsp
@@ -34,9 +34,9 @@
 <% Bootstrap.with(pageContext)
           .headTitle("Performance ")
           .headTitle("Reports")
-          .headTitle("KSC")
+          .headTitle("Graph Collections")
           .breadcrumb("Reports", "report/index.jsp")
-          .breadcrumb("KSC Reports", "KSC/index.jsp")
+          .breadcrumb("Graph Collections", "KSC/index.jsp")
           .breadcrumb("Custom Graph")
           .flags("renderGraphs")
           .build(request);

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customReport.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customReport.jsp
@@ -37,9 +37,9 @@
 <% Bootstrap.with(pageContext)
           .headTitle("Performance")
           .headTitle("Reports")
-          .headTitle("KSC")
+          .headTitle("Graph Collections")
           .breadcrumb("Reports", "report/index.jsp")
-          .breadcrumb("KSC Reports", "KSC/index.jsp")
+          .breadcrumb("Graph Collections", "KSC/index.jsp")
           .breadcrumb("Custom Report")
           .flags("renderGraphs")
           .build(request);

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customView.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customView.jsp
@@ -37,9 +37,9 @@
 <% Bootstrap.with(pageContext)
           .headTitle("Performance")
           .headTitle("Reports")
-          .headTitle("KSC")
+          .headTitle("Graph Collections")
           .breadcrumb("Reports", "report/index.jsp")
-          .breadcrumb("KSC Reports", "KSC/index.jsp")
+          .breadcrumb("Graph Collections", "KSC/index.jsp")
           .breadcrumb("Custom View")
           .flags("renderGraphs")
           .build(request);

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/graph/results.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/graph/results.jsp
@@ -262,7 +262,7 @@
                     <!-- graph-search div should be immediate parent to graph-container as search depends on this. -->
                     <div class="graph-search" ng-show="enableGraph" ng-controller="graphSearchCtrl" resourceid ="${resultSet.resource.id}" graphname="${graph.name}" graphtitle = "${graph.title}">
 	                    <div class="graph-aux-controls" style="padding-bottom: 5px" data-resource-id="${resultSet.resource.id}" data-graph-name="${graph.name}">
-                            <a style="padding-right: 3px" title="Add ${graph.title} to KSC Report">
+                            <a style="padding-right: 3px" title="Add ${graph.title} to Graph Collection">
                                 <button type="button" class="btn btn-secondary btn-sm" ng-click="open('${resultSet.resource.id}','${resultSet.resource.label}','${graph.name}','${graph.title}')">
                                     <i class="fas fa-plus" aria-hidden="true"></i>
                                 </button>

--- a/opennms-webapp/src/main/webapp/includes/search-box.jsp
+++ b/opennms-webapp/src/main/webapp/includes/search-box.jsp
@@ -39,7 +39,7 @@
 
   <div class="card">
     <div class="card-header">
-      <span><a href="KSC/index.jsp">KSC Reports</a></span>
+      <span><a href="KSC/index.jsp">Graph Collections</a></span>
     </div>
     <div class="card-body">
       <onms-search-ksc />

--- a/opennms-webapp/src/main/webapp/report/index.jsp
+++ b/opennms-webapp/src/main/webapp/report/index.jsp
@@ -66,8 +66,8 @@
                     <div class="pull-right">
                         <form class="form-inline" role="form" name="kscReports">
                             <div class="form-group">
-                                <label class="sr-only">KSC Reports</label>
-                                <p class="form-control-static">KSC Reports</p>
+                                <label class="sr-only">Graph Collections</label>
+                                <p class="form-control-static">Graph Collections</p>
                             </div>
                             <onms-search-ksc />
                         </form>
@@ -79,7 +79,7 @@
                     <ul class="list-unstyled">
                         <li><a href="charts/index.jsp">Charts</a></li>
                         <li><a href="graph/index.jsp">Resource Graphs</a></li>
-                        <li><a href="KSC/index.jsp">KSC Performance, Nodes, Domains</a></li>
+                        <li><a href="KSC/index.jsp">Graph Collections (Performance, Nodes, Domains)</a></li>
                         <li><a href="report/database/index.jsp">Database Reports</a></li>
                         <li><a href="statisticsReports/index.htm">Statistics Reports</a></li>
                     </ul>
@@ -104,15 +104,15 @@
                 string in the "Name contains" field. This will invoke a case-insensitive
                 substring match on resource names.
             </p>
-            <p><b>Key SNMP Customized (KSC) Performance Reports</b>, <b>Node Reports</b>
-                and <b>Domain Reports</b>. KSC reports allow the user to create and view
-                SNMP performance data using prefabricated graph types. The reports
-                provide a great deal of flexibility in timespans and graphtypes. KSC
-                report configurations may be saved allowing the user to define key reports
+            <p><b>Graph Collections</b> (formerly KSC reports), <b>Node Reports</b>
+                and <b>Domain Reports</b>. Graph collections allow the user to create and view
+                SNMP performance data using prefabricated graph types. The collections
+                provide a great deal of flexibility in timespans and graphtypes. Graph
+                collection configurations may be saved allowing the user to define key reports
                 that may be referred to at future dates. Node reports show SNMP data for
                 all SNMP interfaces on a node. Domain reports show SNMP data for all SNMP
                 interfaces in a domain. Node reports and domain reports may be loaded into
-                the customizer and saved as a KSC report.
+                the customizer and saved as a graph collection.
             </p>
             <p>You may narrow your selection of resources by entering a search string
                 in the "Name contains" field. This will invoke a case-insensitive substring

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -78,7 +78,7 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         clickMenuItem("dashboardsMenu", "Metrics Statistics (statsd)");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span")));
 
-        clickMenuItem("dashboardsMenu", "Metrics Dashboard (KSC Reports)");
+        clickMenuItem("dashboardsMenu", "Graph Collections");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Customized Reports']")));
 
         clickMenuItem("dashboardsMenu", "Surveillance Dashboard");
@@ -371,7 +371,7 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         findElementByXpath("//div[@class='card-header']/span[text()='Network Performance Data']");
 
         reportsPage();
-        findElementByLink("KSC Performance, Nodes, Domains").click();
+        findElementByLink("Graph Collections (Performance, Nodes, Domains)").click();
         findElementByXpath("//div[@class='card-header']/span[text()='Customized Reports']");
         findElementByXpath("//div[@class='card-header']/span[text()='Descriptions']");
 


### PR DESCRIPTION
Cosmetic, user-facing-only rename of the "KSC Reports" feature to "Graph Collections" across the web UI navigation, JSP pages, JS apps, the global-search category label, and the documentation.

Internal class names, the kscReports JAXB package, the ksc-performance-reports.xml config, the REST endpoints (/rest/ksc), and the KSC/*.jsp URLs are intentionally unchanged, so the rename is fully backward-compatible.

Updates the MenuHeaderIT smoke-test assertions to match the new labels.

Assisted-by: Claude Code:Opus 4.7/4.8

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19771
