### PR TITLE
NMS-19033: scvcli should prompt for password if none supplied

### DIFF
--- a/features/scv/scvcli/pom.xml
+++ b/features/scv/scvcli/pom.xml
@@ -67,5 +67,10 @@
             <artifactId>org.opennms.features.scv.jceks-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/features/scv/scvcli/src/main/java/org/opennms/features/scv/cli/ScvCli.java
+++ b/features/scv/scvcli/src/main/java/org/opennms/features/scv/cli/ScvCli.java
@@ -141,7 +141,8 @@ public class ScvCli {
         } catch (final CmdLineException e) {
             System.err.println("Error: " + e.getMessage() + "\n");
 
-            System.err.println("Usage: scvcli [--keystore KEYSTORE] [--password PASSWORD] set ALIAS USERNAME PASSWORD [--attribute key=value]...");
+            System.err.println("Usage: scvcli [--keystore KEYSTORE] [--password PASSWORD] set ALIAS USERNAME [PASSWORD] [--from-stdin] [--attribute key=value]...");
+            System.err.println("       (if PASSWORD is omitted, it is read from stdin with --from-stdin, otherwise prompted for interactively)");
             System.err.println("       scvcli [--keystore KEYSTORE] [--password PASSWORD] get ALIAS");
             System.err.println("       scvcli [--keystore KEYSTORE] [--password PASSWORD] list");
             System.err.println("       scvcli [--keystore KEYSTORE] [--password PASSWORD] delete ALIAS");

--- a/features/scv/scvcli/src/main/java/org/opennms/features/scv/cli/commands/SetCommand.java
+++ b/features/scv/scvcli/src/main/java/org/opennms/features/scv/cli/commands/SetCommand.java
@@ -21,6 +21,12 @@
  */
 package org.opennms.features.scv.cli.commands;
 
+import java.io.BufferedReader;
+import java.io.Console;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -44,10 +50,10 @@ public class SetCommand implements Function<ScvCli, Integer> {
             usage = "the username to be set")
     private String username = null;
 
-    @Argument(required = true,
+    @Argument(required = false,
             index = 2,
             metaVar = "password",
-            usage = "the password to be set")
+            usage = "the password to be set; if omitted, it is read from --from-stdin or prompted for interactively")
     private String password = null;
 
     @Option(name="--attribute",
@@ -55,9 +61,75 @@ public class SetCommand implements Function<ScvCli, Integer> {
             handler = MapOptionHandler.class)
     Map<String,String> attributes = new HashMap<>();
 
+    @Option(name = "--from-stdin",
+            aliases = {"-S"},
+            usage = "read the password from standard input instead of the command line")
+    private boolean fromStdin = false;
+
     @Override
     public Integer apply(ScvCli scvCli) {
-        scvCli.getSecureCredentialsVault().setCredentials(alias, new Credentials(username, password, attributes));
+        scvCli.getSecureCredentialsVault().setCredentials(alias, new Credentials(username, resolvePassword(), attributes));
         return 0;
+    }
+
+    /**
+     * Determines the password to set, in order of precedence:
+     * <ol>
+     *   <li>the {@code password} positional argument, when supplied;</li>
+     *   <li>standard input, when {@code --from-stdin} is given;</li>
+     *   <li>an interactive prompt otherwise.</li>
+     * </ol>
+     *
+     * <p>Package-visible for testing.</p>
+     */
+    String resolvePassword() {
+        if (password != null) {
+            if (fromStdin) {
+                System.err.println("Warning: a password argument was provided; ignoring --from-stdin.");
+            }
+            return password;
+        }
+        if (fromStdin) {
+            return readPasswordFromStdin();
+        }
+        return promptForPassword();
+    }
+
+    private static String readPasswordFromStdin() {
+        try {
+            // Note: deliberately not closing the reader, as that would close System.in.
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+            final String line = reader.readLine();
+            if (line == null) {
+                throw new IllegalStateException("expected a password on standard input, but none was provided");
+            }
+            return line;
+        } catch (final IOException e) {
+            throw new RuntimeException("failed to read password from standard input", e);
+        }
+    }
+
+    private static String promptForPassword() {
+        final Console console = System.console();
+        if (console == null) {
+            // No interactive console (e.g. input is piped/redirected); fall back to reading stdin.
+            return readPasswordFromStdin();
+        }
+        while (true) {
+            final char[] first = console.readPassword("Enter password: ");
+            final char[] second = console.readPassword("Confirm password: ");
+            if (first == null || second == null) {
+                throw new IllegalStateException("no password entered");
+            }
+            try {
+                if (Arrays.equals(first, second)) {
+                    return new String(first);
+                }
+                System.err.println("Passwords do not match. Please try again.");
+            } finally {
+                Arrays.fill(first, '\0');
+                Arrays.fill(second, '\0');
+            }
+        }
     }
 }

--- a/features/scv/scvcli/src/main/java/org/opennms/features/scv/cli/commands/SetCommand.java
+++ b/features/scv/scvcli/src/main/java/org/opennms/features/scv/cli/commands/SetCommand.java
@@ -111,6 +111,7 @@ public class SetCommand implements Function<ScvCli, Integer> {
 
     private static String promptForPassword() {
         final Console console = System.console();
+        int count = 0;
         if (console == null) {
             // No interactive console (e.g. input is piped/redirected); fall back to reading stdin.
             return readPasswordFromStdin();
@@ -126,9 +127,14 @@ public class SetCommand implements Function<ScvCli, Integer> {
                     return new String(first);
                 }
                 System.err.println("Passwords do not match. Please try again.");
+                count++;
             } finally {
                 Arrays.fill(first, '\0');
                 Arrays.fill(second, '\0');
+            }
+            if (count >= 5) {
+                System.err.println("Too many mismatches, giving up!");
+                return null;
             }
         }
     }

--- a/features/scv/scvcli/src/test/java/org/opennms/features/scv/cli/commands/SetCommandTest.java
+++ b/features/scv/scvcli/src/test/java/org/opennms/features/scv/cli/commands/SetCommandTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.scv.cli.commands;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.After;
+import org.junit.Test;
+import org.kohsuke.args4j.CmdLineParser;
+
+public class SetCommandTest {
+
+    private final InputStream originalStdin = System.in;
+
+    @After
+    public void restoreStdin() {
+        System.setIn(originalStdin);
+    }
+
+    private static void setStdin(final String content) {
+        System.setIn(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /** With --from-stdin and no positional password, the password is read from stdin. */
+    @Test
+    public void readsPasswordFromStdinWhenRequested() throws Exception {
+        final SetCommand command = new SetCommand();
+        new CmdLineParser(command).parseArgument("my-alias", "my-user", "--from-stdin");
+
+        setStdin("s3cr3t-from-stdin\n");
+
+        assertEquals("s3cr3t-from-stdin", command.resolvePassword());
+    }
+
+    /** A trailing newline from e.g. `echo` is stripped; the rest of the line is preserved verbatim. */
+    @Test
+    public void preservesPasswordContentFromStdin() throws Exception {
+        final SetCommand command = new SetCommand();
+        new CmdLineParser(command).parseArgument("my-alias", "my-user", "-S");
+
+        setStdin("pass with spaces & symbols!@#\n");
+
+        assertEquals("pass with spaces & symbols!@#", command.resolvePassword());
+    }
+
+    /** An explicit positional password wins over --from-stdin and stdin is not consulted. */
+    @Test
+    public void positionalPasswordTakesPrecedenceOverStdin() throws Exception {
+        final SetCommand command = new SetCommand();
+        new CmdLineParser(command).parseArgument("my-alias", "my-user", "explicit-pass", "--from-stdin");
+
+        // Provide different content on stdin to prove it is ignored.
+        setStdin("should-be-ignored\n");
+
+        assertEquals("explicit-pass", command.resolvePassword());
+    }
+}

--- a/opennms-base-assembly/src/main/filtered/bin/scvcli
+++ b/opennms-base-assembly/src/main/filtered/bin/scvcli
@@ -2,4 +2,4 @@
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)"
 KEYSTORE_PATH="$SCRIPT_PATH/../etc"
 
-cd $KEYSTORE_PATH && java -jar $SCRIPT_PATH/org.opennms.features.scv.cli.jar "${@}" && cd $SCRIPT_PATH
+cd $KEYSTORE_PATH && $(<java.conf) -jar $SCRIPT_PATH/org.opennms.features.scv.cli.jar "${@}" && cd $SCRIPT_PATH


### PR DESCRIPTION
This PR adds to scvcli the ability to:
 * accept a password on `stdin`, e.g. `echo $FOO | /opt/opennms/bin/scvcli set thisAlias someUsername`
 * Prompt for a password if none is supplied:
 ```
 $ /opt/opennms/bin/scvcli set thisAlias someUsername
Enter password:
Confirm password:
$ 
```
 * in addition to the usual positional `/opt/opennms/bin/scvcli set thisAlias someUsername somePassword`
 * This PR also corrects the `scvcli` on core to use the configured JVM from `java.conf`.  Minion and Sentinel maintain the previous behavior of calling the system `java` directly.

Assisted by Claude Opus Bill-Ack-Thppt 4.8

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19033

