### PR TITLE
Remove stray emoji from pom.xml comment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1093,7 +1093,7 @@
           <licenseSets>
             <licenseSet>
               <header>src/main/resources/license-header.txt</header>
-              <!-- some of these excludes are aspirational, for when we expand this beyond the basics 😅 -->
+              <!-- some of these excludes are aspirational, for when we expand this beyond the basics -->
               <excludes>
                 <!-- short term, let's exclude everything but c/c++/groovy/java/js/ts -->
                 <exclude>**/*.css</exclude>


### PR DESCRIPTION
I am not opening an NMS for this unless someone really wants me to... it's too absurd.  I'm tired of it causing me build issues because something is complaining about UTF-8.