### PR TITLE
NMS-19928: Fix filter rule precedence bug by parenthesizing the parsed rule

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
@@ -708,7 +708,11 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
             }
             regex.appendTail(tempStringBuff);
             sqlRule = tempStringBuff.toString();
-            return "WHERE " + sqlRule;
+            // Wrap the parsed rule in parentheses so that any clauses appended by callers
+            // (the isManaged/deleted filter, ipaddr/nodeID/service constraints) apply to the
+            // whole rule rather than binding only to the last branch of a top-level OR.
+            // Without this, "a | b" + " AND ipaddr = ?" parses as "a OR (b AND ipaddr = ?)".
+            return "WHERE (" + sqlRule + ")";
         }
         return "";
     }

--- a/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoParenthesizationTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoParenthesizationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.filter;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.netmgt.config.DatabaseSchemaConfigFactory;
+
+/**
+ * Pure (no-database) test that the WHERE clause produced by {@link JdbcFilterDao#parseRule}
+ * is wrapped in parentheses, so that constraints appended by callers (ipaddr/nodeID/service,
+ * the isManaged/deleted filter) apply to the whole rule rather than binding only to the last
+ * branch of a top-level OR.
+ */
+public class JdbcFilterDaoParenthesizationTest {
+
+    private JdbcFilterDao m_dao;
+
+    @Before
+    public void setUp() throws Exception {
+        m_dao = new JdbcFilterDao();
+        m_dao.setDatabaseSchemaConfigFactory(
+                new DatabaseSchemaConfigFactory(getClass().getResourceAsStream("/database-schema.xml")));
+    }
+
+    @Test
+    public void orRuleIsParenthesized() throws Exception {
+        // "a | b" must become "WHERE (a OR b)" — not "WHERE a OR b"
+        final String sql = m_dao.getInterfaceWithServiceStatement("catincFoo | catincBar");
+        System.out.println("getInterfaceWithServiceStatement: " + sql);
+        final String where = sql.substring(sql.indexOf("WHERE "));
+        assertTrue("rule should be parenthesized: " + where, where.startsWith("WHERE ("));
+        assertTrue("rule should be closed with ): " + where, where.endsWith(")"));
+        assertTrue("OR should be inside the parentheses", where.contains(" OR "));
+    }
+
+    @Test
+    public void appendedConstraintIsOutsideTheOr() throws Exception {
+        // getSQLStatement(rule, nodeId, ...) appends "AND <col> = nodeId" after the rule.
+        // With the fix the nodeID constraint must sit OUTSIDE the rule's parentheses:
+        //   WHERE (<rule with OR>) AND node.nodeID = 5
+        // (Before the fix it was "WHERE <a> OR <b> AND node.nodeID = 5", scoping the
+        //  constraint to only the right OR branch.)
+        final String sql = m_dao.getSQLStatement("catincFoo | catincBar", 5L, null, null);
+        System.out.println("getSQLStatement(rule, nodeId): " + sql);
+        final String where = sql.substring(sql.indexOf("WHERE "));
+        assertTrue("appended constraint must follow the closed rule parenthesis: " + where,
+                where.contains(") AND "));
+        // The OR must be enclosed before the appended AND-constraint
+        final int orIdx = where.indexOf(" OR ");
+        final int closeParenIdx = where.indexOf(") AND ");
+        assertTrue("OR must appear before the closing paren of the rule",
+                orIdx > 0 && orIdx < closeParenIdx);
+    }
+
+    @Test
+    public void plainRuleStillWorks() throws Exception {
+        final String sql = m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *.*.*.*");
+        System.out.println("plain rule: " + sql);
+        final String where = sql.substring(sql.indexOf("WHERE "));
+        assertTrue(where.startsWith("WHERE (IPLIKE("));
+        assertTrue(where.endsWith(")"));
+    }
+}

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/JdbcFilterDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/JdbcFilterDaoIT.java
@@ -281,6 +281,26 @@ public class JdbcFilterDaoIT implements InitializingBean {
     }
 
     @Test
+    public void testIsValidOrRuleResolvedByAddressDoesNotOverMatch() throws Exception {
+        // Regression test for the filter precedence bug. isValid()/getActiveIPAddress() append
+        // "AND ipInterface.ipaddr = ?" to the parsed rule. For a rule with a top-level OR, the
+        // unparenthesized form parsed as "<branchA> OR (<branchB> AND ipaddr = ?)", so an address
+        // that matched NEITHER branch was still reported valid whenever branchA matched some other
+        // interface in the system. With the rule parenthesized it becomes
+        // "(<branchA> OR <branchB>) AND ipaddr = ?", scoping the address to the whole rule.
+        final String orRule = "ipaddr == '192.168.1.1' | ipaddr == '192.168.1.2'";
+
+        // 192.168.1.1 is populated and satisfies the left branch -> valid (positive control).
+        assertTrue("address matching a branch of the OR should be valid",
+                m_dao.isValid("192.168.1.1", orRule));
+
+        // 1.1.1.1 matches neither branch; it must NOT be reported valid just because 192.168.1.1
+        // exists and satisfies the left branch. (Fails against the un-parenthesized rule.)
+        assertFalse("address matching no branch of the OR must not be valid",
+                m_dao.isValid("1.1.1.1", orRule));
+    }
+
+    @Test
     public void testGetActiveIPListWithDeletedNode() throws Exception {
         m_transTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override
@@ -324,12 +344,12 @@ public class JdbcFilterDaoIT implements InitializingBean {
 
     @Test
     public void testGetInterfaceWithServiceStatement() throws Exception {
-        assertEquals("SQL from getInterfaceWithServiceStatement", "SELECT DISTINCT ipInterface.ipAddr, service.serviceName, node.nodeID FROM ipInterface JOIN ifServices ON (ipInterface.id = ifServices.ipInterfaceId) JOIN service ON (ifServices.serviceID = service.serviceID) JOIN node ON (ipInterface.nodeID = node.nodeID) WHERE IPLIKE(ipInterface.ipaddr, '*.*.*.*')", m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *.*.*.*"));
+        assertEquals("SQL from getInterfaceWithServiceStatement", "SELECT DISTINCT ipInterface.ipAddr, service.serviceName, node.nodeID FROM ipInterface JOIN ifServices ON (ipInterface.id = ifServices.ipInterfaceId) JOIN service ON (ifServices.serviceID = service.serviceID) JOIN node ON (ipInterface.nodeID = node.nodeID) WHERE (IPLIKE(ipInterface.ipaddr, '*.*.*.*'))", m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *.*.*.*"));
     }
 
     @Test
     public void testGetIpv6InterfaceWithServiceStatement() throws Exception {
-        assertEquals("SQL from getIpv6InterfaceWithServiceStatement", "SELECT DISTINCT ipInterface.ipAddr, service.serviceName, node.nodeID FROM ipInterface JOIN ifServices ON (ipInterface.id = ifServices.ipInterfaceId) JOIN service ON (ifServices.serviceID = service.serviceID) JOIN node ON (ipInterface.nodeID = node.nodeID) WHERE IPLIKE(ipInterface.ipaddr, '*:*:*:*:*:*:*:*')", m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *:*:*:*:*:*:*:*"));
+        assertEquals("SQL from getIpv6InterfaceWithServiceStatement", "SELECT DISTINCT ipInterface.ipAddr, service.serviceName, node.nodeID FROM ipInterface JOIN ifServices ON (ipInterface.id = ifServices.ipInterfaceId) JOIN service ON (ifServices.serviceID = service.serviceID) JOIN node ON (ipInterface.nodeID = node.nodeID) WHERE (IPLIKE(ipInterface.ipaddr, '*:*:*:*:*:*:*:*'))", m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *:*:*:*:*:*:*:*"));
     }
 
     @Test


### PR DESCRIPTION
I've run a few different tests against this and it really does seem to make a performance difference at larger scales so I think it's worth putting in the PR for.

Filter rules are translated to SQL WHERE clauses in JdbcFilterDao, and callers append further constraints to that clause: the deleted/isManaged filter in getIPAddressList, and the nodeID/ipAddr/serviceName constraints in getSQLStatement(rule, nodeId, ipaddr, service). parseRule emitted the rule unparenthesized, so for a rule with a top-level OR the appended "AND ..." bound only to the last OR branch:

```
WHERE <a> OR <b> AND ipInterface.ipaddr = ?
parses as
WHERE <a> OR (<b> AND ipInterface.ipaddr = ?)
```

This caused both a correctness bug (an address matching neither branch was still reported valid whenever the other branch matched some interface) and full-table scans on large instances, since the address no longer restricted the query.

Wrap the parsed rule in parentheses so every appended constraint applies to the whole rule: 

`WHERE (<a> OR <b>) AND ipInterface.ipaddr = ?`

Adds a unit test for the generated SQL and an IT regression case for an OR-rule resolved by address.

Assisted by Claude Opus 4.8

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19928

