### PR TITLE
NMS-19547: Stop black-hole hosts from exhausting the provisiond scan pool

### DIFF
--- a/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/support/BaseDetectorHandler.java
+++ b/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/support/BaseDetectorHandler.java
@@ -88,9 +88,10 @@ public class BaseDetectorHandler<Request, Response> extends IoHandlerAdapter {
     /** {@inheritDoc} */
     @Override
     public void sessionIdle(IoSession session, IdleStatus status) throws Exception {
-        // @see http://issues.opennms.org/browse/NMS-5311
-        if (getConversation().hasBanner() && status == IdleStatus.READER_IDLE) {
-            LOG.info("Session went idle without receiving banner. Setting service detection to false.");
+        // If the read side goes idle before detection finished, mark the service not detected and close;
+        // otherwise no-banner checks (HTTP/HTTPS) wait forever for a reply that never comes. See NMS-5311, NMS-19547.
+        if (status == IdleStatus.READER_IDLE && !getFuture().isDone()) {
+            LOG.info("Session went idle (READER_IDLE) before detection completed. Setting service detection to false.");
             getFuture().setServiceDetected(false);
             session.close(true);
         }


### PR DESCRIPTION
I do not actually know if this will resolve NMS-19547 at this point but I am about 90% confident this is the core issue based on the logs we got from the customer.  Cisco Catalyst switches with web interface enabled are genuinely notorious for having small client pools.  I can confirm that testing with a webserver resulted in the exact behavior that we've seen.  I haven't run this through all the tests so it's possible CircleCI catches something.

Assisted by Claude Opus 4.8

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19547