### PR TITLE
feat(ui): global plugin overlay slot via Teleport (companion to OIA PR #181)

### DIFF
--- a/ui/src/components/Plugin/GlobalPlugin.vue
+++ b/ui/src/components/Plugin/GlobalPlugin.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { computed, onMounted } from 'vue'
+import Container from '@/components/Plugin/Container.vue'
+import { addStylesheet, getCSSPath, getJSPath } from '@/components/Plugin/utils'
+import type { Plugin } from '@/types'
+
+const props = defineProps<{ plugin: Plugin }>()
+
+const baseRestUrl = import.meta.env.VITE_BASE_REST_URL
+
+// globalModuleFileName is guaranteed non-null by the v-for filter in App.vue,
+// but we guard anyway so the type system stays happy.
+const scriptUrl = computed(() =>
+  props.plugin.globalModuleFileName
+    ? getJSPath(baseRestUrl, props.plugin.extensionId, props.plugin.resourceRootPath, props.plugin.globalModuleFileName)
+    : null
+)
+
+onMounted(() => {
+  addStylesheet(getCSSPath(baseRestUrl, props.plugin.extensionId))
+})
+</script>
+
+<template>
+  <Container v-if="scriptUrl" :script="scriptUrl" />
+</template>

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -20,13 +20,24 @@
       <Footer />
     </template>
   </FeatherAppLayout>
+
+  <!-- Global plugin overlays: plugins that declare a globalModuleFileName are mounted
+       here so they are visible on every page, not just under Plugins > menu entry.
+       Teleport renders outside FeatherAppLayout to avoid z-index / overflow clipping. -->
+  <Teleport to="body">
+    <GlobalPlugin
+      v-for="plugin in globalPlugins"
+      :key="plugin.extensionId"
+      :plugin="plugin"
+    />
+  </Teleport>
 </template>
 
 <script
   setup
   lang="ts"
 >
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 
 import { FeatherAppLayout } from '@featherds/app-layout'
 import Footer from '@/components/Layout/Footer.vue'
@@ -34,6 +45,7 @@ import Menubar from '@/components/Menu/Menubar.vue'
 import SideMenu from '@/components/Menu/SideMenu.vue'
 import Spinner from '@/components/Common/Spinner.vue'
 import Snackbar from '@/components/Common/Snackbar.vue'
+import GlobalPlugin from '@/components/Plugin/GlobalPlugin.vue'
 import { useAuthStore } from '@/stores/authStore'
 import { useInfoStore } from '@/stores/infoStore'
 import { usePluginStore } from '@/stores/pluginStore'
@@ -47,6 +59,8 @@ const menuStore = useMenuStore()
 const monitoringSystemStore = useMonitoringSystemStore()
 const nodeStructureStore = useNodeStructureStore()
 const pluginStore = usePluginStore()
+
+const globalPlugins = computed(() => pluginStore.plugins.filter(p => p.globalModuleFileName))
 
 onMounted(() => {
   authStore.getWhoAmI()

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -544,6 +544,8 @@ export interface Plugin {
   menuEntry: string
   moduleFileName: string
   resourceRootPath: string
+  /** Present when the plugin registers a global overlay component (ALEC-302 / OIA UIExtension.getGlobalModuleFileName). */
+  globalModuleFileName?: string
 }
 
 export enum SetOperator {


### PR DESCRIPTION
ALEC-302

## Summary

Plugins that declare `UIExtension.getGlobalModuleFileName()` (new OIA default method, [OIA PR #181](https://github.com/OpenNMS/opennms-integration-api/pull/181)) now get their module loaded and rendered in a `<Teleport to="body">` at the root App level — visible on every page, not just under Plugins > menu.

## Changes

| File | What changed |
|---|---|
| `ui/src/main/App.vue` | Import `GlobalPlugin`; compute `globalPlugins`; add `<Teleport to="body">` |
| `ui/src/components/Plugin/GlobalPlugin.vue` | **New** — loads a plugin's global module via the existing `Container` component |
| `ui/src/types/index.ts` | Add optional `globalModuleFileName?: string` to the `Plugin` type |

## Backward compatibility

- Plugins without `getGlobalModuleFileName()` (all existing plugins) return `null`; the REST layer omits or nulls the field; the `v-for` filter skips them — **zero behaviour change**.
- Old OpenNMS that does not serve this field: `globalPlugins` is always empty, `<Teleport>` renders nothing — **no visual or functional regression**.
- No new REST endpoints, no schema migration, no OSGi changes.

## Dependencies

Requires OIA [PR #181](https://github.com/OpenNMS/opennms-integration-api/pull/181) to be merged and a new OIA snapshot published before `globalModuleFileName` appears in `/rest/plugins` responses for plugins that implement the method.

## First consumer

ALEC-302 — ALEC context-aware chatbot overlay.