### PR TITLE
docs(rest): fix minions v2 write endpoints and ksc resourceId xref

### DIFF
--- a/docs/modules/development/pages/rest/minions.adoc
+++ b/docs/modules/development/pages/rest/minions.adoc
@@ -24,7 +24,7 @@ The v1 API is read-only and produces `application/xml`, `application/json`, and 
 
 == Version 2 (`/api/v2/minions`)
 
-The v2 API supports read, update, and delete operations (Minions are created automatically on registration, not through REST) and produces/consumes `application/json` and `application/xml`.
+The v2 API supports read, update, and delete operations and produces/consumes `application/json` and `application/xml`.
 
 === GETs (reading data)
 
@@ -42,18 +42,6 @@ The v2 API supports read, update, and delete operations (Minions are created aut
 
 |===
 
-=== POSTs (Creating Data)
-
-[caption=]
-.Minions API (v2) POST function
-[options="autowidth"]
-|===
-| Resource  | Description
-
-| `/api/v2/minions` | Not implemented -- returns `501 Not Implemented`. Minions register automatically with OpenNMS when they connect; there is no create-via-REST operation.
-
-|===
-
 === PUT (modifying data)
 
 [caption=]
@@ -64,7 +52,6 @@ The v2 API supports read, update, and delete operations (Minions are created aut
 
 | `/api/v2/minions`        | Bulk-updates the matching Minions. Consumes `application/x-www-form-urlencoded`.
 | `/api/v2/minions/\{id}`  | Replaces a single Minion. Consumes `application/json` or `application/xml`. The `id` must match the `id` in the payload, otherwise `400 Bad Request`.
-| `/api/v2/minions/\{id}`  | Not implemented -- returns `501 Not Implemented`. To update properties, use the bulk `PUT /api/v2/minions` above with a filter (for example `?_s=id=={id}`), or replace the Minion with the `application/json`/`application/xml` `PUT` above.
 
 |===
 

--- a/docs/modules/development/pages/rest/minions.adoc
+++ b/docs/modules/development/pages/rest/minions.adoc
@@ -1,7 +1,7 @@
 
 = Minions API
 
-The Minions API exposes the Minions registered with OpenNMS. Two versions are available: the read-only v1 API under `/rest/minions`, and the full CRUD v2 API under `/api/v2/minions`.
+The Minions API exposes the Minions registered with OpenNMS. Two versions are available: the read-only v1 API under `/rest/minions`, and the v2 API under `/api/v2/minions`.
 
 A Minion is represented by the `OnmsMinion` model: `id`, `label`, `location`, `type`, `status`, `version`, `date`, `lastCheckedIn`, and a `properties` map.
 
@@ -24,7 +24,7 @@ The v1 API is read-only and produces `application/xml`, `application/json`, and 
 
 == Version 2 (`/api/v2/minions`)
 
-The v2 API supports full CRUD and produces/consumes `application/json` and `application/xml`.
+The v2 API supports read, update, and delete operations (Minions are created automatically on registration, not through REST) and produces/consumes `application/json` and `application/xml`.
 
 === GETs (reading data)
 
@@ -50,7 +50,7 @@ The v2 API supports full CRUD and produces/consumes `application/json` and `appl
 |===
 | Resource  | Description
 
-| `/api/v2/minions` | Creates a new Minion. Returns `201 Created` with a `Location` header.
+| `/api/v2/minions` | Not implemented -- returns `501 Not Implemented`. Minions register automatically with OpenNMS when they connect; there is no create-via-REST operation.
 
 |===
 
@@ -64,7 +64,7 @@ The v2 API supports full CRUD and produces/consumes `application/json` and `appl
 
 | `/api/v2/minions`        | Bulk-updates the matching Minions. Consumes `application/x-www-form-urlencoded`.
 | `/api/v2/minions/\{id}`  | Replaces a single Minion. Consumes `application/json` or `application/xml`. The `id` must match the `id` in the payload, otherwise `400 Bad Request`.
-| `/api/v2/minions/\{id}`  | Updates individual properties of a single Minion. Consumes `application/x-www-form-urlencoded`.
+| `/api/v2/minions/\{id}`  | Not implemented -- returns `501 Not Implemented`. To update properties, use the bulk `PUT /api/v2/minions` above with a filter (for example `?_s=id=={id}`), or replace the Minion with the `application/json`/`application/xml` `PUT` above.
 
 |===
 

--- a/docs/modules/development/pages/rest/resources.adoc
+++ b/docs/modules/development/pages/rest/resources.adoc
@@ -4,6 +4,7 @@
 Use the Resources API to list or delete resources at the node level and below.
 This service is especially useful in conjunction with the Measurements API.
 
+[#gets-reading-data]
 == GETs (reading data)
 
 [caption=]


### PR DESCRIPTION
## Summary

Follow-up to #8611. Fixes three documentation defects in the REST API pages, all **verified at runtime** against a local **Horizon 34.0.1** stack with a **live gRPC-connected Minion** (`minion-01`).

### `minions.adoc` — two v2 write endpoints returned 501, not what was documented
| Endpoint | Documented | Actual (34.0.1) |
|---|---|---|
| `POST /api/v2/minions` | `201 Created` | **`501 Not Implemented`** — `MinionRestService` doesn't override `doCreate`; Minions self-register on connect |
| `PUT /api/v2/minions/{id}` (form-urlencoded) | updates individual properties | **`501 Not Implemented`** — `doUpdateProperties` not overridden |

- Corrected both rows to reflect the `501` behavior and point readers at the operations that **do** work.
- Dropped the "full CRUD" claim from the v2 intro (no Create).
- The bulk form-urlencoded `PUT /api/v2/minions` **does** work (returns `204` and persists) and is unchanged.

### `resources.adoc` / `ksc_reports.adoc` — broken xref anchor
`ksc_reports.adoc` linked `xref:rest/resources.adoc#gets-reading-data[resourceId]` (twice), but the `== GETs (reading data)` section had no explicit anchor — Asciidoctor auto-generates `_gets_reading_data`, so the reference didn't resolve. Added an explicit `[#gets-reading-data]` anchor to the Resources section, fixing both occurrences without touching the linking pages.

## Test evidence
POST → `501`, single-item form PUT → `501` (row unchanged in `monitoringsystems`), bulk form PUT → `204` (row updated), against a genuinely registered Minion.

Documentation only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)