### PR TITLE
NMS-19970: Tolerate unknown properties when reading CM config JSON

### DIFF
--- a/features/config/service/impl/src/main/java/org/opennms/features/config/service/util/ConfigConvertUtil.java
+++ b/features/config/service/impl/src/main/java/org/opennms/features/config/service/util/ConfigConvertUtil.java
@@ -24,13 +24,19 @@ package org.opennms.features.config.service.util;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.opennms.features.config.exception.ConfigConversionException;
 
 public class ConfigConvertUtil {
+    // Ignore unknown properties so persisted config written by a newer version (with
+    // fields not yet known to the running code) can still be read. Without this, adding a
+    // field to a config class (e.g. Snmpv3User.id) breaks reading that config on any older
+    // version during a downgrade, rollback, or rolling upgrade. See NMS-19970 / NMS-19723.
     private static final ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
             .setPropertyNamingStrategy(new PropertyNamingStrategies.KebabCaseStrategy());
 

--- a/features/config/service/impl/src/test/java/org/opennms/features/config/service/util/ConfigConvertUtilTest.java
+++ b/features/config/service/impl/src/test/java/org/opennms/features/config/service/util/ConfigConvertUtilTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.config.service.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConfigConvertUtilTest {
+
+    /**
+     * Stand-in for a persisted config entity. Mirrors how real config classes are shaped for
+     * the CM ObjectMapper: field visibility is ANY and property names are kebab-cased, so the
+     * camelCase field {@code securityName} maps to the JSON key {@code security-name}.
+     */
+    public static class SampleConfig {
+        private String securityName;
+
+        public String getSecurityName() {
+            return securityName;
+        }
+
+        public void setSecurityName(final String securityName) {
+            this.securityName = securityName;
+        }
+    }
+
+    /**
+     * Regression test for NMS-19970 / NMS-19723.
+     *
+     * Config JSON persisted by a newer version can contain fields the running (older) code does
+     * not yet know about (e.g. the {@code id} attribute added to snmpv3-user). Reading such JSON
+     * must not fail — otherwise a downgrade, rollback, or rolling upgrade cannot start. Before the
+     * fix this threw {@code ConfigConversionException} caused by Jackson's
+     * {@code UnrecognizedPropertyException}.
+     */
+    @Test
+    public void jsonToObjectIgnoresUnknownProperties() {
+        final String json = "{\"security-name\":\"admin\",\"id\":\"abc-123\",\"future-field\":42}";
+
+        final SampleConfig cfg = ConfigConvertUtil.jsonToObject(json, SampleConfig.class);
+
+        Assert.assertNotNull(cfg);
+        Assert.assertEquals("admin", cfg.getSecurityName());
+    }
+
+    /**
+     * Sanity check that known, kebab-cased properties still deserialize. This guards against the
+     * regression test above passing trivially (e.g. if property mapping silently broke).
+     */
+    @Test
+    public void jsonToObjectReadsKnownProperties() {
+        final String json = "{\"security-name\":\"admin\"}";
+
+        final SampleConfig cfg = ConfigConvertUtil.jsonToObject(json, SampleConfig.class);
+
+        Assert.assertEquals("admin", cfg.getSecurityName());
+    }
+}


### PR DESCRIPTION
Tolerate unknown properties when reading CM config JSON.

This issue surfaced during NMS-19723 where we needed to add a field to `Snmpv3User` for Trap Configuration masked credentials. If the DB contains a newer configuration, then even starting up an older version of OpenNMS will fail when deserializing the config JSON via CM (Content Management), because it strictly fails on unknown properties.

This PR make a change to ignore unknown properties, so that a persisted config written by a newer version (with fields not yet known to the running code) can still be read. Without this, adding a field to a config class (e.g. `Snmpv3User.id`) breaks reading that config on any older version during a downgrade, rollback, or rolling upgrade.
    
Adds a regression test that reproduces the failure (`ConfigConversionException` caused by Jackson's `UnrecognizedPropertyException`).

*NOTE* that using a newer config with an older already-built build will still fail. You'll need to rebuild the older build with this fix first, but now the fix is available back to 2024.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19970