### PR TITLE
NMS-19971: Foreign Key with ON DELETE SET NULL for node.nodeparentid

### DIFF
--- a/core/schema/src/main/liquibase/36.0.3/changelog.xml
+++ b/core/schema/src/main/liquibase/36.0.3/changelog.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <!-- NMS-19971: node.nodeparentid (the path-outage / critical-path parent,
+         OnmsNode.getParent()) had no foreign key, so deleting a parent node left
+         its children pointing at a nonexistent row. Dereferencing the lazy parent
+         proxy for such a dangling reference throws Hibernate ObjectNotFoundException.
+
+         Fix it at the database level so every deletion path is covered (provisiond's
+         deleteNode, vacuumd's raw "DELETE FROM node ... nodeType='D'", and any direct
+         DB operation): null out the existing danglers, index the column, then add a
+         self-referential FK with ON DELETE SET NULL, the same pattern ipInterface
+         uses for snmpinterfaceid (constraint snmpinterface_fkey2). -->
+
+    <!-- 1) Clean up references that are already dangling, otherwise the constraint
+            below cannot be added. nodeid is a NOT NULL primary key, so NOT IN is
+            safe here (no NULL in the subquery). -->
+    <changeSet author="mmassengill" id="36.0.3-node-parentid-cleanup">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="node"/>
+            <columnExists tableName="node" columnName="nodeparentid"/>
+        </preConditions>
+        <sql>
+            UPDATE node SET nodeparentid = NULL
+            WHERE nodeparentid IS NOT NULL
+              AND nodeparentid NOT IN (SELECT nodeid FROM node);
+        </sql>
+        <!-- Data cleanup; nothing meaningful to roll back. -->
+        <rollback/>
+    </changeSet>
+
+    <!-- 2) Index the FK column so ON DELETE SET NULL (and parent lookups) don't
+            trigger a sequential scan of node on every node deletion. -->
+    <changeSet author="mmassengill" id="36.0.3-node-parentid-idx">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="node"/>
+            <columnExists tableName="node" columnName="nodeparentid"/>
+            <not>
+                <indexExists tableName="node" indexName="node_nodeparentid_idx"/>
+            </not>
+        </preConditions>
+        <createIndex tableName="node" indexName="node_nodeparentid_idx">
+            <column name="nodeparentid"/>
+        </createIndex>
+        <rollback>
+            <dropIndex tableName="node" indexName="node_nodeparentid_idx"/>
+        </rollback>
+    </changeSet>
+
+    <!-- 3) The constraint itself: a deleted parent now nulls its children's
+            nodeparentid instead of leaving a dangling reference. -->
+    <changeSet author="mmassengill" id="36.0.3-node-parentid-fkey">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="node"/>
+            <columnExists tableName="node" columnName="nodeparentid"/>
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="node_nodeparentid_fkey"/>
+            </not>
+        </preConditions>
+        <addForeignKeyConstraint constraintName="node_nodeparentid_fkey" onDelete="SET NULL"
+            baseTableName="node" baseColumnNames="nodeparentid"
+            referencedTableName="node" referencedColumnNames="nodeid"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="node" constraintName="node_nodeparentid_fkey"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/core/schema/src/main/liquibase/changelog.xml
+++ b/core/schema/src/main/liquibase/changelog.xml
@@ -105,6 +105,7 @@
 	<include file="35.0.0/changelog.xml"/>
 	<include file="36.0.0/changelog.xml"/>
 	<include file="36.0.1/changelog.xml"/>
+	<include file="36.0.3/changelog.xml"/>
 
 	<include file="stored-procedures/getManagePercentAvailIntfWindow.xml" />
 	<include file="stored-procedures/getManagePercentAvailNodeWindow.xml" />

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.pathoutage/src/test/java/org/opennms/features/topology/plugins/topo/pathoutage/PathOutageStatusProviderIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.pathoutage/src/test/java/org/opennms/features/topology/plugins/topo/pathoutage/PathOutageStatusProviderIT.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -126,11 +127,15 @@ public class PathOutageStatusProviderIT {
 
 	@Before
 	public void setUp() {
-		// Generating test nodes and saving them to the temporary database
+		// Generating test nodes and saving them to the temporary database.
+		// Save parents before children: the node.nodeparentid FK (NMS-19971) rejects a
+		// child row whose parent has not been inserted yet, and HashMap key order is
+		// undefined. Every generated child has a larger id than its parent, so ascending
+		// id order guarantees parent-first insertion.
 		Map<OnmsNode, Integer> nodes = TestNodeGenerator.generateNodes(locationDao.getDefaultLocation());
-		for (OnmsNode node : nodes.keySet()) {
-			this.nodeDao.save(node);
-		}
+		nodes.keySet().stream()
+				.sorted(Comparator.comparingInt(OnmsNode::getId))
+				.forEach(this.nodeDao::save);
 		// Generating test interfaces and updating corresponding nodes
 		this.generateInterfaces(nodes);
 		for (OnmsNode node : nodes.keySet()) {


### PR DESCRIPTION
node.nodeparentid (the path-outage/critical-path parent, OnmsNode.getParent()) had no foreign-key constraint, so deleting a parent node left its children pointing at a nonexistent row. Dereferencing the lazy parent proxy for such a dangling reference throws Hibernate ObjectNotFoundException, and no deletion path cleaned it up: DefaultProvisionService.deleteNode() removes only the node row, and vacuumd deletes type-'D' nodes via raw SQL that bypasses application logic entirely.

Fix at the database level so every deletion path is covered. New 36.0.3 changeset: null out already-dangling references, index node(nodeparentid), then add a self-referential FK node.nodeparentid -> node.nodeid with onDelete=SET NULL -- the pattern ipInterface already uses for snmpinterfaceid (snmpinterface_fkey2). Registered in the master changelog after 36.0.1.

Assisted by Anthropic Claude Fable 5

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19971

