### PR TITLE
NMS-20004: tolerate unrepresentable ipaddr values in filter results

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
@@ -243,7 +243,7 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
                 // Iterate through the result and build the array list
                 while (rset.next()) {
                     final Integer nodeId = rset.getInt(1);
-                    final InetAddress ipaddr = addr(rset.getString(2));
+                    final InetAddress ipaddr = toInetAddressOrNull(rset.getString(2));
                     final String serviceName = rset.getString(3);
                     if (ipaddr == null || serviceName == null) {
                         continue;
@@ -352,7 +352,10 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
             if (rset != null) {
                 // Iterate through the result and build the array list
                 while (rset.next()) {
-                	resultList.add(addr(rset.getString(1)));
+                	final InetAddress inetAddress = toInetAddressOrNull(rset.getString(1));
+                	if (inetAddress != null) {
+                	    resultList.add(inetAddress);
+                	}
                 }
             }
 
@@ -371,6 +374,45 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
 
         LOG.debug("Filter.getIPAddressList({}): resultList.size = {}", rule, resultList.size());
         return resultList;
+    }
+
+    /** dotted quad with each octet bounded to 0-255 */
+    private static final Pattern IPV4_LITERAL_PATTERN = Pattern.compile(
+            "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}");
+    /** the characters an IPv6 literal can contain; never a resolvable hostname */
+    private static final Pattern IPV6_LITERAL_PATTERN = Pattern.compile("[0-9a-fA-F:.]+");
+
+    /**
+     * Result-row conversion that must never resolve hostnames and must not
+     * fail the whole evaluation over one bad row: numeric IPv6 zones (the
+     * form OpenNMS stores) convert as-is, interface-name zones fall back to
+     * the zone-stripped address, anything else is logged and skipped.
+     */
+    static InetAddress toInetAddressOrNull(final String rawAddress) {
+        if (rawAddress == null) {
+            return null;
+        }
+        final String value = rawAddress.trim();
+        final int percent = value.indexOf('%');
+        final String addressPart = percent < 0 ? value : value.substring(0, percent);
+        final boolean literal = addressPart.indexOf(':') >= 0
+                ? IPV6_LITERAL_PATTERN.matcher(addressPart).matches()
+                : IPV4_LITERAL_PATTERN.matcher(addressPart).matches();
+        if (literal) {
+            try {
+                return addr(value);
+            } catch (final IllegalArgumentException e) {
+                if (percent >= 0) {
+                    try {
+                        return addr(addressPart);
+                    } catch (final IllegalArgumentException e2) {
+                        // fall through to the warning below
+                    }
+                }
+            }
+        }
+        LOG.warn("Skipping filter result row with an IP address value that cannot be represented: '{}'", rawAddress);
+        return null;
     }
 
 	/**

--- a/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
@@ -395,14 +395,24 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
         final String value = rawAddress.trim();
         final int percent = value.indexOf('%');
         final String addressPart = percent < 0 ? value : value.substring(0, percent);
-        final boolean literal = addressPart.indexOf(':') >= 0
+        final String zone = percent < 0 ? null : value.substring(percent + 1);
+        final boolean v6 = addressPart.indexOf(':') >= 0;
+        final boolean literal = v6
                 ? IPV6_LITERAL_PATTERN.matcher(addressPart).matches()
                 : IPV4_LITERAL_PATTERN.matcher(addressPart).matches();
+        // zone ids are IPv6-only, and only numeric ones are host-independent:
+        // a named zone would resolve against this host's interfaces
+        final boolean numericZone = zone != null && !zone.isEmpty() && zone.chars().allMatch(Character::isDigit);
         if (literal) {
             try {
-                return addr(value);
+                if (zone == null) {
+                    return addr(value);
+                }
+                if (v6) {
+                    return numericZone ? addr(value) : addr(addressPart);
+                }
             } catch (final IllegalArgumentException e) {
-                if (percent >= 0) {
+                if (v6 && numericZone) {
                     try {
                         return addr(addressPart);
                     } catch (final IllegalArgumentException e2) {

--- a/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
@@ -60,6 +60,7 @@ import org.springframework.util.Assert;
 import com.codahale.metrics.jmx.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.common.net.InetAddresses;
 
 /**
  * <p>JdbcFilterDao class.</p>
@@ -376,12 +377,6 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
         return resultList;
     }
 
-    /** dotted quad with each octet bounded to 0-255 */
-    private static final Pattern IPV4_LITERAL_PATTERN = Pattern.compile(
-            "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}");
-    /** the characters an IPv6 literal can contain; never a resolvable hostname */
-    private static final Pattern IPV6_LITERAL_PATTERN = Pattern.compile("[0-9a-fA-F:.]+");
-
     /**
      * Result-row conversion that must never resolve hostnames and must not
      * fail the whole evaluation over one bad row: numeric IPv6 zones (the
@@ -397,9 +392,9 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
         final String addressPart = percent < 0 ? value : value.substring(0, percent);
         final String zone = percent < 0 ? null : value.substring(percent + 1);
         final boolean v6 = addressPart.indexOf(':') >= 0;
-        final boolean literal = v6
-                ? IPV6_LITERAL_PATTERN.matcher(addressPart).matches()
-                : IPV4_LITERAL_PATTERN.matcher(addressPart).matches();
+        // literal-only check that never resolves hostnames; the zone must be
+        // stripped first because Guava 31.1 rejects scoped addresses
+        final boolean literal = InetAddresses.isInetAddress(addressPart);
         // zone ids are IPv6-only, and only numeric ones are host-independent:
         // a named zone would resolve against this host's interfaces
         final boolean numericZone = zone != null && !zone.isEmpty() && zone.chars().allMatch(Character::isDigit);

--- a/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoToInetAddressTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoToInetAddressTest.java
@@ -56,11 +56,23 @@ public class JdbcFilterDaoToInetAddressTest {
     }
 
     @Test
-    public void dropsUnresolvableInterfaceNameZones() {
-        // "no-such-if0" names an interface of the monitored node, not this
-        // host; the address is still usable without its zone
+    public void dropsInterfaceNameZonesWithoutLocalResolution() {
+        // named zones refer to the monitored node's interfaces; they must be
+        // stripped even when a same-named interface exists on this host
         assertEquals(InetAddressUtils.addr("fe80:0000:0000:0000:0000:0000:0000:0001"),
                 JdbcFilterDao.toInetAddressOrNull("fe80:0000:0000:0000:0000:0000:0000:0001%no-such-if0"));
+        assertEquals(InetAddressUtils.addr("fe80:0000:0000:0000:0000:0000:0000:0001"),
+                JdbcFilterDao.toInetAddressOrNull("fe80:0000:0000:0000:0000:0000:0000:0001%lo"));
+        assertEquals(InetAddressUtils.addr("fe80:0000:0000:0000:0000:0000:0000:0001"),
+                JdbcFilterDao.toInetAddressOrNull("fe80:0000:0000:0000:0000:0000:0000:0001%"));
+    }
+
+    @Test
+    public void skipsZoneSuffixOnIpv4() {
+        // zone ids are IPv6-only; a suffixed IPv4 literal must not reach
+        // hostname resolution
+        assertNull(JdbcFilterDao.toInetAddressOrNull("10.0.0.1%eth0"));
+        assertNull(JdbcFilterDao.toInetAddressOrNull("10.0.0.1%1"));
     }
 
     @Test

--- a/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoToInetAddressTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoToInetAddressTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+
+import org.junit.Test;
+import org.opennms.core.utils.InetAddressUtils;
+
+/**
+ * A single row whose ipaddr value cannot be converted to an InetAddress must
+ * not abort a whole filter evaluation (NMS-20004). These cover the tolerant
+ * conversion the result-row paths use.
+ */
+public class JdbcFilterDaoToInetAddressTest {
+
+    @Test
+    public void convertsPlainAddresses() {
+        assertEquals(InetAddressUtils.addr("10.0.1.2"),
+                JdbcFilterDao.toInetAddressOrNull("10.0.1.2"));
+        assertEquals(InetAddressUtils.addr("fe80:0000:0000:0000:0000:0000:0000:0001"),
+                JdbcFilterDao.toInetAddressOrNull("fe80:0000:0000:0000:0000:0000:0000:0001"));
+    }
+
+    @Test
+    public void keepsNumericZoneIds() {
+        // the form OpenNMS itself stores for scoped addresses
+        final InetAddress converted =
+                JdbcFilterDao.toInetAddressOrNull("fe80:0000:0000:0000:0000:0000:0000:0001%4");
+        assertTrue(converted instanceof Inet6Address);
+        assertEquals(4, ((Inet6Address) converted).getScopeId());
+    }
+
+    @Test
+    public void dropsUnresolvableInterfaceNameZones() {
+        // "no-such-if0" names an interface of the monitored node, not this
+        // host; the address is still usable without its zone
+        assertEquals(InetAddressUtils.addr("fe80:0000:0000:0000:0000:0000:0000:0001"),
+                JdbcFilterDao.toInetAddressOrNull("fe80:0000:0000:0000:0000:0000:0000:0001%no-such-if0"));
+    }
+
+    @Test
+    public void skipsHostnamesWithoutResolving() {
+        assertNull(JdbcFilterDao.toInetAddressOrNull("some-host.example.org"));
+        // all-hex-digit labels must not be mistaken for address literals
+        assertNull(JdbcFilterDao.toInetAddressOrNull("bad.cafe"));
+    }
+
+    @Test
+    public void skipsNonAddressValues() {
+        assertNull(JdbcFilterDao.toInetAddressOrNull(null));
+        assertNull(JdbcFilterDao.toInetAddressOrNull(""));
+        assertNull(JdbcFilterDao.toInetAddressOrNull("   "));
+        assertNull(JdbcFilterDao.toInetAddressOrNull("1.2.3.4.5"));
+        assertNull(JdbcFilterDao.toInetAddressOrNull("10.999.0.1"));
+        assertNull(JdbcFilterDao.toInetAddressOrNull(":::"));
+    }
+}


### PR DESCRIPTION
A single ipinterface row whose ipaddr value can't be converted to an InetAddress aborted the entire filter evaluation with an opaque UndeclaredThrowableException — and the default *.*.*.* rule matches every row, so one bad value could break every package filter evaluation for pollerd, collectd, threshd, and notifd. Trigger values include IPv6 zone IDs naming an interface that doesn't resolve locally (fe80::…%eth0), hostname-like strings (which also caused a DNS lookup per row), and empty strings (silently converted to loopback).

Fix: convert result rows tolerantly — accept only IP literals (no DNS resolution; numeric zones unchanged), fall back to the zone-stripped address for interface-name zones, and log-and-skip anything still unrepresentable instead of failing the evaluation. Unit tests cover each failing shape; JdbcFilterDaoIT passes unchanged.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20004

