### PR TITLE
NMS-19976: Primevue migration: Menubar

### DIFF
--- a/core/web-assets/src/main/assets/style/opennms-theme.scss
+++ b/core/web-assets/src/main/assets/style/opennms-theme.scss
@@ -365,10 +365,27 @@ iframe.vaadin-fullscreen {
   width:100%;
 }
 
+// Offset for legacy JSP/Vaadin content that renders beneath the fixed Vue top
+// menu bar and side menu rail. Both the bar height and the collapsed rail width
+// are 3.75rem (--onms-header-height); we add 0.25rem of breathing room so
+// content isn't cramped right against them, giving 4rem. Derived via calc from
+// --onms-header-height (which must remain the true bar height) rather than a
+// hard-coded 4rem, so it tracks the bar height and still works before the Vue
+// bundle defines the variable (fallback 3.75rem + 0.25rem).
+:root {
+  --onms-legacy-content-offset: calc(var(--onms-header-height, 3.75rem) + 0.25rem);
+}
+
 // Main content container for all pages, used in bootstrap.jsp
 #content {
-  // Note, the Vue side menu will add top and left padding to push this content over
-  // both when the menu is expanded and collapsed
+  // The Vue top menu bar and side menu rail are both position:fixed, so page
+  // content would otherwise render underneath them. Offset it:
+  //  - top: the fixed top menu bar height (+ breathing room), set here.
+  //  - left: the collapsed rail width (+ breathing room), set here as a base.
+  //    The Vue side menu's script overrides padding-left dynamically for the
+  //    pinned-expanded rail width (see SideMenu.vue applyPush).
+  padding-top: var(--onms-legacy-content-offset);
+  padding-left: var(--onms-legacy-content-offset);
 
   // Revert padding as growl added this, which was required in bootstrap 3 but is
   // no longer required, so without this the padding to the right is too much

--- a/core/web-assets/src/main/assets/style/vaadin-theme.scss
+++ b/core/web-assets/src/main/assets/style/vaadin-theme.scss
@@ -106,18 +106,24 @@ body.v-generated-body {
     :: Vue Menu UI
     -------------------------------------------------- */
 /**
-* Move topology UI over past the Vue top and side menus.
+* Move topology UI over past the Vue top and side menus, which are both
+* position:fixed. Clear the top menu bar height (top) and the collapsed side
+* menu rail (left). --onms-legacy-content-offset (defined in opennms-theme.scss,
+* imported above) is the bar/rail height plus a little breathing room.
 * Note this only moves it past the collapsed side menu.
 */
 .v-app.topo_default.topologyui {
-  margin-top: 0.5em;
-  margin-left: 4em;
+  margin-top: var(--onms-legacy-content-offset);
+  margin-left: var(--onms-legacy-content-offset);
 }
 
-/* Safari 10+/20+ specific, needs extra top margin */
+/* Safari 10+/20+ specific: uses padding-top instead of margin-top (Vaadin's
+   top margin collapses oddly on Safari). Zero the margin so it does not stack
+   on top of the padding. */
 body[class*="v-sa1"] .v-app.topo_default.topologyui,
 body[class*="v-sa2"] .v-app.topo_default.topologyui {
-  padding-top: 4em !important;
+  margin-top: 0;
+  padding-top: var(--onms-legacy-content-offset) !important;
 }
 
 /*  --------------------------------------------------

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -47,7 +47,6 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -611,37 +610,62 @@ public abstract class AbstractOpenNMSSeleniumHelper {
 
         final WebDriverWait shortWait = new WebDriverWait(getDriver(), Duration.ofSeconds(1));
 
+        // Right after navigation, the top link is in the DOM but the Vue menu app is still settling
+        // (re-rendering as getMainMenu/getPlugins resolve), so the first click on it is (usually) a no-op --
+        // PrimeVue never marks the item active and no flyout renders. Once settled, a click opens
+        // the flyout and it renders in ~25ms. So keep this wait SHORT: a registered click is found
+        // almost immediately, and a no-op click is re-issued by the next outer retry ~1s later
+        // (the guard below makes re-clicking toggle-safe), which catches the menu as soon as it is
+        // interactive instead of wasting a multi-second cap per attempt. Keep it comfortably above
+        // the flyout render time so a good click is never mistaken for a timeout.
+        final WebDriverWait popupWait = new WebDriverWait(getDriver(), Duration.ofSeconds(1));
+
         // Return values. Need to be final to be used in a closure
         final WebElement[] foundElement = new WebElement[] { null };
 
-        Unreliables.retryUntilTrue(timeout, TimeUnit.SECONDS, () -> {
-            final String topMenuXpath = TOP_MENU_XPATH.replace("$MENU_ITEM_TEXT", topMenuItemText);
-            final String topMenuLinkXpath = topMenuXpath + TOP_MENU_LINK_XPATH;
+        // A large implicit wait (LOAD_TIMEOUT) would make every explicit-wait poll below block for
+        // the full implicit timeout while the flyout is still absent, defeating popupWait. Drop it
+        // to zero for the duration of this method and restore it in the finally block.
+        setImplicitWait(0, TimeUnit.MILLISECONDS);
 
-            final WebElement topMenuLinkElement = findElementByXpath(topMenuLinkXpath);
-            shortWait.until(ExpectedConditions.visibilityOf(topMenuLinkElement));
+        try {
+            Unreliables.retryUntilTrue(timeout, TimeUnit.SECONDS, () -> {
+                final String topMenuXpath = TOP_MENU_XPATH.replace("$MENU_ITEM_TEXT", topMenuItemText);
+                final String topMenuLinkXpath = topMenuXpath + TOP_MENU_LINK_XPATH;
 
-            // if this is a top-level menu element, return it, caller will click it
-            if (isTopMenuItem) {
-                foundElement[0] = topMenuLinkElement;
-                return true;
-            }
+                final WebElement topMenuLinkElement = findElementByXpath(topMenuLinkXpath);
+                shortWait.until(ExpectedConditions.visibilityOf(topMenuLinkElement));
 
-            // click the top menu link element to display the popup/flyout menu item
-            topMenuLinkElement.click();
+                // if this is a top-level menu element, return it, caller will click it
+                if (isTopMenuItem) {
+                    foundElement[0] = topMenuLinkElement;
+                    return true;
+                }
 
-            // popup menu item link element
-            final String popupMenuItemXpath = topMenuXpath + POPUP_MENU_ITEM_XPATH.replace("$SUBMENU_TEXT", subMenuText);
+                final String popupMenuItemXpath = topMenuXpath + POPUP_MENU_ITEM_XPATH.replace("$SUBMENU_TEXT", subMenuText);
 
-            final WebElement popupMenuItemLink = findElementByXpath(popupMenuItemXpath);
+                // Only click to OPEN the flyout when it isn't already open. This keeps re-clicking on
+                // the next retry toggle-safe (PrimeVue closes the submenu on a second click of an open
+                // item) and lets us recover from a click that had no effect -- right after navigation
+                // the top link can be present but not yet interactive while the Vue menu app settles,
+                // so the first click is often a no-op and the retry ~1s later is what actually opens it.
+                if (findElementsByXpath(popupMenuItemXpath).isEmpty()) {
+                    topMenuLinkElement.click();
+                }
 
-            if (popupMenuItemLink != null) {
-                foundElement[0] = popupMenuItemLink;
-                return true;
-            }
-
-            return false;
-        });
+                // Wait (briefly) for the flyout to render rather than querying once immediately -- that
+                // immediate query was the original CI race, since the flyout renders asynchronously.
+                try {
+                    foundElement[0] = popupWait.until(
+                            ExpectedConditions.elementToBeClickable(By.xpath(popupMenuItemXpath)));
+                    return true;
+                } catch (final TimeoutException e) {
+                    return false;
+                }
+            });
+        } finally {
+            setImplicitWait();
+        }
 
         return foundElement[0];
     }
@@ -656,34 +680,33 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         final String LOGOUT_XPATH = "//div[@id='opennms-sidemenu-container']//div[contains(@class, 'self-service-menubar-dropdown-item-content')]//a[@name='self-service-logout']";
         final String CHANGE_PASSWORD_XPATH = "//div[@id='opennms-sidemenu-container']//div[contains(@class, 'self-service-menubar-dropdown-item-content')]//a[@name='self-service-changePassword']";
 
-        final int timeout = 5;
+        final String itemXpath = (itemType == SelfServiceMenuType.CHANGE_PASSWORD) ? CHANGE_PASSWORD_XPATH : LOGOUT_XPATH;
+
+        final int timeout = 10;
         final WebDriverWait shortWait = new WebDriverWait(getDriver(), Duration.ofSeconds(1));
+        // The dropdown panel opens asynchronously on hover, so poll for the item with an explicit wait.
+        final WebDriverWait popupWait = new WebDriverWait(getDriver(), Duration.ofSeconds(4));
 
-        Unreliables.retryUntilSuccess(timeout, TimeUnit.SECONDS, () -> {
-            String itemXpath = LOGOUT_XPATH;
+        // As in findMenuItemLink: drop the large implicit wait (LOAD_TIMEOUT) so the explicit waits
+        // below don't block for the full implicit timeout while the dropdown is still opening.
+        setImplicitWait(0, TimeUnit.MILLISECONDS);
+        try {
+            Unreliables.retryUntilSuccess(timeout, TimeUnit.SECONDS, () -> {
+                final Actions action = new Actions(getDriver());
 
-            if (itemType == SelfServiceMenuType.LOGOUT) {
-                itemXpath = LOGOUT_XPATH;
-            } else if (itemType == SelfServiceMenuType.CHANGE_PASSWORD) {
-                itemXpath = CHANGE_PASSWORD_XPATH;
-            }
+                // Find the self service menu trigger and hover over it so the dropdown appears.
+                final WebElement selfServiceMenu = findElementByXpath(SELF_SERVICE_BUTTON_XPATH);
+                shortWait.until(ExpectedConditions.visibilityOf(selfServiceMenu));
+                action.moveToElement(selfServiceMenu).build().perform();
 
-            final Actions action = new Actions(getDriver());
+                // Wait for the dropdown item to render (hover-open is async), then click it.
+                popupWait.until(ExpectedConditions.elementToBeClickable(By.xpath(itemXpath))).click();
 
-            // Find the self service menu and hover over it so that the dropdown menu appears
-            final WebElement selfServiceMenu = findElementByXpath(SELF_SERVICE_BUTTON_XPATH);
-            shortWait.until(ExpectedConditions.visibilityOf(selfServiceMenu ));
-
-            action.moveToElement(selfServiceMenu).build().perform();
-
-            // Find and click the link item on the dropdown menu
-            WebElement linkToClick = findElementByXpath(itemXpath);
-
-            shortWait.until(ExpectedConditions.visibilityOf(linkToClick));
-            linkToClick.click();
-
-            return null;
-        });
+                return null;
+            });
+        } finally {
+            setImplicitWait();
+        }
     }
 
     protected void clickLogout() {

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -549,67 +549,65 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         }
     }
 
-    protected void clickTopMenuItem(final String menuItemId) {
-        LOG.debug("Clicking top menu item with id '{}'", menuItemId);
+    protected void clickTopMenuItem(final String topMenuItemText) {
+        LOG.debug("Clicking top menu item with text '{}'", topMenuItemText);
 
-        WebElement link = findTopMenuItemLink(menuItemId);
+        WebElement link = findMenuItemLink(topMenuItemText, "", true, MENU_ITEM_TIMEOUT);
 
         if (link != null) {
             link.click();
         }
     }
 
-    protected void clickMenuItem(final String menuItemId, final String subMenuText) {
-        clickMenuItem(menuItemId, subMenuText, MENU_ITEM_TIMEOUT);
+    protected void clickMenuItem(final String topMenuItemText, final String subMenuText) {
+        clickMenuItem(topMenuItemText, subMenuText, MENU_ITEM_TIMEOUT);
     }
 
     /**
      * Click on a side menu item to navigate to the linked page.
-     * See 'menu-template.json' for the menu and submenu IDs.
-     * Note that the UI adds a prefix to the IDs to make sure they are unique.
-     * @param menuItemId the 'id' of the top-level menu item (not including the prefix)
+     * See 'menu-template.json' for the menu and submenu text.
+     * @param topMenuItemText the text of the top-level menu item
      * @param subMenuText the text of the sub menu item under the menu item
      */
-    protected void clickMenuItem(final String menuItemId, final String subMenuText, int timeout) {
-        LOG.debug("Clicking menu item with id '{}' and text '{}'", menuItemId, subMenuText);
+    protected void clickMenuItem(final String topMenuItemText, final String subMenuText, int timeout) {
+        LOG.debug("Clicking menu item with top menu text '{}' and submenu text '{}'", topMenuItemText, subMenuText);
 
-        WebElement link = findMenuItemLink(menuItemId, subMenuText, false, timeout);
+        WebElement link = findMenuItemLink(topMenuItemText, subMenuText, false, timeout);
 
         if (link != null) {
             link.click();
         }
     }
 
-    protected WebElement findTopMenuItemLink(final String menuItemId) {
-        return findMenuItemLink(menuItemId, "", true, MENU_ITEM_TIMEOUT);
-    }
-
-    protected WebElement findMenuItemLink(final String menuItemId, final String subMenuText) {
-        return findMenuItemLink(menuItemId, subMenuText, false, MENU_ITEM_TIMEOUT);
+    protected WebElement findMenuItemLink(final String topMenuItemText, final String subMenuText) {
+        return findMenuItemLink(topMenuItemText, subMenuText, false, MENU_ITEM_TIMEOUT);
     }
 
     /**
-     * Find a side menu item.
-     * See 'menu-template.json' for the menu and submenu IDs.
-     * Note that the UI adds a prefix to the IDs to make sure they are unique.
-     * @param menuItemId the 'id' of the top-level menu item (not including the prefix)
-     * @param subMenuText the text of the sub menu item under the menu item
+     * Find a side menu item in the PrimeVue TieredMenu side rail.
+     * See 'menu-template.json' for the menu and submenu text.
+     * @param topMenuItemText the text (aria-label) of the top-level menu item
+     * @param subMenuText the text (aria-label) of the sub menu item under the top menu item
      * @param isTopMenuItem if true, the item to find is a top menu item, not a submenu item. In
-     *                      this case, only 'menuItemId' is needed and 'subMenuText' should be left empty.
+     *                      this case, only 'topMenuItemText' is needed and 'subMenuText' should be left empty.
      */
-    protected WebElement findMenuItemLink(final String menuItemId, final String subMenuText,
+    protected WebElement findMenuItemLink(final String topMenuItemText, final String subMenuText,
                                           boolean isTopMenuItem, int timeout) {
-        LOG.debug("Finding {} menu item with id '{}' and text '{}'",
-                isTopMenuItem ? "top" : "", menuItemId, subMenuText);
+        LOG.debug("Finding {} menu item with top menu text '{}' and submenu text '{}'",
+                isTopMenuItem ? "top" : "", topMenuItemText, subMenuText);
 
         if (timeout <= 0) {
             timeout = MENU_ITEM_TIMEOUT;
         }
 
-        final String TOP_MENU_PREFIX = "opennms-menu-id-";
-        final String TOP_MENU_XPATH = "//div[@id='opennms-sidebar-control-content']/ul[@id='opennms-sidebar-control-menu']/li[@id='$ID']";
-        final String TOP_MENU_ONLY_XPATH = "//div[@id='opennms-sidebar-control-content']/ul[@id='opennms-sidebar-control-menu']/li/a[@id='$ID']";
-        final String POPUP_MENU_ITEMS_XPATH = "//div[@id='opennms-sidebar-control-content']/ul/div[contains(@class, 'feather-popover-container')]/div[@class='popover']/ul[@id='opennms-sidebar-control-menu-opennms-menu-id-$ID-menu']/li/a[contains(@class, 'feather-list-item')]";
+        // Top-level <li> wrapper, anchored to the TieredMenu root list so it can only match a
+        // top-level item (never a same-named submenu item). 'aria-label' is the top menu text.
+        final String TOP_MENU_XPATH = "//nav[@id='opennms-sidemenu-vue-container']//ul[contains(@class, 'p-tieredmenu-root-list')]/li[@role='menuitem' and @aria-label='$MENU_ITEM_TEXT']";
+        // The top item's own link, scoped to its item-content so it can't match a submenu link.
+        final String TOP_MENU_LINK_XPATH = "/div[contains(@class, 'p-tieredmenu-item-content')]//a[contains(@class, 'onms-side-menu__link')]";
+
+        // relative path of the popup menu item link, after TOP_MENU_XPATH
+        final String POPUP_MENU_ITEM_XPATH = "/ul[contains(@class, 'p-tieredmenu-submenu')]/li[@aria-label='$SUBMENU_TEXT']//a[contains(@class, 'onms-side-menu__link')]";
 
         final WebDriverWait shortWait = new WebDriverWait(getDriver(), Duration.ofSeconds(1));
 
@@ -617,30 +615,29 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         final WebElement[] foundElement = new WebElement[] { null };
 
         Unreliables.retryUntilTrue(timeout, TimeUnit.SECONDS, () -> {
-            final Actions action = new Actions(getDriver());
+            final String topMenuXpath = TOP_MENU_XPATH.replace("$MENU_ITEM_TEXT", topMenuItemText);
+            final String topMenuLinkXpath = topMenuXpath + TOP_MENU_LINK_XPATH;
 
-            final String topMenuXpath = isTopMenuItem ?
-                TOP_MENU_ONLY_XPATH.replace("$ID", TOP_MENU_PREFIX + menuItemId) :
-                TOP_MENU_XPATH.replace("$ID", TOP_MENU_PREFIX + menuItemId);
+            final WebElement topMenuLinkElement = findElementByXpath(topMenuLinkXpath);
+            shortWait.until(ExpectedConditions.visibilityOf(topMenuLinkElement));
 
-            final WebElement topMenuElement = findElementByXpath(topMenuXpath);
-            shortWait.until(ExpectedConditions.visibilityOf(topMenuElement));
-
+            // if this is a top-level menu element, return it, caller will click it
             if (isTopMenuItem) {
-                foundElement[0] = topMenuElement;
+                foundElement[0] = topMenuLinkElement;
                 return true;
             }
 
-            topMenuElement.click();
+            // click the top menu link element to display the popup/flyout menu item
+            topMenuLinkElement.click();
 
-            final String popupMenuItemsXpath = POPUP_MENU_ITEMS_XPATH.replace("$ID", menuItemId);
-            final List<WebElement> popupMenuItems = findElementsByXpath(popupMenuItemsXpath);
+            // popup menu item link element
+            final String popupMenuItemXpath = topMenuXpath + POPUP_MENU_ITEM_XPATH.replace("$SUBMENU_TEXT", subMenuText);
 
-            for (WebElement link : popupMenuItems) {
-                if (link.getText().trim().equals(subMenuText)) {
-                    foundElement[0] = link;
-                    return true;
-                }
+            final WebElement popupMenuItemLink = findElementByXpath(popupMenuItemXpath);
+
+            if (popupMenuItemLink != null) {
+                foundElement[0] = popupMenuItemLink;
+                return true;
             }
 
             return false;
@@ -652,9 +649,12 @@ public abstract class AbstractOpenNMSSeleniumHelper {
     private void clickSelfServiceItem(final SelfServiceMenuType itemType) {
         LOG.debug("Clicking self service item: {}", itemType);
 
-        final String SELF_SERVICE_BUTTON_XPATH = "//div[@id='opennms-sidemenu-container']//div[contains(@class, 'self-service-menubar-dropdown')]//featherbutton[@class='self-service-menubar-dropdown-button-dark']";
-        final String LOGOUT_XPATH = "//div[@id='opennms-sidemenu-container']//div[@class='self-service-menubar-dropdown-item-content']//a[@name='self-service-logout']";
-        final String CHANGE_PASSWORD_XPATH = "//div[@id='opennms-sidemenu-container']//div[@class='self-service-menubar-dropdown-item-content']//a[@name='self-service-changePassword']";
+        // The self-service dropdown lives in the top Menubar (UserSelfServiceMenuItem.vue), which is
+        // mounted inside the same #opennms-sidemenu-container app root as the side rail. The trigger is
+        // a PrimeVue <Button> (renders a <button> with additional p-button classes), not a <featherbutton>.
+        final String SELF_SERVICE_BUTTON_XPATH = "//div[@id='opennms-sidemenu-container']//div[contains(@class, 'self-service-menubar-icon-wrapper')]//button[contains(@class, 'self-service-menubar-dropdown-button-dark')]";
+        final String LOGOUT_XPATH = "//div[@id='opennms-sidemenu-container']//div[contains(@class, 'self-service-menubar-dropdown-item-content')]//a[@name='self-service-logout']";
+        final String CHANGE_PASSWORD_XPATH = "//div[@id='opennms-sidemenu-container']//div[contains(@class, 'self-service-menubar-dropdown-item-content')]//a[@name='self-service-changePassword']";
 
         final int timeout = 5;
         final WebDriverWait shortWait = new WebDriverWait(getDriver(), Duration.ofSeconds(1));

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -62,26 +62,25 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         WebElement foundElement = null;
 
         // Dashboards Menu
-        clickMenuItem("dashboardsMenu", "Heatmap");
+        clickMenuItem("Dashboards", "Heatmap");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/a[starts-with(text(), 'Alarm Heatmap')]")));
-        
 
-        clickMenuItem("dashboardsMenu", "Trends");
+        clickMenuItem("Dashboards", "Trends");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Trend']")));
 
-        clickMenuItem("dashboardsMenu", "Charts");
+        clickMenuItem("Dashboards", "Charts");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.id("include-charts")));
 
-        clickMenuItem("dashboardsMenu", "Database Reports");
+        clickMenuItem("Dashboards", "Database Reports");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//a[@data-name='report-templates']")));
 
-        clickMenuItem("dashboardsMenu", "Metrics Statistics (statsd)");
+        clickMenuItem("Dashboards", "Metrics Statistics (statsd)");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span")));
 
-        clickMenuItem("dashboardsMenu", "Graph Collections");
+        clickMenuItem("Dashboards", "Graph Collections");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Customized Reports']")));
 
-        clickMenuItem("dashboardsMenu", "Surveillance Dashboard");
+        clickMenuItem("Dashboards", "Surveillance Dashboard");
         driver.switchTo().frame(findElementByXpath("/html/body/div/iframe"));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//span[text()='Surveillance view: default']")));
 
@@ -90,34 +89,34 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         // Inventory Menu
         // Note, some items are below under Vue UI checks
-        clickMenuItem("inventoryMenu", "Nodes (Legacy)");
+        clickMenuItem("Inventory", "Nodes (Legacy)");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']//li[contains(text()[normalize-space()], 'Node List')]")));
 
-        clickMenuItem("inventoryMenu", "Assets");
+        clickMenuItem("Inventory", "Assets");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='content']//div[@class='card-header']/span[text()='Search Asset Information']")));
 
-        clickMenuItem("inventoryMenu", "Search Inventory");
+        clickMenuItem("Inventory", "Search Inventory");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Search for Nodes']")));
 
         // Monitoring Menu
-        clickMenuItem("monitoringMenu", "Applications");
+        clickMenuItem("Monitoring", "Applications");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//li[text()='Application Status']")));
 
-        clickMenuItem("monitoringMenu", "Alarms");
+        clickMenuItem("Monitoring", "Alarms");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']//li/a[contains(text()[normalize-space()], 'Alarms')]")));
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='content']//a[text()='View all alarms']")));
 
-        clickMenuItem("monitoringMenu", "Outages");
+        clickMenuItem("Monitoring", "Outages");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Outage Menu']")));
 
-        clickMenuItem("monitoringMenu", "Events");
+        clickMenuItem("Monitoring", "Events");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']//li/a[contains(text()[normalize-space()], 'Events')]")));
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='content']//div[@class='form-group']//a[text()='View all events']")));
 
-        clickMenuItem("monitoringMenu", "Path Outages");
+        clickMenuItem("Monitoring", "Path Outages");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='All Path Outages']")));
 
-        clickMenuItem("monitoringMenu", "Surveillance View");
+        clickMenuItem("Monitoring", "Surveillance View");
         // switchTo() by xpath is much faster than by ID
         driver.switchTo().frame(findElementByXpath("/html/body/div/iframe"));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//span[text()='Surveillance view: default']")));
@@ -125,103 +124,103 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         frontPage();
 
         // Metrics Menu
-        clickMenuItem("metricsMenu", "Resource Graphs");
+        clickMenuItem("Metrics (Resource Graphs)", "Resource Graphs");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//a[@class='router-link-active router-link-exact-active'][contains(text()[normalize-space()], 'Resource Graphs')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='main-content']//li[contains(text()[normalize-space()], 'Resources')]")));
 
         // Distributed Monitoring
-        clickMenuItem("distributedMonitoringMenu", "Manage Minions");
+        clickMenuItem("Distributed Monitoring", "Manage Minions");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Manage Minions')]")));
 
-        clickMenuItem("distributedMonitoringMenu", "Manage Applications");
+        clickMenuItem("Distributed Monitoring", "Manage Applications");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Applications')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Applications']")));
 
-        clickMenuItem("distributedMonitoringMenu", "Manage Monitoring Locations");
+        clickMenuItem("Distributed Monitoring", "Manage Monitoring Locations");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Monitoring Locations')]")));
 
         // Manage Inventory Menu
-        clickMenuItem("manageInventoryMenu", "Provisioning Requisitions");
+        clickMenuItem("Manage Inventory", "Provisioning Requisitions");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Provisioning Requisitions')]")));
 
-        clickMenuItem("manageInventoryMenu", "Scheduled Node Discovery");
+        clickMenuItem("Manage Inventory", "Scheduled Node Discovery");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Modify Configuration')]")));
 
-        clickMenuItem("manageInventoryMenu", "One-shot Node Discovery");
+        clickMenuItem("Manage Inventory", "One-shot Node Discovery");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Create Discovery Scan')]")));
 
         // quick-add node screen
-        clickMenuItem("manageInventoryMenu", "Add a Single Node");
+        clickMenuItem("Manage Inventory", "Add a Single Node");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Quick-Add Node')]")));
 
-        clickMenuItem("manageInventoryMenu", "Delete Nodes");
+        clickMenuItem("Manage Inventory", "Delete Nodes");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Delete Nodes']")));
 
-        clickMenuItem("manageInventoryMenu", "Manage Business Services");
+        clickMenuItem("Manage Inventory", "Manage Business Services");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Business Services')]")));
         frontPage();
 
         // User Management Menu
-        clickMenuItem("userManagementMenu", "Manage Users");
+        clickMenuItem("User Management", "Manage Users");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'User List')]")));
 
-        clickMenuItem("userManagementMenu", "Manage Groups");
+        clickMenuItem("User Management", "Manage Groups");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Group List')]")));
 
-        clickMenuItem("userManagementMenu", "Manage On-call Roles");
+        clickMenuItem("User Management", "Manage On-call Roles");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Role List')]")));
 
         // Integrations Menu
-        clickMenuItem("integrationsMenu", "Geocoding Services");
+        clickMenuItem("Integrations", "Geocoding Services");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Geocoder Configuration')]")));
 
-        clickMenuItem("integrationsMenu", "Grafana PDF Reporting");
+        clickMenuItem("Integrations", "Grafana PDF Reporting");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Endpoint Configuration')]")));
 
         // Omitting Zenith Connect for now
 
         // Tools Menu
-        clickMenuItem("toolsMenu", "SNMP MIB Compiler");
+        clickMenuItem("Tools", "SNMP MIB Compiler");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'SNMP MIB Compiler')]")));
 
-        clickMenuItem("toolsMenu", "JMX Metric Configuration Generator");
+        clickMenuItem("Tools", "JMX Metric Configuration Generator");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'JMX Configuration Generator')]")));
 
-        clickMenuItem("toolsMenu", "Import/Export Node Asset Information");
+        clickMenuItem("Tools", "Import/Export Node Asset Information");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Import/Export Assets')]")));
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Import and Export Assets']")));
 
-        clickMenuItem("toolsMenu", "Send Custom Events");
+        clickMenuItem("Tools", "Send Custom Events");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Send Event')]")));
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Send Event to OpenNMS']")));
 
         // Administration Menu
-        clickMenuItem("administrationMenu", "Surveillance Categories");
+        clickMenuItem("Administration", "Surveillance Categories");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Surveillance Categories']")));
 
-        clickMenuItem("administrationMenu", "Configure Thresholds");
+        clickMenuItem("Administration", "Configure Thresholds");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Threshold Configuration']")));
 
-        clickMenuItem("administrationMenu", "Flow Classification");
+        clickMenuItem("Administration", "Flow Classification");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Flow Classification')]")));
 
-        clickMenuItem("administrationMenu", "Notifications");
+        clickMenuItem("Administration", "Notifications");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Notification queries']")));
 
-        clickMenuItem("administrationMenu", "Manage Event Configurations");
+        clickMenuItem("Administration", "Manage Event Configurations");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='app']//div[@class='event-config']//div[@class='heading']//h1[text()='Manage Event Configurations']")));
 
-        clickMenuItem("administrationMenu", "Manage SNMP Data Collection per Interface");
+        clickMenuItem("Administration", "Manage SNMP Data Collection per Interface");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Manage SNMP Data Collection per Interface']")));
 
-        clickMenuItem("administrationMenu", "Scheduled Outages");
+        clickMenuItem("Administration", "Scheduled Outages");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Scheduled Outages')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/h4[text()='Scheduled Outages']")));
 
-        clickMenuItem("administrationMenu", "Product Update Enrollment");
+        clickMenuItem("Administration", "Product Update Enrollment");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Product Update Enrollment')]")));
 
-        clickMenuItem("administrationMenu", "Configure OpenNMS");
+        clickMenuItem("Administration", "Configure OpenNMS");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='OpenNMS System']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Provisioning']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Event Management']")));
@@ -230,67 +229,67 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Distributed Monitoring']")));
 
         // Internal Logs Menu
-        clickMenuItem("internalLogsMenu", "Instrumentation Log Reader");
+        clickMenuItem("Internal Logs", "Instrumentation Log Reader");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Instrumentation Log Reader')]")));
 
         // API Documentation Menu
         // Omit clicking for now, some of these are external links
-        foundElement = findMenuItemLink("apiDocumentationMenu", "REST Open API Documentation");
+        foundElement = findMenuItemLink("API Documentation", "REST Open API Documentation");
         assertNotNull("apiDocumentationMenu / REST Open API Documentation", foundElement);
 
-        foundElement = findMenuItemLink("apiDocumentationMenu", "REST API Reference Documentation");
+        foundElement = findMenuItemLink("API Documentation", "REST API Reference Documentation");
         assertNotNull("apiDocumentationMenu / REST API Reference Documentation", foundElement);
 
-        foundElement = findMenuItemLink("apiDocumentationMenu", "Source Code");
+        foundElement = findMenuItemLink("API Documentation", "Source Code");
         assertNotNull("apiDocumentationMenu / Source Code", foundElement);
 
         // Help Documentation menu
-        clickMenuItem("helpDocumentationMenu", "Help");
+        clickMenuItem("Help", "Help");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Help')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Documentation']")));
 
-        clickMenuItem("helpDocumentationMenu", "About");
+        clickMenuItem("Help", "About");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'About')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Version Details']")));
 
-        clickMenuItem("helpDocumentationMenu", "Support");
+        clickMenuItem("Help", "Support");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Support')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Commercial Support']")));
 
         // Support Menu
-        foundElement = findMenuItemLink("supportMenu", "Professional Support");
+        foundElement = findMenuItemLink("Support", "Professional Support");
         assertNotNull("supportMenu / Professional Support", foundElement);
 
-        foundElement = findMenuItemLink("supportMenu", "Chat");
+        foundElement = findMenuItemLink("Support", "Chat");
         assertNotNull("supportMenu / Chat", foundElement);
 
-        foundElement = findMenuItemLink("supportMenu", "Community Support (Discourse)");
+        foundElement = findMenuItemLink("Support", "Community Support (Discourse)");
         assertNotNull("supportMenu / Community Support (Discourse)", foundElement);
 
-        foundElement = findMenuItemLink("supportMenu", "Public Issue Tracker");
+        foundElement = findMenuItemLink("Support", "Public Issue Tracker");
         assertNotNull("supportMenu / Public Issue Tracker", foundElement);
 
-        clickMenuItem("supportMenu", "Generate System Report");
+        clickMenuItem("Support", "Generate System Report");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'System Reports')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-body']//div[@class='form-group']/input[@type='submit' and @value='Generate System Report']")));
 
         // Omitting for now - need to fix!
         // Vaadin Topology page
         frontPage();
-        clickTopMenuItem("topologiesMenu");
+        clickTopMenuItem("Topology Map");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[contains(text(), 'Selection Context')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[starts-with(@id, 'opennmstopology-')]")));
 
         // Navigation on Vue UI pages
         frontPage();
-        clickMenuItem("inventoryMenu", "Nodes");
+        clickMenuItem("Inventory", "Nodes");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='card']//span[text()='Nodes']")));
 
-        clickMenuItem("inventoryMenu", "Device Configs");
+        clickMenuItem("Inventory", "Device Configs");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='Device Config Backup']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//span[text()='Device Configuration']")));
 
-        clickMenuItem("toolsMenu", "Secure Credentials Vault");
+        clickMenuItem("Tools", "Secure Credentials Vault");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='Secure Credentials Vault']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='scv-container']//p[text()='Add Credentials']")));
 
@@ -299,25 +298,25 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         // wait.until(ExpectedConditions.presenceOfElementLocated(By.id("app")));
         // wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//span[text()='File Editor']")));
 
-        clickMenuItem("integrationsMenu", "SNMP Agent Configuration");
+        clickMenuItem("Integrations", "SNMP Agent Configuration");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='Manage SNMP Configuration']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//h2[text()='Manage SNMP Configuration']")));
 
-        clickMenuItem("integrationsMenu", "External Requisitions");
+        clickMenuItem("Integrations", "External Requisitions");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='External Requisitions and Thread Pools']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//h2[text()='External Requisitions and Thread Pools']")));
 
-        clickMenuItem("administrationMenu", "Usage Statistics Sharing");
+        clickMenuItem("Administration", "Usage Statistics Sharing");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='Usage Statistics Collection']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='usage-stats-container']//span[text()='Usage Statistics Sharing']")));
 
-        clickMenuItem("internalLogsMenu", "Log Viewer");
+        clickMenuItem("Internal Logs", "Log Viewer");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='Logs']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='logs-sidebar']")));
 
         // Geographical map page
         frontPage();
-        clickTopMenuItem("mapsMenu");
+        clickTopMenuItem("Geographical Map");
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='geo-map']")));
 
         // Alarms/Nodes table at bottom of map

--- a/smoke-test/src/test/java/org/opennms/smoketest/ProvisioningNewUIIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ProvisioningNewUIIT.java
@@ -271,7 +271,7 @@ public class ProvisioningNewUIIT extends OpenNMSSeleniumIT {
 
         // Open the legacy nodes list page
         driver.get(getBaseUrlInternal() + "opennms/");
-        clickMenuItem("inventoryMenu", "Nodes (Legacy)");
+        clickMenuItem("Inventory", "Nodes (Legacy)");
 
         try {
             // Don't wait as long as usual for just the node page, it should be pretty quick

--- a/smoke-test/src/test/java/org/opennms/smoketest/QuickAddNodeIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/QuickAddNodeIT.java
@@ -73,7 +73,7 @@ public class QuickAddNodeIT extends OpenNMSSeleniumIT {
 
     @Test
     public void testQuickAddNode() throws Exception {
-        clickMenuItem("manageInventoryMenu", "Add a Single Node");
+        clickMenuItem("Manage Inventory", "Add a Single Node");
 
         Thread.sleep(5000);
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/UIRefreshIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/UIRefreshIT.java
@@ -61,7 +61,7 @@ public class UIRefreshIT extends OpenNMSSeleniumIT {
         assertEquals("ItsRainingItsPouring", node.getLabel());
 
         // Switch to the new UI
-        clickMenuItem("inventoryMenu", "Nodes");
+        clickMenuItem("Inventory", "Nodes");
     }
 
     @After

--- a/smoke-test/src/test/java/org/opennms/smoketest/UserIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/UserIT.java
@@ -287,7 +287,7 @@ public class UserIT extends OpenNMSSeleniumIT {
                 "<input type='hidden' name='dutySchedules' value='0' />" +
                 "<input type='hidden' name='numSchedules' value='1' />" +
                 // force input button to be clear of the side menu
-                "<input type='submit' id='submitIt' style='margin-left: 300px' />" +
+                "<input type='submit' id='submitIt' style='margin-left: 4rem' />" +
                 "</form>";
 
         String script = "var foo = document.createElement('div'); " +

--- a/smoke-test/src/test/java/org/opennms/smoketest/UserIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/UserIT.java
@@ -286,8 +286,10 @@ public class UserIT extends OpenNMSSeleniumIT {
                 "<input type='hidden' name='timeZoneId' value=' ' />" +
                 "<input type='hidden' name='dutySchedules' value='0' />" +
                 "<input type='hidden' name='numSchedules' value='1' />" +
-                "<input type='submit' id='submitIt' />" +
+                // force input button to be clear of the side menu
+                "<input type='submit' id='submitIt' style='margin-left: 300px' />" +
                 "</form>";
+
         String script = "var foo = document.createElement('div'); " +
                 "foo.innerHTML=\"" + html + "\"; " +
                 "document.body.appendChild(foo)";

--- a/ui/src/components/Menu/Menubar.vue
+++ b/ui/src/components/Menu/Menubar.vue
@@ -1,25 +1,27 @@
 <template>
-  <FeatherAppBar :labels="{ skip: 'main' }" content="app" :ref="outsideClick" @mouseleave="resetMenuItems">
-    <template v-slot:left>
+  <header class="onms-menubar" ref="outsideClick" @mouseleave="resetMenuItems">
+    <div class="onms-menubar__left">
       <div class="center-flex">
-        <FeatherAppBarLink :icon="IconLogo" title="Home" class="logo-link home" type="home" :url="mainMenu.homeUrl || '/'" />
+        <a class="logo-link home" title="Home" :href="mainMenu.homeUrl || '/'">
+          <IconLogo class="onms-menubar__logo" />
+        </a>
       </div>
-    </template>
+    </div>
 
-    <template v-slot:center>
-        <Search class="search-left-margin" id="onms-central-search-control" />
+    <div class="onms-menubar__center">
+      <Search class="search-left-margin" id="onms-central-search-control" />
 
-        <!-- Provision/Quick add node menu -->
-        <div v-if="displayAddNodeButton" class="quick-add-node-wrapper">
-          <FeatherButton
-            primary
-            v-if="mainMenu.provisionMenu"
-            @click="onAddNode"
-          >Add a Node</FeatherButton>
-        </div>
-    </template>
+      <!-- Provision/Quick add node menu -->
+      <div v-if="displayAddNodeButton" class="quick-add-node-wrapper">
+        <Button
+          v-if="mainMenu.provisionMenu"
+          label="Add a Node"
+          @click="onAddNode"
+        />
+      </div>
+    </div>
 
-    <template v-slot:right>
+    <div class="onms-menubar__right">
       <div class="date-wrapper">
         <div class="date-formatted-time">{{ formattedTime }}</div>
         <div class="date-formatted-date">{{ formattedDate }}</div>
@@ -49,18 +51,17 @@
           @menuHide="() => onMenuHide(DropdownMenuType.SelfService)"
         />
       </template>
-    </template>
-  </FeatherAppBar>
+    </div>
+  </header>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
 
 import { useOutsideClick } from '@featherds/composables/events/OutsideClick'
-import { FeatherAppBar, FeatherAppBarLink } from '@featherds/app-bar'
-import { FeatherButton } from '@featherds/button'
 import { FeatherIcon } from '@featherds/icon'
 import LightDarkMode from '@featherds/icon/action/LightDarkMode'
+import Button from 'primevue/button'
 
 // see vite.config.ts, resolve.alias for the actual logo file that is imported
 import IconLogo from './src/assets/ProductLogo.vue'
@@ -173,11 +174,61 @@ onUnmounted(() => {
 </script>
 
 <style lang="scss" scoped>
-@use "@featherds/styles/mixins/typography" as typo;
 @import "@featherds/dropdown/scss/mixins";
 @import "@featherds/styles/mixins/elevation";
 @import "@featherds/styles/mixins/typography";
 @import "@featherds/styles/themes/variables";
+
+// Fixed top menu bar. Replaces FeatherAppBar, which was used only as a fixed
+// 3-column flex bar (its skip-link, responsive hamburger, scroll-hide and
+// full-width features were all inactive/hidden here).
+.onms-menubar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--feather-zindex-fixed, 1030);
+  display: flex;
+  align-items: center;
+  height: var(--onms-header-height, 3.75rem);
+  padding: 0 1rem;
+  background-color: var(--feather-surface-dark);
+  color: var(--feather-state-text-color-on-surface-dark);
+}
+
+.onms-menubar__left {
+  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.onms-menubar__center {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+}
+
+.onms-menubar__right {
+  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.logo-link.home {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+// The logo is a wide wordmark SVG (viewBox 624x69). Size by height and let
+// width follow; override the SVG's own max-width so it isn't clamped/distorted.
+.onms-menubar__logo {
+  height: 1.75rem;
+  width: auto;
+  max-width: none;
+}
 
 // Notification-status colors stay on their light-theme Feather values so
 // the indicator meaning doesn't change with the active theme. We re-declare
@@ -216,17 +267,6 @@ onUnmounted(() => {
 .quick-add-node-wrapper {
   margin-left: 1em;
   margin-right: 1em;
-
-  .btn {
-    :deep(.btn-content) {
-      @include typo.button();
-      color: var(--feather-primary-text-on-color);
-      font-family: var(--feather-header-font-family);
-      font-size: var(--feather-button-font-size);
-      font-weight: var(--feather-button-font-weight);
-      letter-spacing: var(--feather-button-letter-spacing);
-    }
-  }
 }
 
 .notice-status-display {
@@ -256,6 +296,11 @@ onUnmounted(() => {
 </style>
 
 <style lang="scss">
+// Shared header height, consumed by both the top menu bar and the side menu rail.
+:root {
+  --onms-header-height: 3.75rem;
+}
+
 .light-dark {
   font-size: 24px;
   margin-top: 2px;
@@ -275,44 +320,9 @@ onUnmounted(() => {
   }
 }
 
-.header .header-content {
-  padding-left: 1rem;
-  padding-right: 1rem;
-  max-width: 100%;
-}
-
-.banner .header {
-  .logo-link.home {
-    padding-left: 0;
-    margin-right: 1rem;
-    padding-top: 2px;
-    padding-bottom: 0;
-    padding-right: 0;
-  }
-}
-
-// remove elevation from menubar
-.header-wrapper.feather-app-bar-wrapper .header {
-  box-shadow: none;
-}
-
-.header-wrapper.feather-app-bar-wrapper a.skip {
-  display: none;
-}
-
 .center-flex {
   display: flex;
   align-items: center;
   padding-top: 3px;
-}
-
-.header-content {
-  .right.center-horiz {
-    margin-right:2px;
-  }
-
-  .top-menu-search {
-    margin-right:5px;
-  }
 }
 </style>

--- a/ui/src/components/Menu/Search.vue
+++ b/ui/src/components/Menu/Search.vue
@@ -277,10 +277,6 @@ const onKeyDown = async (event: KeyboardEvent) => {
 </script>
 
 <style lang="scss" scoped>
-@import "@featherds/styles/mixins/typography";
-@import "@featherds/styles/mixins/elevation";
-@import "@featherds/styles/themes/variables";
-
 .onms-search-control-wrapper {
   position: relative;
   min-width: 30em;
@@ -291,9 +287,9 @@ const onKeyDown = async (event: KeyboardEvent) => {
   top: 100%;
   left: 0;
   width: 100%;
-  background: var($background);
-  color: var(--feather-secondary-text-on-surface);
-  border: 1px solid var($secondary);
+  background: var(--p-content-background);
+  color: var(--p-text-muted-color);
+  border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
   max-height: 400px;
   overflow-y: auto;
@@ -305,19 +301,19 @@ const onKeyDown = async (event: KeyboardEvent) => {
     display: flex;
     justify-content: flex-end;
     padding: 0.25em 0.5em;
-    border-bottom: 1px solid var($border-on-surface);
+    border-bottom: 1px solid var(--p-content-border-color);
 
     .search-results-close {
       cursor: pointer;
-      color: var($secondary-text-on-surface);
+      color: var(--p-text-muted-color);
       font-size: 1.25rem;
 
       &:hover {
-        color: var($primary-text-on-surface);
+        color: var(--p-text-color);
       }
 
       &:focus-visible {
-        outline: 2px solid var($primary);
+        outline: 2px solid var(--p-primary-color);
         outline-offset: 2px;
         border-radius: 2px;
       }
@@ -325,24 +321,24 @@ const onKeyDown = async (event: KeyboardEvent) => {
   }
 
   .search-category {
-    background-color: var(--feather-background);
+    background-color: var(--p-content-background);
     padding: 0.5em 0.75em;
-    border-bottom: 1px solid var(--feather-surface);
+    border-bottom: 1px solid var(--p-content-border-color);
     font-weight: 800;
   }
 
   .search-result-item {
-    border-bottom: 1px solid var(--feather-surface);
+    border-bottom: 1px solid var(--p-content-border-color);
     transition: background-color 0.15s ease;
     padding-left: 0.5em;
-    color: var(--feather-secondary-text-on-surface);
+    color: var(--p-text-muted-color);
 
     &:hover {
-      background-color: var(--feather-surface);
+      background-color: var(--p-highlight-background);
     }
 
     &.keyboard-selected {
-      background-color: var(--feather-surface);
+      background-color: var(--p-highlight-background);
     }
 
     &:last-child {
@@ -356,15 +352,15 @@ const onKeyDown = async (event: KeyboardEvent) => {
   position: relative;
   align-items: center;
   width: 100%;
-  background-color: var($surface);
-  border: 1px solid var($border-on-surface);
+  background-color: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
   border-radius: 4px;
 
   .search-icon {
     position: absolute;
     left: 8px;
     z-index: 1;
-    color: var($secondary-text-on-surface);
+    color: var(--p-text-muted-color);
     pointer-events: none;
   }
 
@@ -375,35 +371,15 @@ const onKeyDown = async (event: KeyboardEvent) => {
     background: transparent;
     outline: none;
     font-size: 14px;
-    color: var($primary-text-on-surface);
+    color: var(--p-text-color);
 
     &::placeholder {
-      color: var($secondary-text-on-surface);
+      color: var(--p-text-muted-color);
     }
 
     &:focus {
       box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
     }
   }
-}
-
-:deep(.feather-input-wrapper-container .feather-input-border .pre-border) {
-  border-radius: 0 !important;
-}
-
-:deep(.feather-input-wrapper-container .feather-input-border .post-border) {
-  border-radius: 0 !important;
-}
-
-:deep(.feather-input-border) {
-  background: var(--surface);
-}
-
-:deep(.feather-input-sub-text) {
-  display: none !important;
-}
-
-:deep(.feather-input-wrapper-container.raised .feather-input-label) {
-  display: none !important;
 }
 </style>

--- a/ui/src/components/Menu/SearchResult.vue
+++ b/ui/src/components/Menu/SearchResult.vue
@@ -113,7 +113,7 @@ const onItemOut = () => {
     appearance: none;
     block-size: 24px;
     caret-color: rgb(10,12,27,0.7);
-    color: var(--feather-secondary-text-on-surface);
+    color: var(--p-text-muted-color);
     column-rule-color: rgba(10, 12, 27, 0.7);
     cursor: pointer;
     display: block;
@@ -139,7 +139,7 @@ const onItemOut = () => {
 .search-item-details {
   margin-left: 1em;
   z-index: 1100;
-  color: var(--feather-secondary-text-on-surface);
+  color: var(--p-text-muted-color);
   padding: 0.25em;
 }
 </style>

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -1,41 +1,69 @@
 <template>
-  <div id="opennms-sidemenu-vue-container">
-    <FeatherSidenav
-      id="opennms-sidebar-control"
-      :hoverMode="true"
-      :items="topPanels"
-      v-model="isExpanded"
-      @update:modelValue="(val: any) => isExpanded = !!val"
-      :pushedSelector="pushedSelector"
-      menuTitle="OpenNMS"
-      menuHeader
-      menuFooter
-      @update:expanded="() => menuStore.setSideMenuExpanded(true)"
-      @update:collapsed="() => menuStore.setSideMenuExpanded(false)"
-      @update:="() => menuStore.setSideMenuExpanded(false)"
-    />
-  </div>
+  <nav
+    id="opennms-sidemenu-vue-container"
+    class="onms-side-menu"
+    :class="{ 'onms-side-menu--open': isOpen }"
+    @mouseenter="onRailEnter"
+    @mouseleave="isHovering = false"
+  >
+    <button
+      type="button"
+      class="onms-side-menu__toggle"
+      :title="isPinned ? 'Collapse menu' : 'Expand menu'"
+      :aria-label="isPinned ? 'Collapse menu' : 'Expand menu'"
+      :aria-expanded="isPinned"
+      @click="togglePinned"
+    >
+      <i class="pi" :class="isPinned ? 'pi-angle-double-left' : 'pi-angle-double-right'" aria-hidden="true" />
+    </button>
+
+    <TieredMenu
+      ref="tieredMenuRef"
+      :model="topPanels"
+      class="onms-side-menu__menu"
+      breakpoint="0px"
+    >
+      <template #item="{ item, props, hasSubmenu }">
+        <a
+          class="onms-side-menu__link"
+          :href="item.url || undefined"
+          :target="item.target || undefined"
+          v-bind="props.action"
+        >
+          <span class="onms-side-menu__icon">
+            <component :is="item.iconComponent" v-if="item.iconComponent" aria-hidden="true" />
+          </span>
+          <span class="onms-side-menu__label">{{ item.label }}</span>
+          <i v-if="hasSubmenu" class="pi pi-angle-right onms-side-menu__chevron" aria-hidden="true" />
+        </a>
+      </template>
+    </TieredMenu>
+  </nav>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
-import { FeatherSidenav } from '@featherds/sidebar'
-import { MenuListEntry } from '@featherds/menu'
+import TieredMenu from 'primevue/tieredmenu'
+import type { MenuItem } from 'primevue/menuitem'
 import { performLogout } from '@/services/logoutService'
 import { useMenuStore } from '@/stores/menuStore'
 import { usePluginStore } from '@/stores/pluginStore'
 import { Plugin } from '@/types'
 import { MainMenu } from '@/types/mainMenu'
-import { createTopMenuListEntry, updateWithPluginsMenuItems } from './utils'
+import { createPrimeMenuModel, updateWithPluginsMenuItems } from './utils'
 import useMenuIcons from './useMenuIcons'
 
-defineProps({
+const props = defineProps({
   pushedSelector: {
     type: String,
     required: true
   }
 })
+
+// Rail widths — keep in sync with the CSS custom properties below.
+const RAIL_COLLAPSED = '3.75rem'
+const RAIL_EXPANDED = '20rem'
 
 const menuStore = useMenuStore()
 const pluginStore = usePluginStore()
@@ -43,13 +71,34 @@ const { getIcon } = useMenuIcons()
 
 const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 const plugins = computed<Plugin[]>(() => pluginStore.plugins)
-const isExpanded = ref<boolean>(menuStore.sideMenuExpanded() ?? false)
+
+// isPinned is the persisted expanded/collapsed state (toggle button).
+// isHovering expands the rail transiently (open-on-hover) without persisting.
+const isPinned = ref<boolean>(menuStore.sideMenuExpanded() ?? false)
+const isHovering = ref<boolean>(false)
+const isOpen = computed<boolean>(() => isPinned.value || isHovering.value)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tieredMenuRef = ref<any>(null)
+
+const onRailEnter = () => {
+  isHovering.value = true
+
+  // PrimeVue's TieredMenu only opens submenus on hover once it is "dirty"
+  // (after an initial click / keyboard interaction). Enable that flag on entry
+  // so the rail behaves as open-on-hover from the first interaction, matching
+  // the previous FeatherSidenav. Guarded so it degrades to click-to-open if the
+  // internal flag ever changes.
+  if (tieredMenuRef.value) {
+    tieredMenuRef.value.dirty = true
+  }
+}
 
 const onPerformLogout = async () => {
   await performLogout()
 }
 
-const topPanels = computed<MenuListEntry[]>(() => {
+const topPanels = computed<MenuItem[]>(() => {
   // If user not logged in, don't display any menus
   if (!mainMenu.value.username) {
     return []
@@ -57,83 +106,190 @@ const topPanels = computed<MenuListEntry[]>(() => {
 
   const allMenus = updateWithPluginsMenuItems(mainMenu.value.menus ?? [], plugins.value)
 
-  return allMenus.map(i => createTopMenuListEntry(i, mainMenu.value.baseHref, getIcon, onPerformLogout) as MenuListEntry)
+  return createPrimeMenuModel(allMenus, mainMenu.value.baseHref, getIcon, onPerformLogout)
+})
+
+const togglePinned = () => {
+  isPinned.value = !isPinned.value
+  menuStore.setSideMenuExpanded(isPinned.value)
+}
+
+// Push the main content aside by the rail width. We only push for the pinned
+// (persisted) state; hover-expansion overlays the content instead of pushing
+// it, to avoid reflowing the whole page on every hover.
+const getPushedElement = (): HTMLElement | null => {
+  try {
+    return document.querySelector<HTMLElement>(props.pushedSelector)
+  } catch {
+    return null
+  }
+}
+
+const applyPush = () => {
+  const el = getPushedElement()
+
+  if (!el) {
+    return
+  }
+
+  el.style.transition = 'padding-left 0.1s linear'
+  el.style.paddingLeft = isPinned.value ? RAIL_EXPANDED : RAIL_COLLAPSED
+}
+
+watch(isPinned, applyPush)
+
+onMounted(() => {
+  applyPush()
+})
+
+onBeforeUnmount(() => {
+  const el = getPushedElement()
+
+  if (el) {
+    el.style.paddingLeft = ''
+  }
 })
 </script>
 
 <style lang="scss" scoped>
-@import "@featherds/dropdown/scss/mixins";
-@import "@featherds/styles/mixins/elevation";
-@import "@featherds/styles/mixins/typography";
 @import "@featherds/styles/themes/variables";
 
-#opennms-sidemenu-vue-container {
-  // put Sidenav below the top menu and make sure popover menus are over geomap
-  :deep(.feather-dock) {
-    z-index: 2000;    // over the geomap
+// Fixed, collapsible side menu rail. Replaces FeatherSidenav/FeatherDock.
+// Pinned dark (independent of the active light/dark app theme) so it stays
+// visually consistent with the top menu bar.
+.onms-side-menu {
+  position: fixed;
+  top: var(--onms-header-height, 3.75rem);
+  left: 0;
+  bottom: 0;
+  z-index: 2000; // over the geomap, matching the previous FeatherDock
+  display: flex;
+  flex-direction: column;
+  width: var(--onms-side-menu-collapsed, 3.75rem);
+  background-color: var(--feather-surface-dark);
+  color: var(--feather-state-text-color-on-surface-dark);
+  transition: width 0.1s linear;
+  // Flyout submenus are absolutely positioned descendants; keep overflow
+  // visible so they are not clipped by the (narrow) rail.
+  overflow: visible;
+
+  // Force the TieredMenu (and its flyout submenus, which are descendants of
+  // this nav) onto the dark surface via PrimeVue design tokens.
+  --p-tieredmenu-background: var(--feather-surface-dark);
+  --p-tieredmenu-color: var(--feather-state-text-color-on-surface-dark);
+  --p-tieredmenu-border-color: transparent;
+  --p-tieredmenu-border-radius: 0;
+  --p-tieredmenu-item-color: var(--feather-state-text-color-on-surface-dark);
+  --p-tieredmenu-item-icon-color: var(--feather-state-text-color-on-surface-dark);
+  --p-tieredmenu-item-focus-color: #fff;
+  --p-tieredmenu-item-icon-focus-color: #fff;
+  --p-tieredmenu-item-focus-background: rgba(255, 255, 255, 0.12);
+  --p-tieredmenu-submenu-icon-color: var(--feather-state-text-color-on-surface-dark);
+  --p-tieredmenu-submenu-icon-focus-color: #fff;
+  --p-tieredmenu-separator-border-color: rgba(255, 255, 255, 0.2);
+}
+
+.onms-side-menu--open {
+  width: var(--onms-side-menu-expanded, 20rem);
+}
+
+.onms-side-menu__toggle {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  height: 2.75rem;
+  padding: 0 1.15rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.1rem;
+
+  &:hover {
+    opacity: 0.85;
   }
 
-  #opennms-sidebar-control {
-    --feather-dock-header-offset: 3.75rem;
-
-    // tighten spacing between toggle button and top of menu items
-    --feather-dock-content-padding-top: 3em;
-    --feather-dock-toggle-top: 2em;
-
-    // Pin the side menu to dark regardless of active theme so that the
-    // side menu and top menubar stay visually consistent with one another.
-    --feather-dock-background-color: var(--feather-surface-dark);
-    --feather-dock-color: var(--feather-state-text-color-on-surface-dark);
-  }
-
-  // fix Sidenav toggle button placement
-  :deep(.feather-dock.dock-open > button.feather-dock-toggle) {
-    top: var(--feather-header-height);
-    left: calc(var(--feather-dock-width) - 3.75rem);
-  }
-
-  :deep(.feather-dock.dock-closed > button.feather-dock-toggle) {
-    top: 0;
-    left: 0;
-  }
-
-  :deep(li.feather-list-item.li-separator.disabled span.feather-list-item-text > hr) {
-      border: 1px;
-      border: 1px solid var(--feather-dock-color);
-  }
-
-  :deep(.feather-popover-container > .popover) {
-    max-width: 24rem;
+  &:focus-visible {
+    outline: 2px solid var(--feather-primary);
+    outline-offset: -2px;
   }
 }
-</style>
 
-<style lang="scss">
-#opennms-sidebar-control {
-  #opennms-sidebar-control-content {
-    // tighten spacing around menu separator
-    // less padding around menu separator so it doesn't just go fully across the menu
-    #opennms-sidebar-control-menu {
-      .feather-list-item.hover.focus.disabled.li-separator {
-        height: 1.25em;
-        padding: 0 0.5rem;
-      }
+// The TieredMenu component root does not receive this component's scope id, so
+// it must be reached with :deep(). Override PrimeVue's default 12.5rem min-width
+// so the menu fits the rail, and drop the panel chrome (border/padding/bg).
+.onms-side-menu :deep(.p-tieredmenu) {
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  padding: 0;
+}
 
-      // tighten vertical space between expand/collapse button and first actual menu item
-      // note, menu-template.json has a "dummy" first menu item of type="header" so the the
-      // hard-coded "Menu" header is not emitted. This overrides the min-height of the empty li
-      li:first-child.feather-list-header {
-        min-height: 0.1rem;
-      }
-    }
+// Flyout submenus should be comfortably wide (labels are hidden in the rail).
+.onms-side-menu :deep(.p-tieredmenu-submenu) {
+  min-width: 14rem;
+}
 
-    // when dock is closed, want the separator not quite fully across horizontally, but closer to fully across than when it's open
-    #opennms-sidebar-control-menu.dock-closed {
-      .feather-list-item.hover.focus.disabled.li-separator {
-        height: 1.25em;
-        padding: 0 0.1rem;
-      }
-    }
+// Slot content is compiled in this component's scope, so these classes match
+// without :deep(). The interactive link also carries PrimeVue's own
+// p-tieredmenu-item-link class (merged via props.action).
+.onms-side-menu__link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
+.onms-side-menu__icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  width: 1.4rem;
+  height: 1.4rem;
+
+  :deep(svg) {
+    width: 1em;
+    height: 1em;
+    fill: currentColor;
   }
+}
+
+.onms-side-menu__label {
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.onms-side-menu__chevron {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-size: 0.85rem;
+}
+
+// Collapsed rail: only the top-level (root list) items are icon-only. Flyout
+// submenus always keep their labels, since they only appear on hover/expand.
+.onms-side-menu:not(.onms-side-menu--open) :deep(.p-tieredmenu-root-list > .p-tieredmenu-item > .p-tieredmenu-item-content) {
+  .onms-side-menu__label,
+  .onms-side-menu__chevron {
+    display: none;
+  }
+
+  .onms-side-menu__link {
+    justify-content: center;
+  }
+}
+
+// Flyout submenus are absolutely-positioned descendants of this nav; keep them
+// above surrounding page content.
+:deep(.p-tieredmenu-submenu) {
+  z-index: 2001;
 }
 </style>

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -1,10 +1,11 @@
 <template>
   <nav
+    ref="navRef"
     id="opennms-sidemenu-vue-container"
     class="onms-side-menu"
     :class="{ 'onms-side-menu--open': isOpen }"
     @mouseenter="onRailEnter"
-    @mouseleave="isHovering = false"
+    @mouseleave="onRailLeave"
   >
     <button
       type="button"
@@ -95,6 +96,17 @@ const onRailEnter = () => {
   }
 }
 
+const onRailLeave = () => {
+  isHovering.value = false
+
+  // The flyout submenus are position:fixed (see positionFlyouts) so they are
+  // visually detached from the rail. When the pointer leaves the rail+flyout,
+  // close any open flyout via TieredMenu's hide() (clears activeItemPath) so it
+  // doesn't linger orphaned after the rail collapses. hide() also resets the
+  // internal `dirty` flag, which onRailEnter re-enables on the next hover.
+  tieredMenuRef.value?.hide?.()
+}
+
 const onPerformLogout = async () => {
   await performLogout()
 }
@@ -143,8 +155,89 @@ const applyPush = () => {
 
 watch(isPinned, applyPush)
 
+// The menu list scrolls vertically (see .p-tieredmenu overflow in the style
+// block). That overflow would clip the flyout submenus, which open to the side
+// (a scroll container clips absolutely-positioned descendants on BOTH axes,
+// regardless of whether a scrollbar is showing). So promote each open
+// FIRST-LEVEL flyout to position:fixed, anchored to its item's viewport rect —
+// fixed elements escape the scroll container's clip. Nested submenus live inside
+// the now-unclipped flyout and keep PrimeVue's own positioning.
+const navRef = ref<HTMLElement | null>(null)
+let flyoutRaf = 0
+let flyoutObserver: MutationObserver | null = null
+
+// Gap kept between a flyout and the viewport edges.
+const FLYOUT_VIEWPORT_MARGIN = 8
+
+const positionFlyouts = () => {
+  const nav = navRef.value
+
+  if (!nav) {
+    return
+  }
+
+  const items = nav.querySelectorAll<HTMLElement>('.p-tieredmenu-root-list > .p-tieredmenu-item')
+  // Keep flyouts within the rail's vertical band: never above the rail top (so
+  // they don't overlap the fixed header) and never past the viewport bottom.
+  const minTop = nav.getBoundingClientRect().top
+  const maxBottom = window.innerHeight - FLYOUT_VIEWPORT_MARGIN
+  const availableHeight = maxBottom - minTop
+
+  items.forEach((item) => {
+    const submenu = item.querySelector<HTMLElement>(':scope > .p-tieredmenu-submenu')
+
+    if (!submenu || getComputedStyle(submenu).display === 'none') {
+      return
+    }
+
+    const rect = item.getBoundingClientRect()
+
+    submenu.style.setProperty('position', 'fixed', 'important')
+    submenu.style.setProperty('inset-inline-start', 'auto', 'important')
+    submenu.style.setProperty('left', `${rect.right}px`, 'important')
+
+    // scrollHeight is the full content height regardless of any max-height
+    // already applied, so it's a stable measure of the natural flyout height.
+    if (submenu.scrollHeight <= availableHeight) {
+      // Fits: align with the item, but nudge up if it would run off the bottom.
+      let top = Math.max(minTop, rect.top)
+
+      if (top + submenu.scrollHeight > maxBottom) {
+        top = Math.max(minTop, maxBottom - submenu.scrollHeight)
+      }
+
+      submenu.style.setProperty('top', `${top}px`, 'important')
+      submenu.style.removeProperty('max-height')
+      submenu.style.removeProperty('overflow-y')
+    } else {
+      // Taller than the available band: pin to the top and scroll internally.
+      submenu.style.setProperty('top', `${minTop}px`, 'important')
+      submenu.style.setProperty('max-height', `${availableHeight}px`, 'important')
+      submenu.style.setProperty('overflow-y', 'auto', 'important')
+    }
+  })
+}
+
+const scheduleFlyoutPosition = () => {
+  cancelAnimationFrame(flyoutRaf)
+  flyoutRaf = requestAnimationFrame(positionFlyouts)
+}
+
 onMounted(() => {
   applyPush()
+
+  const nav = navRef.value
+
+  if (nav) {
+    // Watch class changes (PrimeVue toggles .p-tieredmenu-item-active when a
+    // submenu opens, and .onms-side-menu--open when the rail expands) rather
+    // than style, to avoid re-triggering on our own style writes.
+    flyoutObserver = new MutationObserver(scheduleFlyoutPosition)
+    flyoutObserver.observe(nav, { attributes: true, attributeFilter: ['class'], subtree: true })
+    // scroll does not bubble; capture catches the inner list scrolling.
+    nav.addEventListener('scroll', scheduleFlyoutPosition, true)
+    window.addEventListener('resize', scheduleFlyoutPosition)
+  }
 })
 
 onBeforeUnmount(() => {
@@ -153,6 +246,17 @@ onBeforeUnmount(() => {
   if (el) {
     el.style.paddingLeft = ''
   }
+
+  flyoutObserver?.disconnect()
+  cancelAnimationFrame(flyoutRaf)
+
+  const nav = navRef.value
+
+  if (nav) {
+    nav.removeEventListener('scroll', scheduleFlyoutPosition, true)
+  }
+
+  window.removeEventListener('resize', scheduleFlyoutPosition)
 })
 </script>
 
@@ -174,8 +278,8 @@ onBeforeUnmount(() => {
   background-color: var(--feather-surface-dark);
   color: var(--feather-state-text-color-on-surface-dark);
   transition: width 0.1s linear;
-  // Flyout submenus are absolutely positioned descendants; keep overflow
-  // visible so they are not clipped by the (narrow) rail.
+  // The nav itself does not scroll (the inner .p-tieredmenu list does); keep it
+  // visible so the toggle button and rail chrome are never clipped.
   overflow: visible;
 
   // Force the TieredMenu (and its flyout submenus, which are descendants of
@@ -224,10 +328,19 @@ onBeforeUnmount(() => {
 // The TieredMenu component root does not receive this component's scope id, so
 // it must be reached with :deep(). Override PrimeVue's default 12.5rem min-width
 // so the menu fits the rail, and drop the panel chrome (border/padding/bg).
+// This is the scroll region (the toggle button above stays pinned): when the
+// item list is taller than the rail it scrolls vertically. min-height:0 lets
+// the flex item shrink below its content height so scrolling actually engages.
+// overflow-x is hidden (never a horizontal scrollbar); the side-opening flyout
+// submenus would be clipped by this overflow, so they are promoted to
+// position:fixed in script (positionFlyouts) to escape the clip.
 .onms-side-menu :deep(.p-tieredmenu) {
   flex: 1 1 auto;
   width: 100%;
   min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
   border: none;
   background: transparent;
   padding: 0;

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -27,9 +27,9 @@
       <template #item="{ item, props, hasSubmenu }">
         <a
           class="onms-side-menu__link"
+          v-bind="props.action"
           :href="item.url || undefined"
           :target="item.target || undefined"
-          v-bind="props.action"
         >
           <span class="onms-side-menu__icon">
             <component :is="item.iconComponent" v-if="item.iconComponent" aria-hidden="true" />

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -62,8 +62,9 @@ const props = defineProps({
 })
 
 // Rail widths — keep in sync with the CSS custom properties below.
-const RAIL_COLLAPSED = '3.75rem'
 const RAIL_EXPANDED = '20rem'
+// Small breathing room so pushed content isn't flush against the rail edge.
+const RAIL_GAP = '0.25rem'
 
 const menuStore = useMenuStore()
 const pluginStore = usePluginStore()
@@ -114,9 +115,13 @@ const togglePinned = () => {
   menuStore.setSideMenuExpanded(isPinned.value)
 }
 
-// Push the main content aside by the rail width. We only push for the pinned
-// (persisted) state; hover-expansion overlays the content instead of pushing
-// it, to avoid reflowing the whole page on every hover.
+// Push the main content aside for the pinned (persisted) expanded rail only;
+// hover-expansion overlays the content instead of pushing it, to avoid
+// reflowing the whole page on every hover. The COLLAPSED/base left offset is
+// owned by each host's stylesheet (JSP #content, SPA .app-layout) so the two
+// contexts can differ; when not pinned we clear the inline padding-left so that
+// base applies. This keeps the collapsed gap "guaranteed" (JS never clobbers
+// it) while still widening the push when the rail is pinned open.
 const getPushedElement = (): HTMLElement | null => {
   try {
     return document.querySelector<HTMLElement>(props.pushedSelector)
@@ -133,7 +138,7 @@ const applyPush = () => {
   }
 
   el.style.transition = 'padding-left 0.1s linear'
-  el.style.paddingLeft = isPinned.value ? RAIL_EXPANDED : RAIL_COLLAPSED
+  el.style.paddingLeft = isPinned.value ? `calc(${RAIL_EXPANDED} + ${RAIL_GAP})` : ''
 }
 
 watch(isPinned, applyPush)

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -80,7 +80,6 @@ const isPinned = ref<boolean>(menuStore.sideMenuExpanded() ?? false)
 const isHovering = ref<boolean>(false)
 const isOpen = computed<boolean>(() => isPinned.value || isHovering.value)
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tieredMenuRef = ref<any>(null)
 
 const onRailEnter = () => {

--- a/ui/src/components/Menu/UserNotificationsMenuItem.vue
+++ b/ui/src/components/Menu/UserNotificationsMenuItem.vue
@@ -65,7 +65,7 @@
         @click="onNotificationItemClick(item)"
       >
         <div class="notification-dropdown-item-content dropdown-menu-wrapper">
-          <div @click="onNotificationItemClick(item)" class="notification-dropdown-item-content-button">
+          <div class="notification-dropdown-item-content-button">
             <i :class="`notification-badge-pill badge-severity-${item?.severity?.toLocaleLowerCase() ?? 'indeterminate'}`" />
             <div class="full-width-left">
               <div>

--- a/ui/src/components/Menu/UserNotificationsMenuItem.vue
+++ b/ui/src/components/Menu/UserNotificationsMenuItem.vue
@@ -1,35 +1,36 @@
 <template>
-  <FeatherDropdown
-    class="user-notification-menubar-dropdown"
-    :modelValue="expanded"
-    @update:modelValue="(val: any) => updateDisplay(val)"
-  >
-    <template v-slot:trigger="{ attrs, on }">
-      <div @mouseenter="showMenu" class="user-notification-badge-wrapper">
-        <span
-          :class="['notification-badge-pill', userNotificationBadgeClass]">
-          {{ notificationSummary.userUnacknowledgedCount }}
-        </span>
-        <span
-          :class="['notification-badge-pill', teamNotificationBadgeClass]">
-          {{ notificationSummary.teamUnacknowledgedCount }}
-        </span>
+  <div ref="triggerEl" class="user-notification-badge-wrapper" @mouseenter="showMenu">
+    <span
+      :class="['notification-badge-pill', userNotificationBadgeClass]">
+      {{ notificationSummary.userUnacknowledgedCount }}
+    </span>
+    <span
+      :class="['notification-badge-pill', teamNotificationBadgeClass]">
+      {{ notificationSummary.teamUnacknowledgedCount }}
+    </span>
 
-        <FeatherButton link href="#" v-bind="attrs" v-on="on" class="menubar-dropdown-button-dark">
-          <FeatherIcon
-            :icon="noticeStatusDisplay?.iconComponent"
-            :class="[noticeStatusDisplay?.colorClass, 'notice-status-display']"
-          />
-
-          <FeatherIcon class="user-notification-arrow-dropdown" :icon="IconArrowDropDown" />
-        </FeatherButton>
-      </div>
-    </template>
-
-    <FeatherDropdownItem
-      @click="onMenuItemClick(notificationConfigUrl)"
+    <Button
+      text
+      class="menubar-dropdown-button-dark"
+      aria-haspopup="true"
+      aria-label="User notifications menu"
+      @click="onTriggerClick"
     >
-      <div class="menubar-dropdown-item-content">
+      <FeatherIcon
+        :icon="noticeStatusDisplay?.iconComponent"
+        :class="[noticeStatusDisplay?.colorClass, 'notice-status-display']"
+      />
+
+      <FeatherIcon class="user-notification-arrow-dropdown" :icon="IconArrowDropDown" />
+    </Button>
+
+    <Popover
+      ref="pop"
+      appendTo="self"
+      class="onms-user-dropdown-panel user-notification-dropdown-panel"
+      @hide="onPopoverHide"
+    >
+      <div class="menubar-dropdown-item-content" @click="onMenuItemClick(notificationConfigUrl)">
         <a :href="computeLink(notificationConfigUrl)" class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper">
           <FeatherIcon
             :icon="noticeStatusDisplay?.iconComponent"
@@ -41,14 +42,13 @@
           </span>
         </a>
       </div>
-    </FeatherDropdownItem>
 
-    <FeatherDropdownItem
-      v-for="item in mainMenu.userNotificationMenu?.items?.filter(i => i.id === 'userNotificationUser')"
-      :key="item.name || ''"
-      @click="onMenuItemClick(item.url || '')"
-    >
-      <div class="menubar-dropdown-item-content">
+      <div
+        v-for="item in mainMenu.userNotificationMenu?.items?.filter(i => i.id === 'userNotificationUser')"
+        :key="item.name || ''"
+        class="menubar-dropdown-item-content"
+        @click="onMenuItemClick(item.url || '')"
+      >
         <a :href="computeLink(item.url || '')" class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper">
           <FeatherIcon :icon="IconPerson" class="user-notifications-icon" />
           <span class="left-margin-small">
@@ -56,58 +56,52 @@
           </span>
         </a>
       </div>
-    </FeatherDropdownItem>
 
-    <!-- user notifications -->
-    <FeatherDropdownItem
-      v-for="item in notificationSummary.userUnacknowledgedNotifications.notification.slice(0, maxNotifications)"
-      :key="item.id || ''"
-      class="notification-dropdown-item"
-      @click="onNotificationItemClick(item)"
-    >
-      <template #default>
-        <div class="menubar-dropdown-item-content">
-          <div class="notification-dropdown-item-content dropdown-menu-wrapper">
-            <div @click="onNotificationItemClick(item)" class="notification-dropdown-item-content-button">
-              <i :class="`notification-badge-pill badge-severity-${item?.severity?.toLocaleLowerCase() ?? 'indeterminate'}`" />
-              <div class="full-width-left">
-                <div>
-                  <span class="font-weight-bold">
-                    {{ new Date(item.pageTime).toLocaleDateString() }} {{ new
-                    Date(item.pageTime).toLocaleTimeString()
-                    }}
-                  </span>
-                </div>
-                <div class="dropdown-info-bar">
-                  <span>{{ item.notificationName }}</span>
-                  <span>{{ item.nodeLabel }}</span>
-                  <span>{{ item.ipAddress }}</span>
-                  <span>{{ item.serviceType?.name }}</span>
-                </div>
+      <!-- user notifications -->
+      <div
+        v-for="item in notificationSummary.userUnacknowledgedNotifications.notification.slice(0, maxNotifications)"
+        :key="item.id || ''"
+        class="menubar-dropdown-item-content notification-dropdown-item"
+        @click="onNotificationItemClick(item)"
+      >
+        <div class="notification-dropdown-item-content dropdown-menu-wrapper">
+          <div @click="onNotificationItemClick(item)" class="notification-dropdown-item-content-button">
+            <i :class="`notification-badge-pill badge-severity-${item?.severity?.toLocaleLowerCase() ?? 'indeterminate'}`" />
+            <div class="full-width-left">
+              <div>
+                <span class="font-weight-bold">
+                  {{ new Date(item.pageTime).toLocaleDateString() }} {{ new
+                  Date(item.pageTime).toLocaleTimeString()
+                  }}
+                </span>
+              </div>
+              <div class="dropdown-info-bar">
+                <span>{{ item.notificationName }}</span>
+                <span>{{ item.nodeLabel }}</span>
+                <span>{{ item.ipAddress }}</span>
+                <span>{{ item.serviceType?.name }}</span>
               </div>
             </div>
           </div>
         </div>
-      </template>
-    </FeatherDropdownItem>
+      </div>
 
-    <FeatherDropdownItem
-      v-if="notificationSummary.userUnacknowledgedCount > maxNotifications"
-    >
-      <div class="menubar-dropdown-item-content">
+      <div
+        v-if="notificationSummary.userUnacknowledgedCount > maxNotifications"
+        class="menubar-dropdown-item-content"
+      >
         <div class="dropdown-menu-wrapper show-more-link notification-dropdown-item-content">
           <a :href="notificationsShowMoreLink" @click="onMenuItemClick(notificationsShowMoreLink)">Show more...</a>
         </div>
       </div>
-    </FeatherDropdownItem>
 
-    <!-- Team and On-Call links -->
-    <FeatherDropdownItem
-      v-for="item in mainMenu.userNotificationMenu?.items?.filter(i => i.id !== 'userNotificationUser' && i.id !== 'userNotificationConfiguration')"
-      :key="item.name || ''"
-      @click="onMenuItemClick(item.url || '')"
-    >
-      <div class="menubar-dropdown-item-content">
+      <!-- Team and On-Call links -->
+      <div
+        v-for="item in mainMenu.userNotificationMenu?.items?.filter(i => i.id !== 'userNotificationUser' && i.id !== 'userNotificationConfiguration')"
+        :key="item.name || ''"
+        class="menubar-dropdown-item-content"
+        @click="onMenuItemClick(item.url || '')"
+      >
         <a :href="computeLink(item.url || '')"
           class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper">
           <template v-if="item.id === 'userNotificationTeam'">
@@ -129,14 +123,13 @@
           </span>
         </a>
       </div>
-    </FeatherDropdownItem>
-  </FeatherDropdown>
+    </Popover>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { computed, markRaw } from 'vue'
+import { computed, markRaw, ref, watch } from 'vue'
 
-import { FeatherDropdown, FeatherDropdownItem } from '@featherds/dropdown'
 import { FeatherIcon } from '@featherds/icon'
 import IconArrowDropDown from '@featherds/icon/navigation/ArrowDropDown'
 import IconCalendar from '@featherds/icon/action/Calendar'
@@ -144,6 +137,8 @@ import IconGroup from '@featherds/icon/action/Group'
 import IconNotificationsOff from '@featherds/icon/notification/NotificationsOff'
 import IconNotificationSelected from '@featherds/icon/notification/NotificationSelected'
 import IconPerson from '@featherds/icon/action/Person'
+import Button from 'primevue/button'
+import Popover from 'primevue/popover'
 import { useMenuStore } from '@/stores/menuStore'
 import {
   MainMenu,
@@ -156,7 +151,7 @@ const menuStore = useMenuStore()
 const maxNotifications = 2
 const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 
-defineProps({
+const props = defineProps({
   expanded: {
     required: true,
     type: Boolean
@@ -165,17 +160,38 @@ defineProps({
 
 const emit = defineEmits(['menu-show', 'menu-hide'])
 
-const updateDisplay = (val: any) => {
-  if (val === true) {
-    emit('menu-show')
-  } else {
-    emit('menu-hide')
-  }
-}
+const pop = ref()
+const triggerEl = ref<HTMLElement>()
 
 const showMenu = () => {
   emit('menu-show')
 }
+
+const onTriggerClick = () => {
+  if (props.expanded) {
+    emit('menu-hide')
+  } else {
+    emit('menu-show')
+  }
+}
+
+const onPopoverHide = () => {
+  emit('menu-hide')
+}
+
+// The parent (Menubar) owns the open/close state via the `expanded` prop
+// (hover to open, close on header mouseleave / other dropdown / outside click).
+// Drive the Popover imperatively from that single source of truth. A synthetic
+// event carrying `currentTarget` is required because Popover.show reads it.
+watch(() => props.expanded, (val) => {
+  if (val) {
+    if (triggerEl.value) {
+      pop.value?.show({ currentTarget: triggerEl.value }, triggerEl.value)
+    }
+  } else {
+    pop.value?.hide()
+  }
+})
 
 const notificationSummary = computed<NotificationSummary>(() => menuStore.notificationSummary)
 
@@ -259,59 +275,45 @@ const onNotificationItemClick = (item: OnmsNotification) => {
 </script>
 
 <style lang="scss" scoped>
-@import "@featherds/dropdown/scss/mixins";
-@import "@featherds/styles/mixins/elevation";
 @import "@featherds/styles/mixins/typography";
 @import "@featherds/styles/themes/variables";
 
+// Foreground uses PrimeVue tokens (not FeatherDS vars) so text tracks the same
+// dark-mode selector that drives the Popover background. On embedded JSP pages
+// the FeatherDS theme vars may not be toggled, which would leave dark-on-dark.
 .dropdown-menu-link {
-  color: var($primary-text-on-surface) !important;
+  color: var(--p-text-color) !important;
 
   &:hover {
     text-decoration: none;
   }
 }
 
-.user-notification-menubar-dropdown {
+.user-notification-badge-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
   margin-left: 2px;
-
-  :deep(.feather-dropdown) {
-    @include dropdown-menu-height(10);
-  }
 }
 
-.menubar-dropdown-dark {
-  margin-left: 2px;
-  &.help-menu {
-    margin-left:1px;
-  }
-  :deep(.feather-dropdown) {
-    @include dropdown-menu-height(10);
-  }
-}
-
+// Dark trigger button (replaces FeatherButton link). Matches the OG menu look.
 .menubar-dropdown-button-dark {
-  // make it look more like OG menu
   color: rgba(255, 255, 255, 0.78); // --feather-surface-light or --feather-state-text-color-on-surface-dark
-  background-color: #131736; // --feather-surface-dark
+  background-color: transparent;
+  border: none;
   text-transform: none;
   letter-spacing: normal;
-  font-weight: 600; // 400
+  font-weight: 600;
   font-size: 0.875rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
+  padding: 0 7px;
 
-.btn.menubar-dropdown-button-dark {
-  :deep(.btn-content) {
-    // make it look more like OG menu
-    color: rgba(255, 255, 255, 0.78); // --feather-surface-light or --feather-state-text-color-on-surface-dark
-    text-transform: none;
-    letter-spacing: normal;
-    font-weight: 600;
-    font-size: 0.875rem;
-    padding-left: 0.1rem;
-    padding-right: 0.1rem;
+  &:hover,
+  &:focus,
+  &:focus-visible {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: #ffffff;
+    box-shadow: none;
+    outline: none;
   }
 }
 
@@ -334,6 +336,13 @@ div.user-notification-badge-wrapper {
   padding-left: 0.5rem;
   font-size: 0.875rem;
   font-weight: 400;
+  cursor: pointer;
+
+  // Shaded background on hover / keyboard focus of the item row.
+  &:hover,
+  &:focus-within {
+    background-color: var(--p-highlight-background);
+  }
 
   .user-notifications-icon {
     font-size: 1.25rem;
@@ -381,14 +390,11 @@ div.user-notification-badge-wrapper {
   padding-right: 6px;
   margin-left: 4px;
   margin-right: 2px;
-  line-height: 3rem;
+  line-height: 1.5rem;
+  font-weight: 800;
   background-color: #ffffff;
   color: #131736; // --feather-surface-dark
   border-radius: .8rem;
-}
-
-.notification-dropdown-item {
-  //  min-height: 200px;
 }
 
 .notification-dropdown-item-content {
@@ -406,6 +412,46 @@ div.user-notification-badge-wrapper {
     width: 15px;
     height: 15px;
     margin-right: 15px;
+  }
+}
+
+.dropdown-info-bar {
+  display: flex;
+  align-items: center;
+  text-align: left;
+  margin-bottom: 10px;
+
+  span {
+    margin-right: 10px;
+  }
+}
+
+.full-width-left {
+  width: 100%;
+  text-align: left;
+}
+
+.dropdown-menu-wrapper {
+  padding: 0 1em;
+  min-width: 400px;
+  padding-top: 10px;
+
+  &.show-more-link {
+    padding-bottom: 10px;
+
+    a {
+      color: var(--p-text-color)
+    }
+  }
+}
+
+.final-menu-wrapper {
+  display: block;
+  padding-left: 20px;
+  padding-bottom: 10px;
+
+  svg {
+    margin-right: 10px;
   }
 }
 
@@ -443,70 +489,28 @@ div.user-notification-badge-wrapper {
 </style>
 
 <style lang="scss">
-@import "@featherds/styles/themes/open-mixins";
-@import "@featherds/styles/themes/variables";
+// The Popover is rendered inline (appendTo="self") so it stays inside the fixed
+// header's DOM subtree, preserving the header's close-on-mouseleave behavior
+// (moving the pointer into the panel does not "leave" the header). PrimeVue
+// positions the panel with inline absolute coords computed from viewport +
+// scroll offset, which is wrong inside a fixed header — pin it under the
+// trigger instead and drop the arrow (FeatherDropdown had none).
+.user-notification-dropdown-panel.p-popover {
+  top: 100% !important;
+  inset-inline-start: auto !important;
+  right: 0 !important;
+  margin-top: 0 !important;
 
-body .feather-menu .feather-menu-dropdown {
-  border-radius: 4px;
-
-  .feather-dropdown {
-    border: 1px solid rgba(0, 0, 0, .35);
-  }
-}
-
-.feather-dropdown {
-  .feather-list-item {
-    height: auto;
-    padding: 0;
-  }
-
-  .dropdown-menu-wrapper {
-    padding: 0 1em;
-    min-width: 400px;
-    padding-top: 10px;
-
-    &.show-more-link {
-      padding-bottom: 10px;
-
-      a {
-        color: var(--feather-primary-text-on-surface)
-      }
-    }
+  &::before,
+  &::after {
+    display: none !important;
   }
 
-  .final-menu-wrapper {
-    display: block;
-    padding-left: 20px;
-    padding-bottom: 10px;
-
-    svg {
-      margin-right: 10px;
-    }
-  }
-}
-
-.dropdown-info-bar {
-  display: flex;
-  align-items: center;
-  text-align: left;
-  margin-bottom: 10px;
-
-  span {
-    margin-right: 10px;
-  }
-}
-
-.full-width-left {
-  width: 100%;
-  text-align: left;
-}
-
-.feather-menu {
-  &.menubar-dropdown {
-    margin-left:0;
-  }
-  .menubar-dropdown-button-dark {
-    padding: 0 7px;
+  .p-popover-content {
+    padding: 0.25rem 0;
+    // Baseline PrimeVue-aware text color so all panel content stays legible
+    // in dark mode even where FeatherDS theme vars aren't active (JSP pages).
+    color: var(--p-text-color);
   }
 }
 </style>

--- a/ui/src/components/Menu/UserSelfServiceMenuItem.vue
+++ b/ui/src/components/Menu/UserSelfServiceMenuItem.vue
@@ -32,7 +32,7 @@
         class="self-service-menubar-dropdown-item-content"
         @click="onMenuItemClick(item)"
       >
-        <a :href="computeLink(item?.url || '')" class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper" :name="`self-service-${item.id}`">
+        <a :href="item.action === 'logout' ? '#' : computeLink(item?.url || '')" class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper" :name="`self-service-${item.id}`">
           <FeatherIcon :icon="createIcon(item)" class="self-service-icon" />
           <span class="left-margin-small">
             {{ item?.name || '' }}

--- a/ui/src/components/Menu/UserSelfServiceMenuItem.vue
+++ b/ui/src/components/Menu/UserSelfServiceMenuItem.vue
@@ -1,22 +1,23 @@
 <template>
-  <FeatherDropdown
-    class="self-service-menubar-dropdown"
-    :modelValue="expanded"
-    @update:modelValue="(val: any) => updateDisplay(val)"
-  >
-    <template v-slot:trigger="{ attrs, on }">
-      <div @mouseenter="showMenu" class="self-service-menubar-icon-wrapper">
-        <FeatherButton link href="#" v-bind="attrs" v-on="on" class="self-service-menubar-dropdown-button-dark">
-          <FeatherIcon :icon="IconAccountCircle" class="self-service-top-icon" />
-          <FeatherIcon class="self-service-arrow-dropdown" :icon="ArrowDropDown" />
-        </FeatherButton>
-      </div>
-    </template>
-
-    <FeatherDropdownItem
-      @click="onUserProfileMenuClick"
+  <div ref="triggerEl" class="self-service-menubar-icon-wrapper" @mouseenter="showMenu">
+    <Button
+      text
+      class="self-service-menubar-dropdown-button-dark"
+      aria-haspopup="true"
+      aria-label="User self-service menu"
+      @click="onTriggerClick"
     >
-      <div class="self-service-menubar-dropdown-item-content">
+      <FeatherIcon :icon="IconAccountCircle" class="self-service-top-icon" />
+      <FeatherIcon class="self-service-arrow-dropdown" :icon="ArrowDropDown" />
+    </Button>
+
+    <Popover
+      ref="pop"
+      appendTo="self"
+      class="onms-user-dropdown-panel self-service-dropdown-panel"
+      @hide="onPopoverHide"
+    >
+      <div class="self-service-menubar-dropdown-item-content" @click="onUserProfileMenuClick">
         <a :href="computeLink('')" class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper" name="self-service-user">
           <FeatherIcon :icon="IconAccountCircle" class="self-service-icon" />
           <span class="left-margin-small">
@@ -24,14 +25,13 @@
           </span>
         </a>
       </div>
-    </FeatherDropdownItem>
 
-    <FeatherDropdownItem
-       v-for="item in menuItems"
-       :key="item?.id || ''"
-       @click="onMenuItemClick(item)"
-    >
-      <div class="self-service-menubar-dropdown-item-content">
+      <div
+        v-for="item in menuItems"
+        :key="item?.id || ''"
+        class="self-service-menubar-dropdown-item-content"
+        @click="onMenuItemClick(item)"
+      >
         <a :href="computeLink(item?.url || '')" class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper" :name="`self-service-${item.id}`">
           <FeatherIcon :icon="createIcon(item)" class="self-service-icon" />
           <span class="left-margin-small">
@@ -39,19 +39,20 @@
           </span>
         </a>
       </div>
-    </FeatherDropdownItem>
-  </FeatherDropdown>
+    </Popover>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { DefineComponent, computed } from 'vue'
-import { FeatherDropdown, FeatherDropdownItem } from '@featherds/dropdown'
+import { DefineComponent, computed, ref, watch } from 'vue'
 import { FeatherIcon } from '@featherds/icon'
 import ArrowDropDown from '@featherds/icon/navigation/ArrowDropDown'
 import IconAccountCircle from '@featherds/icon/action/AccountCircle'
 import IconHelp from '@featherds/icon/action/Help'
 import IconLogout from '@featherds/icon/action/LogOut'
 import IconSecurity from '@featherds/icon/network/Security'
+import Button from 'primevue/button'
+import Popover from 'primevue/popover'
 import { ellipsify } from '@/lib/utils'
 import { performLogout } from '@/services/logoutService'
 import { useMenuStore } from '@/stores/menuStore'
@@ -63,7 +64,7 @@ import {
 const menuStore = useMenuStore()
 const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 
-defineProps({
+const props = defineProps({
   expanded: {
     required: true,
     type: Boolean
@@ -72,17 +73,38 @@ defineProps({
 
 const emit = defineEmits(['menu-show', 'menu-hide'])
 
-const updateDisplay = (val: any) => {
-  if (val === true) {
-    emit('menu-show')
-  } else {
-    emit('menu-hide')
-  }
-}
+const pop = ref()
+const triggerEl = ref<HTMLElement>()
 
 const showMenu = () => {
   emit('menu-show')
 }
+
+const onTriggerClick = () => {
+  if (props.expanded) {
+    emit('menu-hide')
+  } else {
+    emit('menu-show')
+  }
+}
+
+const onPopoverHide = () => {
+  emit('menu-hide')
+}
+
+// The parent (Menubar) owns the open/close state via the `expanded` prop
+// (hover to open, close on header mouseleave / other dropdown / outside click).
+// Drive the Popover imperatively from that single source of truth. A synthetic
+// event carrying `currentTarget` is required because Popover.show reads it.
+watch(() => props.expanded, (val) => {
+  if (val) {
+    if (triggerEl.value) {
+      pop.value?.show({ currentTarget: triggerEl.value }, triggerEl.value)
+    }
+  } else {
+    pop.value?.hide()
+  }
+})
 
 const menuItems = computed<MenuItem[]>(() => {
   const helpMenu = mainMenu.value.helpMenu?.items?.find(m => m.id === 'helpMain')
@@ -129,59 +151,45 @@ const onMenuItemClick = async (item: MenuItem) => {
 </script>
 
 <style lang="scss" scoped>
-@import "@featherds/dropdown/scss/mixins";
-@import "@featherds/styles/mixins/elevation";
 @import "@featherds/styles/mixins/typography";
 @import "@featherds/styles/themes/variables";
 
+.self-service-menubar-icon-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: 2px;
+}
+
+// Foreground uses PrimeVue tokens (not FeatherDS vars) so text tracks the same
+// dark-mode selector that drives the Popover background. On embedded JSP pages
+// the FeatherDS theme vars may not be toggled, which would leave dark-on-dark.
 .dropdown-menu-link {
-  color: var($primary-text-on-surface) !important;
+  color: var(--p-text-color) !important;
 
   &:hover {
     text-decoration: none;
   }
 }
 
-.self-service-menubar-dropdown {
-  margin-left: 2px;
-
-  :deep(.feather-dropdown) {
-    @include dropdown-menu-height(10);
-  }
-}
-
-.self-service-menubar-dropdown-dark {
-  margin-left: 2px;
-  &.help-menu {
-    margin-left:1px;
-  }
-  :deep(.feather-dropdown) {
-    @include dropdown-menu-height(10);
-  }
-}
-
+// Dark trigger button (replaces FeatherButton link). Matches the OG menu look.
 .self-service-menubar-dropdown-button-dark {
-  // make it look more like OG menu
   color: rgba(255, 255, 255, 0.78); // --feather-surface-light or --feather-state-text-color-on-surface-dark
-  background-color: #131736; // --feather-surface-dark
+  background-color: transparent;
+  border: none;
   text-transform: none;
   letter-spacing: normal;
-  font-weight: 600; // 400
+  font-weight: 600;
   font-size: 0.875rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
+  padding: 0 7px;
 
-.btn.self-service-menubar-dropdown-button-dark {
-  :deep(.btn-content) {
-    // make it look more like OG menu
-    color: rgba(255, 255, 255, 0.78); // --feather-surface-light or --feather-state-text-color-on-surface-dark
-    text-transform: none;
-    letter-spacing: normal;
-    font-weight: 600;
-    font-size: 0.875rem;
-    padding-left: 0.1rem;
-    padding-right: 0.1rem;
+  &:hover,
+  &:focus,
+  &:focus-visible {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: #ffffff;
+    box-shadow: none;
+    outline: none;
   }
 }
 
@@ -204,6 +212,13 @@ div.self-service-menubar-icon-wrapper {
   padding-left: 0.5rem;
   font-size: 0.875rem;
   font-weight: 400;
+  cursor: pointer;
+
+  // Shaded background on hover / keyboard focus of the item row.
+  &:hover,
+  &:focus-within {
+    background-color: var(--p-highlight-background);
+  }
 }
 
 .feather-icon.self-service-top-icon {
@@ -218,57 +233,55 @@ div.self-service-menubar-icon-wrapper {
 .self-service-menubar-dropdown-item-content.menubar-padding {
   padding: 10px;
 }
+
+.dropdown-menu-wrapper {
+  padding: 0 1em;
+  min-width: 400px;
+  padding-top: 10px;
+
+  &.show-more-link {
+    padding-bottom: 10px;
+
+    a {
+      color: var(--p-text-color)
+    }
+  }
+}
+
+.final-menu-wrapper {
+  display: block;
+  padding-left: 20px;
+  padding-bottom: 10px;
+
+  svg {
+    margin-right: 10px;
+  }
+}
 </style>
 
 <style lang="scss">
-@import "@featherds/styles/themes/open-mixins";
-@import "@featherds/styles/themes/variables";
+// The Popover is rendered inline (appendTo="self") so it stays inside the fixed
+// header's DOM subtree, preserving the header's close-on-mouseleave behavior
+// (moving the pointer into the panel does not "leave" the header). PrimeVue
+// positions the panel with inline absolute coords computed from viewport +
+// scroll offset, which is wrong inside a fixed header — pin it under the
+// trigger instead and drop the arrow (FeatherDropdown had none).
+.self-service-dropdown-panel.p-popover {
+  top: 100% !important;
+  inset-inline-start: auto !important;
+  right: 0 !important;
+  margin-top: 0 !important;
 
-body .feather-menu .feather-menu-dropdown {
-  border-radius: 4px;
-
-  .feather-dropdown {
-    border: 1px solid rgba(0, 0, 0, .35);
-  }
-}
-
-.feather-dropdown {
-  .feather-list-item {
-    height: auto;
-    padding: 0;
-  }
-
-  .dropdown-menu-wrapper {
-    padding: 0 1em;
-    min-width: 400px;
-    padding-top: 10px;
-
-    &.show-more-link {
-      padding-bottom: 10px;
-
-      a {
-        color: var(--feather-primary-text-on-surface)
-      }
-    }
+  &::before,
+  &::after {
+    display: none !important;
   }
 
-  .final-menu-wrapper {
-    display: block;
-    padding-left: 20px;
-    padding-bottom: 10px;
-
-    svg {
-      margin-right: 10px;
-    }
-  }
-}
-
-.feather-menu {
-  &.self-service-menubar-dropdown {
-    margin-left:0;
-  }
-  .self-service-menubar-dropdown-button-dark {
-    padding: 0 7px;
+  .p-popover-content {
+    padding: 0.25rem 0;
+    // Baseline PrimeVue-aware text color so all panel content stays legible
+    // in dark mode even where FeatherDS theme vars aren't active (JSP pages).
+    color: var(--p-text-color);
   }
 }
 </style>

--- a/ui/src/components/Menu/utils.ts
+++ b/ui/src/components/Menu/utils.ts
@@ -24,6 +24,7 @@ import { DefineComponent, markRaw } from 'vue'
 import { FeatherMenuList, MenuListEntry } from '@featherds/menu'
 import { FeatherIcon } from '@featherds/icon'
 import IconHome from '@featherds/icon/action/Home'
+import type { MenuItem as PrimeMenuItem } from 'primevue/menuitem'
 import { Plugin } from '@/types'
 import { MenuItem } from '@/types/mainMenu'
 
@@ -198,6 +199,108 @@ const createTopMenuListEntry = (
   return entry
 }
 
+// ---------------------------------------------------------------------------
+// PrimeVue menu model
+//
+// The side menu now renders with a PrimeVue TieredMenu instead of Feather's
+// FeatherMenuList/Sidenav. TieredMenu consumes PrimeVue `MenuItem[]`, so the
+// functions below transform our raw `MenuItem` data into that shape. We keep
+// the Feather transform (createTopMenuListEntry above) untouched for now.
+//
+// PrimeVue's `MenuItem.icon` is a CSS class string, but we keep the Feather
+// icon *components*, so the icon component is stashed on a custom
+// `iconComponent` field (MenuItem allows arbitrary keys) and rendered via the
+// TieredMenu `#item` slot.
+// ---------------------------------------------------------------------------
+
+const createPrimeChildItem = (
+  menuItem: MenuItem,
+  baseHref: string | null | undefined,
+  getIcon: (iconId?: string | null) => DefineComponent | null,
+  onLogout: () => void
+): PrimeMenuItem => {
+  const item: PrimeMenuItem = {
+    key: menuItem.id ?? menuItem.name ?? undefined,
+    label: menuItem.name ?? undefined
+  }
+
+  if (menuItem.icon) {
+    item.iconComponent = createMenuIcon(menuItem, getIcon)
+  }
+
+  if (menuItem.action === 'logout') {
+    item.command = () => onLogout()
+    return item
+  }
+
+  if (menuItem.onClick) {
+    const onClick = menuItem.onClick
+    item.command = () => onClick()
+  }
+
+  const href = getMenuLink(menuItem, baseHref)
+
+  if (href && href !== '#') {
+    item.url = href
+    item.target = menuItem.linkTarget === '_blank' ? '_blank' : '_self'
+  }
+
+  return item
+}
+
+const createPrimeTopItem = (
+  topMenuItem: MenuItem,
+  baseHref: string | null | undefined,
+  getIcon: (iconId?: string | null) => DefineComponent | null,
+  onLogout: () => void
+): PrimeMenuItem | null => {
+  if (topMenuItem.type === 'separator') {
+    return { separator: true }
+  }
+
+  // Drop 'header' entries: Feather emitted a hard-coded "Menu" header that the
+  // template suppressed with a dummy first header item; PrimeVue has no such
+  // header, so these entries are simply not rendered.
+  if (topMenuItem.type === 'header') {
+    return null
+  }
+
+  const item: PrimeMenuItem = {
+    key: `${TOP_MENU_ID_PREFIX}${topMenuItem.id ?? topMenuItem.name ?? ''}`,
+    label: topMenuItem.name ?? undefined,
+    iconComponent: createMenuIcon(topMenuItem, getIcon)
+  }
+
+  const children = topMenuItem.items ?? []
+
+  if (children.length > 0) {
+    item.items = children.map(child => createPrimeChildItem(child, baseHref, getIcon, onLogout))
+  }
+
+  // Top-level entries that are direct links (no submenu), e.g. the maps.
+  if (topMenuItem.action === 'link' && topMenuItem.url && topMenuItem.url.length > 0) {
+    item.url = getMenuLink(topMenuItem, baseHref)
+  }
+
+  return item
+}
+
+/**
+ * Transforms the raw main-menu items into the PrimeVue `MenuItem[]` model
+ * consumed by the side menu's TieredMenu. Separators are preserved; the dummy
+ * top-level header is dropped.
+ */
+const createPrimeMenuModel = (
+  menus: MenuItem[],
+  baseHref: string | null | undefined,
+  getIcon: (iconId?: string | null) => DefineComponent | null,
+  onLogout: () => void
+): PrimeMenuItem[] => {
+  return menus
+    .map(menu => createPrimeTopItem(menu, baseHref, getIcon, onLogout))
+    .filter((item): item is PrimeMenuItem => item !== null)
+}
+
 /**
  * Applies plugin menu logic to the given menu items:
  * - If plugins are installed and a 'plugins' menu entry exists, each such entry is replaced with a
@@ -239,6 +342,7 @@ export {
   createFakePlugin,
   createMenuItem,
   createPluginsMenu,
+  createPrimeMenuModel,
   createTopMenuItem,
   createTopMenuListEntry,
   getMenuLink,

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -75,7 +75,7 @@ html {
 // rail. SideMenu's applyPush only overrides this (inline) while the rail is
 // pinned-expanded; otherwise this base applies.
 .app-layout {
-  padding-left: 3rem;
+  padding-left: calc(var(--onms-header-height, 3.75rem) + 0.25rem);
 }
 .main-content {
   table {

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -71,6 +71,12 @@ onMounted(() => {
 html {
   overflow-x: hidden;
 }
+// Collapsed/base left offset for the SPA content, clearing the fixed side menu
+// rail. SideMenu's applyPush only overrides this (inline) while the rail is
+// pinned-expanded; otherwise this base applies.
+.app-layout {
+  padding-left: 3rem;
+}
 .main-content {
   table {
     width: 100%;

--- a/ui/tests/components/Nodes/InterfacesTabs.test.ts
+++ b/ui/tests/components/Nodes/InterfacesTabs.test.ts
@@ -22,9 +22,9 @@
 
 import InterfacesTabs from '@/components/Nodes/InterfacesTabs.vue'
 import { createTestingPinia } from '@pinia/testing'
-import { mount } from '@vue/test-utils'
+import { mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({ params: { id: '42' }})
@@ -39,14 +39,25 @@ vi.mock('@/components/Nodes/SnmpInterfacesTable.vue', () => ({
   default: { name: 'SnmpInterfacesTable', template: '<div data-test="snmp-interfaces-table-stub" />' }
 }))
 
-const mountComponent = () =>
-  mount(InterfacesTabs, {
+let wrapper: VueWrapper<any>
+const mountComponent = () => {
+  wrapper = mount(InterfacesTabs, {
     global: {
       plugins: [createTestingPinia({ createSpy: vi.fn }), PrimeVue]
     }
   })
+  return wrapper
+}
 
 describe('InterfacesTabs.vue', () => {
+  afterEach(() => {
+    // Unmount so PrimeVue TabList's template refs are cleared before its
+    // orphaned mounted() setTimeout(updateInkBar, 150) fires. Without this the
+    // timer outlives the test file and runs against the torn-down happy-dom
+    // environment, throwing "HTMLElement is not defined" (flaky on CI).
+    wrapper?.unmount()
+  })
+
   describe('Tab labels', () => {
     it('renders two tabs with correct labels', () => {
       const wrapper = mountComponent()

--- a/ui/tests/containers/SnmpDataCollection.test.ts
+++ b/ui/tests/containers/SnmpDataCollection.test.ts
@@ -58,6 +58,11 @@ describe('SnmpDataCollection.vue (container)', () => {
   })
 
   afterEach(() => {
+    // Unmount so PrimeVue TabList's template refs are cleared before its
+    // orphaned mounted() setTimeout(updateInkBar, 150) fires. Without this the
+    // timer outlives the test file and runs against the torn-down happy-dom
+    // environment, throwing "HTMLElement is not defined" (flaky on CI).
+    wrapper.unmount()
     vi.restoreAllMocks()
   })
 

--- a/ui/tests/containers/TrapdConfiguration.test.ts
+++ b/ui/tests/containers/TrapdConfiguration.test.ts
@@ -4,10 +4,10 @@ import { validateTrapdXml } from '@/lib/trapdValidator'
 import { useMenuStore } from '@/stores/menuStore'
 import { useTrapdConfigStore } from '@/stores/trapdConfigStore'
 import { createTestingPinia } from '@pinia/testing'
-import { mount } from '@vue/test-utils'
+import { mount, VueWrapper } from '@vue/test-utils'
 import { setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { showSnackBarMock } = vi.hoisted(() => ({
   showSnackBarMock: vi.fn()
@@ -32,8 +32,9 @@ describe('TrapdConfiguration.vue', () => {
   let menuStore: ReturnType<typeof useMenuStore>
 
   const validateTrapdXmlMock = vi.mocked(validateTrapdXml)
+  let wrapper: VueWrapper<any>
   const mountComponent = () => {
-    return mount(TrapdConfiguration, {
+    wrapper = mount(TrapdConfiguration, {
       global: {
         plugins: [PrimeVue],
         stubs: {
@@ -45,6 +46,7 @@ describe('TrapdConfiguration.vue', () => {
         }
       }
     })
+    return wrapper
   }
 
   beforeEach(() => {
@@ -55,6 +57,14 @@ describe('TrapdConfiguration.vue', () => {
     menuStore.mainMenu = { homeUrl: '/home' } as any
     trapStore.fetchTrapConfig = vi.fn().mockResolvedValue(undefined)
     validateTrapdXmlMock.mockReturnValue({ valid: true, errors: [] })
+  })
+
+  afterEach(() => {
+    // Unmount so PrimeVue TabList's template refs are cleared before its
+    // orphaned mounted() setTimeout(updateInkBar, 150) fires. Without this the
+    // timer outlives the test file and runs against the torn-down happy-dom
+    // environment, throwing "HTMLElement is not defined" (flaky on CI).
+    wrapper?.unmount()
   })
 
   it('renders heading and child sections', () => {


### PR DESCRIPTION
Migrate the top and side menubars from FeatherDS -> PrimeVue.

Uses the PrimeVue `TieredMenu`, plus some custom code and styling to match Feather behavior. This should be pretty close to indistinguishable from the previous Feather menus in both Vue SPA and JSP.

The menus are still dynamically created via the `menu-template.json` and the Menu REST API.

Note that we retain `FeatherIcon` and the Feather icons in this PR, they will be removed/replaced in a subsequent step.

There are still some small issues, which will be fixed in subsequent PRs.

See the Jira ticket for some screenshots. Should look very similar to Feather menu.

Updated the smoke tests, this required some work to get working properly and with minimal timeout between menu item clicks in `MenuHeaderIT`.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19976
