### PR TITLE
NMS-20007: Thresholding builds metadata scopes per resource and per threshold

### DIFF
--- a/core/mate/api/src/main/java/org/opennms/core/mate/api/LazyScope.java
+++ b/core/mate/api/src/main/java/org/opennms/core/mate/api/LazyScope.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.mate.api;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
+
+/**
+ * A {@link Scope} that defers construction of its delegate until the first lookup and
+ * memoizes the result. Entity scopes issue database transactions when built, and
+ * interpolation only consults a scope when the input contains a metadata expression,
+ * so this makes that cost demand-driven and paid at most once.
+ */
+public class LazyScope implements Scope {
+    private final Supplier<Scope> delegate;
+
+    public LazyScope(final Supplier<Scope> delegate) {
+        this.delegate = Suppliers.memoize(Objects.requireNonNull(delegate)::get);
+    }
+
+    @Override
+    public Optional<ScopeValue> get(final ContextKey contextKey) {
+        return this.delegate.get().get(contextKey);
+    }
+
+    @Override
+    public Set<ContextKey> keys() {
+        return this.delegate.get().keys();
+    }
+}

--- a/core/mate/api/src/main/java/org/opennms/core/mate/api/LazyScope.java
+++ b/core/mate/api/src/main/java/org/opennms/core/mate/api/LazyScope.java
@@ -38,7 +38,8 @@ public class LazyScope implements Scope {
     private final Supplier<Scope> delegate;
 
     public LazyScope(final Supplier<Scope> delegate) {
-        this.delegate = Suppliers.memoize(Objects.requireNonNull(delegate)::get);
+        Objects.requireNonNull(delegate);
+        this.delegate = Suppliers.memoize(() -> Objects.requireNonNull(delegate.get(), "scope supplier returned null"));
     }
 
     @Override

--- a/core/mate/api/src/test/java/org/opennms/core/mate/api/LazyScopeTest.java
+++ b/core/mate/api/src/test/java/org/opennms/core/mate/api/LazyScopeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.mate.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+public class LazyScopeTest {
+
+    private static final ContextKey CONTEXT_KEY = new ContextKey("node", "label");
+
+    @Test
+    public void delegateIsNotBuiltWithoutLookup() {
+        final AtomicInteger builds = new AtomicInteger();
+        new LazyScope(() -> {
+            builds.incrementAndGet();
+            return EmptyScope.EMPTY;
+        });
+
+        assertThat(builds.get(), is(0));
+    }
+
+    @Test
+    public void delegateIsBuiltAtMostOnce() {
+        final AtomicInteger builds = new AtomicInteger();
+        final Scope scope = new LazyScope(() -> {
+            builds.incrementAndGet();
+            return MapScope.singleContext(Scope.ScopeName.NODE, "node", Map.of("label", "n1"));
+        });
+
+        assertThat(scope.get(CONTEXT_KEY).map(v -> v.value).orElse(null), is("n1"));
+        assertThat(scope.get(CONTEXT_KEY).map(v -> v.value).orElse(null), is("n1"));
+        assertThat(scope.keys().contains(CONTEXT_KEY), is(true));
+        assertThat(builds.get(), is(1));
+    }
+
+    @Test
+    public void interpolationWithoutExpressionsNeverBuildsDelegate() {
+        final AtomicInteger builds = new AtomicInteger();
+        final Scope scope = new LazyScope(() -> {
+            builds.incrementAndGet();
+            return EmptyScope.EMPTY;
+        });
+
+        final Interpolator.Result result = Interpolator.interpolate("no expressions here", scope);
+
+        assertThat(result.output, is("no expressions here"));
+        assertThat(builds.get(), is(0));
+    }
+
+    @Test
+    public void interpolationWithExpressionBuildsDelegate() {
+        final AtomicInteger builds = new AtomicInteger();
+        final Scope scope = new LazyScope(() -> {
+            builds.incrementAndGet();
+            return MapScope.singleContext(Scope.ScopeName.NODE, "node", Map.of("label", "n1"));
+        });
+
+        final Interpolator.Result result = Interpolator.interpolate("${node:label}", scope);
+
+        assertThat(result.output, is("n1"));
+        assertThat(builds.get(), is(1));
+    }
+}

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEntity.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEntity.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.opennms.core.mate.api.EmptyScope;
 import org.opennms.core.mate.api.EntityScopeProvider;
 import org.opennms.core.mate.api.FallbackScope;
+import org.opennms.core.mate.api.LazyScope;
 import org.opennms.core.mate.api.Scope;
 import org.opennms.netmgt.threshd.ThresholdEvaluatorState.Status;
 import org.opennms.netmgt.threshd.api.ThresholdingEventProxy;
@@ -221,6 +222,14 @@ public final class ThresholdEntity implements Cloneable {
      * @param resource a {@link org.opennms.netmgt.threshd.CollectionResourceWrapper} object.
      */
     public List<Event> evaluateAndCreateEvents(CollectionResourceWrapper resource, Map<String, Double> values, Date date) {
+        return evaluateAndCreateEvents(resource, values, date, getScopeForResource(resource));
+    }
+
+    /**
+     * Like {@link #evaluateAndCreateEvents(CollectionResourceWrapper, Map, Date)}, but the caller
+     * provides the scope so one instance can be shared across all thresholds for a resource.
+     */
+    public List<Event> evaluateAndCreateEvents(CollectionResourceWrapper resource, Map<String, Double> values, Date date, Scope scope) {
         List<Event> events = new LinkedList<Event>();
 
         String instance = null;
@@ -238,9 +247,6 @@ public final class ThresholdEntity implements Cloneable {
 
         // This reference contains the function that will be used by each evaluator to retrieve the status
         AtomicReference<EvaluateFunction> evaluateFunctionRef = new AtomicReference<>(null);
-
-        // compute scope here, see NMS-16966
-        final Scope scope = getScopeForResource(resource);
 
         // Depending on the type of threshold, we want to evaluate it differently
         // Threshold Values like value, rearm, trigger and expression are interpolated and cached in state so that
@@ -312,18 +318,23 @@ public final class ThresholdEntity implements Cloneable {
     }
 
     public static Scope getScopeForResource(EntityScopeProvider entityScopeProvider, CollectionResourceWrapper resource) {
+        if (resource == null) {
+            return getScope(entityScopeProvider, null, null, null);
+        }
+        return getScope(entityScopeProvider, resource.getNodeId(), resource.getHostAddress(), resource.getServiceName());
+    }
+
+    public static Scope getScope(EntityScopeProvider entityScopeProvider, Integer nodeId, String hostAddress, String serviceName) {
         // Default to empty scopes and then attempt to populate each of node, interface, and service
-        // scopes below
+        // scopes below. Scopes are lazy: entities are only loaded if an expression is resolved (NMS-16966).
         Scope[] scopes = new Scope[]{EmptyScope.EMPTY, EmptyScope.EMPTY, EmptyScope.EMPTY};
 
-        if (resource != null) {
-            scopes[0] = entityScopeProvider.getScopeForNode(resource.getNodeId());
-            String interfaceIp = resource.getHostAddress();
-            if (interfaceIp != null) {
-                scopes[1] = entityScopeProvider.getScopeForInterface(resource.getNodeId(),
-                        interfaceIp);
-                scopes[2] = entityScopeProvider.getScopeForService(resource.getNodeId(),
-                        InetAddresses.forString(interfaceIp), resource.getServiceName());
+        if (nodeId != null) {
+            scopes[0] = new LazyScope(() -> entityScopeProvider.getScopeForNode(nodeId));
+            if (hostAddress != null) {
+                scopes[1] = new LazyScope(() -> entityScopeProvider.getScopeForInterface(nodeId, hostAddress));
+                scopes[2] = new LazyScope(() -> entityScopeProvider.getScopeForService(nodeId,
+                        InetAddresses.forString(hostAddress), serviceName));
             }
         }
         return new FallbackScope(scopes);

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSetImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSetImpl.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 import org.opennms.core.mate.api.EntityScopeProvider;
 import org.opennms.core.mate.api.Interpolator;
+import org.opennms.core.mate.api.Scope;
 import org.opennms.netmgt.collectd.AliasedResource;
 import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
@@ -253,13 +254,15 @@ public class ThresholdingSetImpl implements ThresholdingSet {
      * @return a {@link java.util.List} object.
      */
     protected final List<Event> applyThresholds(CollectionResourceWrapper resourceWrapper, Map<String, CollectionAttribute> attributesMap) {
+        return applyThresholds(resourceWrapper, attributesMap, buildScope());
+    }
+
+    protected final List<Event> applyThresholds(CollectionResourceWrapper resourceWrapper, Map<String, CollectionAttribute> attributesMap, Scope scope) {
         List<Event> eventsList = new LinkedList<>();
         if (attributesMap == null || attributesMap.size() == 0) {
             LOG.debug("applyThresholds: Ignoring resource {} because required attributes map is empty.", resourceWrapper);
             return eventsList;
         }
-        // compute scope here, see NMS-16966
-        final var scope = ThresholdEntity.getScopeForResource(m_entityScopeProvider, resourceWrapper);
 
         LOG.debug("applyThresholds: Applying thresholds on {} using {} attributes.", resourceWrapper, attributesMap.size());
         Date date = new Date();
@@ -271,7 +274,7 @@ public class ThresholdingSetImpl implements ThresholdingSet {
                         final String key = entry.getKey();
                         final Set<ThresholdEntity> value = entry.getValue();
                         for (final ThresholdEntity thresholdEntity : value) {
-                            if (passedThresholdFilters(resourceWrapper, thresholdEntity)) {
+                            if (passedThresholdFilters(resourceWrapper, thresholdEntity, scope)) {
                                 LOG.info("applyThresholds: Processing threshold {} : {} on resource {}", key, thresholdEntity, resourceWrapper);
                                 Collection<String> requiredDatasources = thresholdEntity.getThresholdConfig().getRequiredDatasources();
                                 final Map<String, Double> values = new HashMap<String,Double>();
@@ -290,7 +293,7 @@ public class ThresholdingSetImpl implements ThresholdingSet {
 
                                     resourceWrapper.setDsLabel(Interpolator.interpolate(thresholdEntity.getDatasourceLabel(), scope).output);
                                     try {
-                                        List<Event> thresholdEvents = thresholdEntity.evaluateAndCreateEvents(resourceWrapper, values, date);
+                                        List<Event> thresholdEvents = thresholdEntity.evaluateAndCreateEvents(resourceWrapper, values, date, scope);
                                         eventsList.addAll(thresholdEvents);
                                     } catch (Exception e) {
                                         LOG.warn("applyThresholds: Can't evaluate {} on {} because {}", key, resourceWrapper, e.getMessage());
@@ -308,15 +311,16 @@ public class ThresholdingSetImpl implements ThresholdingSet {
     }
 
     protected boolean passedThresholdFilters(CollectionResourceWrapper resource, ThresholdEntity thresholdEntity) {
+        return passedThresholdFilters(resource, thresholdEntity, ThresholdEntity.getScopeForResource(m_entityScopeProvider, resource));
+    }
+
+    protected boolean passedThresholdFilters(CollectionResourceWrapper resource, ThresholdEntity thresholdEntity, Scope scope) {
         // Check Valid Interface Resource based on suggestions from Bug 2711
         if (resource.isAnInterfaceResource() && !resource.isValidInterfaceResource()) {
             LOG.info("passedThresholdFilters: Could not get data interface information for '{}' or this interface has an invalid ifIndex.  Not evaluating threshold.",
                      resource.getIfLabel());
             return false;
         }
-
-        // compute scope here, see NMS-16966
-        final var scope = ThresholdEntity.getScopeForResource(m_entityScopeProvider, resource);
 
         // Find the filters for threshold definition for selected group/dataSource
         final List<ResourceFilter> filters = thresholdEntity.getThresholdConfig().getBasethresholddef().getResourceFilters();
@@ -494,6 +498,11 @@ public class ThresholdingSetImpl implements ThresholdingSet {
 
     public List<Event> applyThresholds(CollectionResource resource, Map<String, CollectionAttribute> attributesMap,
                                        Date collectionTimestamp, Long sequenceNumber) {
+        return applyThresholds(resource, attributesMap, collectionTimestamp, sequenceNumber, buildScope());
+    }
+
+    public List<Event> applyThresholds(CollectionResource resource, Map<String, CollectionAttribute> attributesMap,
+                                       Date collectionTimestamp, Long sequenceNumber, Scope scope) {
         if (!isCollectionEnabled(resource)) {
             LOG.debug("applyThresholds: Ignoring resource {} because data collection is disabled for this resource.", resource);
             return new LinkedList<>();
@@ -501,7 +510,15 @@ public class ThresholdingSetImpl implements ThresholdingSet {
         CollectionResourceWrapper resourceWrapper = new CollectionResourceWrapper(collectionTimestamp, m_nodeId,
                 m_hostAddress, m_serviceName, resource, attributesMap, m_ifLabelDao, sequenceNumber);
         resourceWrapper.setCounterReset(m_counterReset);
-        return Collections.unmodifiableList(applyThresholds(resourceWrapper, attributesMap));
+        return Collections.unmodifiableList(applyThresholds(resourceWrapper, attributesMap, scope));
+    }
+
+    /**
+     * The scope only depends on session-level state (node, host address, service), never on the
+     * individual resource, so one instance can be shared across a whole collection set (NMS-16966).
+     */
+    public Scope buildScope() {
+        return ThresholdEntity.getScope(m_entityScopeProvider, m_nodeId, m_hostAddress, m_serviceName);
     }
 
     public List<ThresholdGroup> getThresholdGroups() {

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitorImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitorImpl.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opennms.core.mate.api.Scope;
 import org.opennms.netmgt.collection.api.AttributeGroup;
 import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
@@ -75,8 +76,10 @@ public class ThresholdingVisitorImpl extends AbstractCollectionSetVisitor implem
 	private Date m_collectionTimestamp;
 
     private ThresholdingEventProxy m_thresholdingEventProxy;
-    
+
     private final Long m_sequenceNumber;
+
+    private Scope m_scope;
 
     protected ThresholdingVisitorImpl(ThresholdingSetImpl thresholdingSet,
                                       ThresholdingEventProxy eventProxy, Long sequenceNumber) {
@@ -107,6 +110,8 @@ public class ThresholdingVisitorImpl extends AbstractCollectionSetVisitor implem
     @Override
     public void visitCollectionSet(CollectionSet set) {
         m_collectionTimestamp = set.getCollectionTimestamp();
+        // one lazy scope per collection set, shared by every resource in it (NMS-16966)
+        m_scope = m_thresholdingSet.buildScope();
     }
     
     /**
@@ -149,8 +154,9 @@ public class ThresholdingVisitorImpl extends AbstractCollectionSetVisitor implem
      */
     @Override
     public void completeResource(CollectionResource resource) {
+        final Scope scope = m_scope != null ? m_scope : m_thresholdingSet.buildScope();
         List<Event> eventList = m_thresholdingSet.applyThresholds(resource, m_attributesMap, m_collectionTimestamp,
-                m_sequenceNumber);
+                m_sequenceNumber, scope);
         for (Event event : eventList) {
             m_thresholdingEventProxy.sendEvent(event);
         }


### PR DESCRIPTION
Since NMS-16966 (Meridian 2024.2.3+, Horizon 33.1.3+), ThresholdingSetImpl.applyThresholds, passedThresholdFilters, and ThresholdEntity.evaluateAndCreateEvents each eagerly build a metadata scope for every collection resource and every threshold entity, on every collection cycle. 

Possible Fix: introduce LazyScope, a memoizing Scope wrapper that defers entity loading until an expression is actually resolved, and share a single scope per collection set (the scope depends only on node/host/service, never the resource). Configs without metadata expressions do zero DB work in thresholding; configs with them build at most one scope per service per cycle.

Assisted by Anthropic Claude Fable 5

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20007

