### PR TITLE
NMS-20008: thresholding-enabled parameter is ignored by collectd

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -127,7 +127,7 @@ public class CollectableService implements ReadyRunnable {
 
     private ThresholdingSession m_thresholdingSession;
 
-    // same parameter the poller honors in LatencyStoringServiceMonitorAdaptor; defaults to enabled
+    // also honored by the poller (LatencyStoringServiceMonitorAdaptor, default false there); collectd defaults to enabled
     private static final String THRESHOLDING_ENABLED_PARAM = "thresholding-enabled";
 
     private boolean m_thresholdingEnabled = true;

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -127,6 +127,11 @@ public class CollectableService implements ReadyRunnable {
 
     private ThresholdingSession m_thresholdingSession;
 
+    // same parameter the poller honors in LatencyStoringServiceMonitorAdaptor; defaults to enabled
+    private static final String THRESHOLDING_ENABLED_PARAM = "thresholding-enabled";
+
+    private boolean m_thresholdingEnabled = true;
+
     /**
      * Constructs a new instance of a CollectableService object.
      *
@@ -159,11 +164,22 @@ public class CollectableService implements ReadyRunnable {
 
         m_spec.initialize(m_agent);
 
-        try {
-            m_thresholdingSession = thresholdingService.createSession(m_nodeId, getHostAddress(), m_spec.getServiceName(), m_spec.getServiceParameters());
-        } catch (ThresholdInitializationException e) {
-            LOG.error("Error when initializing Thresholding. No Thresholding will be performed on this service.", e);
+        final ServiceParameters serviceParameters = m_spec.getServiceParameters();
+        m_thresholdingEnabled = isThresholdingEnabled(serviceParameters);
+        if (m_thresholdingEnabled) {
+            try {
+                m_thresholdingSession = thresholdingService.createSession(m_nodeId, getHostAddress(), m_spec.getServiceName(), serviceParameters);
+            } catch (ThresholdInitializationException e) {
+                LOG.error("Error when initializing Thresholding. No Thresholding will be performed on this service.", e);
+            }
+        } else {
+            LOG.info("Thresholding is disabled for {}/{}/{} ({}=false).", m_nodeId, getHostAddress(), m_spec.getServiceName(), THRESHOLDING_ENABLED_PARAM);
         }
+    }
+
+    private static boolean isThresholdingEnabled(final ServiceParameters serviceParameters) {
+        final Object value = serviceParameters.getParameters().get(THRESHOLDING_ENABLED_PARAM);
+        return value == null || !"false".equalsIgnoreCase(value.toString().trim());
     }
     
     /**
@@ -429,7 +445,7 @@ public class CollectableService implements ReadyRunnable {
                     } catch (ThresholdInitializationException e) {
                         LOG.warn("ThresholdInitializationException for {}. Thresholding skipped.", this, e);
                     }
-                } else {
+                } else if (m_thresholdingEnabled) {
                     LOG.warn("No thresholding session for {}. Thresholding skipped.", this);
                 }
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectableServiceTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectableServiceTest.java
@@ -24,8 +24,10 @@ package org.opennms.netmgt.collectd;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -75,6 +77,7 @@ public class CollectableServiceTest {
     private CollectionSpecification spec;
     private Scheduler scheduler;
     private CollectableService service;
+    private ThresholdingService thresholdingService;
 
     private File snmpDirectory;
     private FileAnticipator fileAnticipator;
@@ -217,7 +220,39 @@ public class CollectableServiceTest {
                 lastUpdateTimeInSecs < (afterInSecs - (collectionDelayInSecs / 2d)));
     }
 
+    @Test
+    public void thresholdingSessionIsNotCreatedWhenExplicitlyDisabled() throws Exception {
+        Map<String, Object> paramsMap = new HashMap<>();
+        paramsMap.put("thresholding-enabled", "false");
+        createCollectableService(paramsMap);
+
+        verify(thresholdingService, never()).createSession(anyInt(), any(), any(), any());
+    }
+
+    @Test
+    public void thresholdingSessionIsCreatedWhenParameterIsAbsent() throws Exception {
+        createCollectableService(new HashMap<>());
+
+        verify(thresholdingService, times(1)).createSession(anyInt(), any(), any(), any());
+    }
+
+    @Test
+    public void thresholdingSessionIsCreatedWhenExplicitlyEnabled() throws Exception {
+        Map<String, Object> paramsMap = new HashMap<>();
+        paramsMap.put("thresholding-enabled", "true");
+        createCollectableService(paramsMap);
+
+        verify(thresholdingService, times(1)).createSession(anyInt(), any(), any(), any());
+    }
+
     private void createCollectableService() throws CollectionInitializationException, IOException {
+        // Disable thresholding
+        Map<String, Object> paramsMap = new HashMap<>();
+        paramsMap.put("thresholding-enabled", Boolean.FALSE.toString());
+        createCollectableService(paramsMap);
+    }
+
+    private void createCollectableService(Map<String, Object> paramsMap) throws CollectionInitializationException, IOException {
         // Mock it all!
         OnmsIpInterface iface = mock(OnmsIpInterface.class, RETURNS_DEEP_STUBS);
         IpInterfaceDao ifaceDao = mock(IpInterfaceDao.class);
@@ -229,9 +264,6 @@ public class CollectableServiceTest {
         persisterFactory.setRrdStrategy(rrdStrategy);
         ResourceStorageDao resourceStorageDao = mock(ResourceStorageDao.class);
 
-        // Disable thresholding
-        Map<String, Object> paramsMap = new HashMap<>();
-        paramsMap.put("thresholding-enabled", Boolean.FALSE.toString());
         ServiceParameters params = new ServiceParameters(paramsMap);
 
         when(iface.getNode().getId()).thenReturn(1);
@@ -240,9 +272,9 @@ public class CollectableServiceTest {
         when(ifaceDao.load(any())).thenReturn(iface);
         when(iface.getIpAddress()).thenReturn(InetAddrUtils.getLocalHostAddress());
 
-        ThresholdingService mockThresholdingService = mock(ThresholdingService.class, RETURNS_DEEP_STUBS);
+        thresholdingService = mock(ThresholdingService.class, RETURNS_DEEP_STUBS);
 
-        service = new CollectableService(iface, ifaceDao, spec, scheduler, schedulingCompletedFlag, transMgr, persisterFactory, mockThresholdingService);
+        service = new CollectableService(iface, ifaceDao, spec, scheduler, schedulingCompletedFlag, transMgr, persisterFactory, thresholdingService);
     }
 
     private RrdRepository createRrdRepository() throws IOException {


### PR DESCRIPTION
Collectd creates a thresholding session and runs threshold processing on every collection regardless, so setting thresholding-enabled="false" in collectd-configuration.xml silently does nothing.

Possible Fix: CollectableService skips thresholding session creation when the parameter is explicitly false. Default remains enabled, so configurations that don't set the parameter are unaffected.

Assisted by Anthropic Claude Fable 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20008

