### PR TITLE
NMS-20009: Poller builds the metadata scope twice per poll

### DIFF
--- a/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerRequestBuilderImpl.java
+++ b/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerRequestBuilderImpl.java
@@ -68,6 +68,7 @@ public class PollerRequestBuilderImpl implements PollerRequestBuilder {
     @Override
     public PollerRequestBuilder withService(MonitoredService service) {
         this.service = service;
+        this.scope = null;
         return this;
     }
 
@@ -115,13 +116,15 @@ public class PollerRequestBuilderImpl implements PollerRequestBuilder {
     @Override
     public PollerRequestBuilder withPatternVariables(Map<String, String> patternVariables) {
         this.patternVariables.putAll(patternVariables);
+        this.scope = null;
         return this;
     }
 
+    // memoized scope; invalidated by the mutators that feed it (withService, withPatternVariables)
     private Scope scope;
 
     private Scope getScope() {
-        // memoized: execute() needs the scope twice and each build hits the database
+        // execute() needs the scope twice and each build hits the database
         if (this.scope == null) {
             this.scope = new FallbackScope(
                     this.client.getEntityScopeProvider().getScopeForNode(this.service.getNodeId()),

--- a/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerRequestBuilderImpl.java
+++ b/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/PollerRequestBuilderImpl.java
@@ -118,13 +118,19 @@ public class PollerRequestBuilderImpl implements PollerRequestBuilder {
         return this;
     }
 
+    private Scope scope;
+
     private Scope getScope() {
-        return new FallbackScope(
-                this.client.getEntityScopeProvider().getScopeForNode(this.service.getNodeId()),
-                this.client.getEntityScopeProvider().getScopeForInterface(this.service.getNodeId(), this.service.getIpAddr()),
-                this.client.getEntityScopeProvider().getScopeForService(this.service.getNodeId(), this.service.getAddress(), this.service.getSvcName()),
-                MapScope.singleContext(Scope.ScopeName.SERVICE, "pattern", this.patternVariables)
-        );
+        // memoized: execute() needs the scope twice and each build hits the database
+        if (this.scope == null) {
+            this.scope = new FallbackScope(
+                    this.client.getEntityScopeProvider().getScopeForNode(this.service.getNodeId()),
+                    this.client.getEntityScopeProvider().getScopeForInterface(this.service.getNodeId(), this.service.getIpAddr()),
+                    this.client.getEntityScopeProvider().getScopeForService(this.service.getNodeId(), this.service.getAddress(), this.service.getSvcName()),
+                    MapScope.singleContext(Scope.ScopeName.SERVICE, "pattern", this.patternVariables)
+            );
+        }
+        return this.scope;
     }
 
     @Override


### PR DESCRIPTION
PollerRequestBuilderImpl.execute() builds the node/interface/service metadata scope twice per poll. Once when interpolating the configured attributes and again when interpolating the monitor's runtime attributes.

Possible Fix: memoize the scope on the request builder so it is built at most once per poll request

Assisted by Anthropic Claude Fable 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20009

