### PR TITLE
NMS-19980: Translate IPLIKE filter expressions to indexable native PostgreSQL inet predicates

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/IplikeSqlTranslator.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/IplikeSqlTranslator.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.utils;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Translates iplike match expressions into native-inet SQL predicates that
+ * PostgreSQL can answer through an expression index, instead of calling the
+ * iplike() stored procedure per row.
+ *
+ * <p>An iplike pattern is a per-field cross-product of integer segments
+ * (specific value, range {@code a-b}, comma list, {@code *}), which always
+ * denotes a union of contiguous address ranges. This class renders that union
+ * as {@code opennms_safe_inet(col) BETWEEN ... OR ...} range comparisons,
+ * matching the expression index created on the same function.
+ *
+ * <p>{@link #toSqlPredicate(String, String)} returns {@code null} whenever the
+ * pattern cannot be translated with identical semantics, and callers MUST fall
+ * back to emitting {@code iplike(col, ?)} exactly as before. Untranslatable
+ * cases: patterns carrying an IPv6 zone id (no inet representation), patterns
+ * whose range expansion exceeds {@link #MAX_RANGES}, and anything malformed
+ * (iplike evaluates those to false at runtime; the fallback preserves that).
+ *
+ * <p>Semantics are defined by the iplike C implementation's test corpus
+ * (tests.dat, mirrored by IPLikeCoverageIT); the unit test evaluates every
+ * corpus case against the translated ranges.
+ */
+public abstract class IplikeSqlTranslator {
+
+    /** The garbage-tolerant cast function the expression indexes are built on. */
+    public static final String SAFE_INET_FUNCTION = "opennms_safe_inet";
+
+    /**
+     * Expansion cap. Patterns exceeding this many address ranges fall back to
+     * iplike(): with the expression index present even thousands of ranges
+     * answer quickly, but an OR-chain this size evaluated per row (index
+     * missing or dropped) degrades far below iplike, so the cap bounds the
+     * worst case.
+     */
+    public static final int MAX_RANGES = 1024;
+
+    /** Escape hatch: set to "false" to disable translation globally. */
+    public static final String ENABLED_PROPERTY = "org.opennms.iplike.native";
+
+    private static final String V4_MATCH_ALL = "*.*.*.*";
+    private static final String V6_MATCH_ALL = "*:*:*:*:*:*:*:*";
+
+    private static class Untranslatable extends Exception {
+        private static final long serialVersionUID = 1L;
+    }
+
+    private IplikeSqlTranslator() {
+    }
+
+    /**
+     * @param pattern the iplike match expression (user-supplied filter text)
+     * @param columnExpression SQL text for the address column, e.g.
+     *        {@code "ipaddr"} or {@code "{alias}.ipaddr"}
+     * @return a self-contained SQL predicate built only from re-rendered
+     *         numeric literals (never from the raw pattern text), or
+     *         {@code null} if the caller must fall back to iplike()
+     */
+    public static String toSqlPredicate(final String pattern, final String columnExpression) {
+        if (!Boolean.parseBoolean(System.getProperty(ENABLED_PROPERTY, "true"))) {
+            return null;
+        }
+        if (pattern == null || columnExpression == null) {
+            return null;
+        }
+        if (V4_MATCH_ALL.equals(pattern) || V6_MATCH_ALL.equals(pattern)) {
+            // the shipped PL/pgSQL iplike fast-paths both match-all forms to
+            // true for every non-null value; NULL never matches
+            return columnExpression + " IS NOT NULL";
+        }
+
+        final List<BigInteger[]> ranges;
+        final int family;
+        try {
+            final Parsed parsed = parse(pattern);
+            family = parsed.family;
+            ranges = buildRanges(parsed);
+        } catch (final Untranslatable e) {
+            return null;
+        }
+        if (ranges.isEmpty()) {
+            return null;
+        }
+
+        final String func = SAFE_INET_FUNCTION + "(" + columnExpression + ")";
+        final StringBuilder sb = new StringBuilder();
+        // the func IS NOT NULL conjunct forces the predicate to FALSE (not
+        // NULL) for values opennms_safe_inet() cannot parse, so callers that
+        // wrap it in NOT include those rows exactly like NOT iplike() does
+        sb.append("(").append(columnExpression).append(" IS NOT NULL AND ")
+          .append(func).append(" IS NOT NULL AND (");
+        for (int i = 0; i < ranges.size(); i++) {
+            if (i > 0) {
+                sb.append(" OR ");
+            }
+            final BigInteger lo = ranges.get(i)[0];
+            final BigInteger hi = ranges.get(i)[1];
+            if (lo.equals(hi)) {
+                sb.append(func).append(" = inet '").append(render(family, lo)).append("'");
+            } else {
+                sb.append("(").append(func).append(" >= inet '").append(render(family, lo))
+                  .append("' AND ").append(func).append(" <= inet '").append(render(family, hi))
+                  .append("')");
+            }
+        }
+        sb.append("))");
+        return sb.toString();
+    }
+
+    /**
+     * Evaluates a pattern against an address value using the same range
+     * translation the SQL predicate is built from, mirroring
+     * opennms_safe_inet()'s treatment of the value (zone id stripped on IPv6
+     * only, strict dotted-quad or 8-group format). Exists so tests can verify corpus parity
+     * without a database; returns null when the pattern is untranslatable.
+     */
+    static Boolean matches(final String value, final String pattern) {
+        if (V4_MATCH_ALL.equals(pattern) || V6_MATCH_ALL.equals(pattern)) {
+            return value != null;
+        }
+        final Parsed parsed;
+        final List<BigInteger[]> ranges;
+        try {
+            parsed = parse(pattern);
+            ranges = buildRanges(parsed);
+        } catch (final Untranslatable e) {
+            return null;
+        }
+        final BigInteger n = safeInetValue(value, parsed.family);
+        if (n == null) {
+            return false;
+        }
+        for (final BigInteger[] r : ranges) {
+            if (n.compareTo(r[0]) >= 0 && n.compareTo(r[1]) <= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** The value side of opennms_safe_inet(), restricted to one family. */
+    private static BigInteger safeInetValue(final String value, final int family) {
+        if (value == null) {
+            return null;
+        }
+        final int pct = value.indexOf('%');
+        if (family == 4) {
+            // zone ids are IPv6-only; iplike rejects IPv4 values carrying one
+            if (pct >= 0) {
+                return null;
+            }
+            final String[] toks = value.split("\\.", -1);
+            if (toks.length != 4) {
+                return null;
+            }
+            long n = 0;
+            for (final String t : toks) {
+                if (!t.matches("0|[1-9][0-9]{0,2}")) {
+                    return null;
+                }
+                final int octet = Integer.parseInt(t);
+                if (octet > 255) {
+                    return null;
+                }
+                n = (n << 8) | octet;
+            }
+            return BigInteger.valueOf(n);
+        }
+        final String v = pct >= 0 ? value.substring(0, pct) : value;
+        final String[] toks = v.split(":", -1);
+        if (toks.length != 8) {
+            return null;
+        }
+        BigInteger n = BigInteger.ZERO;
+        for (final String t : toks) {
+            if (!t.matches("[0-9a-fA-F]{1,4}")) {
+                return null;
+            }
+            n = n.shiftLeft(16).or(BigInteger.valueOf(Integer.parseInt(t, 16)));
+        }
+        return n;
+    }
+
+    private static class Parsed {
+        final int family;
+        final int bits;
+        final List<List<long[]>> fields;
+
+        Parsed(final int family, final int bits, final List<List<long[]>> fields) {
+            this.family = family;
+            this.bits = bits;
+            this.fields = fields;
+        }
+    }
+
+    private static Parsed parse(final String pattern) throws Untranslatable {
+        if (pattern.indexOf('%') >= 0) {
+            throw new Untranslatable(); // zone ids have no inet representation
+        }
+        if (pattern.indexOf(':') >= 0) {
+            final String[] toks = pattern.toLowerCase().split(":", -1);
+            if (toks.length != 8) {
+                throw new Untranslatable();
+            }
+            final List<List<long[]>> fields = new ArrayList<>(8);
+            for (final String tok : toks) {
+                fields.add(parseField(tok, 0xffff, true));
+            }
+            return new Parsed(6, 16, fields);
+        }
+        final String[] toks = pattern.split("\\.", -1);
+        if (toks.length != 4) {
+            throw new Untranslatable();
+        }
+        final List<List<long[]>> fields = new ArrayList<>(4);
+        for (final String tok : toks) {
+            fields.add(parseField(tok, 255, false));
+        }
+        return new Parsed(4, 8, fields);
+    }
+
+    private static List<long[]> parseField(final String token, final long maxValue, final boolean hex) throws Untranslatable {
+        final List<long[]> segments = new ArrayList<>();
+        for (final String part : token.split(",", -1)) {
+            if ("*".equals(part)) {
+                final List<long[]> all = new ArrayList<>(1);
+                all.add(new long[] {0, maxValue});
+                return all;
+            }
+            final long lo, hi;
+            final int dash = part.indexOf('-');
+            if (dash >= 0) {
+                lo = parseValue(part.substring(0, dash), hex);
+                hi = parseValue(part.substring(dash + 1), hex);
+            } else {
+                lo = hi = parseValue(part, hex);
+            }
+            if (lo > maxValue) {
+                continue; // rule element above the field maximum never matches
+            }
+            segments.add(new long[] {lo, Math.min(hi, maxValue)});
+        }
+        if (segments.isEmpty()) {
+            throw new Untranslatable();
+        }
+        return segments;
+    }
+
+    private static long parseValue(final String s, final boolean hex) throws Untranslatable {
+        if (s.isEmpty() || s.length() > 8 || !s.matches(hex ? "[0-9a-f]+" : "[0-9]+")) {
+            throw new Untranslatable();
+        }
+        return Long.parseLong(s, hex ? 16 : 10);
+    }
+
+    private static List<BigInteger[]> buildRanges(final Parsed parsed) throws Untranslatable {
+        final List<BigInteger[]> out = new ArrayList<>();
+        recurse(parsed, 0, BigInteger.ZERO, out);
+        out.sort((a, b) -> a[0].compareTo(b[0]));
+        final List<BigInteger[]> merged = new ArrayList<>();
+        for (final BigInteger[] r : out) {
+            if (!merged.isEmpty() && r[0].compareTo(merged.get(merged.size() - 1)[1].add(BigInteger.ONE)) <= 0) {
+                final BigInteger[] last = merged.get(merged.size() - 1);
+                last[1] = last[1].max(r[1]);
+            } else {
+                merged.add(r);
+            }
+        }
+        return merged;
+    }
+
+    private static void recurse(final Parsed parsed, final int pos, final BigInteger acc,
+            final List<BigInteger[]> out) throws Untranslatable {
+        final int n = parsed.fields.size();
+        final int shift = parsed.bits * (n - 1 - pos);
+        final long maxValue = (1L << parsed.bits) - 1;
+
+        boolean restFull = true;
+        for (int q = pos + 1; q < n && restFull; q++) {
+            final List<long[]> segs = parsed.fields.get(q);
+            restFull = segs.size() == 1 && segs.get(0)[0] == 0 && segs.get(0)[1] == maxValue;
+        }
+
+        if (restFull) {
+            final BigInteger lowOnes = BigInteger.ONE.shiftLeft(shift).subtract(BigInteger.ONE);
+            for (final long[] seg : parsed.fields.get(pos)) {
+                out.add(new BigInteger[] {
+                        acc.or(BigInteger.valueOf(seg[0]).shiftLeft(shift)),
+                        acc.or(BigInteger.valueOf(seg[1]).shiftLeft(shift)).or(lowOnes)});
+                if (out.size() > MAX_RANGES) {
+                    throw new Untranslatable();
+                }
+            }
+            return;
+        }
+        for (final long[] seg : parsed.fields.get(pos)) {
+            for (long v = seg[0]; v <= seg[1]; v++) {
+                recurse(parsed, pos + 1, acc.or(BigInteger.valueOf(v).shiftLeft(shift)), out);
+            }
+        }
+    }
+
+    /**
+     * Rendered by hand rather than through InetAddress: getByAddress()
+     * collapses IPv4-mapped IPv6 addresses (::ffff:0:0/96) to Inet4Address,
+     * which would emit a family-4 inet literal that never compares equal to
+     * the family-6 value opennms_safe_inet() produces.
+     */
+    private static String render(final int family, final BigInteger n) {
+        final StringBuilder sb = new StringBuilder();
+        if (family == 4) {
+            final long v = n.longValueExact();
+            sb.append((v >> 24) & 0xff).append('.').append((v >> 16) & 0xff)
+              .append('.').append((v >> 8) & 0xff).append('.').append(v & 0xff);
+        } else {
+            for (int group = 7; group >= 0; group--) {
+                sb.append(Long.toHexString(n.shiftRight(group * 16).intValue() & 0xffff));
+                if (group > 0) {
+                    sb.append(':');
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/core/lib/src/main/java/org/opennms/core/utils/IplikeSqlTranslator.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/IplikeSqlTranslator.java
@@ -261,8 +261,13 @@ public abstract class IplikeSqlTranslator {
             } else {
                 lo = hi = parseValue(part, hex);
             }
-            if (lo > maxValue) {
-                continue; // rule element above the field maximum never matches
+            if (lo > hi || lo > maxValue) {
+                // descending or above-maximum elements never match (iplike
+                // uses BETWEEN). Descending segments MUST be dropped before
+                // expansion: a zero-iteration segment in recurse() would
+                // enumerate every preceding combination without ever
+                // reaching the MAX_RANGES backstop.
+                continue;
             }
             segments.add(new long[] {lo, Math.min(hi, maxValue)});
         }

--- a/core/lib/src/test/java/org/opennms/core/utils/IplikeSqlTranslatorTest.java
+++ b/core/lib/src/test/java/org/opennms/core/utils/IplikeSqlTranslatorTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class IplikeSqlTranslatorTest {
+
+    /**
+     * Every case in the iplike reference corpus (tests.dat from the
+     * OpenNMS/iplike repository, also covered DB-side by IPLikeCoverageIT)
+     * must either translate with identical match semantics or be declared
+     * untranslatable so callers fall back to iplike().
+     */
+    @Test
+    public void testCorpusParity() throws Exception {
+        int translated = 0;
+        final List<String> untranslatable = new ArrayList<>();
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(
+                getClass().getResourceAsStream("iplike-tests.dat"), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = in.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                final String[] cols = line.split("\\s+");
+                final String value = cols[0], rule = cols[1];
+                final boolean expected = Boolean.parseBoolean(cols[2]);
+
+                final Boolean got = IplikeSqlTranslator.matches(value, rule);
+                if (got == null) {
+                    assertNull("untranslatable rule must yield a null predicate: " + rule,
+                            IplikeSqlTranslator.toSqlPredicate(rule, "ipaddr"));
+                    untranslatable.add(rule);
+                    continue;
+                }
+                translated++;
+                assertEquals("value=" + value + " rule=" + rule, expected, got);
+                assertNotNull("translatable rule must yield a predicate: " + rule,
+                        IplikeSqlTranslator.toSqlPredicate(rule, "ipaddr"));
+            }
+        }
+        assertTrue("expected most of the corpus to translate, got " + translated, translated >= 30);
+        for (final String rule : untranslatable) {
+            // only zone-id rules and wildcard-before-constrained-field IPv6
+            // rules (not a bounded union of ranges) may fall back
+            assertTrue("unexpected untranslatable rule: " + rule,
+                    rule.contains("%") || rule.matches(".*\\*.*:.*[0-9a-f].*"));
+        }
+    }
+
+    @Test
+    public void testMatchAllTranslatesToNotNull() {
+        assertEquals("ipaddr IS NOT NULL", IplikeSqlTranslator.toSqlPredicate("*.*.*.*", "ipaddr"));
+        assertEquals("{alias}.ipaddr IS NOT NULL",
+                IplikeSqlTranslator.toSqlPredicate("*:*:*:*:*:*:*:*", "{alias}.ipaddr"));
+    }
+
+    @Test
+    public void testSingleRangePredicate() {
+        assertEquals("(ipaddr IS NOT NULL AND opennms_safe_inet(ipaddr) IS NOT NULL AND ("
+                + "(opennms_safe_inet(ipaddr) >= inet '10.0.1.0'"
+                + " AND opennms_safe_inet(ipaddr) <= inet '10.0.3.255')))",
+                IplikeSqlTranslator.toSqlPredicate("10.0.1-3.*", "ipaddr"));
+    }
+
+    @Test
+    public void testExactAddressPredicate() {
+        assertEquals("(ipaddr IS NOT NULL AND opennms_safe_inet(ipaddr) IS NOT NULL AND "
+                + "(opennms_safe_inet(ipaddr) = inet '192.168.1.1'))",
+                IplikeSqlTranslator.toSqlPredicate("192.168.1.1", "ipaddr"));
+    }
+
+    @Test
+    public void testAdjacentListCoalesces() {
+        // 0, 1, 2 in the third octet are adjacent /24s -> one contiguous range
+        assertEquals("(ipaddr IS NOT NULL AND opennms_safe_inet(ipaddr) IS NOT NULL AND ("
+                + "(opennms_safe_inet(ipaddr) >= inet '192.168.0.0'"
+                + " AND opennms_safe_inet(ipaddr) <= inet '192.168.2.255')))",
+                IplikeSqlTranslator.toSqlPredicate("192.168.0,1,2.*", "ipaddr"));
+    }
+
+    @Test
+    public void testCompoundPatternEmitsDisjointRanges() {
+        final String sql = IplikeSqlTranslator.toSqlPredicate("192.168.0,1,2-4.0-20", "ipaddr");
+        assertNotNull(sql);
+        // 5 third-octet values x constrained fourth octet -> 5 disjoint ranges
+        assertEquals(5, sql.split(" OR ", -1).length);
+    }
+
+    @Test
+    public void testIpv6RangePredicate() {
+        assertEquals("(ipaddr IS NOT NULL AND opennms_safe_inet(ipaddr) IS NOT NULL AND ("
+                + "(opennms_safe_inet(ipaddr) >= inet 'fe80:0:0:0:0:0:0:0'"
+                + " AND opennms_safe_inet(ipaddr) <= inet 'fe80:0:0:0:0:0:0:ff')))",
+                IplikeSqlTranslator.toSqlPredicate(
+                        "fe80:0000:0000:0000:0000:0000:0000:0000-00ff", "ipaddr"));
+    }
+
+    @Test
+    public void testIpv4MappedIpv6RendersAsFamily6() {
+        // InetAddress.getByAddress() would collapse ::ffff:0:0/96 to an
+        // Inet4Address; the emitted literal must stay 8-group IPv6 so it
+        // compares equal to what opennms_safe_inet() yields for the value
+        assertEquals("(ipaddr IS NOT NULL AND opennms_safe_inet(ipaddr) IS NOT NULL AND "
+                + "(opennms_safe_inet(ipaddr) = inet '0:0:0:0:0:ffff:102:304'))",
+                IplikeSqlTranslator.toSqlPredicate("0:0:0:0:0:ffff:0102:0304", "ipaddr"));
+        assertEquals(Boolean.TRUE, IplikeSqlTranslator.matches(
+                "0000:0000:0000:0000:0000:ffff:0102:0304", "0:0:0:0:0:ffff:0102:0304"));
+    }
+
+    @Test
+    public void testZoneIdValueNeverMatchesIpv4Rules() {
+        // zone ids are IPv6-only; iplike() returns false for IPv4 values
+        // carrying one, and opennms_safe_inet() must not strip it
+        assertEquals(Boolean.FALSE, IplikeSqlTranslator.matches("1.2.3.4%eth0", "1.2.3.*"));
+    }
+
+    @Test
+    public void testExpansionCapFallsBack() {
+        // 3 x 254 x 6 x 2 = 9,144 ranges, past MAX_RANGES
+        assertNull(IplikeSqlTranslator.toSqlPredicate(
+                "10,172,192.1-254.1,3,5,7,9,11.0-100,200-255", "ipaddr"));
+    }
+
+    @Test
+    public void testZoneIdPatternFallsBack() {
+        assertNull(IplikeSqlTranslator.toSqlPredicate("fe80:*:*:*:*:*:*:*%45", "ipaddr"));
+    }
+
+    @Test
+    public void testMalformedPatternsFallBack() {
+        assertNull(IplikeSqlTranslator.toSqlPredicate("1.2.3", "ipaddr"));
+        assertNull(IplikeSqlTranslator.toSqlPredicate("1.2.3.4.5", "ipaddr"));
+        assertNull(IplikeSqlTranslator.toSqlPredicate("a.b.c.d", "ipaddr"));
+        assertNull(IplikeSqlTranslator.toSqlPredicate("", "ipaddr"));
+        assertNull(IplikeSqlTranslator.toSqlPredicate(null, "ipaddr"));
+    }
+
+    @Test
+    public void testZoneIdValueMatchesLikeIplike() {
+        // the C implementation ignores the value's zone when the rule has none
+        assertEquals(Boolean.TRUE, IplikeSqlTranslator.matches(
+                "fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4", "fe80:*:*:*:*:*:*:*"));
+    }
+
+    @Test
+    public void testDisabledViaSystemProperty() {
+        System.setProperty(IplikeSqlTranslator.ENABLED_PROPERTY, "false");
+        try {
+            assertNull(IplikeSqlTranslator.toSqlPredicate("192.168.1.1", "ipaddr"));
+        } finally {
+            System.clearProperty(IplikeSqlTranslator.ENABLED_PROPERTY);
+        }
+    }
+}

--- a/core/lib/src/test/java/org/opennms/core/utils/IplikeSqlTranslatorTest.java
+++ b/core/lib/src/test/java/org/opennms/core/utils/IplikeSqlTranslatorTest.java
@@ -147,6 +147,29 @@ public class IplikeSqlTranslatorTest {
         assertEquals(Boolean.FALSE, IplikeSqlTranslator.matches("1.2.3.4%eth0", "1.2.3.*"));
     }
 
+    /**
+     * A descending range stored as a segment would make recurse() enumerate
+     * every preceding combination through a zero-iteration loop that never
+     * reaches the MAX_RANGES backstop — 65536^2 dead paths for this pattern.
+     * Descending segments must be dropped before expansion, making this
+     * return (untranslatable) immediately.
+     */
+    @Test(timeout = 5000)
+    public void testDescendingRangeReturnsImmediately() {
+        assertNull(IplikeSqlTranslator.toSqlPredicate("0-ffff:0-ffff:1-0:0:0:0:0:0", "ipaddr"));
+        assertNull(IplikeSqlTranslator.toSqlPredicate("192.168.5-3.1", "ipaddr"));
+    }
+
+    @Test
+    public void testDescendingListElementIsDroppedNotFatal() {
+        // iplike's BETWEEN matches nothing for 5-3, so only the 7 survives
+        assertEquals(Boolean.TRUE, IplikeSqlTranslator.matches("192.168.7.1", "192.168.5-3,7.1"));
+        assertEquals(Boolean.FALSE, IplikeSqlTranslator.matches("192.168.4.1", "192.168.5-3,7.1"));
+        assertEquals("(ipaddr IS NOT NULL AND opennms_safe_inet(ipaddr) IS NOT NULL AND "
+                + "(opennms_safe_inet(ipaddr) = inet '192.168.7.1'))",
+                IplikeSqlTranslator.toSqlPredicate("192.168.5-3,7.1", "ipaddr"));
+    }
+
     @Test
     public void testExpansionCapFallsBack() {
         // 3 x 254 x 6 x 2 = 9,144 ranges, past MAX_RANGES

--- a/core/lib/src/test/resources/org/opennms/core/utils/iplike-tests.dat
+++ b/core/lib/src/test/resources/org/opennms/core/utils/iplike-tests.dat
@@ -1,0 +1,78 @@
+### IF YOU UPDATE THESE TESTS, UPDATE IPLikeCoverageIT IN THE OPENNMS CODEBASE AS WELL ###
+
+# value		rule			true/false
+1.2.3.4		1.2.3.4			true
+1.2.3.4		1.2.3.5			false
+1.2.3.4		1.2.3.*			true
+1.2.3.4		1.*.3.4			true
+1.2.3.4		1.*.3.5			false
+
+# range matches
+192.168.10.11	192.168.10.10-11	true
+192.168.10.12	192.168.10.10-11	false
+192.168.223.9	192.168.216-223.*	true
+192.168.224.9	192.168.216-223.*	false
+
+# list matches
+192.168.1.9	192.168.0,1,2.*		true
+192.168.1.9	192.168.1,2,0.*		true
+192.168.1.9	192.168.2,0,1.*		true
+192.168.3.9	192.168.0,1,2.*		false
+192.168.3.9	192.168.1,2,0.*		false
+192.168.3.9	192.168.2,0,1.*		false
+192.168.3.9	192.168.*,1,2.*		true
+192.168.3.9	192.168.0,*,2.*		true
+192.168.3.9	192.168.0,1,*.*		true
+
+# list and range in separate octet
+192.168.1.9	192.168.0,1,2.0-20	true
+192.168.1.21	192.168.0,1,2.0-20	false
+
+# list and range in same octet
+192.168.1.9	192.168.0,1,2-4.0-20	true
+192.168.3.9	192.168.0,1,2-4.0-20	true
+192.168.5.9	192.168.0,1,2-4.0-20	false
+192.168.1.21	192.168.0,1,2,3-4.0-20	false
+192.168.0.1	192.168.1-2,5.*	false
+
+# Oh noes, IPv6 tests!!
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	*:*:*:*:*:*:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:*:*:*:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:*:*:*:*:*%4	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	*:*:*:*:*:*:*:*%4	false
+
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	fe80:*:*:*:*:*:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%45	fe80:*:*:*:*:*:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%45	fe80:*:*:*:*:*:*:*%45	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	fe80:*:*:*:*:*:*:*%45	false
+
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	*:*:*:0:*:*:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:0:*:*:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:0:*:*:*:*%4	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	*:*:*:0:*:*:*:*%4	false
+
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	*:*:*:*:*:bbbb:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:*:*:bbbb:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:*:*:bbbb:*:*%4	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:*:*:bbbb:*:*%5	false
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	*:*:*:*:*:bbbb:*:*%4	false
+
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	*:*:*:*:*:bbb0-bbbf:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:*:*:bbb0-bbbf:*:*	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	*:*:*:*:*:bbb0-bbbf:*:*%4	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	*:*:*:*:*:bbb0-bbbf:*:*%4	false
+
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	fe80:0000:0000:0000:aaaa:bbb0-bbbf:cccc:dddd	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	fe80:0000:0000:0000:aaaa:bbb0-bbbf:cccc:dddd	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	fe80:0000:0000:0000:aaaa:bbb0-bbbf:cccc:dddd%4	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	fe80:0000:0000:0000:aaaa:bbb0-bbbf:cccc:dddd%4	false
+
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	fe20,fe70-fe90:0000:0000:0000:*:bbb0,bbb1,bbb2,bbb3,bbb4,bbbb,bbbc:cccc:dddd	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	fe20,fe70-fe90:0000:0000:0000:*:bbb0,bbb1,bbb2,bbb3,bbb4,bbbb,bbbc:cccc:dddd	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	fe20,fe70-fe90:0000:0000:0000:*:bbb0,bbb1,bbb2,bbb3,bbb4,bbbb,bbbc:cccc:dddd%4	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	fe20,fe70-fe90:0000:0000:0000:*:bbb0,bbb1,bbb2,bbb3,bbb4,bbbb,bbbc:cccc:dddd%4	false
+
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	true
+fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd	fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4	false

--- a/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
+++ b/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
@@ -77,6 +77,13 @@ public class Migrator {
 
     private static final String IPLIKE_SQL_RESOURCE = "iplike.sql";
 
+    /**
+     * Revision tag of the PL/pgSQL iplike implementation shipped in
+     * {@link #IPLIKE_SQL_RESOURCE} (set there via COMMENT ON FUNCTION).
+     * {@link #updateIplike()} replaces older PL/pgSQL revisions in place.
+     */
+    public static final String IPLIKE_PLPGSQL_REVISION = "opennms-iplike-plpgsql-2";
+
     private DataSource m_dataSource;
     private DataSource m_adminDataSource;
     private Float m_databaseVersion;
@@ -652,14 +659,14 @@ public class Migrator {
      */
     public void updateIplike() throws MigrationException {
 
-        boolean insert_iplike = !isIpLikeUsable();
-
-        if (insert_iplike) {
+        if (!isIpLikeUsable()) {
             dropExistingIpLike();
-
-            if (!installCIpLike("foo")) {
-                setupPlPgsqlIplike();
-            }
+            setupPlPgsqlIplike();
+        } else if (isStalePlPgsqlIplike()) {
+            // a working but older PL/pgSQL revision: replace it in place.
+            // A working C-extension iplike is intentionally left untouched.
+            dropExistingIpLike();
+            setupPlPgsqlIplike();
         }
 
         // XXX This error is generated from Postgres if eventtime(text)
@@ -720,30 +727,32 @@ public class Migrator {
         return true;
     }
 
-    private boolean installCIpLike(String pgIplikeLocation) throws MigrationException {
-        if (pgIplikeLocation == null) {
-            LOG.info("Skipped inserting C iplike function (location of iplike function not set)");
-            return false;
-        }
-
-        LOG.info("inserting C iplike function");
-
-        Statement st = null;
+    /**
+     * True when the installed iplike is a PL/pgSQL implementation older than
+     * {@link #IPLIKE_PLPGSQL_REVISION}. A C-extension iplike never counts as
+     * stale here: installs that added the optional compiled extension keep it.
+     */
+    private boolean isStalePlPgsqlIplike() throws MigrationException {
         Connection c = null;
+        Statement st = null;
+        ResultSet rs = null;
 
         try {
-            c  = m_dataSource.getConnection();
+            c = m_dataSource.getConnection();
             st = c.createStatement();
-            try {
-                st.execute("CREATE FUNCTION iplike(text,text) RETURNS bool " + "AS '" + pgIplikeLocation + "' LANGUAGE 'c' WITH(isstrict)");
-                return true;
-            } catch (final SQLException e) {
+            rs = st.executeQuery("SELECT l.lanname, obj_description(p.oid, 'pg_proc')"
+                    + " FROM pg_proc p JOIN pg_language l ON p.prolang = l.oid"
+                    + " WHERE p.oid = 'iplike(text,text)'::regprocedure");
+            if (!rs.next()) {
                 return false;
             }
+            final String language = rs.getString(1);
+            final String revision = rs.getString(2);
+            return "plpgsql".equals(language) && !IPLIKE_PLPGSQL_REVISION.equals(revision);
         } catch (final SQLException e) {
-            throw new MigrationException("error installing C iplike function", e);
+            throw new MigrationException("error checking the installed iplike revision", e);
         } finally {
-            cleanUpDatabase(c, null, st, null);
+            cleanUpDatabase(c, null, st, rs);
         }
     }
 

--- a/core/schema/src/main/liquibase/36.0.3/changelog.xml
+++ b/core/schema/src/main/liquibase/36.0.3/changelog.xml
@@ -69,4 +69,59 @@
         </rollback>
     </changeSet>
 
+    <!-- Native-inet IP filtering: a garbage-tolerant cast function plus
+         expression indexes over the text ipaddr columns. IplikeSqlTranslator
+         emits predicates over opennms_safe_inet(ipaddr) so PostgreSQL answers
+         iplike filter expressions through these indexes instead of evaluating
+         iplike() per row. The stored values stay text; IPv6 addresses carrying
+         a zone id (which the inet type cannot represent) index as the
+         zone-stripped address, and match expressions that constrain the zone
+         are not translated and call iplike() instead. -->
+
+    <changeSet runOnChange="true" author="mmassengill" id="opennms-safe-inet-function">
+        <createProcedure>
+CREATE OR REPLACE FUNCTION opennms_safe_inet(i_ipaddress text) RETURNS inet AS $safeinet$
+-- the zone id is stripped for IPv6 only: zone ids are IPv6-only, and
+-- iplike() rejects IPv4 values that carry one
+SELECT CASE
+  WHEN i_ipaddress ~ '^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}$'
+  THEN i_ipaddress::inet
+  WHEN split_part(i_ipaddress, '%', 1) ~ '^[0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){7}$'
+  THEN split_part(i_ipaddress, '%', 1)::inet
+  ELSE NULL
+END
+$safeinet$ LANGUAGE sql IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT;
+        </createProcedure>
+        <rollback>
+            <sql>DROP FUNCTION IF EXISTS opennms_safe_inet(text);</sql>
+        </rollback>
+    </changeSet>
+
+    <!-- CONCURRENTLY cannot run inside a transaction. The plain DROP first
+         clears any invalid index left behind by an interrupted concurrent
+         build, so a re-run of the changeset converges. -->
+    <changeSet runInTransaction="false" author="mmassengill" id="36.0.3-ipinterface-safe-inet-index">
+        <sql>DROP INDEX IF EXISTS ipinterface_safe_inet_idx;</sql>
+        <sql>CREATE INDEX CONCURRENTLY ipinterface_safe_inet_idx ON ipinterface (opennms_safe_inet(ipaddr));</sql>
+        <rollback>
+            <sql>DROP INDEX IF EXISTS ipinterface_safe_inet_idx;</sql>
+        </rollback>
+    </changeSet>
+
+    <!-- Partial: most events carry no ipaddr, and skipping them keeps the
+         per-insert index-maintenance cost on this high-churn table low.
+         Translated predicates always include "ipaddr IS NOT NULL" so the
+         planner can prove this index applicable.
+         The existing events_ipaddr_idx btree deliberately stays: the v1
+         event-list exact-interface filter (IPADDR = ?), ORDER BY ipaddr
+         sorting, and the REST v2 ipinterface join still compare the text
+         column directly and would regress to sequential scans without it. -->
+    <changeSet runInTransaction="false" author="mmassengill" id="36.0.3-events-safe-inet-index">
+        <sql>DROP INDEX IF EXISTS events_safe_inet_idx;</sql>
+        <sql>CREATE INDEX CONCURRENTLY events_safe_inet_idx ON events (opennms_safe_inet(ipaddr)) WHERE ipaddr IS NOT NULL;</sql>
+        <rollback>
+            <sql>DROP INDEX IF EXISTS events_safe_inet_idx;</sql>
+        </rollback>
+    </changeSet>
+
 </databaseChangeLog>

--- a/core/schema/src/main/resources/org/opennms/core/schema/iplike.sql
+++ b/core/schema/src/main/resources/org/opennms/core/schema/iplike.sql
@@ -27,8 +27,9 @@
 -- (verified against the iplike reference corpus by IPLikeCoverageIT):
 --   * value classification via family(::inet) instead of regex matching
 --     (the zone id is stripped with split_part first: ::inet cannot parse
---     it, and an 8-field LIKE guard keeps compressed IPv6 out of the
---     field-parsing loop, which assumes exactly 8 groups)
+--     it; an 8-field LIKE guard plus a strpos '::' rejection keep
+--     compressed IPv6 out of the field-parsing loop, which assumes
+--     exactly 8 groups)
 --   * to_number(x, '999') replaced by ::integer casts
 --   * regex operators in check_rule replaced by strpos()
 --   * parsing wrapped in a nested block whose EXCEPTION handler turns any
@@ -88,9 +89,13 @@ create or replace function iplike(i_ipaddress text, i_rule text) returns boolean
 
                 i := i + 1;
             end loop;
-        -- IPv6 (the LIKE guard requires the 8 fully-expanded groups this
-        -- parsing loop assumes, as the previous regex did)
+        -- IPv6: the parsing loop assumes 8 fully-expanded groups. The LIKE
+        -- guard alone still admits a middle one-group compression (seven
+        -- colons, e.g. fe80::1:2:3:4:5:6, valid to ::inet), which ltrim
+        -- would swallow and shift every later field — the strpos check
+        -- rejects all compressed forms, as the previous regex did
         elsif i_ipaddress like '%:%:%:%:%:%:%:%'
+              and strpos(split_part(i_ipaddress, '%', 1), '::') = 0
               and family(split_part(i_ipaddress, '%', 1)::inet) = 6
               and i_rule ~ E'^[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+(%.+)?$' then
             c_addrwork := i_ipaddress;

--- a/core/schema/src/main/resources/org/opennms/core/schema/iplike.sql
+++ b/core/schema/src/main/resources/org/opennms/core/schema/iplike.sql
@@ -20,6 +20,22 @@
 -- License.
 --
 
+-- PL/pgSQL implementation of iplike, revision 2 (see the COMMENT ON at the
+-- end; the Migrator uses it to upgrade older PL/pgSQL revisions in place).
+--
+-- Profiling-driven changes relative to revision 1, semantics unchanged
+-- (verified against the iplike reference corpus by IPLikeCoverageIT):
+--   * value classification via family(::inet) instead of regex matching
+--     (the zone id is stripped with split_part first: ::inet cannot parse
+--     it, and an 8-field LIKE guard keeps compressed IPv6 out of the
+--     field-parsing loop, which assumes exactly 8 groups)
+--   * to_number(x, '999') replaced by ::integer casts
+--   * regex operators in check_rule replaced by strpos()
+--   * parsing wrapped in a nested block whose EXCEPTION handler turns any
+--     cast/parse error into 'f' (this is what tolerates garbage input); the
+--     null check and the match-all fast paths stay OUTSIDE that block so the
+--     most common calls never pay the handler's subtransaction setup
+
 create or replace function iplike(i_ipaddress text, i_rule text) returns boolean as $$
   declare
     c_i integer;
@@ -28,14 +44,13 @@ create or replace function iplike(i_ipaddress text, i_rule text) returns boolean
     c_addrwork text;
     c_addrtemp text;
     c_rulework text;
-    c_ruletemp text;
     c_scopeid text;
     c_rulescope text;
 
     i integer;
 
   begin
-    if i_ipaddress is NULL or i_ipaddress is null then
+    if i_ipaddress is null then
         return 'f';
     end if;
 
@@ -43,94 +58,91 @@ create or replace function iplike(i_ipaddress text, i_rule text) returns boolean
         return 't';
     end if;
 
-    -- First, strip apart the IP address into octets, and
-    -- verify that they are legitimate (0-255)
-    --
-    -- IPv4
-    if i_ipaddress ~ E'^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' and i_rule ~ E'^[0-9*,-]+\.[0-9*,-]+\.[0-9*,-]+\.[0-9*,-]+$' then
-        c_addrwork := i_ipaddress;
-        c_rulework := i_rule;
+    begin
+        -- IPv4
+        if family(split_part(i_ipaddress, '%', 1)::inet) = 4 and i_rule ~ E'^[0-9*,-]+\\.[0-9*,-]+\\.[0-9*,-]+\\.[0-9*,-]+$' then
+            c_addrwork := i_ipaddress;
+            c_rulework := i_rule;
 
-        i := 0;
-        while i < 4 loop
-            if (strpos(c_addrwork, '.') > 0) then
-                c_i := to_number(substr(c_addrwork, 0, strpos(c_addrwork, '.')), '999');
-            else 
-                c_i := to_number(c_addrwork, '999');
-            end if;
+            i := 0;
+            while i < 4 loop
+                if (strpos(c_addrwork, '.') > 0) then
+                    c_i := (substr(c_addrwork, 0, strpos(c_addrwork, '.')))::integer;
+                else
+                    c_i := c_addrwork::integer;
+                end if;
 
-            if c_i > 255 then
-                return 'f';
-            end if;
-            c_addrwork := ltrim(ltrim(c_addrwork, '0123456789'), '.');
+                c_addrwork := ltrim(ltrim(c_addrwork, '0123456789'), '.');
 
-            if (strpos(c_rulework, '.') > 0) then
-                c_r := substr(c_rulework, 0, strpos(c_rulework, '.'));
-            else
-                c_r := c_rulework;
-            end if;
+                if (strpos(c_rulework, '.') > 0) then
+                    c_r := substr(c_rulework, 0, strpos(c_rulework, '.'));
+                else
+                    c_r := c_rulework;
+                end if;
 
-            if check_rule(c_i, c_r) is not true then
-                return 'f';
-            end if;
+                if check_rule(c_i, c_r) is not true then
+                    return 'f';
+                end if;
 
-            c_rulework := ltrim(ltrim(c_rulework, '0123456789,-*'), '.');
+                c_rulework := ltrim(ltrim(c_rulework, '0123456789,-*'), '.');
 
-            i := i + 1;
-        end loop;
-    -- IPv6
-    elsif i_ipaddress ~ E'^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+(%.+)?$' and i_rule ~ E'^[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+(%.+)?$' then
-        c_addrwork := i_ipaddress;
-        c_rulework := i_rule;
-
-        i := 0;
-        while i < 8 loop
-            if (strpos(c_addrwork, ':') > 0) then
-                c_addrtemp = substr(c_addrwork, 0, strpos(c_addrwork, ':'));
-            else 
-                c_addrtemp = c_addrwork;
-            end if;
-            if (strpos(c_addrtemp, '%') > 0) then
-                -- Strip off the scope ID for now
-                c_scopeid = substr(c_addrtemp, strpos(c_addrtemp, '%') + 1);
-                c_addrtemp = substr(c_addrtemp, 0, strpos(c_addrtemp, '%'));
-            end if;
-            while length(c_addrtemp) < 4 loop
-                c_addrtemp := '0' || c_addrtemp;
+                i := i + 1;
             end loop;
-            c_i := cast(cast('x' || cast(c_addrtemp as text) as bit(16)) as integer);
+        -- IPv6 (the LIKE guard requires the 8 fully-expanded groups this
+        -- parsing loop assumes, as the previous regex did)
+        elsif i_ipaddress like '%:%:%:%:%:%:%:%'
+              and family(split_part(i_ipaddress, '%', 1)::inet) = 6
+              and i_rule ~ E'^[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+:[0-9a-f*,-]+(%.+)?$' then
+            c_addrwork := i_ipaddress;
+            c_rulework := i_rule;
 
-            -- Max 16-bit integer value
-            if c_i > 65535 then
-                return 'f';
-            end if;
-            c_addrwork := ltrim(ltrim(c_addrwork, '0123456789abcdef'), ':');
+            i := 0;
+            while i < 8 loop
+                if (strpos(c_addrwork, ':') > 0) then
+                    c_addrtemp = substr(c_addrwork, 0, strpos(c_addrwork, ':'));
+                else
+                    c_addrtemp = c_addrwork;
+                end if;
+                if (strpos(c_addrtemp, '%') > 0) then
+                    -- Strip off the scope ID for now
+                    c_scopeid = substr(c_addrtemp, strpos(c_addrtemp, '%') + 1);
+                    c_addrtemp = substr(c_addrtemp, 0, strpos(c_addrtemp, '%'));
+                end if;
+                while length(c_addrtemp) < 4 loop
+                    c_addrtemp := '0' || c_addrtemp;
+                end loop;
+                c_i := cast(cast('x' || cast(c_addrtemp as text) as bit(16)) as integer);
 
-            if (strpos(c_rulework, ':') > 0) then
-                c_r := substr(c_rulework, 0, strpos(c_rulework, ':'));
-            elsif (strpos(c_rulework, '%') > 0) then
-                c_rulescope := substr(c_rulework, strpos(c_rulework, '%') + 1);
-                c_r := substr(c_rulework, 0, strpos(c_rulework, '%'));
-            else
-                c_r := c_rulework;
-            end if;
+                c_addrwork := ltrim(ltrim(c_addrwork, '0123456789abcdef'), ':');
 
-            if check_hex_rule(c_i, c_r) is not true then
-                return 'f';
-            end if;
-            if (c_rulescope is not null) and ((c_scopeid = c_rulescope) is not true) then
-                return 'f';
-            end if;
+                if (strpos(c_rulework, ':') > 0) then
+                    c_r := substr(c_rulework, 0, strpos(c_rulework, ':'));
+                elsif (strpos(c_rulework, '%') > 0) then
+                    c_rulescope := substr(c_rulework, strpos(c_rulework, '%') + 1);
+                    c_r := substr(c_rulework, 0, strpos(c_rulework, '%'));
+                else
+                    c_r := c_rulework;
+                end if;
 
-            c_rulework := ltrim(ltrim(c_rulework, '0123456789abcdef,-*'), ':');
+                if check_hex_rule(c_i, c_r) is not true then
+                    return 'f';
+                end if;
+                if (c_rulescope is not null) and ((c_scopeid = c_rulescope) is not true) then
+                    return 'f';
+                end if;
 
-            i := i + 1;
-        end loop;
-    else
+                c_rulework := ltrim(ltrim(c_rulework, '0123456789abcdef,-*'), ':');
+
+                i := i + 1;
+            end loop;
+        else
+            return 'f';
+        end if;
+
+        return 't';
+    exception when others then
         return 'f';
-    end if;
-
-  return 't';
+    end;
 end;
 $$ language plpgsql;
 
@@ -139,9 +151,8 @@ declare
     c_r1 integer;
     c_r2 integer;
 begin
-
-    c_r1 := to_number(split_part(i_rule, '-', 1), '999');
-    c_r2 := to_number(split_part(i_rule, '-', 2), '999');
+    c_r1 := split_part(i_rule, '-', 1)::integer;
+    c_r2 := split_part(i_rule, '-', 2)::integer;
     if i_octet between c_r1 and c_r2 then
         return 't';
     end if;
@@ -184,8 +195,7 @@ begin
 
     c_work := i_rule;
     while c_work <> '' loop
-        -- raise notice 'c_work = %',c_work;
-        if c_work ~ ',' then
+        if (strpos(c_work, ',') > 0) then
             c_element := substr(c_work, 0, strpos(c_work, ','));
             c_work := substr(c_work, strpos(c_work, ',')+1);
         else
@@ -193,14 +203,14 @@ begin
             c_work := '';
         end if;
 
-        if c_element ~ '-' then
+        if (strpos(c_element, '-') > 0) then
             if check_range(i_octet, c_element) then
                 return 't';
             end if;
         else
             if c_element = '*' then
                 return 't';
-            elsif i_octet = to_number(c_element, '99999') then
+            elsif i_octet = c_element::integer then
                 return 't';
             end if;
         end if;
@@ -220,8 +230,7 @@ begin
 
     c_work := i_rule;
     while c_work <> '' loop
-        -- raise notice 'c_work = %',c_work;
-        if c_work ~ ',' then
+        if (strpos(c_work, ',') > 0) then
             c_element := substr(c_work, 0, strpos(c_work, ','));
             c_work := substr(c_work, strpos(c_work, ',')+1);
         else
@@ -229,7 +238,7 @@ begin
             c_work := '';
         end if;
 
-        if c_element ~ '-' then
+        if (strpos(c_element, '-') > 0) then
             if check_hex_range(i_octet, c_element) then
                 return 't';
             end if;
@@ -245,3 +254,5 @@ begin
     return 'f';
 end;
 $$ language plpgsql;
+
+comment on function iplike(text, text) is 'opennms-iplike-plpgsql-2';

--- a/core/test-api/db/src/test/java/org/opennms/core/test/db/IPLikeCoverageIT.java
+++ b/core/test-api/db/src/test/java/org/opennms/core/test/db/IPLikeCoverageIT.java
@@ -22,15 +22,19 @@
 package org.opennms.core.test.db;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.opennms.core.schema.Migrator;
 import org.opennms.core.utils.DBUtils;
+import org.opennms.core.utils.IplikeSqlTranslator;
 
 public class IPLikeCoverageIT {
     private TemporaryDatabasePostgreSQL m_db;
@@ -153,8 +157,125 @@ public class IPLikeCoverageIT {
             rs.next();
             final boolean result = rs.getBoolean(1);
             assertEquals("SELECT iplike(" + value + "," + rule + ") === " + expected, expected, result);
+
+            // Where the rule translates to a native-inet predicate (what the
+            // SQL emitters produce instead of the iplike() call), the
+            // database must give the same answer for the same value — both
+            // directly and under NOT. The NOT check matters for values the
+            // predicate cannot parse: it must evaluate to FALSE there, not
+            // NULL, or negated filters would drop rows NOT iplike() keeps.
+            final String predicate = IplikeSqlTranslator.toSqlPredicate(rule, "v");
+            if (predicate != null) {
+                final PreparedStatement nativeSt = c.prepareStatement(
+                        "SELECT " + predicate + ", NOT " + predicate
+                        + " FROM (VALUES (CAST(? AS TEXT))) AS t(v)");
+                util.watch(nativeSt);
+                nativeSt.setString(1, value);
+                nativeSt.execute();
+                final ResultSet nativeRs = nativeSt.getResultSet();
+                util.watch(nativeRs);
+                nativeRs.next();
+                assertEquals("native predicate for rule " + rule + " on value " + value
+                        + ": " + predicate, expected, nativeRs.getBoolean(1));
+                assertEquals("negated native predicate for rule " + rule + " on value " + value
+                        + ": " + predicate, !expected, nativeRs.getBoolean(2));
+                assertFalse("negated native predicate must never be NULL for rule " + rule
+                        + " on value " + value, nativeRs.wasNull());
+            }
         } finally {
             util.cleanUp();
+        }
+    }
+
+    /**
+     * A working PL/pgSQL iplike older than the shipped revision must be
+     * replaced in place on upgrade (its revision tag lives in the function
+     * comment), while any working non-PL/pgSQL implementation — the compiled
+     * C extension in real installs — is left untouched.
+     */
+    @Test
+    public void testUpdateIplikeReplacesStalePlpgsqlRevision() throws Exception {
+        final Migrator migrator = new Migrator();
+        migrator.setDataSource(m_db.getDataSource());
+        migrator.setAdminDataSource(m_db.getDataSource());
+
+        executeSql("DROP FUNCTION iplike(text,text)");
+        executeSql("CREATE FUNCTION iplike(text,text) RETURNS boolean AS "
+                + "$$ begin return 't'; end; $$ LANGUAGE plpgsql");
+        executeSql("COMMENT ON FUNCTION iplike(text,text) IS 'opennms-iplike-plpgsql-1'");
+
+        migrator.updateIplike();
+
+        assertEquals(Migrator.IPLIKE_PLPGSQL_REVISION, getIplikeComment());
+        // the always-true stub is gone and real matching is back
+        checkIplikeRule("1.2.3.4", "1.2.3.5", false);
+        checkIplikeRule("1.2.3.4", "1.2.3.4", true);
+    }
+
+    @Test
+    public void testUpdateIplikeLeavesForeignImplementationsAlone() throws Exception {
+        final Migrator migrator = new Migrator();
+        migrator.setDataSource(m_db.getDataSource());
+        migrator.setAdminDataSource(m_db.getDataSource());
+
+        // a working iplike that is not PL/pgSQL stands in for the compiled
+        // extension: the stale check only ever replaces plpgsql revisions
+        executeSql("DROP FUNCTION iplike(text,text)");
+        executeSql("CREATE FUNCTION iplike(text,text) RETURNS boolean AS "
+                + "$$ SELECT true $$ LANGUAGE sql");
+        executeSql("COMMENT ON FUNCTION iplike(text,text) IS 'custom-iplike'");
+
+        migrator.updateIplike();
+
+        assertEquals("custom-iplike", getIplikeComment());
+    }
+
+    private void executeSql(final String sql) throws Exception {
+        final DBUtils util = new DBUtils();
+        try {
+            final Connection c = m_db.getDataSource().getConnection();
+            util.watch(c);
+            final Statement st = c.createStatement();
+            util.watch(st);
+            st.execute(sql);
+        } finally {
+            util.cleanUp();
+        }
+    }
+
+    private String getIplikeComment() throws Exception {
+        final DBUtils util = new DBUtils();
+        try {
+            final Connection c = m_db.getDataSource().getConnection();
+            util.watch(c);
+            final Statement st = c.createStatement();
+            util.watch(st);
+            final ResultSet rs = st.executeQuery(
+                    "SELECT obj_description('iplike(text,text)'::regprocedure, 'pg_proc')");
+            util.watch(rs);
+            rs.next();
+            return rs.getString(1);
+        } finally {
+            util.cleanUp();
+        }
+    }
+
+    /**
+     * Values iplike() rejects but that can sit in text ipaddr columns (the
+     * events table in particular). The native predicate must agree with
+     * iplike() on them in both polarities.
+     */
+    @Test
+    public void testUnrepresentableValuesAgainstTranslatableRules() throws Exception {
+        for (final String garbage : new String[] {
+                "garbage",
+                "fe80::1",              // compressed IPv6: iplike needs 8 groups
+                "1.2.3.4%eth0",         // zone ids are IPv6-only
+                "10.0.0.999",
+                " 1.2.3.4",
+                ""}) {
+            checkIplikeRule(garbage, "1.2.3.*", false);
+            checkIplikeRule(garbage, "fe80:*:*:*:*:*:*:*", false);
         }
     }
 

--- a/core/test-api/db/src/test/java/org/opennms/core/test/db/IPLikeCoverageIT.java
+++ b/core/test-api/db/src/test/java/org/opennms/core/test/db/IPLikeCoverageIT.java
@@ -270,6 +270,9 @@ public class IPLikeCoverageIT {
         for (final String garbage : new String[] {
                 "garbage",
                 "fe80::1",              // compressed IPv6: iplike needs 8 groups
+                "fe80::1:2:3:4:5:6",    // one-group compression still has 7 colons
+                "::1:2:3:4:5:6:7",
+                "1:2:3:4:5:6:7::",
                 "1.2.3.4%eth0",         // zone ids are IPv6-only
                 "10.0.0.999",
                 " 1.2.3.4",
@@ -277,6 +280,19 @@ public class IPLikeCoverageIT {
             checkIplikeRule(garbage, "1.2.3.*", false);
             checkIplikeRule(garbage, "fe80:*:*:*:*:*:*:*", false);
         }
+    }
+
+    /**
+     * A middle one-group compression (seven colons, valid inet) must not
+     * enter the 8-group parsing loop: ltrim would swallow the '::' and
+     * shift every later field, so the shifted rule matched and the correct
+     * expansion did not.
+     */
+    @Test
+    public void testCompressedIpv6NeverParsesShifted() throws Exception {
+        checkIplikeRule("fe80::1:2:3:4:5:6", "fe80:1:2:3:4:5:6:0", false); // the shifted misparse
+        checkIplikeRule("fe80::1:2:3:4:5:6", "fe80:0:1:2:3:4:5:6", false); // the correct expansion (value is rejected, as revision 1 did)
+        checkIplikeRule("fe80::1:2:0:4:5:6", "*:*:*:0:*:*:*:*", false);    // untranslatable rule -> the iplike() fallback path
     }
 
 }

--- a/docs/modules/reference/pages/configuration/filters/filters.adoc
+++ b/docs/modules/reference/pages/configuration/filters/filters.adoc
@@ -65,6 +65,24 @@ AND (snmpInterface.snmpifdescr = 'something else')
 LIMIT 1
 ----
 
-The IPLIKE function is shorthand to call a PostgreSQL function that was written in C to compare ipaddresses using *, lists, and ranges.
+The IPLIKE operator compares IP addresses using `*`, lists, and ranges.
+Where possible, the expression is translated to native PostgreSQL `inet` comparisons that can be answered through an index; expressions that cannot be translated (for example, patterns that contain an IPv6 zone identifier) call the `iplike` stored procedure instead.
 isService is shorthand to build a complicated join to match on a service name.
 notisService is also available.
+
+[NOTE]
+====
+The same translation applies to IP address searches on the event and alarm list pages and the corresponding REST endpoints.
+Selective searches are answered through an index and should not need tuning.
+On databases with very large `events` tables, broad patterns that match a large share of all events (for example, an entire /8) may still fall back to scanning.
+If such searches matter in your environment, the following can help PostgreSQL choose a better plan; measure before and after, since the effect depends on storage and data distribution:
+
+[source, sql]
+----
+CREATE STATISTICS events_ipaddr_inet_stats ON (opennms_safe_inet(ipaddr)) FROM events;
+ANALYZE events;
+----
+
+together with an SSD-appropriate `random_page_cost` setting (commonly `1.1`) in `postgresql.conf`.
+Both are standard PostgreSQL tuning mechanisms and work on all supported PostgreSQL versions.
+====

--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -19,6 +19,16 @@ Most installations require no action, but there are behavior and compatibility c
 custom Spring Security configuration (SSO, LDAP), custom Camel routes, or plugins that use the OpenNMS persistence APIs.
 See xref:spring-hibernate-upgrade.adoc[Spring, Hibernate, and Camel Platform Upgrade] for details.
 
+=== Faster IP address filtering (IPLIKE)
+
+Filter expressions that use IPLIKE are now translated to native PostgreSQL `inet` comparisons where possible, and new expression indexes on the `ipinterface` and `events` tables let the database answer them without scanning every row.
+This primarily benefits large environments: filter evaluation and event searches by IP address that previously took seconds to minutes generally complete in milliseconds.
+
+Expressions that cannot be translated (for example, patterns that contain an IPv6 zone identifier) continue to use the `iplike` stored procedure.
+The bundled PL/pgSQL implementation of `iplike` has been reworked for speed and is installed automatically during the upgrade; installs that use the optional compiled iplike extension keep it, but it is no longer needed.
+On installs that use the compiled extension, translated expressions follow the PL/pgSQL implementation's semantics; the one visible difference is the match-all patterns (`*.*.*.*` and `*:*:*:*:*:*:*:*`), which now match every non-null address regardless of address family, as they always have under the PL/pgSQL implementation.
+If necessary, set the system property `org.opennms.iplike.native=false` to restore the previous query behavior.
+
 === SNMP datacollection config moved to DB with new UI
 The contents of `etc/datacollection-config.xml` and `etc/datacollection/\*.xml` are migrated into the database during the upgrade process, and the original files are moved to `etc_archive/`.
 After upgrade, manage SNMP data collection through the *Administration -> Manage SNMP Data Collection Config* page (or the REST API under `/api/v2/datacollectionconf`).

--- a/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
@@ -46,6 +46,7 @@ import javax.sql.DataSource;
 
 import org.opennms.core.utils.DBUtils;
 import org.opennms.core.utils.InetAddressComparator;
+import org.opennms.core.utils.IplikeSqlTranslator;
 import org.opennms.netmgt.config.api.DatabaseSchemaConfig;
 import org.opennms.netmgt.config.filter.Table;
 import org.opennms.netmgt.filter.api.FilterDao;
@@ -701,13 +702,30 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
             sqlRule = sqlRule.replaceAll("\\s*!(?!=)\\s*", " NOT ");
             sqlRule = sqlRule.replaceAll("==", "=");
 
-            // Translate IPLIKE operators to IPLIKE() functions
+            // Translate IPLIKE operators to native-inet predicates where the
+            // match expression allows it, or to IPLIKE() functions otherwise
             // If IPLIKE is already used as a function in the filter, this regex should not match it
             regex = SQL_IPLIKE_PATTERN.matcher(sqlRule);
             tempStringBuff = new StringBuffer();
             while (regex.find()) {
-                // Is the second argument already a quoted string?
-                if (regex.group().charAt(0) == '#') {
+                // Resolve the raw match expression: group 2 is either a bare
+                // pattern or a placeholder for an extracted quoted string
+                String pattern = regex.group(2);
+                if (pattern.startsWith("###@")) {
+                    final String extracted = extractedStrings.get(Integer.parseInt(pattern.substring(4, pattern.length() - 4)));
+                    pattern = extracted.substring(1, extracted.length() - 1).replaceAll("''", "'");
+                }
+                if (IplikeSqlTranslator.toSqlPredicate(pattern, "ipaddr") != null) {
+                    // Translatable: emit an indexable native predicate. It is
+                    // stashed as an extracted string so the keyword/column
+                    // passes below leave its contents untouched; the column
+                    // reference therefore gets schema-qualified here.
+                    final String column = m_databaseSchemaConfigFactory.addColumn(tables, regex.group(1));
+                    extractedStrings.add(IplikeSqlTranslator.toSqlPredicate(pattern, column));
+                    regex.appendReplacement(tempStringBuff, "###@" + (extractedStrings.size() - 1) + "@###");
+                } else if (regex.group(2).startsWith("###@")) {
+                    // an extracted-string placeholder merges back with its own
+                    // quotes; wrapping it in quotes here would double them
                     regex.appendReplacement(tempStringBuff, "IPLIKE($1, $2)");
                 } else {
                     regex.appendReplacement(tempStringBuff, "IPLIKE($1, '$2')");

--- a/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoNativeInetTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoNativeInetTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.filter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.core.utils.IplikeSqlTranslator;
+import org.opennms.netmgt.config.DatabaseSchemaConfigFactory;
+
+/**
+ * Pure (no-database) tests that {@link JdbcFilterDao#parseRule} rewrites
+ * translatable IPLIKE expressions into native-inet predicates over
+ * {@code opennms_safe_inet()} (served by an expression index) and keeps the
+ * iplike() call for everything the translator declines.
+ */
+public class JdbcFilterDaoNativeInetTest {
+
+    private JdbcFilterDao m_dao;
+
+    @Before
+    public void setUp() throws Exception {
+        m_dao = new JdbcFilterDao();
+        m_dao.setDatabaseSchemaConfigFactory(
+                new DatabaseSchemaConfigFactory(getClass().getResourceAsStream("/database-schema.xml")));
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(IplikeSqlTranslator.ENABLED_PROPERTY);
+    }
+
+    private String whereClause(final String rule) {
+        final String sql = m_dao.getInterfaceWithServiceStatement(rule);
+        return sql.substring(sql.indexOf("WHERE "));
+    }
+
+    @Test
+    public void translatableBareRuleBecomesNativePredicate() {
+        final String where = whereClause("ipaddr IPLIKE 10.0.1-3.*");
+        assertTrue("expected a schema-qualified safe_inet predicate: " + where,
+                where.contains("opennms_safe_inet(ipInterface.ipaddr) >= inet '10.0.1.0'"));
+        assertTrue(where.contains("opennms_safe_inet(ipInterface.ipaddr) <= inet '10.0.3.255'"));
+        assertTrue(where.contains("ipInterface.ipaddr IS NOT NULL"));
+        assertFalse("no iplike call expected: " + where, where.toUpperCase().contains("IPLIKE("));
+    }
+
+    @Test
+    public void translatableQuotedRuleBecomesNativePredicate() {
+        final String where = whereClause("ipaddr IPLIKE \"192.168.1.1\"");
+        assertTrue("expected an equality safe_inet predicate: " + where,
+                where.contains("opennms_safe_inet(ipInterface.ipaddr) = inet '192.168.1.1'"));
+        assertFalse(where.toUpperCase().contains("IPLIKE("));
+    }
+
+    @Test
+    public void matchAllBecomesNotNull() {
+        final String where = whereClause("ipaddr IPLIKE *.*.*.*");
+        assertTrue(where.contains("ipInterface.ipaddr IS NOT NULL"));
+        assertFalse(where.toUpperCase().contains("IPLIKE("));
+    }
+
+    @Test
+    public void zoneIdRuleKeepsIplike() {
+        // zone-id patterns have no inet representation; must fall back to a
+        // correctly single-quoted iplike() call (the extracted string carries
+        // its own quotes and must not be wrapped in another pair)
+        final String where = whereClause("ipaddr IPLIKE \"fe80:*:*:*:*:*:*:*%1\"");
+        assertTrue("zone-id rules must keep iplike(): " + where,
+                where.contains("IPLIKE(ipInterface.ipaddr, 'fe80:*:*:*:*:*:*:*%1')"));
+        assertFalse(where.contains("''"));
+        assertFalse(where.contains("opennms_safe_inet"));
+    }
+
+    @Test
+    public void negatedRuleWrapsNativePredicate() {
+        final String where = whereClause("!(ipaddr IPLIKE 10.0.1-3.*)");
+        assertTrue("negation must survive translation: " + where, where.contains(" NOT "));
+        assertTrue(where.contains("opennms_safe_inet(ipInterface.ipaddr)"));
+    }
+
+    @Test
+    public void escapeHatchRestoresIplike() {
+        System.setProperty(IplikeSqlTranslator.ENABLED_PROPERTY, "false");
+        final String where = whereClause("ipaddr IPLIKE 10.0.1-3.*");
+        assertTrue("disabled translation must emit iplike(): " + where,
+                where.toUpperCase().contains("IPLIKE("));
+        assertFalse(where.contains("opennms_safe_inet"));
+    }
+}

--- a/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoParenthesizationTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/filter/JdbcFilterDaoParenthesizationTest.java
@@ -76,10 +76,11 @@ public class JdbcFilterDaoParenthesizationTest {
 
     @Test
     public void plainRuleStillWorks() throws Exception {
+        // *.*.*.* translates to a native match-all (see JdbcFilterDaoNativeInetTest)
         final String sql = m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *.*.*.*");
         System.out.println("plain rule: " + sql);
         final String where = sql.substring(sql.indexOf("WHERE "));
-        assertTrue(where.startsWith("WHERE (IPLIKE("));
+        assertTrue(where.startsWith("WHERE (ipInterface.ipaddr IS NOT NULL"));
         assertTrue(where.endsWith(")"));
     }
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/HibernateCriteriaConverter.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/HibernateCriteriaConverter.java
@@ -498,6 +498,16 @@ public class HibernateCriteriaConverter implements CriteriaConverter<DetachedCri
             if (Strings.isNullOrEmpty(attribute)) {
                 attribute = "ipAddr";
             }
+            if (restriction.getValue() instanceof String) {
+                // translatable match expressions become native-inet range
+                // predicates answered through an expression index
+                final String nativePredicate = org.opennms.core.utils.IplikeSqlTranslator
+                        .toSqlPredicate((String) restriction.getValue(), "{alias}." + attribute);
+                if (nativePredicate != null) {
+                    m_criterions.add(org.hibernate.criterion.Restrictions.sqlRestriction(nativePredicate));
+                    return;
+                }
+            }
             final String sql = String.format("ipLike({alias}.%s, ?)", attribute);
             m_criterions.add(org.hibernate.criterion.Restrictions.sqlRestriction(sql, restriction.getValue(), STRING_TYPE));
         }

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/HibernateCriteriaConverterIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/HibernateCriteriaConverterIT.java
@@ -22,6 +22,7 @@
 package org.opennms.netmgt.dao.hibernate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -34,9 +35,12 @@ import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.model.OnmsCriteria;
+import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.slf4j.Logger;
@@ -67,6 +71,9 @@ public class HibernateCriteriaConverterIT implements InitializingBean {
 
     @Autowired
     NodeDao m_nodeDao;
+
+    @Autowired
+    IpInterfaceDao m_ipInterfaceDao;
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -123,5 +130,49 @@ public class HibernateCriteriaConverterIT implements InitializingBean {
         nodes = m_nodeDao.findMatching(cb.toCriteria());
         assertEquals(1, nodes.size());
         assertEquals(Integer.valueOf(1), nodes.get(0).getId());
+    }
+
+    /**
+     * The iplike restriction rides the converter's native-inet translation
+     * for translatable match expressions and the iplike() stored procedure
+     * for the rest; both must agree with plain string matching on the
+     * populated interfaces, in both polarities.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    public void testIplikeQuery() {
+        final List<OnmsIpInterface> all = m_ipInterfaceDao.findAll();
+        final long expected = all.stream()
+                .map(iface -> InetAddressUtils.str(iface.getIpAddress()))
+                .filter(addr -> addr.startsWith("192.168.1."))
+                .count();
+        assertTrue(expected > 0);
+
+        // translatable pattern: answered by the native-inet predicate
+        CriteriaBuilder cb = new CriteriaBuilder(OnmsIpInterface.class);
+        cb.iplike("ipAddr", "192.168.1.*");
+        assertEquals(expected, m_ipInterfaceDao.findMatching(cb.toCriteria()).size());
+
+        // negated: everything else must come back, exactly like NOT iplike()
+        cb = new CriteriaBuilder(OnmsIpInterface.class);
+        cb.not().iplike("ipAddr", "192.168.1.*");
+        assertEquals(all.size() - expected, m_ipInterfaceDao.findMatching(cb.toCriteria()).size());
+
+        // a zoneless v6 rule matches the populator's zoned fe80:...%5
+        // interface through the native predicate (the value's zone id is
+        // stripped by opennms_safe_inet)
+        cb = new CriteriaBuilder(OnmsIpInterface.class);
+        cb.iplike("ipAddr", "fe80:*:*:*:*:*:*:*");
+        assertEquals(1, m_ipInterfaceDao.findMatching(cb.toCriteria()).size());
+
+        // a zone-constrained rule is untranslatable and falls back to the
+        // iplike() stored procedure
+        cb = new CriteriaBuilder(OnmsIpInterface.class);
+        cb.iplike("ipAddr", "fe80:*:*:*:*:*:*:*%5");
+        assertEquals(1, m_ipInterfaceDao.findMatching(cb.toCriteria()).size());
+
+        cb = new CriteriaBuilder(OnmsIpInterface.class);
+        cb.iplike("ipAddr", "fe80:*:*:*:*:*:*:*%99");
+        assertEquals(0, m_ipInterfaceDao.findMatching(cb.toCriteria()).size());
     }
 }

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/JdbcFilterDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/JdbcFilterDaoIT.java
@@ -346,12 +346,12 @@ public class JdbcFilterDaoIT implements InitializingBean {
 
     @Test
     public void testGetInterfaceWithServiceStatement() throws Exception {
-        assertEquals("SQL from getInterfaceWithServiceStatement", "SELECT DISTINCT ipInterface.ipAddr, service.serviceName, node.nodeID FROM ipInterface JOIN ifServices ON (ipInterface.id = ifServices.ipInterfaceId) JOIN service ON (ifServices.serviceID = service.serviceID) JOIN node ON (ipInterface.nodeID = node.nodeID) WHERE (IPLIKE(ipInterface.ipaddr, '*.*.*.*'))", m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *.*.*.*"));
+        assertEquals("SQL from getInterfaceWithServiceStatement", "SELECT DISTINCT ipInterface.ipAddr, service.serviceName, node.nodeID FROM ipInterface JOIN ifServices ON (ipInterface.id = ifServices.ipInterfaceId) JOIN service ON (ifServices.serviceID = service.serviceID) JOIN node ON (ipInterface.nodeID = node.nodeID) WHERE (ipInterface.ipaddr IS NOT NULL)", m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *.*.*.*"));
     }
 
     @Test
     public void testGetIpv6InterfaceWithServiceStatement() throws Exception {
-        assertEquals("SQL from getIpv6InterfaceWithServiceStatement", "SELECT DISTINCT ipInterface.ipAddr, service.serviceName, node.nodeID FROM ipInterface JOIN ifServices ON (ipInterface.id = ifServices.ipInterfaceId) JOIN service ON (ifServices.serviceID = service.serviceID) JOIN node ON (ipInterface.nodeID = node.nodeID) WHERE (IPLIKE(ipInterface.ipaddr, '*:*:*:*:*:*:*:*'))", m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *:*:*:*:*:*:*:*"));
+        assertEquals("SQL from getIpv6InterfaceWithServiceStatement", "SELECT DISTINCT ipInterface.ipAddr, service.serviceName, node.nodeID FROM ipInterface JOIN ifServices ON (ipInterface.id = ifServices.ipInterfaceId) JOIN service ON (ifServices.serviceID = service.serviceID) JOIN node ON (ipInterface.nodeID = node.nodeID) WHERE (ipInterface.ipaddr IS NOT NULL)", m_dao.getInterfaceWithServiceStatement("ipaddr IPLIKE *:*:*:*:*:*:*:*"));
     }
 
     @Test

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsRestrictions.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsRestrictions.java
@@ -24,6 +24,7 @@ package org.opennms.netmgt.model;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.type.StringType;
+import org.opennms.core.utils.IplikeSqlTranslator;
 
 /**
  * Provide OpenNMS-specific Hibernate Restrictions.
@@ -33,14 +34,20 @@ import org.hibernate.type.StringType;
  */
 public abstract class OnmsRestrictions {
     private static final StringType STRING_TYPE = new StringType();
-    
+
     /**
      * Performs an iplike match on the ipAddr column of the current table.
+     * Translatable match expressions become native-inet range predicates the
+     * database answers through an expression index; the rest call iplike().
      *
      * @param value iplike match
      * @return SQL restriction for this iplike match
      */
     public static Criterion ipLike(String value) {
+        final String nativePredicate = IplikeSqlTranslator.toSqlPredicate(value, "{alias}.ipAddr");
+        if (nativePredicate != null) {
+            return Restrictions.sqlRestriction(nativePredicate);
+        }
         return Restrictions.sqlRestriction("iplike({alias}.ipAddr, ?)", value, STRING_TYPE);
     }
 }

--- a/opennms-model/src/test/java/org/opennms/netmgt/model/OnmsRestrictionsTest.java
+++ b/opennms-model/src/test/java/org/opennms/netmgt/model/OnmsRestrictionsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * {@link OnmsRestrictions#ipLike} must emit a native-inet predicate for
+ * translatable match expressions and keep the iplike() call for the rest;
+ * both are SQL fragments over the aliased ipAddr column.
+ */
+public class OnmsRestrictionsTest {
+
+    @Test
+    public void translatableExpressionBecomesNativePredicate() {
+        final String sql = OnmsRestrictions.ipLike("192.168.1-5.*").toString();
+        assertTrue("expected a safe_inet range predicate: " + sql,
+                sql.contains("opennms_safe_inet({alias}.ipAddr) >= inet '192.168.1.0'"));
+        assertTrue(sql.contains("opennms_safe_inet({alias}.ipAddr) <= inet '192.168.5.255'"));
+        assertFalse("no iplike call expected: " + sql, sql.contains("iplike("));
+    }
+
+    @Test
+    public void zoneIdExpressionKeepsIplike() {
+        final String sql = OnmsRestrictions.ipLike("fe80:*:*:*:*:*:*:*%1").toString();
+        assertTrue("zone-id rules must keep iplike(): " + sql,
+                sql.contains("iplike({alias}.ipAddr, ?)"));
+        assertFalse(sql.contains("opennms_safe_inet"));
+    }
+
+    @Test
+    public void malformedExpressionKeepsIplike() {
+        // iplike() evaluates malformed rules to false at runtime; the
+        // translator must decline them rather than guess
+        final String sql = OnmsRestrictions.ipLike("not-an-address").toString();
+        assertTrue(sql.contains("iplike({alias}.ipAddr, ?)"));
+        assertFalse(sql.contains("opennms_safe_inet"));
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -53,6 +53,7 @@ import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.core.utils.IplikeSqlTranslator;
 import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -296,12 +297,24 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
                 return;
             }
             final String pattern = ((String)v).replaceAll("%", "*");
+            // translatable patterns become native-inet range predicates the
+            // database answers through an expression index; the rest keep iplike()
+            final String nativePredicate = IplikeSqlTranslator.toSqlPredicate(pattern, "ipaddr");
+            final String match = nativePredicate != null ? nativePredicate : "iplike(ipaddr, ?)";
             switch (c) {
             case EQUALS:
-                b.sql("{alias}.nodeid in (select nodeid from ipinterface where iplike(ipaddr, ?))", pattern, Type.STRING);
+                if (nativePredicate != null) {
+                    b.sql("{alias}.nodeid in (select nodeid from ipinterface where " + match + ")");
+                } else {
+                    b.sql("{alias}.nodeid in (select nodeid from ipinterface where " + match + ")", pattern, Type.STRING);
+                }
                 break;
             case NOT_EQUALS:
-                b.sql("{alias}.nodeid not in (select nodeid from ipinterface where iplike(ipaddr, ?))", pattern, Type.STRING);
+                if (nativePredicate != null) {
+                    b.sql("{alias}.nodeid not in (select nodeid from ipinterface where " + match + ")");
+                } else {
+                    b.sql("{alias}.nodeid not in (select nodeid from ipinterface where " + match + ")", pattern, Type.STRING);
+                }
                 break;
             default:
                 throw new IllegalArgumentException("Illegal condition type for iplike expression: " + c);

--- a/opennms-webapp/src/main/java/org/opennms/web/filter/IPLikeFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/filter/IPLikeFilter.java
@@ -24,6 +24,7 @@ package org.opennms.web.filter;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.type.StringType;
+import org.opennms.core.utils.IplikeSqlTranslator;
 
 
 /**
@@ -46,15 +47,24 @@ public abstract class IPLikeFilter extends OneArgFilter<String> {
     /** {@inheritDoc} */
     @Override
     public String getSQLTemplate() {
+        // stays on iplike(): the template contract requires exactly one %s
+        // consumed as a bound JDBC parameter (bindParam is final and always
+        // binds one), which a translated predicate cannot satisfy
         return " IPLIKE(" + getSQLFieldName() + ", %s) ";
     }
 
     /** {@inheritDoc} */
     @Override
     public Criterion getCriterion() {
+        // translatable match expressions become native-inet range predicates
+        // answered through an expression index; the rest call iplike()
+        final String nativePredicate = IplikeSqlTranslator.toSqlPredicate(getValue(), "{alias}." + getPropertyName());
+        if (nativePredicate != null) {
+            return Restrictions.sqlRestriction(nativePredicate);
+        }
         return Restrictions.sqlRestriction("iplike( {alias}."+getPropertyName()+", ?)", getValue(), StringType.INSTANCE);
     }
-    
-    
+
+
 
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/filter/NegativeIPLikeFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/filter/NegativeIPLikeFilter.java
@@ -52,6 +52,15 @@ public abstract class NegativeIPLikeFilter extends OneArgFilter<String> {
     /** {@inheritDoc} */
     @Override
     public Criterion getCriterion() {
+        // translatable match expressions become native-inet range predicates
+        // answered through an expression index; the rest call iplike().
+        // Under NOT, rows with a NULL address are included either way, same
+        // as the PL/pgSQL iplike (which returns false, not NULL, for them).
+        final String nativePredicate = org.opennms.core.utils.IplikeSqlTranslator
+                .toSqlPredicate(getValue(), "{alias}." + getPropertyName());
+        if (nativePredicate != null) {
+            return Restrictions.not(Restrictions.sqlRestriction(nativePredicate));
+        }
         return Restrictions.not(Restrictions.sqlRestriction("iplike( {alias}." + getPropertyName() + ", ?)", getValue(), StringType.INSTANCE));
     }
 }

--- a/opennms-webapp/src/test/java/org/opennms/web/event/filter/WebEventRepositoryFilterIT.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/event/filter/WebEventRepositoryFilterIT.java
@@ -24,9 +24,12 @@ package org.opennms.web.event.filter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+
+import javax.sql.DataSource;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +54,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,6 +90,9 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
     
     @Autowired
     ApplicationContext m_appContext;
+
+    @Autowired
+    DataSource m_dataSource;
     
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -244,6 +251,28 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
         filter = new IPAddrLikeFilter("193.168");
         events = getMatchingDaoEvents(filter);
         assertEquals(0, events.length);
+    }
+
+    @Test
+    @JUnitTemporaryDatabase // commits a raw row, so it needs a throwaway database
+    public void testNegativeIpAddrLikeFilterKeepsUnparseableAddresses() {
+        // A compressed-IPv6 ipaddr: hydrates fine Java-side but neither
+        // iplike() nor opennms_safe_inet() parses it (both require the
+        // 8-group stored form). Inserted with raw SQL because the entity
+        // path always normalizes to the 8-group form. A negated IP filter
+        // must keep such rows, exactly like NOT iplike() does.
+        new JdbcTemplate(m_dataSource).update(
+                "INSERT INTO events (eventid, eventuei, eventtime, eventsource, eventcreatetime, eventseverity, eventlog, eventdisplay, ipaddr, systemid) "
+                + "VALUES (nextval('eventsNxtId'), 'uei.opennms.org/test/unparseable', now(), 'test', now(), ?, 'Y', 'Y', 'fe80::1', ?)",
+                OnmsSeverity.NORMAL.getId(), m_dbPopulator.getDistPollerDao().whoami().getId());
+
+        final Event[] negated = getMatchingDaoEvents(new NegativeIPAddrLikeFilter("192.168.*.*"));
+        assertTrue("negated iplike filters must keep rows whose ipaddr no engine can parse",
+                Arrays.stream(negated).anyMatch(e -> "uei.opennms.org/test/unparseable".equals(e.getUei())));
+
+        final Event[] matched = getMatchingDaoEvents(new IPAddrLikeFilter("192.168.*.*"));
+        assertTrue(Arrays.stream(matched).noneMatch(e -> "uei.opennms.org/test/unparseable".equals(e.getUei())));
+        assertEquals(2, matched.length);
     }
     
     @Test


### PR DESCRIPTION
This change introduces a translation layer for IPLIKE along with using native inet from PostgreSQL where possible (there is an exception with IPv6 Zone IDs).  It's a decent performance improvement (benchmark results in the NMS issue).

The speedups for the PL/pgSQL are from work done by @dino2gnt.  

Assisted by Anthropic Claude Fable 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19980

