### PR TITLE
NMS-20045: Backend for new UI for Surveillance Views

### DIFF
--- a/features/bsm/rest/impl/pom.xml
+++ b/features/bsm/rest/impl/pom.xml
@@ -73,6 +73,13 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Same reason: SurveillanceViewRestService's model classes. -->
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>org.opennms.features.surveillance-views</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.opennms.features.distributed</groupId>
       <artifactId>org.opennms.features.distributed.kv-store.json.postgres</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -23,6 +23,9 @@
     <!-- Custom topology views + the image assets they reference -->
     <module>topology-views</module>
 
+    <!-- Surveillance view definitions + status/drill-down data services -->
+    <module>surveillance-views</module>
+
     <!-- ActiveMQ broker -->
     <module>activemq</module>
 

--- a/features/status/rest/pom.xml
+++ b/features/status/rest/pom.xml
@@ -64,6 +64,13 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Same reason: SurveillanceViewRestService's model classes. -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>org.opennms.features.surveillance-views</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.opennms.features.distributed</groupId>
             <artifactId>org.opennms.features.distributed.kv-store.json.postgres</artifactId>

--- a/features/surveillance-views/pom.xml
+++ b/features/surveillance-views/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.opennms</groupId>
+    <artifactId>org.opennms.features</artifactId>
+    <version>36.0.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>org.opennms.features.surveillance-views</artifactId>
+  <packaging>bundle</packaging>
+  <name>OpenNMS :: Features :: Surveillance Views</name>
+  <description>
+    Surveillance view definitions and the data services behind them, replacing
+    the Vaadin surveillance-views feature:
+    (1) view definitions: named row/column grids of node categories (model +
+    JsonStore DAO, kvstore_jsonb, context "surveillance-views"); an empty
+    store is seeded with the stock default view (the legacy XML is not read);
+    (2) data: cell status (nodes down/total per row-and-column category
+    intersection) plus the alarm / notification / node-RTC drill-downs.
+    The JAX-RS resource exposing /api/v2/surveillance/views lives in
+    opennms-webapp-rest.
+  </description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>hibernate-dependencies</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>spring-dependencies</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.features.distributed</groupId>
+      <artifactId>org.opennms.features.distributed.kv-store.api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gsonVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-dao-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core</groupId>
+      <artifactId>org.opennms.core.criteria</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-dao</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-dao-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-config</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.lib</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.db</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.services</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Provides PostgresJsonStore + applicationContext-postgresJsonStore.xml
+         for the DAO integration test. -->
+    <dependency>
+      <groupId>org.opennms.features.distributed</groupId>
+      <artifactId>org.opennms.features.distributed.kv-store.json.postgres</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- applicationContext-mockConfigManager.xml for the data-service ITs. -->
+    <dependency>
+      <groupId>org.opennms.features.config</groupId>
+      <artifactId>org.opennms.features.config.mock</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Pulls the default (rrd) timeseries strategy beans that
+         applicationContext-dao.xml wires, so the test context loads. -->
+    <dependency>
+      <groupId>org.opennms.features.collection</groupId>
+      <artifactId>org.opennms.features.collection.persistence.rrd</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-rrdtool-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.features.collection</groupId>
+      <artifactId>org.opennms.features.collection.persistence.osgi</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>jrrd2-dependencies</artifactId>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/SurveillanceView.java
+++ b/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/SurveillanceView.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A surveillance view definition: a named grid whose rows and columns are
+ * each a labelled set of node categories. A grid cell reports on the nodes
+ * in the intersection of its row's and column's category sets.
+ *
+ * <p>This is the successor to the {@code view} element of the legacy
+ * {@code surveillance-views.xml}. Views are persisted as JSON blobs in the
+ * generic key-value store (see {@code SurveillanceViewJsonStore}); the
+ * {@code id} is a store-assigned key (a UUID), not a database sequence value.
+ *
+ * <p>Per-user targeting is by naming convention, as it always was: a view
+ * whose name equals a username (or one of the user's group names) is that
+ * user's view; otherwise the configured default applies. There is no ACL on
+ * the view itself. {@link #getOwner() owner} records who created it
+ * (informational).
+ */
+public class SurveillanceView {
+
+    public static final int DEFAULT_REFRESH_SECONDS = 300;
+
+    private String id;
+    private String name;
+    private Integer refreshSeconds;
+    private List<SurveillanceViewDef> rows = new ArrayList<>();
+    private List<SurveillanceViewDef> columns = new ArrayList<>();
+    private String owner;
+    private Date created;
+    private Date lastModified;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getRefreshSeconds() {
+        return refreshSeconds;
+    }
+
+    public void setRefreshSeconds(Integer refreshSeconds) {
+        this.refreshSeconds = refreshSeconds;
+    }
+
+    public List<SurveillanceViewDef> getRows() {
+        return rows;
+    }
+
+    public void setRows(List<SurveillanceViewDef> rows) {
+        this.rows = rows == null ? new ArrayList<>() : rows;
+    }
+
+    public List<SurveillanceViewDef> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(List<SurveillanceViewDef> columns) {
+        this.columns = columns == null ? new ArrayList<>() : columns;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public Date getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(Date lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("id", id)
+                .add("name", name)
+                .add("refreshSeconds", refreshSeconds)
+                .add("rows", rows)
+                .add("columns", columns)
+                .add("owner", owner)
+                .toString();
+    }
+}

--- a/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/SurveillanceViewDao.java
+++ b/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/SurveillanceViewDao.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views;
+
+import java.util.List;
+
+/**
+ * Persistence for surveillance view definitions. A small, purpose-built CRUD
+ * contract (not the generic {@code OnmsDao}) so it can be backed by the
+ * generic JSON key-value store rather than Hibernate.
+ */
+public interface SurveillanceViewDao {
+
+    /** All views, in no particular order. */
+    List<SurveillanceView> findAll();
+
+    /** A view by id, or {@code null} if none exists. */
+    SurveillanceView get(String id);
+
+    /** A view by its unique name, or {@code null} if none exists. */
+    SurveillanceView findByName(String name);
+
+    /**
+     * Persist a new view, assigning and returning its generated id. The view's
+     * {@code id} is ignored on input.
+     */
+    String save(SurveillanceView view);
+
+    /** Persist changes to an existing view (identified by its {@code id}). */
+    void update(SurveillanceView view);
+
+    /** Remove a view (identified by its {@code id}). */
+    void delete(SurveillanceView view);
+
+    /**
+     * The id of the view to fall back to when neither the username nor any of
+     * the user's group names matches a view name, or {@code null} if no
+     * default is configured.
+     */
+    String getDefaultViewId();
+
+    /** Set (or, with {@code null}, clear) the default view id. */
+    void setDefaultViewId(String viewId);
+}

--- a/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/SurveillanceViewDataService.java
+++ b/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/SurveillanceViewDataService.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import org.opennms.netmgt.model.SurveillanceStatus;
+
+/**
+ * Computes the data a surveillance view renders: the grid of cell statuses,
+ * plus the alarm / notification / node-RTC drill-downs for a selected
+ * row-and-column category intersection.
+ *
+ * <p>This is the non-UI core of the retired Vaadin
+ * {@code SurveillanceViewService}. Drill-downs take category <em>names</em>
+ * (a view row's or column's {@code categories}) and return detached value
+ * objects, fully materialized inside the service's transaction, so callers
+ * never touch lazy Hibernate state.
+ */
+public interface SurveillanceViewDataService {
+
+    /**
+     * The status of every cell of the view: for each row/column pair, the
+     * count of nodes with at least one down service ("down") out of all nodes
+     * ("total") in the intersection of the row's and column's categories.
+     * Indexed {@code [row][column]} in definition order.
+     *
+     * @throws IllegalArgumentException if the view references a category name
+     *                                  that does not exist
+     */
+    SurveillanceStatus[][] calculateCellStatus(SurveillanceView view);
+
+    /**
+     * The most recent unacknowledged alarms (up to 100) on non-deleted nodes
+     * in the intersection of the two category sets.
+     */
+    List<SurveillanceAlarm> getAlarmsForCategories(Set<String> rowCategories, Set<String> columnCategories);
+
+    /**
+     * Notifications for nodes in the intersection of the two category sets,
+     * bucketed the way the legacy dashboard did: unresponded and older than 15
+     * minutes are "Critical", unresponded but newer are "Minor", and responded
+     * ones from the last week are "Normal" (see {@code getSeverity()}).
+     */
+    List<SurveillanceNotification> getNotificationsForCategories(Set<String> rowCategories, Set<String> columnCategories);
+
+    /**
+     * Per-node 24-hour availability (RTC) for nodes in the intersection of the
+     * two category sets.
+     */
+    List<NodeRtc> getNodeRtcsForCategories(Set<String> rowCategories, Set<String> columnCategories);
+
+    /** An unacknowledged alarm, flattened for display. */
+    class SurveillanceAlarm {
+        private final Integer id;
+        private final String uei;
+        private final String severity;
+        private final Integer nodeId;
+        private final String nodeLabel;
+        private final String logMessage;
+        private final Date lastEventTime;
+        private final Integer count;
+
+        public SurveillanceAlarm(Integer id, String uei, String severity, Integer nodeId, String nodeLabel, String logMessage, Date lastEventTime, Integer count) {
+            this.id = id;
+            this.uei = uei;
+            this.severity = severity;
+            this.nodeId = nodeId;
+            this.nodeLabel = nodeLabel;
+            this.logMessage = logMessage;
+            this.lastEventTime = lastEventTime;
+            this.count = count;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public String getUei() {
+            return uei;
+        }
+
+        public String getSeverity() {
+            return severity;
+        }
+
+        public Integer getNodeId() {
+            return nodeId;
+        }
+
+        public String getNodeLabel() {
+            return nodeLabel;
+        }
+
+        public String getLogMessage() {
+            return logMessage;
+        }
+
+        public Date getLastEventTime() {
+            return lastEventTime;
+        }
+
+        public Integer getCount() {
+            return count;
+        }
+    }
+
+    /** A notification with its dashboard severity bucket. */
+    class SurveillanceNotification {
+        private final Integer id;
+        private final Integer nodeId;
+        private final String nodeLabel;
+        private final String serviceName;
+        private final String textMessage;
+        private final Date pageTime;
+        private final Date respondTime;
+        private final String answeredBy;
+        private final String severity;
+
+        public SurveillanceNotification(Integer id, Integer nodeId, String nodeLabel, String serviceName, String textMessage, Date pageTime, Date respondTime, String answeredBy, String severity) {
+            this.id = id;
+            this.nodeId = nodeId;
+            this.nodeLabel = nodeLabel;
+            this.serviceName = serviceName;
+            this.textMessage = textMessage;
+            this.pageTime = pageTime;
+            this.respondTime = respondTime;
+            this.answeredBy = answeredBy;
+            this.severity = severity;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Integer getNodeId() {
+            return nodeId;
+        }
+
+        public String getNodeLabel() {
+            return nodeLabel;
+        }
+
+        public String getServiceName() {
+            return serviceName;
+        }
+
+        public String getTextMessage() {
+            return textMessage;
+        }
+
+        public Date getPageTime() {
+            return pageTime;
+        }
+
+        public Date getRespondTime() {
+            return respondTime;
+        }
+
+        public String getAnsweredBy() {
+            return answeredBy;
+        }
+
+        public String getSeverity() {
+            return severity;
+        }
+    }
+
+    /** A node's 24-hour availability: service counts and the up-time ratio (0..1). */
+    class NodeRtc {
+        private final Integer nodeId;
+        private final String nodeLabel;
+        private final int serviceCount;
+        private final int downServiceCount;
+        private final double availability;
+
+        public NodeRtc(Integer nodeId, String nodeLabel, int serviceCount, int downServiceCount, double availability) {
+            this.nodeId = nodeId;
+            this.nodeLabel = nodeLabel;
+            this.serviceCount = serviceCount;
+            this.downServiceCount = downServiceCount;
+            this.availability = availability;
+        }
+
+        public Integer getNodeId() {
+            return nodeId;
+        }
+
+        public String getNodeLabel() {
+            return nodeLabel;
+        }
+
+        public int getServiceCount() {
+            return serviceCount;
+        }
+
+        public int getDownServiceCount() {
+            return downServiceCount;
+        }
+
+        public double getAvailability() {
+            return availability;
+        }
+    }
+}

--- a/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/SurveillanceViewDef.java
+++ b/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/SurveillanceViewDef.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * One row or column of a {@link SurveillanceView}: a label plus the node
+ * category names it aggregates (the legacy {@code row-def}/{@code column-def}).
+ * {@code reportCategory} is carried for round-trip fidelity with the legacy
+ * XML model; nothing in the new stack consumes it.
+ */
+public class SurveillanceViewDef {
+
+    private String label;
+    private List<String> categories = new ArrayList<>();
+    private String reportCategory;
+
+    public SurveillanceViewDef() {
+    }
+
+    public SurveillanceViewDef(String label, String... categories) {
+        this.label = label;
+        for (String category : categories) {
+            this.categories.add(category);
+        }
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public List<String> getCategories() {
+        return categories;
+    }
+
+    public void setCategories(List<String> categories) {
+        this.categories = categories == null ? new ArrayList<>() : categories;
+    }
+
+    public String getReportCategory() {
+        return reportCategory;
+    }
+
+    public void setReportCategory(String reportCategory) {
+        this.reportCategory = reportCategory;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("label", label)
+                .add("categories", categories)
+                .add("reportCategory", reportCategory)
+                .toString();
+    }
+}

--- a/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/impl/DefaultSurveillanceViewDataService.java
+++ b/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/impl/DefaultSurveillanceViewDataService.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.opennms.core.criteria.Alias;
+import org.opennms.core.criteria.Criteria;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.core.criteria.Order;
+import org.opennms.core.criteria.restrictions.Restriction;
+import org.opennms.core.criteria.restrictions.Restrictions;
+import org.opennms.core.criteria.restrictions.SqlRestriction.Type;
+import org.opennms.netmgt.dao.api.AlarmDao;
+import org.opennms.netmgt.dao.api.CategoryDao;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.NotificationDao;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsNotification;
+import org.opennms.netmgt.model.OnmsOutage;
+import org.opennms.netmgt.model.SurveillanceStatus;
+import org.opennms.netmgt.surveillance.views.SurveillanceView;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDataService;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDef;
+import org.springframework.transaction.support.TransactionOperations;
+
+/**
+ * Port of the aggregation logic from the retired Vaadin
+ * {@code DefaultSurveillanceViewService}: the category-intersection SQL, the
+ * notification severity bucketing, and the 24-hour RTC math are carried over
+ * unchanged. Everything runs inside {@link TransactionOperations} and returns
+ * detached value objects.
+ */
+public class DefaultSurveillanceViewDataService implements SurveillanceViewDataService {
+
+    private NodeDao m_nodeDao;
+    private CategoryDao m_categoryDao;
+    private AlarmDao m_alarmDao;
+    private NotificationDao m_notificationDao;
+    private OutageDao m_outageDao;
+    private MonitoredServiceDao m_monitoredServiceDao;
+    private TransactionOperations m_transactionOperations;
+
+    public void setNodeDao(NodeDao nodeDao) {
+        m_nodeDao = nodeDao;
+    }
+
+    public void setCategoryDao(CategoryDao categoryDao) {
+        m_categoryDao = categoryDao;
+    }
+
+    public void setAlarmDao(AlarmDao alarmDao) {
+        m_alarmDao = alarmDao;
+    }
+
+    public void setNotificationDao(NotificationDao notificationDao) {
+        m_notificationDao = notificationDao;
+    }
+
+    public void setOutageDao(OutageDao outageDao) {
+        m_outageDao = outageDao;
+    }
+
+    public void setMonitoredServiceDao(MonitoredServiceDao monitoredServiceDao) {
+        m_monitoredServiceDao = monitoredServiceDao;
+    }
+
+    public void setTransactionOperations(TransactionOperations transactionOperations) {
+        m_transactionOperations = transactionOperations;
+    }
+
+    @Override
+    public SurveillanceStatus[][] calculateCellStatus(final SurveillanceView view) {
+        return m_transactionOperations.execute(status -> {
+            final List<Collection<OnmsCategory>> rowCategories = resolveDefs(view, view.getRows());
+            final List<Collection<OnmsCategory>> columnCategories = resolveDefs(view, view.getColumns());
+
+            final SurveillanceStatus[][] cellStatus = new SurveillanceStatus[rowCategories.size()][columnCategories.size()];
+            for (int rowIndex = 0; rowIndex < rowCategories.size(); rowIndex++) {
+                for (int colIndex = 0; colIndex < columnCategories.size(); colIndex++) {
+                    cellStatus[rowIndex][colIndex] = m_nodeDao.findSurveillanceStatusByCategoryLists(rowCategories.get(rowIndex), columnCategories.get(colIndex));
+                }
+            }
+            return cellStatus;
+        });
+    }
+
+    private List<Collection<OnmsCategory>> resolveDefs(final SurveillanceView view, final List<SurveillanceViewDef> defs) {
+        final List<Collection<OnmsCategory>> resolved = new ArrayList<>(defs.size());
+        for (final SurveillanceViewDef def : defs) {
+            final List<OnmsCategory> categories = new ArrayList<>(def.getCategories().size());
+            for (final String categoryName : def.getCategories()) {
+                final OnmsCategory category = m_categoryDao.findByName(categoryName);
+                if (category == null) {
+                    throw new IllegalArgumentException("Surveillance view '" + view.getName() + "' references the unknown category '" + categoryName + "'");
+                }
+                categories.add(category);
+            }
+            resolved.add(categories);
+        }
+        return resolved;
+    }
+
+    @Override
+    public List<SurveillanceAlarm> getAlarmsForCategories(final Set<String> rowCategories, final Set<String> columnCategories) {
+        if (rowCategories.isEmpty() || columnCategories.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return m_transactionOperations.execute(status -> {
+            final CriteriaBuilder criteriaBuilder = new CriteriaBuilder(OnmsAlarm.class);
+
+            criteriaBuilder.alias("node", "node");
+            criteriaBuilder.ne("node.type", "D");
+            criteriaBuilder.isNull("alarmAckUser");
+
+            criteriaBuilder.limit(100);
+            criteriaBuilder.distinct();
+
+            addCategoryIntersectionRestriction(criteriaBuilder, "{alias}.nodeId", rowCategories, columnCategories);
+
+            final List<SurveillanceAlarm> alarms = new ArrayList<>();
+            for (final OnmsAlarm alarm : m_alarmDao.findMatching(criteriaBuilder.toCriteria())) {
+                final OnmsNode node = alarm.getNode();
+                alarms.add(new SurveillanceAlarm(
+                        alarm.getId(),
+                        alarm.getUei(),
+                        alarm.getSeverity() != null ? alarm.getSeverity().getLabel() : null,
+                        node != null ? node.getId() : null,
+                        node != null ? node.getLabel() : null,
+                        alarm.getLogMsg(),
+                        alarm.getLastEventTime(),
+                        alarm.getCounter()));
+            }
+            return alarms;
+        });
+    }
+
+    @Override
+    public List<SurveillanceNotification> getNotificationsForCategories(final Set<String> rowCategories, final Set<String> columnCategories) {
+        if (rowCategories.isEmpty() || columnCategories.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return m_transactionOperations.execute(status -> {
+            final Date fifteenMinutesAgo = new Date(System.currentTimeMillis() - (15 * 60 * 1000));
+            final Date oneWeekAgo = new Date(System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000));
+
+            final List<SurveillanceNotification> notifications = new ArrayList<>();
+            notifications.addAll(getNotificationsWithCriterias(rowCategories, columnCategories, "Critical", Restrictions.isNull("respondTime"), Restrictions.le("pageTime", fifteenMinutesAgo)));
+            notifications.addAll(getNotificationsWithCriterias(rowCategories, columnCategories, "Minor", Restrictions.isNull("respondTime"), Restrictions.gt("pageTime", fifteenMinutesAgo)));
+            notifications.addAll(getNotificationsWithCriterias(rowCategories, columnCategories, "Normal", Restrictions.isNotNull("respondTime"), Restrictions.gt("pageTime", oneWeekAgo)));
+            return notifications;
+        });
+    }
+
+    @Override
+    public List<NodeRtc> getNodeRtcsForCategories(final Set<String> rowCategories, final Set<String> columnCategories) {
+        if (rowCategories.isEmpty() || columnCategories.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return m_transactionOperations.execute(status -> {
+            final CriteriaBuilder outageCriteriaBuilder = new CriteriaBuilder(OnmsOutage.class);
+
+            outageCriteriaBuilder.isNull("perspective");
+            outageCriteriaBuilder.alias("monitoredService", "monitoredService", Alias.JoinType.INNER_JOIN);
+            outageCriteriaBuilder.alias("monitoredService.ipInterface", "ipInterface", Alias.JoinType.INNER_JOIN);
+            outageCriteriaBuilder.alias("monitoredService.ipInterface.node", "node", Alias.JoinType.INNER_JOIN);
+            outageCriteriaBuilder.eq("monitoredService.status", "A");
+            outageCriteriaBuilder.ne("ipInterface.isManaged", "D");
+            outageCriteriaBuilder.ne("node.type", "D");
+
+            final CriteriaBuilder serviceCriteriaBuilder = new CriteriaBuilder(OnmsMonitoredService.class);
+
+            serviceCriteriaBuilder.alias("ipInterface", "ipInterface", Alias.JoinType.INNER_JOIN);
+            serviceCriteriaBuilder.alias("ipInterface.node", "node", Alias.JoinType.INNER_JOIN);
+            serviceCriteriaBuilder.alias("serviceType", "serviceType", Alias.JoinType.INNER_JOIN);
+            serviceCriteriaBuilder.alias("currentOutages", "currentOutages", Alias.JoinType.LEFT_JOIN);
+            serviceCriteriaBuilder.eq("status", "A");
+            serviceCriteriaBuilder.ne("ipInterface.isManaged", "D");
+            serviceCriteriaBuilder.ne("node.type", "D");
+
+            // HACK (carried over from the Vaadin service): Hibernate aliases
+            // 'node' as 'node2_' for this entity graph, so the raw SQL
+            // restriction must use that alias.
+            addCategoryIntersectionRestriction(serviceCriteriaBuilder, "node2_.nodeId", rowCategories, columnCategories);
+
+            return getNodeRtcsForCriteria(serviceCriteriaBuilder.toCriteria(), outageCriteriaBuilder.toCriteria());
+        });
+    }
+
+    /**
+     * Restricts a query to nodes that are members of at least one row category
+     * AND at least one column category (the surveillance-view cell semantics).
+     */
+    private static void addCategoryIntersectionRestriction(final CriteriaBuilder criteriaBuilder, final String nodeIdProperty, final Set<String> rowCategories, final Set<String> columnCategories) {
+        final List<String> parameters = new ArrayList<>(rowCategories);
+        parameters.addAll(columnCategories);
+
+        final Type[] types = new Type[parameters.size()];
+        Arrays.fill(types, Type.STRING);
+
+        criteriaBuilder.sql(
+                createQuery(nodeIdProperty, rowCategories.size(), columnCategories.size()),
+                parameters.toArray(new String[parameters.size()]),
+                types);
+    }
+
+    private static String createQuery(final String nodeIdProperty, final int rowCategoryCount, final int columnCategoryCount) {
+        final StringBuilder stringBuffer = new StringBuilder();
+
+        stringBuffer.append(nodeIdProperty + " in (select distinct cn.nodeId from category_node cn join categories c on cn.categoryId = c.categoryId where c.categoryName in (");
+
+        String[] questionMarks = new String[rowCategoryCount];
+        Arrays.fill(questionMarks, "?");
+        stringBuffer.append(String.join(",", questionMarks));
+
+        stringBuffer.append("))");
+
+        stringBuffer.append("and " + nodeIdProperty + " in (select distinct cn.nodeId from category_node cn join categories c on cn.categoryId = c.categoryId where c.categoryName in (");
+
+        questionMarks = new String[columnCategoryCount];
+        Arrays.fill(questionMarks, "?");
+        stringBuffer.append(String.join(",", questionMarks));
+
+        stringBuffer.append("))");
+
+        return stringBuffer.toString();
+    }
+
+    private List<SurveillanceNotification> getNotificationsWithCriterias(final Set<String> rowCategories, final Set<String> columnCategories, final String severity, final Restriction... criterias) {
+        final CriteriaBuilder criteriaBuilder = new CriteriaBuilder(OnmsNotification.class);
+
+        criteriaBuilder.alias("node", "node");
+
+        addCategoryIntersectionRestriction(criteriaBuilder, "{alias}.nodeId", rowCategories, columnCategories);
+
+        criteriaBuilder.ne("node.type", "D");
+        criteriaBuilder.orderBy("pageTime", false);
+
+        final Criteria criteria = criteriaBuilder.toCriteria();
+
+        for (final Restriction restriction : criterias) {
+            criteria.addRestriction(restriction);
+        }
+
+        final List<SurveillanceNotification> notifications = new ArrayList<>();
+        for (final OnmsNotification notification : m_notificationDao.findMatching(criteria)) {
+            final OnmsNode node = notification.getNode();
+            notifications.add(new SurveillanceNotification(
+                    notification.getNotifyId(),
+                    node != null ? node.getId() : null,
+                    node != null ? node.getLabel() : null,
+                    notification.getServiceType() != null ? notification.getServiceType().getName() : null,
+                    notification.getTextMsg(),
+                    notification.getPageTime(),
+                    notification.getRespondTime(),
+                    notification.getAnsweredBy(),
+                    severity));
+        }
+        return notifications;
+    }
+
+    private static double calculateAvailability(final long serviceCount, final long downMillisCount) {
+        final long upMillis = (serviceCount * (24L * 60L * 60L * 1000L)) - downMillisCount;
+
+        return ((double) upMillis / (double) (serviceCount * (24 * 60 * 60 * 1000)));
+    }
+
+    private static Map<OnmsMonitoredService, Long> calculateServiceDownTime(final Date periodEnd, final Date periodStart, final List<OnmsOutage> outages) {
+        final Map<OnmsMonitoredService, Long> map = new HashMap<>();
+        for (final OnmsOutage outage : outages) {
+            if (map.get(outage.getMonitoredService()) == null) {
+                map.put(outage.getMonitoredService(), Long.valueOf(0));
+            }
+
+            final Date begin;
+            if (outage.getIfLostService().before(periodStart)) {
+                begin = periodStart;
+            } else {
+                begin = outage.getIfLostService();
+            }
+
+            final Date end;
+            if (outage.getIfRegainedService() == null || !outage.getIfRegainedService().before(periodEnd)) {
+                end = periodEnd;
+            } else {
+                end = outage.getIfRegainedService();
+            }
+
+            Long count = map.get(outage.getMonitoredService());
+            count += (end.getTime() - begin.getTime());
+            map.put(outage.getMonitoredService(), count);
+        }
+        return map;
+    }
+
+    private List<NodeRtc> getNodeRtcsForCriteria(final Criteria serviceCriteria, final Criteria outageCriteria) {
+        final List<Order> ordersService = new ArrayList<>();
+        ordersService.add(Order.asc("node.label"));
+        ordersService.add(Order.asc("node.id"));
+        ordersService.add(Order.asc("ipInterface.ipAddress"));
+        ordersService.add(Order.asc("serviceType.name"));
+        serviceCriteria.setOrders(ordersService);
+
+        final Date periodEnd = new Date(System.currentTimeMillis());
+        final Date periodStart = new Date(periodEnd.getTime() - (24 * 60 * 60 * 1000));
+
+        outageCriteria.addRestriction(Restrictions.any(Restrictions.isNull("ifRegainedService"), Restrictions.ge("ifLostService", periodStart), Restrictions.ge("ifRegainedService", periodStart)));
+        final List<Order> ordersOutage = new ArrayList<>();
+        ordersOutage.add(Order.asc("monitoredService"));
+        ordersOutage.add(Order.asc("ifLostService"));
+        outageCriteria.setOrders(ordersOutage);
+
+        final List<OnmsMonitoredService> services = m_monitoredServiceDao.findMatching(serviceCriteria);
+        final List<OnmsOutage> outages = m_outageDao.findMatching(outageCriteria);
+
+        final Map<OnmsMonitoredService, Long> serviceDownTime = calculateServiceDownTime(periodEnd, periodStart, outages);
+
+        final List<NodeRtc> model = new ArrayList<>();
+
+        OnmsNode lastNode = null;
+        int serviceCount = 0;
+        int serviceDownCount = 0;
+        long downMillisCount = 0;
+        for (final OnmsMonitoredService service : services) {
+            if (!service.getIpInterface().getNode().equals(lastNode) && lastNode != null) {
+                model.add(new NodeRtc(lastNode.getId(), lastNode.getLabel(), serviceCount, serviceDownCount, calculateAvailability(serviceCount, downMillisCount)));
+
+                serviceCount = 0;
+                serviceDownCount = 0;
+                downMillisCount = 0;
+            }
+
+            serviceCount++;
+            if (service.isDown()) {
+                serviceDownCount++;
+            }
+
+            final Long downMillis = serviceDownTime.get(service);
+            if (downMillis != null) {
+                downMillisCount += downMillis;
+            }
+
+            lastNode = service.getIpInterface().getNode();
+        }
+        if (lastNode != null) {
+            model.add(new NodeRtc(lastNode.getId(), lastNode.getLabel(), serviceCount, serviceDownCount, calculateAvailability(serviceCount, downMillisCount)));
+        }
+
+        return model;
+    }
+}

--- a/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/impl/DefaultSurveillanceViewDataService.java
+++ b/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/impl/DefaultSurveillanceViewDataService.java
@@ -245,7 +245,7 @@ public class DefaultSurveillanceViewDataService implements SurveillanceViewDataS
         Arrays.fill(questionMarks, "?");
         stringBuffer.append(String.join(",", questionMarks));
 
-        stringBuffer.append("))");
+        stringBuffer.append(")) ");
 
         stringBuffer.append("and " + nodeIdProperty + " in (select distinct cn.nodeId from category_node cn join categories c on cn.categoryId = c.categoryId where c.categoryName in (");
 

--- a/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/impl/SurveillanceViewJsonStore.java
+++ b/features/surveillance-views/src/main/java/org/opennms/netmgt/surveillance/views/impl/SurveillanceViewJsonStore.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views.impl;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.opennms.features.distributed.kvstore.api.JsonStore;
+import org.opennms.netmgt.surveillance.views.SurveillanceView;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDao;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * Stores surveillance view definitions in the generic JSON key-value store
+ * ({@link JsonStore}), replacing the legacy {@code etc/surveillance-views.xml}
+ * (which is not read: pre-existing customized views are recreated through the
+ * REST API/UI). Each view is one JSON blob under the {@value #CONTEXT}
+ * context, keyed by a generated UUID; the default-view setting is a single
+ * blob in its own {@value #SETTINGS_CONTEXT} context so enumerating views
+ * stays clean.
+ *
+ * <p>{@link #init()} seeds the stock default view (the same grid the legacy
+ * XML shipped) into an empty store, so fresh installs and upgrades start with
+ * a working view.
+ *
+ * <p>Listing the catalog ({@link #findAll()} / {@link #findByName(String)})
+ * enumerates the context; the catalog is human-scale (a handful of views), so
+ * this is inexpensive.
+ */
+public class SurveillanceViewJsonStore implements SurveillanceViewDao {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SurveillanceViewJsonStore.class);
+
+    static final String CONTEXT = "surveillance-views";
+    static final String SETTINGS_CONTEXT = "surveillance-views-settings";
+    static final String SETTINGS_KEY = "settings";
+
+    /** Stable id for the seeded stock view. */
+    static final String DEFAULT_VIEW_ID = "default";
+    static final String DEFAULT_VIEW_NAME = "default";
+
+    private final JsonStore jsonStore;
+    private final Gson gson = new Gson();
+
+    public SurveillanceViewJsonStore(final JsonStore jsonStore) {
+        this.jsonStore = Objects.requireNonNull(jsonStore);
+    }
+
+    /**
+     * Wire as the bean {@code init-method}: seed the stock default view if the
+     * store holds no views at all. Once any view exists, restarts never add or
+     * resurrect anything.
+     */
+    public void init() {
+        try {
+            if (!findAll().isEmpty()) {
+                return;
+            }
+            final SurveillanceView view = stockDefaultView();
+            view.setId(DEFAULT_VIEW_ID);
+            view.setCreated(new Date());
+            put(view);
+            setDefaultViewId(DEFAULT_VIEW_ID);
+            LOG.info("Seeded the stock default surveillance view");
+        } catch (final Exception e) {
+            // Never block context startup on a seeding hiccup.
+            LOG.warn("Could not seed the default surveillance view: {}", e.getMessage());
+        }
+    }
+
+    /** The grid the legacy etc/surveillance-views.xml shipped by default. */
+    private static SurveillanceView stockDefaultView() {
+        final SurveillanceView view = new SurveillanceView();
+        view.setName(DEFAULT_VIEW_NAME);
+        view.setRefreshSeconds(SurveillanceView.DEFAULT_REFRESH_SECONDS);
+        view.setOwner("system");
+        view.getRows().add(new SurveillanceViewDef("Routers", "Routers"));
+        view.getRows().add(new SurveillanceViewDef("Switches", "Switches"));
+        view.getRows().add(new SurveillanceViewDef("Servers", "Servers"));
+        view.getColumns().add(new SurveillanceViewDef("PROD", "Production"));
+        view.getColumns().add(new SurveillanceViewDef("TEST", "Test"));
+        view.getColumns().add(new SurveillanceViewDef("DEV", "Development"));
+        return view;
+    }
+
+    @Override
+    public List<SurveillanceView> findAll() {
+        final Map<String, String> entries = jsonStore.enumerateContext(CONTEXT);
+        if (entries == null || entries.isEmpty()) {
+            return new ArrayList<>();
+        }
+        final List<SurveillanceView> views = new ArrayList<>(entries.size());
+        for (final Map.Entry<String, String> entry : entries.entrySet()) {
+            final SurveillanceView view = deserialize(entry.getKey(), entry.getValue());
+            if (view != null) {
+                views.add(view);
+            }
+        }
+        return views;
+    }
+
+    @Override
+    public SurveillanceView get(final String id) {
+        if (id == null) {
+            return null;
+        }
+        return jsonStore.get(id, CONTEXT).map(json -> deserialize(id, json)).orElse(null);
+    }
+
+    @Override
+    public SurveillanceView findByName(final String name) {
+        if (name == null) {
+            return null;
+        }
+        return findAll().stream().filter(v -> name.equals(v.getName())).findFirst().orElse(null);
+    }
+
+    @Override
+    public String save(final SurveillanceView view) {
+        Objects.requireNonNull(view);
+        view.setId(UUID.randomUUID().toString());
+        if (view.getCreated() == null) {
+            view.setCreated(new Date());
+        }
+        put(view);
+        return view.getId();
+    }
+
+    @Override
+    public void update(final SurveillanceView view) {
+        Objects.requireNonNull(view);
+        Objects.requireNonNull(view.getId(), "cannot update a view without an id");
+        put(view);
+    }
+
+    @Override
+    public void delete(final SurveillanceView view) {
+        if (view == null || view.getId() == null) {
+            return;
+        }
+        jsonStore.delete(view.getId(), CONTEXT);
+        // A dangling default would silently resolve to nothing; clear it.
+        if (view.getId().equals(getDefaultViewId())) {
+            setDefaultViewId(null);
+        }
+    }
+
+    @Override
+    public String getDefaultViewId() {
+        return jsonStore.get(SETTINGS_KEY, SETTINGS_CONTEXT).map(json -> {
+            try {
+                final Settings settings = gson.fromJson(json, Settings.class);
+                return settings == null ? null : settings.defaultViewId;
+            } catch (final JsonSyntaxException e) {
+                LOG.warn("Ignoring malformed surveillance view settings: {}", e.getMessage());
+                return null;
+            }
+        }).orElse(null);
+    }
+
+    @Override
+    public void setDefaultViewId(final String viewId) {
+        final Settings settings = new Settings();
+        settings.defaultViewId = viewId;
+        jsonStore.put(SETTINGS_KEY, gson.toJson(settings), SETTINGS_CONTEXT);
+    }
+
+    private void put(final SurveillanceView view) {
+        jsonStore.put(view.getId(), gson.toJson(toStored(view)), CONTEXT);
+    }
+
+    private SurveillanceView deserialize(final String id, final String json) {
+        try {
+            final Stored stored = gson.fromJson(json, Stored.class);
+            if (stored == null) {
+                return null;
+            }
+            final SurveillanceView view = new SurveillanceView();
+            view.setId(id);
+            view.setName(stored.name);
+            view.setRefreshSeconds(stored.refreshSeconds);
+            view.setRows(fromStoredDefs(stored.rows));
+            view.setColumns(fromStoredDefs(stored.columns));
+            view.setOwner(stored.owner);
+            view.setCreated(stored.created != null ? new Date(stored.created) : null);
+            view.setLastModified(stored.lastModified != null ? new Date(stored.lastModified) : null);
+            return view;
+        } catch (final JsonSyntaxException e) {
+            LOG.warn("Skipping malformed surveillance view '{}': {}", id, e.getMessage());
+            return null;
+        }
+    }
+
+    private static Stored toStored(final SurveillanceView view) {
+        final Stored stored = new Stored();
+        stored.name = view.getName();
+        stored.refreshSeconds = view.getRefreshSeconds();
+        stored.rows = toStoredDefs(view.getRows());
+        stored.columns = toStoredDefs(view.getColumns());
+        stored.owner = view.getOwner();
+        stored.created = view.getCreated() != null ? view.getCreated().getTime() : null;
+        stored.lastModified = view.getLastModified() != null ? view.getLastModified().getTime() : null;
+        return stored;
+    }
+
+    private static List<StoredDef> toStoredDefs(final List<SurveillanceViewDef> defs) {
+        final List<StoredDef> storedDefs = new ArrayList<>(defs.size());
+        for (final SurveillanceViewDef def : defs) {
+            final StoredDef storedDef = new StoredDef();
+            storedDef.label = def.getLabel();
+            storedDef.categories = new ArrayList<>(def.getCategories());
+            storedDef.reportCategory = def.getReportCategory();
+            storedDefs.add(storedDef);
+        }
+        return storedDefs;
+    }
+
+    private static List<SurveillanceViewDef> fromStoredDefs(final List<StoredDef> storedDefs) {
+        final List<SurveillanceViewDef> defs = new ArrayList<>();
+        if (storedDefs == null) {
+            return defs;
+        }
+        for (final StoredDef storedDef : storedDefs) {
+            final SurveillanceViewDef def = new SurveillanceViewDef();
+            def.setLabel(storedDef.label);
+            if (storedDef.categories != null) {
+                def.setCategories(new ArrayList<>(storedDef.categories));
+            }
+            def.setReportCategory(storedDef.reportCategory);
+            defs.add(def);
+        }
+        return defs;
+    }
+
+    /** On-the-wire (in-store) shape: timestamps as epoch millis, id is the key. */
+    private static final class Stored {
+        private String name;
+        private Integer refreshSeconds;
+        private List<StoredDef> rows;
+        private List<StoredDef> columns;
+        private String owner;
+        private Long created;
+        private Long lastModified;
+    }
+
+    private static final class StoredDef {
+        private String label;
+        private List<String> categories;
+        private String reportCategory;
+    }
+
+    private static final class Settings {
+        private String defaultViewId;
+    }
+}

--- a/features/surveillance-views/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/surveillance-views/src/main/resources/META-INF/opennms/component-dao.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
+       xsi:schemaLocation="
+           http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+           http://xmlns.opennms.org/xsd/spring/onms-osgi
+           http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
+
+    <!-- Surveillance view definitions are persisted in the generic JSON
+         key-value store. Reuse the existing 'jsonStore' bean (the shared
+         PostgresJsonStore wired into the DAO context) rather than declaring
+         our own, for the same reason as the topology-views DAO: a second
+         JsonStore bean makes type-based @Autowired ambiguous elsewhere.
+         init() imports a legacy etc/surveillance-views.xml once, if the
+         store holds no views yet. -->
+    <bean id="surveillanceViewDao" class="org.opennms.netmgt.surveillance.views.impl.SurveillanceViewJsonStore" init-method="init">
+        <constructor-arg ref="jsonStore" />
+    </bean>
+    <onmsgi:service interface="org.opennms.netmgt.surveillance.views.SurveillanceViewDao" ref="surveillanceViewDao" />
+
+    <!-- The status/drill-down computations behind the surveillance view REST
+         resource. All collaborators are beans of the shared DAO context. -->
+    <bean id="surveillanceViewDataService" class="org.opennms.netmgt.surveillance.views.impl.DefaultSurveillanceViewDataService">
+        <property name="nodeDao" ref="nodeDao" />
+        <property name="categoryDao" ref="categoryDao" />
+        <property name="alarmDao" ref="alarmDao" />
+        <property name="notificationDao" ref="notificationDao" />
+        <property name="outageDao" ref="outageDao" />
+        <property name="monitoredServiceDao" ref="monitoredServiceDao" />
+        <property name="transactionOperations" ref="transactionTemplate" />
+    </bean>
+    <onmsgi:service interface="org.opennms.netmgt.surveillance.views.SurveillanceViewDataService" ref="surveillanceViewDataService" />
+
+</beans>

--- a/features/surveillance-views/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/surveillance-views/src/main/resources/META-INF/opennms/component-dao.xml
@@ -13,8 +13,8 @@
          PostgresJsonStore wired into the DAO context) rather than declaring
          our own, for the same reason as the topology-views DAO: a second
          JsonStore bean makes type-based @Autowired ambiguous elsewhere.
-         init() imports a legacy etc/surveillance-views.xml once, if the
-         store holds no views yet. -->
+         init() seeds the stock default view when the store holds no views
+         at all; the legacy etc/surveillance-views.xml is never read. -->
     <bean id="surveillanceViewDao" class="org.opennms.netmgt.surveillance.views.impl.SurveillanceViewJsonStore" init-method="init">
         <constructor-arg ref="jsonStore" />
     </bean>

--- a/features/surveillance-views/src/test/java/org/opennms/netmgt/surveillance/views/DefaultSurveillanceViewDataServiceAlarmIT.java
+++ b/features/surveillance-views/src/test/java/org/opennms/netmgt/surveillance/views/DefaultSurveillanceViewDataServiceAlarmIT.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.MockDatabase;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.netmgt.dao.api.CategoryDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsDistPoller;
+import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.SurveillanceStatus;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDataService.SurveillanceAlarm;
+import org.opennms.netmgt.surveillance.views.impl.DefaultSurveillanceViewDataService;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Ports the alarm-drill-down coverage of the Vaadin service's
+ * {@code NMS15448_IT} (only unacknowledged alarms appear) onto
+ * {@link DefaultSurveillanceViewDataService}, and adds coverage for the
+ * cell-status computation the grid is built from.
+ */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-postgresJsonStore.xml",
+        "classpath:/META-INF/opennms/applicationContext-config-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockSnmpPeerFactory.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase(reuseDatabase = false, tempDbClass = MockDatabase.class)
+@Transactional
+public class DefaultSurveillanceViewDataServiceAlarmIT implements InitializingBean {
+
+    @Autowired
+    DatabasePopulator databasePopulator;
+
+    @Autowired
+    TransactionTemplate transactionOperations;
+
+    @Autowired
+    NodeDao nodeDao;
+
+    @Autowired
+    CategoryDao categoryDao;
+
+    private OnmsDistPoller distPoller;
+
+    private DefaultSurveillanceViewDataService service;
+
+    private static final Date EVENT_DATE = new Date();
+
+    @Override
+    public void afterPropertiesSet() {
+        BeanUtils.assertAutowiring(this);
+    }
+
+    @Before
+    public void setUp() {
+        databasePopulator.populateDatabase();
+        distPoller = databasePopulator.getDistPollerDao().whoami();
+
+        service = new DefaultSurveillanceViewDataService();
+        service.setTransactionOperations(transactionOperations);
+        service.setNodeDao(nodeDao);
+        service.setCategoryDao(categoryDao);
+        service.setAlarmDao(databasePopulator.getAlarmDao());
+        service.setMonitoredServiceDao(databasePopulator.getMonitoredServiceDao());
+        service.setOutageDao(databasePopulator.getOutageDao());
+    }
+
+    private OnmsAlarm buildAlarm(final OnmsEvent event, boolean acknowledged) {
+        final OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setDistPoller(distPoller);
+        alarm.setUei(event.getEventUei());
+        alarm.setAlarmType(OnmsAlarm.PROBLEM_TYPE);
+        alarm.setNode(databasePopulator.getNode1());
+        alarm.setDescription("This is a test alarm");
+        alarm.setLogMsg("this is a test alarm log message");
+        alarm.setCounter(1);
+        alarm.setIpAddr(InetAddressUtils.getInetAddress("192.168.1.1"));
+        alarm.setSeverity(OnmsSeverity.NORMAL);
+        alarm.setFirstEventTime(event.getEventTime());
+        alarm.setLastEvent(event);
+        alarm.setServiceType(databasePopulator.getServiceTypeDao().findByName("ICMP"));
+        if (acknowledged) {
+            alarm.setAlarmAckUser("foobar");
+            alarm.setAlarmAckTime(EVENT_DATE);
+        }
+        return alarm;
+    }
+
+    private void saveAlarm(final boolean acknowledged) {
+        final OnmsEvent event = databasePopulator.buildEvent(distPoller);
+        event.setEventCreateTime(EVENT_DATE);
+        event.setEventTime(EVENT_DATE);
+        databasePopulator.getEventDao().save(event);
+        databasePopulator.getEventDao().flush();
+
+        databasePopulator.getAlarmDao().save(buildAlarm(event, acknowledged));
+        databasePopulator.getAlarmDao().flush();
+    }
+
+    @Test
+    public void testThatOnlyUnacknowledgedAlarmsAppear() {
+        // one unacknowledged alarm already exists after database creation
+        final List<SurveillanceAlarm> alarmsBefore = service.getAlarmsForCategories(Sets.newHashSet("Routers"), Sets.newHashSet("DEV_AC"));
+
+        Assert.assertEquals(1, alarmsBefore.size());
+        Assert.assertNotNull(alarmsBefore.get(0).getNodeLabel());
+        Assert.assertNotNull(alarmsBefore.get(0).getSeverity());
+
+        // two unacknowledged and one acknowledged alarms on top: three unacknowledged in total
+        saveAlarm(false);
+        saveAlarm(true);
+        saveAlarm(false);
+
+        final List<SurveillanceAlarm> alarmsAfter = service.getAlarmsForCategories(Sets.newHashSet("Routers"), Sets.newHashSet("DEV_AC"));
+        Assert.assertEquals("Only three unacknowledged alarms should appear", 3, alarmsAfter.size());
+    }
+
+    @Test
+    public void testCellStatusMatchesTheViewGrid() {
+        final SurveillanceView view = new SurveillanceView();
+        view.setName("test");
+        view.getRows().add(new SurveillanceViewDef("Routers", "Routers"));
+        view.getRows().add(new SurveillanceViewDef("Servers", "Servers"));
+        view.getColumns().add(new SurveillanceViewDef("DEV_AC", "DEV_AC"));
+
+        final SurveillanceStatus[][] cellStatus = service.calculateCellStatus(view);
+
+        Assert.assertEquals(2, cellStatus.length);
+        Assert.assertEquals(1, cellStatus[0].length);
+        for (final SurveillanceStatus[] row : cellStatus) {
+            for (final SurveillanceStatus status : row) {
+                Assert.assertNotNull(status);
+                Assert.assertNotNull(status.getStatus());
+                Assert.assertTrue(status.getDownEntityCount() <= status.getTotalEntityCount());
+            }
+        }
+        // node1 is in both Routers and DEV_AC, so that cell is non-empty
+        Assert.assertTrue(cellStatus[0][0].getTotalEntityCount() >= 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCellStatusRejectsUnknownCategories() {
+        final SurveillanceView view = new SurveillanceView();
+        view.setName("broken");
+        view.getRows().add(new SurveillanceViewDef("Nope", "NoSuchCategory"));
+        view.getColumns().add(new SurveillanceViewDef("DEV_AC", "DEV_AC"));
+
+        service.calculateCellStatus(view);
+    }
+}

--- a/features/surveillance-views/src/test/java/org/opennms/netmgt/surveillance/views/DefaultSurveillanceViewDataServiceRtcIT.java
+++ b/features/surveillance-views/src/test/java/org/opennms/netmgt/surveillance/views/DefaultSurveillanceViewDataServiceRtcIT.java
@@ -97,7 +97,9 @@ public class DefaultSurveillanceViewDataServiceRtcIT implements InitializingBean
         final OutageDao outageDao = databasePopulator.getOutageDao();
 
         long now = new Date().getTime();
-        outageDao.save(createOutage(databasePopulator.getNode1(), new Date(now - 60 * 60 * 1000), new Date(now - -60 * 60 * 1000 + 300_000)));
+        // lost 1h ago, regained 1h5m in the future: the outage extends past the
+        // end of the 24h RTC period and must be clamped to it
+        outageDao.save(createOutage(databasePopulator.getNode1(), new Date(now - 60 * 60 * 1000), new Date(now + 60 * 60 * 1000 + 300_000)));
         outageDao.save(createOutage(databasePopulator.getNode1(), new Date(now - 24 * 60 * 60 * 1000 - 60 * 60 * 1000), new Date(now - 24 * 60 * 60 * 1000 - 60 * 60 * 1000 + 300_000)));
 
         final DefaultSurveillanceViewDataService service = new DefaultSurveillanceViewDataService();

--- a/features/surveillance-views/src/test/java/org/opennms/netmgt/surveillance/views/DefaultSurveillanceViewDataServiceRtcIT.java
+++ b/features/surveillance-views/src/test/java/org/opennms/netmgt/surveillance/views/DefaultSurveillanceViewDataServiceRtcIT.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.MockDatabase;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsOutage;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDataService.NodeRtc;
+import org.opennms.netmgt.surveillance.views.impl.DefaultSurveillanceViewDataService;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Ports the Vaadin service's {@code NMS14048_IT} onto
+ * {@link DefaultSurveillanceViewDataService}: an outage window overlapping the
+ * 24h RTC period boundary must not push availability past 100%.
+ */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockSnmpPeerFactory.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase(reuseDatabase = false, tempDbClass = MockDatabase.class)
+@Transactional
+public class DefaultSurveillanceViewDataServiceRtcIT implements InitializingBean {
+
+    @Autowired
+    DatabasePopulator databasePopulator;
+
+    @Autowired
+    TransactionTemplate transactionOperations;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        BeanUtils.assertAutowiring(this);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        databasePopulator.populateDatabase();
+    }
+
+    private OnmsOutage createOutage(final OnmsNode node, final Date lost, final Date regained) {
+        final OnmsOutage onmsOutage = new OnmsOutage();
+        onmsOutage.setNode(node);
+        onmsOutage.setIfLostService(lost);
+        onmsOutage.setIfRegainedService(regained);
+        onmsOutage.setMonitoredService(databasePopulator.getMonitoredServiceDao().findByNode(node.getId()).get(0));
+        return onmsOutage;
+    }
+
+    @Test
+    public void testAvailabilityDoesNotExceedOneHundredPercent() {
+        final OutageDao outageDao = databasePopulator.getOutageDao();
+
+        long now = new Date().getTime();
+        outageDao.save(createOutage(databasePopulator.getNode1(), new Date(now - 60 * 60 * 1000), new Date(now - -60 * 60 * 1000 + 300_000)));
+        outageDao.save(createOutage(databasePopulator.getNode1(), new Date(now - 24 * 60 * 60 * 1000 - 60 * 60 * 1000), new Date(now - 24 * 60 * 60 * 1000 - 60 * 60 * 1000 + 300_000)));
+
+        final DefaultSurveillanceViewDataService service = new DefaultSurveillanceViewDataService();
+        service.setTransactionOperations(transactionOperations);
+        service.setMonitoredServiceDao(databasePopulator.getMonitoredServiceDao());
+        service.setOutageDao(databasePopulator.getOutageDao());
+
+        final List<NodeRtc> nodeRtcList = service.getNodeRtcsForCategories(Sets.newHashSet("Routers"), Sets.newHashSet("DEV_AC"));
+
+        Assert.assertNotNull(nodeRtcList);
+        Assert.assertFalse(nodeRtcList.isEmpty());
+        Assert.assertNotNull(nodeRtcList.get(0).getNodeLabel());
+        Assert.assertTrue("Availability must not exceed 100%.", nodeRtcList.get(0).getAvailability() <= 1.0);
+    }
+}

--- a/features/surveillance-views/src/test/java/org/opennms/netmgt/surveillance/views/SurveillanceViewDaoIT.java
+++ b/features/surveillance-views/src/test/java/org/opennms/netmgt/surveillance/views/SurveillanceViewDaoIT.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.surveillance.views;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.features.distributed.kvstore.api.JsonStore;
+import org.opennms.netmgt.surveillance.views.impl.SurveillanceViewJsonStore;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Exercises the JSON-key-value-store-backed {@link SurveillanceViewDao}
+ * against a real (temporary) database, including the seeding of the stock
+ * default view into an empty store. The {@link JsonStore} is a
+ * {@code PostgresJsonStore} over the temp datasource (the standard test
+ * wiring), so this verifies round-trips through the {@code kvstore_jsonb}
+ * table.
+ *
+ * <p>Name-uniqueness is enforced by the REST resource (a 409 on a name
+ * clash), not the DAO; that is covered by {@code SurveillanceViewRestServiceIT}.
+ */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-postgresJsonStore.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class SurveillanceViewDaoIT {
+
+    @Autowired
+    private JsonStore jsonStore;
+
+    private SurveillanceViewJsonStore dao;
+
+    @Before
+    public void setUp() {
+        dao = new SurveillanceViewJsonStore(jsonStore);
+    }
+
+    private static SurveillanceView exampleView(final String name) {
+        final SurveillanceView view = new SurveillanceView();
+        view.setName(name);
+        view.setRefreshSeconds(120);
+        view.setOwner("admin");
+        final SurveillanceViewDef row = new SurveillanceViewDef("Routers", "Routers", "Core");
+        row.setReportCategory("Network Reports");
+        view.getRows().add(row);
+        view.getColumns().add(new SurveillanceViewDef("PROD", "Production"));
+        view.getColumns().add(new SurveillanceViewDef("TEST", "Test"));
+        return view;
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void canCrudView() {
+        assertThat(dao.findAll(), hasSize(0));
+
+        final String id = dao.save(exampleView("Ops"));
+        assertNotNull("save should assign an id", id);
+        assertThat(dao.findAll(), hasSize(1));
+
+        // Read back, all fields round-trip
+        final SurveillanceView loaded = dao.get(id);
+        assertThat(loaded, notNullValue());
+        assertThat(loaded.getId(), is(id));
+        assertThat(loaded.getName(), is("Ops"));
+        assertThat(loaded.getRefreshSeconds(), is(120));
+        assertThat(loaded.getOwner(), is("admin"));
+        assertThat(loaded.getRows(), hasSize(1));
+        assertThat(loaded.getRows().get(0).getLabel(), is("Routers"));
+        assertThat(loaded.getRows().get(0).getCategories(), contains("Routers", "Core"));
+        assertThat(loaded.getRows().get(0).getReportCategory(), is("Network Reports"));
+        assertThat(loaded.getColumns(), hasSize(2));
+        assertThat(loaded.getColumns().get(0).getLabel(), is("PROD"));
+        assertThat(loaded.getColumns().get(1).getCategories(), contains("Test"));
+        assertThat(loaded.getColumns().get(1).getReportCategory(), nullValue());
+        assertThat(loaded.getCreated(), notNullValue());
+        assertThat(loaded.getLastModified(), nullValue());
+
+        // Lookup by (unique) name
+        assertThat(dao.findByName("Ops"), notNullValue());
+
+        // Update
+        loaded.setName("Ops (edited)");
+        loaded.setLastModified(new Date());
+        dao.update(loaded);
+
+        assertThat(dao.findByName("Ops"), nullValue());
+        assertThat(dao.findByName("Ops (edited)"), notNullValue());
+        assertThat(dao.get(id).getLastModified(), notNullValue());
+
+        // Delete
+        dao.delete(loaded);
+        assertThat(dao.findAll(), hasSize(0));
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void findByNameReturnsNullWhenMissing() {
+        assertThat(dao.findByName("does-not-exist"), nullValue());
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void defaultViewIdRoundTripsAndClearsWithItsView() {
+        assertThat(dao.getDefaultViewId(), nullValue());
+
+        final String id = dao.save(exampleView("Ops"));
+        dao.setDefaultViewId(id);
+        assertThat(dao.getDefaultViewId(), is(id));
+
+        // Deleting the default view must not leave a dangling default.
+        dao.delete(dao.get(id));
+        assertThat(dao.getDefaultViewId(), nullValue());
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void initSeedsTheStockDefaultViewIntoAnEmptyStore() {
+        dao.init();
+
+        assertThat(dao.findAll(), hasSize(1));
+
+        final SurveillanceView seeded = dao.findByName("default");
+        assertThat(seeded, notNullValue());
+        assertThat(seeded.getRefreshSeconds(), is(300));
+        assertThat(seeded.getOwner(), is("system"));
+        assertThat(seeded.getRows(), hasSize(3));
+        assertThat(seeded.getRows().get(0).getLabel(), is("Routers"));
+        assertThat(seeded.getRows().get(0).getCategories(), contains("Routers"));
+        assertThat(seeded.getColumns(), hasSize(3));
+        assertThat(seeded.getColumns().get(0).getLabel(), is("PROD"));
+        assertThat(seeded.getColumns().get(0).getCategories(), contains("Production"));
+        assertThat(dao.getDefaultViewId(), is(seeded.getId()));
+
+        // Seeding is idempotent: no duplicates on restart.
+        dao.init();
+        assertThat(dao.findAll(), hasSize(1));
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void initNeverAddsToANonEmptyStore() {
+        final String id = dao.save(exampleView("Ops"));
+
+        // A store with any views is left alone: nothing is seeded or
+        // resurrected, and the default setting is not touched.
+        dao.init();
+        assertThat(dao.findAll(), hasSize(1));
+        assertThat(dao.findByName("default"), nullValue());
+        assertThat(dao.getDefaultViewId(), nullValue());
+
+        // ...even if the seeded view itself was deliberately deleted
+        dao.delete(dao.get(id));
+        final String seededId = dao.save(exampleView("Custom"));
+        dao.init();
+        assertThat(dao.findAll(), hasSize(1));
+        assertThat(dao.get(seededId).getName(), is("Custom"));
+    }
+}

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -1211,6 +1211,13 @@
       <artifactId>org.opennms.features.topology-views</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Surveillance view definitions (kv-store persistence) + the
+         status/drill-down data services behind /api/v2/surveillance/views. -->
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>org.opennms.features.surveillance-views</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Postgres BlobStore for topology-asset image bytes (only the no-op
          blob store ships in lib otherwise). -->
     <dependency>

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -282,6 +282,12 @@
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
+      <artifactId>org.opennms.features.surveillance-views</artifactId>
+      <version>${project.version}</version>
+      <scope>${onmsLibScope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
       <artifactId>opennms-util</artifactId>
       <scope>${onmsLibScope}</scope>
     </dependency>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SurveillanceViewDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SurveillanceViewDTO.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * Wire representation of a surveillance view definition. {@code isDefault}
+ * is read-only and reflects the catalog's default-view setting; it is set via
+ * {@code PUT surveillance/views/default/{id}}, not through this body.
+ */
+public class SurveillanceViewDTO {
+
+    /** One row or column: a label plus the node category names it aggregates. */
+    public static class Def {
+
+        @JsonProperty("label")
+        private String label;
+
+        @JsonProperty("categories")
+        private List<String> categories = new ArrayList<>();
+
+        @JsonProperty("reportCategory")
+        private String reportCategory;
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public List<String> getCategories() {
+            return categories;
+        }
+
+        public void setCategories(List<String> categories) {
+            this.categories = categories == null ? new ArrayList<>() : categories;
+        }
+
+        public String getReportCategory() {
+            return reportCategory;
+        }
+
+        public void setReportCategory(String reportCategory) {
+            this.reportCategory = reportCategory;
+        }
+    }
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("refreshSeconds")
+    private Integer refreshSeconds;
+
+    @JsonProperty("isDefault")
+    private Boolean isDefault;
+
+    @JsonProperty("rows")
+    private List<Def> rows = new ArrayList<>();
+
+    @JsonProperty("columns")
+    private List<Def> columns = new ArrayList<>();
+
+    @JsonProperty("owner")
+    private String owner;
+
+    @JsonProperty("created")
+    private Date created;
+
+    @JsonProperty("lastModified")
+    private Date lastModified;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getRefreshSeconds() {
+        return refreshSeconds;
+    }
+
+    public void setRefreshSeconds(Integer refreshSeconds) {
+        this.refreshSeconds = refreshSeconds;
+    }
+
+    public Boolean getIsDefault() {
+        return isDefault;
+    }
+
+    public void setIsDefault(Boolean isDefault) {
+        this.isDefault = isDefault;
+    }
+
+    public List<Def> getRows() {
+        return rows;
+    }
+
+    public void setRows(List<Def> rows) {
+        this.rows = rows == null ? new ArrayList<>() : rows;
+    }
+
+    public List<Def> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(List<Def> columns) {
+        this.columns = columns == null ? new ArrayList<>() : columns;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public Date getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(Date lastModified) {
+        this.lastModified = lastModified;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SurveillanceViewRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SurveillanceViewRestService.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import org.opennms.netmgt.config.GroupDao;
+import org.opennms.netmgt.config.groups.Group;
+import org.opennms.netmgt.model.SurveillanceStatus;
+import org.opennms.netmgt.surveillance.views.SurveillanceView;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDao;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDataService;
+import org.opennms.netmgt.surveillance.views.SurveillanceViewDef;
+import org.opennms.web.api.Authentication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * Surveillance views: CRUD over the view definitions, per-user default-view
+ * resolution, and the computed data behind the grid (cell status plus the
+ * alarm / notification / node-RTC drill-downs). Replaces the Vaadin
+ * surveillance view servlets, which had no REST facade.
+ *
+ * <p>Reads are open to any authenticated user. Writes require
+ * {@code ROLE_ADMIN}, enforced here (the Vaadin config editor was admin-only;
+ * the default {@code /api/v2/**} rules would also admit {@code ROLE_REST}).
+ *
+ * <p>Persistence is the generic JSON key-value store (via
+ * {@link SurveillanceViewDao}), which manages its own connections, and the
+ * data service runs its own transactions, so no transaction demarcation is
+ * needed here.
+ */
+@Component
+@Path("surveillance/views")
+@Tag(name = "SurveillanceViews", description = "Surveillance views API")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class SurveillanceViewRestService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SurveillanceViewRestService.class);
+
+    /** Serializes the name-uniqueness check-then-write; see {@link #create}. */
+    private static final Object WRITE_LOCK = new Object();
+
+    @Autowired(required = false)
+    private SurveillanceViewDao m_dao;
+
+    @Autowired(required = false)
+    private SurveillanceViewDataService m_dataService;
+
+    /**
+     * Group membership backs the name-convention view targeting (a view named
+     * after one of the user's groups). Optional: without it, resolution still
+     * covers username matches and the configured default.
+     */
+    @Autowired(required = false)
+    private GroupDao m_groupDao;
+
+    @GET
+    public List<SurveillanceViewDTO> list() {
+        final String defaultViewId = getDao().getDefaultViewId();
+        final List<SurveillanceView> views = getDao().findAll();
+        final List<SurveillanceViewDTO> dtos = new ArrayList<>(views.size());
+        for (final SurveillanceView view : views) {
+            dtos.add(toDto(view, defaultViewId));
+        }
+        return dtos;
+    }
+
+    @GET
+    @Path("{id}")
+    public SurveillanceViewDTO get(@PathParam("id") final String id) {
+        return toDto(require(id), getDao().getDefaultViewId());
+    }
+
+    /**
+     * The view for the calling user, by the same convention the Vaadin view
+     * used: a view named like the username wins, then a view named like one of
+     * the user's groups, then the configured default.
+     */
+    @GET
+    @Path("default")
+    public SurveillanceViewDTO getDefaultForUser(@Context final SecurityContext securityContext) {
+        final String username = usernameOf(securityContext);
+
+        SurveillanceView view = getDao().findByName(username);
+
+        if (view == null && m_groupDao != null) {
+            for (final Group group : m_groupDao.findGroupsForUser(username)) {
+                view = getDao().findByName(group.getName());
+                if (view != null) {
+                    break;
+                }
+            }
+        }
+
+        if (view == null) {
+            view = getDao().get(getDao().getDefaultViewId());
+        }
+
+        if (view == null) {
+            throw webException(Response.Status.NOT_FOUND, "No surveillance view matches user '" + username + "' and no default view is configured");
+        }
+        return toDto(view, getDao().getDefaultViewId());
+    }
+
+    @POST
+    public Response create(@Context final UriInfo uriInfo, @Context final SecurityContext securityContext, final SurveillanceViewDTO dto) {
+        requireAdmin(securityContext);
+        final SurveillanceView view = validate(dto);
+        view.setOwner(usernameOf(securityContext));
+        view.setCreated(new Date());
+
+        final String id;
+        // The store has no unique constraint on the name, so serialize the
+        // check-then-save against concurrent writers in this JVM.
+        synchronized (WRITE_LOCK) {
+            if (getDao().findByName(view.getName()) != null) {
+                throw webException(Response.Status.CONFLICT, "A view named '" + view.getName() + "' already exists");
+            }
+            id = getDao().save(view);
+        }
+        return Response.created(uriInfo.getAbsolutePathBuilder().path(id).build()).build();
+    }
+
+    /** Full replace of the view's name, refresh interval, rows and columns. */
+    @PUT
+    @Path("{id}")
+    public Response update(@Context final SecurityContext securityContext, @PathParam("id") final String id, final SurveillanceViewDTO dto) {
+        requireAdmin(securityContext);
+        final SurveillanceView existing = require(id);
+        final SurveillanceView incoming = validate(dto);
+
+        existing.setRefreshSeconds(incoming.getRefreshSeconds());
+        existing.setRows(incoming.getRows());
+        existing.setColumns(incoming.getColumns());
+        existing.setLastModified(new Date());
+
+        // Same name-uniqueness window as create: hold the lock across the
+        // rename collision check and the persist.
+        synchronized (WRITE_LOCK) {
+            if (!incoming.getName().equals(existing.getName())) {
+                final SurveillanceView collision = getDao().findByName(incoming.getName());
+                if (collision != null && !collision.getId().equals(id)) {
+                    throw webException(Response.Status.CONFLICT, "A view named '" + incoming.getName() + "' already exists");
+                }
+                existing.setName(incoming.getName());
+            }
+            getDao().update(existing);
+        }
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Path("{id}")
+    public Response delete(@Context final SecurityContext securityContext, @PathParam("id") final String id) {
+        requireAdmin(securityContext);
+        getDao().delete(require(id));
+        return Response.noContent().build();
+    }
+
+    @PUT
+    @Path("default/{id}")
+    public Response setDefault(@Context final SecurityContext securityContext, @PathParam("id") final String id) {
+        requireAdmin(securityContext);
+        require(id);
+        getDao().setDefaultViewId(id);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("{id}/status")
+    public SurveillanceViewStatusDTO status(@PathParam("id") final String id) {
+        final SurveillanceView view = require(id);
+        final SurveillanceStatus[][] cellStatus = compute(() -> getDataService().calculateCellStatus(view));
+
+        final SurveillanceViewStatusDTO dto = new SurveillanceViewStatusDTO();
+        dto.setViewId(view.getId());
+        dto.setViewName(view.getName());
+        dto.setRefreshSeconds(view.getRefreshSeconds() != null ? view.getRefreshSeconds() : SurveillanceView.DEFAULT_REFRESH_SECONDS);
+        for (final SurveillanceViewDef row : view.getRows()) {
+            dto.getRows().add(row.getLabel());
+        }
+        for (final SurveillanceViewDef column : view.getColumns()) {
+            dto.getColumns().add(column.getLabel());
+        }
+        for (final SurveillanceStatus[] row : cellStatus) {
+            final List<SurveillanceViewStatusDTO.Cell> cells = new ArrayList<>(row.length);
+            for (final SurveillanceStatus status : row) {
+                cells.add(new SurveillanceViewStatusDTO.Cell(status.getDownEntityCount(), status.getTotalEntityCount(), status.getStatus()));
+            }
+            dto.getCells().add(cells);
+        }
+        return dto;
+    }
+
+    @GET
+    @Path("{id}/alarms")
+    public List<SurveillanceViewDataService.SurveillanceAlarm> alarms(@PathParam("id") final String id,
+            @QueryParam("row") final String rowLabel, @QueryParam("column") final String columnLabel) {
+        final SurveillanceView view = require(id);
+        return compute(() -> getDataService().getAlarmsForCategories(
+                categoriesFor(view.getRows(), rowLabel, "row"),
+                categoriesFor(view.getColumns(), columnLabel, "column")));
+    }
+
+    @GET
+    @Path("{id}/notifications")
+    public List<SurveillanceViewDataService.SurveillanceNotification> notifications(@PathParam("id") final String id,
+            @QueryParam("row") final String rowLabel, @QueryParam("column") final String columnLabel) {
+        final SurveillanceView view = require(id);
+        return compute(() -> getDataService().getNotificationsForCategories(
+                categoriesFor(view.getRows(), rowLabel, "row"),
+                categoriesFor(view.getColumns(), columnLabel, "column")));
+    }
+
+    @GET
+    @Path("{id}/rtc")
+    public List<SurveillanceViewDataService.NodeRtc> rtc(@PathParam("id") final String id,
+            @QueryParam("row") final String rowLabel, @QueryParam("column") final String columnLabel) {
+        final SurveillanceView view = require(id);
+        return compute(() -> getDataService().getNodeRtcsForCategories(
+                categoriesFor(view.getRows(), rowLabel, "row"),
+                categoriesFor(view.getColumns(), columnLabel, "column")));
+    }
+
+    /**
+     * The category names behind a drill-down selection: a single row/column
+     * def when a label is given, the union of all defs otherwise.
+     */
+    private static Set<String> categoriesFor(final List<SurveillanceViewDef> defs, final String label, final String axis) {
+        final Set<String> categories = new LinkedHashSet<>();
+        if (label == null || label.trim().isEmpty()) {
+            for (final SurveillanceViewDef def : defs) {
+                categories.addAll(def.getCategories());
+            }
+            return categories;
+        }
+        for (final SurveillanceViewDef def : defs) {
+            if (label.equals(def.getLabel())) {
+                categories.addAll(def.getCategories());
+                return categories;
+            }
+        }
+        throw webException(Response.Status.BAD_REQUEST, "The view has no " + axis + " labelled '" + label + "'");
+    }
+
+    /** Maps the data service's unknown-category complaints to a 400. */
+    private static <T> T compute(final java.util.function.Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (final IllegalArgumentException e) {
+            throw webException(Response.Status.BAD_REQUEST, e.getMessage());
+        }
+    }
+
+    /**
+     * Validates an incoming body against the same shape the legacy XSD
+     * required (a name, and at least one row and column def, each with a label
+     * and at least one category) and normalizes it into a domain view.
+     */
+    private static SurveillanceView validate(final SurveillanceViewDTO dto) {
+        if (dto == null) {
+            throw webException(Response.Status.BAD_REQUEST, "A view body is required");
+        }
+        if (dto.getName() == null || dto.getName().trim().isEmpty()) {
+            throw webException(Response.Status.BAD_REQUEST, "A view name is required");
+        }
+        if (dto.getRefreshSeconds() != null && dto.getRefreshSeconds() <= 0) {
+            throw webException(Response.Status.BAD_REQUEST, "refreshSeconds must be positive");
+        }
+
+        final SurveillanceView view = new SurveillanceView();
+        view.setName(dto.getName().trim());
+        view.setRefreshSeconds(dto.getRefreshSeconds() != null ? dto.getRefreshSeconds() : SurveillanceView.DEFAULT_REFRESH_SECONDS);
+        view.setRows(validateDefs(dto.getRows(), "row"));
+        view.setColumns(validateDefs(dto.getColumns(), "column"));
+        return view;
+    }
+
+    private static List<SurveillanceViewDef> validateDefs(final List<SurveillanceViewDTO.Def> dtos, final String axis) {
+        if (dtos == null || dtos.isEmpty()) {
+            throw webException(Response.Status.BAD_REQUEST, "At least one " + axis + " is required");
+        }
+        final List<SurveillanceViewDef> defs = new ArrayList<>(dtos.size());
+        final Set<String> labels = new LinkedHashSet<>();
+        for (final SurveillanceViewDTO.Def dto : dtos) {
+            if (dto.getLabel() == null || dto.getLabel().trim().isEmpty()) {
+                throw webException(Response.Status.BAD_REQUEST, "Every " + axis + " needs a label");
+            }
+            final String label = dto.getLabel().trim();
+            if (!labels.add(label)) {
+                throw webException(Response.Status.BAD_REQUEST, "Duplicate " + axis + " label '" + label + "'");
+            }
+            if (dto.getCategories() == null || dto.getCategories().isEmpty()) {
+                throw webException(Response.Status.BAD_REQUEST, "The " + axis + " '" + label + "' needs at least one category");
+            }
+            final SurveillanceViewDef def = new SurveillanceViewDef();
+            def.setLabel(label);
+            for (final String category : dto.getCategories()) {
+                if (category == null || category.trim().isEmpty()) {
+                    throw webException(Response.Status.BAD_REQUEST, "The " + axis + " '" + label + "' has an empty category name");
+                }
+                def.getCategories().add(category.trim());
+            }
+            def.setReportCategory(dto.getReportCategory());
+            defs.add(def);
+        }
+        return defs;
+    }
+
+    private SurveillanceView require(final String id) {
+        final SurveillanceView view = getDao().get(id);
+        if (view == null) {
+            throw webException(Response.Status.NOT_FOUND, "No surveillance view with id " + id);
+        }
+        return view;
+    }
+
+    private SurveillanceViewDTO toDto(final SurveillanceView view, final String defaultViewId) {
+        final SurveillanceViewDTO dto = new SurveillanceViewDTO();
+        dto.setId(view.getId());
+        dto.setName(view.getName());
+        dto.setRefreshSeconds(view.getRefreshSeconds() != null ? view.getRefreshSeconds() : SurveillanceView.DEFAULT_REFRESH_SECONDS);
+        dto.setIsDefault(view.getId() != null && view.getId().equals(defaultViewId));
+        for (final SurveillanceViewDef def : view.getRows()) {
+            dto.getRows().add(toDefDto(def));
+        }
+        for (final SurveillanceViewDef def : view.getColumns()) {
+            dto.getColumns().add(toDefDto(def));
+        }
+        dto.setOwner(view.getOwner());
+        dto.setCreated(view.getCreated());
+        dto.setLastModified(view.getLastModified());
+        return dto;
+    }
+
+    private static SurveillanceViewDTO.Def toDefDto(final SurveillanceViewDef def) {
+        final SurveillanceViewDTO.Def dto = new SurveillanceViewDTO.Def();
+        dto.setLabel(def.getLabel());
+        dto.setCategories(new ArrayList<>(def.getCategories()));
+        dto.setReportCategory(def.getReportCategory());
+        return dto;
+    }
+
+    private static void requireAdmin(final SecurityContext securityContext) {
+        if (securityContext == null || !securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
+            throw webException(Response.Status.FORBIDDEN, "ROLE_ADMIN is required to change surveillance views");
+        }
+    }
+
+    /**
+     * A missing principal means the security layer didn't run; reject rather
+     * than resolve or persist anything unattributed.
+     */
+    private static String usernameOf(final SecurityContext securityContext) {
+        if (securityContext == null || securityContext.getUserPrincipal() == null) {
+            throw webException(Response.Status.UNAUTHORIZED, "An authenticated user is required");
+        }
+        return securityContext.getUserPrincipal().getName();
+    }
+
+    private SurveillanceViewDao getDao() {
+        if (m_dao == null) {
+            throw webException(Response.Status.SERVICE_UNAVAILABLE, "Surveillance view persistence is not available");
+        }
+        return m_dao;
+    }
+
+    private SurveillanceViewDataService getDataService() {
+        if (m_dataService == null) {
+            throw webException(Response.Status.SERVICE_UNAVAILABLE, "The surveillance view data service is not available");
+        }
+        return m_dataService;
+    }
+
+    private static WebApplicationException webException(final Response.Status status, final String message) {
+        return new WebApplicationException(Response.status(status).entity(message).type(MediaType.TEXT_PLAIN).build());
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SurveillanceViewRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SurveillanceViewRestService.java
@@ -51,8 +51,6 @@ import org.opennms.netmgt.surveillance.views.SurveillanceViewDao;
 import org.opennms.netmgt.surveillance.views.SurveillanceViewDataService;
 import org.opennms.netmgt.surveillance.views.SurveillanceViewDef;
 import org.opennms.web.api.Authentication;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -79,8 +77,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class SurveillanceViewRestService {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SurveillanceViewRestService.class);
 
     /** Serializes the name-uniqueness check-then-write; see {@link #create}. */
     private static final Object WRITE_LOCK = new Object();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SurveillanceViewStatusDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SurveillanceViewStatusDTO.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * The computed grid of a surveillance view: row/column labels in definition
+ * order plus one cell per row/column pair, indexed {@code cells[row][column]}.
+ */
+public class SurveillanceViewStatusDTO {
+
+    /** One grid cell: nodes with at least one down service, out of all nodes. */
+    public static class Cell {
+
+        @JsonProperty("down")
+        private Integer down;
+
+        @JsonProperty("total")
+        private Integer total;
+
+        @JsonProperty("status")
+        private String status;
+
+        public Cell() {
+        }
+
+        public Cell(Integer down, Integer total, String status) {
+            this.down = down;
+            this.total = total;
+            this.status = status;
+        }
+
+        public Integer getDown() {
+            return down;
+        }
+
+        public void setDown(Integer down) {
+            this.down = down;
+        }
+
+        public Integer getTotal() {
+            return total;
+        }
+
+        public void setTotal(Integer total) {
+            this.total = total;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+    }
+
+    @JsonProperty("viewId")
+    private String viewId;
+
+    @JsonProperty("viewName")
+    private String viewName;
+
+    @JsonProperty("refreshSeconds")
+    private Integer refreshSeconds;
+
+    @JsonProperty("rows")
+    private List<String> rows = new ArrayList<>();
+
+    @JsonProperty("columns")
+    private List<String> columns = new ArrayList<>();
+
+    @JsonProperty("cells")
+    private List<List<Cell>> cells = new ArrayList<>();
+
+    public String getViewId() {
+        return viewId;
+    }
+
+    public void setViewId(String viewId) {
+        this.viewId = viewId;
+    }
+
+    public String getViewName() {
+        return viewName;
+    }
+
+    public void setViewName(String viewName) {
+        this.viewName = viewName;
+    }
+
+    public Integer getRefreshSeconds() {
+        return refreshSeconds;
+    }
+
+    public void setRefreshSeconds(Integer refreshSeconds) {
+        this.refreshSeconds = refreshSeconds;
+    }
+
+    public List<String> getRows() {
+        return rows;
+    }
+
+    public void setRows(List<String> rows) {
+        this.rows = rows;
+    }
+
+    public List<String> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(List<String> columns) {
+        this.columns = columns;
+    }
+
+    public List<List<Cell>> getCells() {
+        return cells;
+    }
+
+    public void setCells(List<List<Cell>> cells) {
+        this.cells = cells;
+    }
+}

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/SurveillanceViewRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/SurveillanceViewRestServiceIT.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.ws.rs.core.MediaType;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+/**
+ * Drives the {@code /api/v2/surveillance/views} resource end to end through
+ * the CXF/Jersey test harness: the CRUD lifecycle and its validation/error
+ * semantics, the in-resource ROLE_ADMIN write guard, per-user default-view
+ * resolution, and the computed status/drill-down endpoints against a
+ * populated database.
+ */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/META-INF/opennms/applicationContext-postgresJsonStore.xml",
+        "classpath:/applicationContext-rest-test.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties = "org.opennms.timeseries.strategy=integration")
+@JUnitTemporaryDatabase
+public class SurveillanceViewRestServiceIT extends AbstractSpringJerseyRestTestCase {
+
+    private static final String BASE = "/surveillance/views";
+
+    private final ObjectMapper m_mapper = new ObjectMapper();
+
+    @Autowired
+    private DatabasePopulator m_databasePopulator;
+
+    public SurveillanceViewRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
+
+    @Override
+    protected void afterServletStart() throws Exception {
+        MockLogAppender.setupLogging(true, "WARN");
+        setUser("admin", new String[] { "ROLE_ADMIN" });
+    }
+
+    private static String viewBody(final String name) {
+        return "{\"name\":\"" + name + "\",\"refreshSeconds\":120,"
+                + "\"rows\":[{\"label\":\"Routers\",\"categories\":[\"Routers\"]}],"
+                + "\"columns\":[{\"label\":\"DEV\",\"categories\":[\"DEV_AC\"]}]}";
+    }
+
+    private String create(final String name) throws Exception {
+        final MockHttpServletResponse post = sendData(POST, MediaType.APPLICATION_JSON, BASE, viewBody(name), 201);
+        return lastPathSegment(post.getHeader("Location"));
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void canCreateReadUpdateDeleteView() throws Exception {
+        // The DAO's init() seeds the stock "default" view into the empty store
+        // at context start.
+        final JsonNode initial = m_mapper.readTree(sendRequest(GET, BASE, 200));
+        assertEquals(1, initial.size());
+        assertEquals("default", initial.get(0).get("name").asText());
+        assertEquals(true, initial.get(0).get("isDefault").asBoolean());
+        assertEquals("system", initial.get(0).get("owner").asText());
+
+        final String id = create("Ops");
+        assertNotNull("POST should return a Location with an id", id);
+
+        final JsonNode view = m_mapper.readTree(sendRequest(GET, BASE + "/" + id, 200));
+        assertEquals("Ops", view.get("name").asText());
+        assertEquals(120, view.get("refreshSeconds").asInt());
+        assertEquals("admin", view.get("owner").asText());
+        assertEquals(false, view.get("isDefault").asBoolean());
+        assertEquals(1, view.get("rows").size());
+        assertEquals("Routers", view.get("rows").get(0).get("label").asText());
+        assertEquals("Routers", view.get("rows").get(0).get("categories").get(0).asText());
+        assertEquals(1, view.get("columns").size());
+        assertTrue(view.get("lastModified").isNull());
+
+        // Full-replace update: rename, retune, reshape
+        final String update = "{\"name\":\"Ops (edited)\",\"refreshSeconds\":60,"
+                + "\"rows\":[{\"label\":\"Servers\",\"categories\":[\"Servers\"]}],"
+                + "\"columns\":[{\"label\":\"DEV\",\"categories\":[\"DEV_AC\"]},{\"label\":\"PROD\",\"categories\":[\"Production\"]}]}";
+        sendData(PUT, MediaType.APPLICATION_JSON, BASE + "/" + id, update, 204);
+
+        final JsonNode updated = m_mapper.readTree(sendRequest(GET, BASE + "/" + id, 200));
+        assertEquals("Ops (edited)", updated.get("name").asText());
+        assertEquals(60, updated.get("refreshSeconds").asInt());
+        assertEquals("Servers", updated.get("rows").get(0).get("label").asText());
+        assertEquals(2, updated.get("columns").size());
+        assertEquals("admin", updated.get("owner").asText());
+        assertTrue("lastModified should be set after an update", !updated.get("lastModified").isNull());
+
+        sendRequest(DELETE, BASE + "/" + id, 204);
+        sendRequest(GET, BASE + "/" + id, 404);
+        // ...leaving just the seeded "default" view
+        assertEquals(1, m_mapper.readTree(sendRequest(GET, BASE, 200)).size());
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void validatesTheViewShape() throws Exception {
+        // name, at least one row and one column, labels and categories are all required
+        sendData(POST, MediaType.APPLICATION_JSON, BASE,
+                "{\"rows\":[{\"label\":\"r\",\"categories\":[\"c\"]}],\"columns\":[{\"label\":\"c\",\"categories\":[\"c\"]}]}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, BASE,
+                "{\"name\":\"x\",\"columns\":[{\"label\":\"c\",\"categories\":[\"c\"]}]}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, BASE,
+                "{\"name\":\"x\",\"rows\":[{\"label\":\"r\",\"categories\":[]}],\"columns\":[{\"label\":\"c\",\"categories\":[\"c\"]}]}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, BASE,
+                "{\"name\":\"x\",\"refreshSeconds\":0,\"rows\":[{\"label\":\"r\",\"categories\":[\"c\"]}],\"columns\":[{\"label\":\"c\",\"categories\":[\"c\"]}]}", 400);
+        // duplicate row labels within a view
+        sendData(POST, MediaType.APPLICATION_JSON, BASE,
+                "{\"name\":\"x\",\"rows\":[{\"label\":\"r\",\"categories\":[\"c\"]},{\"label\":\"r\",\"categories\":[\"c\"]}],\"columns\":[{\"label\":\"c\",\"categories\":[\"c\"]}]}", 400);
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void rejectsDuplicateNames() throws Exception {
+        create("dup");
+        sendData(POST, MediaType.APPLICATION_JSON, BASE, viewBody("dup"), 409);
+
+        // Renaming onto an existing name conflicts, too
+        final String otherId = create("other");
+        sendData(PUT, MediaType.APPLICATION_JSON, BASE + "/" + otherId, viewBody("dup"), 409);
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void writesRequireRoleAdmin() throws Exception {
+        setUser("bob", new String[] { "ROLE_USER" });
+        sendData(POST, MediaType.APPLICATION_JSON, BASE, viewBody("nope"), 403);
+        setUser("admin", new String[] { "ROLE_ADMIN" });
+
+        final String id = create("guarded");
+        setUser("bob", new String[] { "ROLE_USER" });
+        sendData(PUT, MediaType.APPLICATION_JSON, BASE + "/" + id, viewBody("guarded"), 403);
+        sendRequest(DELETE, BASE + "/" + id, 403);
+        // reads stay open to any authenticated user
+        sendRequest(GET, BASE + "/" + id, 200);
+        setUser("admin", new String[] { "ROLE_ADMIN" });
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void resolvesTheDefaultViewByUserGroupThenSetting() throws Exception {
+        // The seeded stock view is the configured default
+        assertEquals("default", m_mapper.readTree(sendRequest(GET, BASE + "/default", 200)).get("name").asText());
+
+        // Repointing the setting changes what resolves
+        final String opsId = create("Ops");
+        sendData(PUT, MediaType.APPLICATION_JSON, BASE + "/default/" + opsId, "", 204);
+        assertEquals("Ops", m_mapper.readTree(sendRequest(GET, BASE + "/default", 200)).get("name").asText());
+        assertEquals(true, m_mapper.readTree(sendRequest(GET, BASE + "/" + opsId, 200)).get("isDefault").asBoolean());
+
+        // A view named like the user beats the configured default
+        final String adminId = create("admin");
+        assertEquals("admin", m_mapper.readTree(sendRequest(GET, BASE + "/default", 200)).get("name").asText());
+
+        // ...and deleting it falls back to the configured default again
+        sendRequest(DELETE, BASE + "/" + adminId, 204);
+        assertEquals("Ops", m_mapper.readTree(sendRequest(GET, BASE + "/default", 200)).get("name").asText());
+
+        // Deleting the default view clears the setting: nothing resolves, even
+        // though the seeded "default" view still exists (no silent fallback)
+        sendRequest(DELETE, BASE + "/" + opsId, 204);
+        sendRequest(GET, BASE + "/default", 404);
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void computesStatusAndDrillDowns() throws Exception {
+        m_databasePopulator.populateDatabase();
+
+        final String id = create("grid");
+
+        final JsonNode status = m_mapper.readTree(sendRequest(GET, BASE + "/" + id + "/status", 200));
+        assertEquals(id, status.get("viewId").asText());
+        assertEquals("grid", status.get("viewName").asText());
+        assertEquals(120, status.get("refreshSeconds").asInt());
+        assertEquals(1, status.get("rows").size());
+        assertEquals("Routers", status.get("rows").get(0).asText());
+        assertEquals(1, status.get("columns").size());
+        assertEquals(1, status.get("cells").size());
+        final JsonNode cell = status.get("cells").get(0).get(0);
+        assertNotNull(cell.get("status").asText());
+        assertTrue("node1 is in Routers and DEV_AC", cell.get("total").asInt() >= 1);
+        assertTrue(cell.get("down").asInt() <= cell.get("total").asInt());
+
+        // The populated database seeds one unacknowledged alarm on node1
+        final JsonNode alarms = m_mapper.readTree(sendRequest(GET, BASE + "/" + id + "/alarms", 200));
+        assertEquals(1, alarms.size());
+        assertNotNull(alarms.get(0).get("nodeLabel").asText());
+
+        final JsonNode rtc = m_mapper.readTree(sendRequest(GET, BASE + "/" + id + "/rtc", 200));
+        assertTrue(rtc.size() >= 1);
+        assertTrue(rtc.get(0).get("availability").asDouble() <= 1.0);
+
+        // Notifications: the populator seeds none, so this is just a clean 200
+        assertEquals(0, m_mapper.readTree(sendRequest(GET, BASE + "/" + id + "/notifications", 200)).size());
+
+        // Drill-down selection: a known label narrows, an unknown one is a 400
+        sendRequest(GET, BASE + "/" + id + "/alarms?row=Routers&column=DEV", 200);
+        sendRequest(GET, BASE + "/" + id + "/alarms?row=NoSuchRow", 400);
+
+        // A view referencing a category that does not exist fails loudly
+        final String brokenId = create("broken-" + System.currentTimeMillis());
+        final String broken = "{\"name\":\"broken\",\"rows\":[{\"label\":\"r\",\"categories\":[\"NoSuchCategory\"]}],"
+                + "\"columns\":[{\"label\":\"c\",\"categories\":[\"DEV_AC\"]}]}";
+        sendData(PUT, MediaType.APPLICATION_JSON, BASE + "/" + brokenId, broken, 204);
+        sendRequest(GET, BASE + "/" + brokenId + "/status", 400);
+    }
+
+    private static String lastPathSegment(final Object location) {
+        if (location == null) {
+            return null;
+        }
+        final String s = location.toString();
+        return s.substring(s.lastIndexOf('/') + 1);
+    }
+}


### PR DESCRIPTION
This issue covers the backend stuff:

- View definitions move to the database (the generic JSON key-value store, same approach as the custom topology views). A default surveillance view is created rather than doing an import (I did explore both and I think this is the cleaner option). 
- A new /api/v2/surveillance/views API provides CRUD over view definitions (writes require ROLE_ADMIN), per-user default-view resolution using the existing naming convention (username, then group name, then the configured default), and the computed data the UI needs: cell status ({id}/status) and the alarm/notification/RTC drill-downs ({id}/alarms, {id}/notifications, {id}/rtc).
- The Vaadin surveillance views remain in place and functional; the replacement Vue UI and the removal of the Vaadin feature are handled separately.

Trying to get us setup for Vaadin removal down the road.

Assisted by Anthropic Claude Fable 5

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20045

