### PR TITLE
NMS-20006: bound local RPC execution with a timeout decoupled from the TTL

### DIFF
--- a/core/ipc/rpc/api/src/main/java/org/opennms/core/rpc/api/RpcExceptionUtils.java
+++ b/core/ipc/rpc/api/src/main/java/org/opennms/core/rpc/api/RpcExceptionUtils.java
@@ -23,6 +23,7 @@ package org.opennms.core.rpc.api;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 
 public class RpcExceptionUtils {
 
@@ -57,6 +58,8 @@ public class RpcExceptionUtils {
         } else if (t instanceof java.util.concurrent.RejectedExecutionException) {
             return Optional.ofNullable(visitor.onRejected(t));
         } else if (t instanceof RequestTimedOutException) {
+            return Optional.ofNullable(visitor.onTimedOut(t));
+        } else if (t instanceof TimeoutException) {
             return Optional.ofNullable(visitor.onTimedOut(t));
         } else {
             return null;

--- a/core/ipc/rpc/camel/src/main/java/org/opennms/core/rpc/camel/CamelRpcClientFactory.java
+++ b/core/ipc/rpc/camel/src/main/java/org/opennms/core/rpc/camel/CamelRpcClientFactory.java
@@ -82,6 +82,10 @@ public class CamelRpcClientFactory implements RpcClientFactory {
      */
     private static final long rpcExecTimeoutMs = SystemProperties.getLong(CAMEL_JMS_REQUEST_TIMEOUT_PROPERTY, CAMEL_JMS_REQUEST_TIMEOUT_DEFAULT);
 
+    public static final String LOCAL_EXEC_TIMEOUT_PROPERTY = "org.opennms.core.ipc.rpc.local.timeout";
+
+    public static final long LOCAL_EXEC_TIMEOUT_MS_DEFAULT = TimeUnit.MINUTES.toMillis(30);
+
     private final ThreadFactory threadFactory = new ThreadFactoryBuilder()
             .setNameFormat("CamelRpcClientFactory-Pool-%d")
             .build();
@@ -114,8 +118,15 @@ public class CamelRpcClientFactory implements RpcClientFactory {
             public CompletableFuture<T> execute(S request) {
 
                 if (request.getLocation() == null || request.getLocation().equals(location)) {
-                    // The request is for the current location, invoke it directly
-                    return module.execute(request);
+                    // The request is for the current location, invoke it directly.
+                    // Bound it to a fixed timeout — deliberately not the request TTL — so a module future that
+                    // never completes cannot wedge the caller (NMS-19951) while slow-but-completing operations
+                    // are unaffected by TTL configuration intended for the Minion path (NMS-20006).
+                    final long localExecTimeoutMs = SystemProperties.getLong(LOCAL_EXEC_TIMEOUT_PROPERTY, LOCAL_EXEC_TIMEOUT_MS_DEFAULT);
+                    if (localExecTimeoutMs <= 0) {
+                        return module.execute(request);
+                    }
+                    return module.execute(request).orTimeout(localExecTimeoutMs, TimeUnit.MILLISECONDS);
                 }
                 Span span = buildAndStartSpan(request);
                 TracingInfoCarrier tracingInfoCarrier = getTracingInfoCarrier(request, span);

--- a/core/ipc/rpc/camel/src/test/java/org/opennms/core/rpc/camel/LocalRpcTimeoutTest.java
+++ b/core/ipc/rpc/camel/src/test/java/org/opennms/core/rpc/camel/LocalRpcTimeoutTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.rpc.camel;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.After;
+import org.junit.Test;
+import org.opennms.core.rpc.api.RpcModule;
+import org.opennms.core.rpc.api.RpcRequest;
+import org.opennms.core.rpc.api.RpcResponse;
+
+import io.opentracing.Span;
+
+/**
+ * NMS-20006 — local (same-location) RPC execution is bounded by a fixed,
+ * configurable timeout instead of the request TTL.
+ */
+public class LocalRpcTimeoutTest {
+
+    private static final String LOCAL_LOCATION = "Default";
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+    @After
+    public void tearDown() {
+        System.clearProperty(CamelRpcClientFactory.LOCAL_EXEC_TIMEOUT_PROPERTY);
+        scheduler.shutdownNow();
+    }
+
+    /**
+     * Regression guard for NMS-20006: a local operation that completes after its
+     * request TTL has expired must still return its result. Enforcing the TTL on
+     * local execution is what broke slow-but-healthy SNMP collections in 36.0.2 /
+     * Meridian 2024.3.11 — this test fails if that behavior is ever reintroduced.
+     */
+    @Test
+    public void slowLocalExecutionCompletesDespiteExpiredTtl() throws Exception {
+        final CompletableFuture<StubResponse> completesLate = new CompletableFuture<>();
+        scheduler.schedule(() -> completesLate.complete(new StubResponse(null)), 1_500, TimeUnit.MILLISECONDS);
+        final RpcModule<StubRequest, StubResponse> slowModule = stubModule(completesLate);
+
+        final CamelRpcClientFactory factory = new CamelRpcClientFactory();
+        factory.setLocation(LOCAL_LOCATION);
+
+        // TTL far below the module's completion time.
+        final StubRequest request = new StubRequest(LOCAL_LOCATION, 200L);
+
+        final StubResponse response = factory.getClient(slowModule).execute(request).get(10, TimeUnit.SECONDS);
+        assertNull(response.getErrorMessage());
+    }
+
+    /**
+     * A custom timeout is honored: with a 5 ms timeout configured, a module future
+     * that never completes fails promptly with a TimeoutException instead of
+     * wedging the caller.
+     */
+    @Test
+    public void customLocalTimeoutIsHonored() throws Exception {
+        System.setProperty(CamelRpcClientFactory.LOCAL_EXEC_TIMEOUT_PROPERTY, "5");
+        final CompletableFuture<StubResponse> neverCompletes = new CompletableFuture<>();
+        final RpcModule<StubRequest, StubResponse> hangingModule = stubModule(neverCompletes);
+
+        final CamelRpcClientFactory factory = new CamelRpcClientFactory();
+        factory.setLocation(LOCAL_LOCATION); // start() intentionally NOT called — the local branch needs no Camel.
+
+        final StubRequest request = new StubRequest(LOCAL_LOCATION, null);
+
+        try {
+            factory.getClient(hangingModule).execute(request).get(10, TimeUnit.SECONDS);
+            fail("Expected the local timeout to fail the hung execution");
+        } catch (ExecutionException e) {
+            assertTrue("expected a TimeoutException cause but was: " + e.getCause(),
+                    e.getCause() instanceof TimeoutException);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Minimal stubs (no Camel/Spring/Mockito needed for the local branch).
+    // -----------------------------------------------------------------------
+
+    private static RpcModule<StubRequest, StubResponse> stubModule(final CompletableFuture<StubResponse> future) {
+        return new RpcModule<StubRequest, StubResponse>() {
+            @Override public CompletableFuture<StubResponse> execute(StubRequest request) { return future; }
+            @Override public String getId() { return "stub"; }
+            @Override public String marshalRequest(StubRequest request) { return ""; }
+            @Override public StubRequest unmarshalRequest(String request) { return new StubRequest(LOCAL_LOCATION, null); }
+            @Override public String marshalResponse(StubResponse response) { return ""; }
+            @Override public StubResponse unmarshalResponse(String response) { return new StubResponse(null); }
+            @Override public StubResponse createResponseWithException(Throwable ex) { return new StubResponse(ex.getMessage()); }
+        };
+    }
+
+    private static final class StubRequest implements RpcRequest {
+        private final String location;
+        private final Long ttlMs;
+        StubRequest(String location, Long ttlMs) { this.location = location; this.ttlMs = ttlMs; }
+        @Override public String getLocation() { return location; }
+        @Override public String getSystemId() { return null; }
+        @Override public Long getTimeToLiveMs() { return ttlMs; }
+        @Override public Map<String, String> getTracingInfo() { return Collections.emptyMap(); }
+        @Override public Span getSpan() { return null; }
+    }
+
+    private static final class StubResponse implements RpcResponse {
+        private final String errorMessage;
+        StubResponse(String errorMessage) { this.errorMessage = errorMessage; }
+        @Override public String getErrorMessage() { return errorMessage; }
+    }
+}

--- a/docs/modules/reference/pages/configuration/ttl-rpc.adoc
+++ b/docs/modules/reference/pages/configuration/ttl-rpc.adoc
@@ -48,6 +48,16 @@ This value can be configured.
 When using the JMS-based RPC implementation, set value of the `org.opennms.jms.timeout` system property to the desired number of milliseconds.
 When using the Kafka-based RPC implementation, set the value of the `org.opennms.core.ipc.rpc.kafka.ttl` system property to the desired number of milliseconds.
 
+== Local execution timeout
+
+TTLs abort requests that are dispatched to a remote Minion.
+Requests for the Core instance's own location run in place; their TTL does not abort them.
+
+When using the JMS-based RPC implementation, local execution is instead bounded by a separate timeout that guards against operations that never complete.
+It defaults to 30 minutes.
+To change it, set the `org.opennms.core.ipc.rpc.local.timeout` system property to the desired number of milliseconds; a value of `0` disables it.
+If legitimately long-running local operations (for example, large SNMP table walks) exceed the limit, raise this property; the TTL settings above do not need to be changed.
+
 [[metadata-ttls]]
 == Using metadata for TTLs
 


### PR DESCRIPTION
Attempting to fix the actual thing I was trying to fix in the first place with this one.  I've kept this tied to the same NMS as I do think we want to address this and just leaving it as the reversion isn't enough.  I'll open it as a draft for now to get comments on the approach.


This restores protection against the failure mode of a module future that never completes wedging its caller without re-introducing the regression: local execution in CamelRpcClientFactory is bounded at 30 minutes by default, configurable via the org.opennms.core.ipc.rpc.local.timeout system property (0 disables). 

The request TTL no longer affects local execution, so no TTL configuration can re-introduce the regression. RpcExceptionUtils now maps java.util.concurrent.TimeoutException to onTimedOut, so an expired local execution is reported as a timeout rather than an unexpected exception.

Assisted by Anthropic Claude Fable 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20006
