### PR TITLE
NMS-20049: harden smoke test login against CSRF/session race

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -311,25 +311,44 @@ public abstract class AbstractOpenNMSSeleniumHelper {
 
         if (navigateToLoginPage) {
             if (!skipCookieDeletion) {
-                // Start with a clean slate
+                // Start with a clean slate. Park on about:blank afterwards so background
+                // requests from the previous page (e.g. Vaadin heartbeats) cannot race the
+                // login page load and swap the session cookie after the form is rendered,
+                // which would invalidate the CSRF token embedded in the form.
                 getDriver().manage().deleteAllCookies();
+                getDriver().get("about:blank");
             }
 
             getDriver().get(getBaseUrlInternal() + "opennms/login.jsp");
         }
 
-        waitForLogin();
+        for (int attempt = 1; ; attempt++) {
+            waitForLogin();
 
-        enterText(By.name("j_username"), username);
-        enterText(By.name("j_password"), password);
-        clickElement(By.name("Login"));
+            enterText(By.name("j_username"), username);
+            enterText(By.name("j_password"), password);
+            clickElement(By.name("Login"));
 
-        wait.until((WebDriver driver) -> {
-            return ! driver.getCurrentUrl().contains("login.jsp");
-        });
+            wait.until((WebDriver driver) -> {
+                return ! driver.getCurrentUrl().contains("login.jsp");
+            });
 
-        // bootstrap header, exists in all JSP-based OpenNMS pages
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='content']")));
+            // bootstrap header, exists in all JSP-based OpenNMS pages
+            wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='content']")));
+
+            // A rejected login POST (e.g. a stale CSRF token after a session cookie swap)
+            // forwards to the access-denied page instead of failing on login.jsp, so it
+            // passes the waits above. Retry with a freshly rendered form in that case.
+            final String landedOn = getDriver().getCurrentUrl();
+            if (!landedOn.contains("accessDenied.jsp") && !landedOn.contains("j_spring_security_check")) {
+                break;
+            }
+            if (attempt >= 3) {
+                fail("Login POST was rejected " + attempt + " times; last landed on: " + landedOn);
+            }
+            LOG.warn("Login POST was rejected (landed on {}), retrying with a fresh login form.", landedOn);
+            getDriver().get(getBaseUrlInternal() + "opennms/login.jsp");
+        }
 
         ensureLoginSuccess();
 
@@ -399,6 +418,13 @@ public abstract class AbstractOpenNMSSeleniumHelper {
      */
     protected void skipPasswordGate(final String username, final String password) {
         if (username.equals(PASSWORD_GATE_USERNAME) && password.equals(PASSWORD_GATE_PASSWORD)) {
+            // Only wait for the skip button if we actually landed on the gate page;
+            // otherwise this would block for the full timeout on a button that never appears.
+            if (!getDriver().getCurrentUrl().contains("passwordGate.jsp")) {
+                LOG.debug("skipPasswordGate: not on the password gate page (url={}), nothing to skip", getDriver().getCurrentUrl());
+                return;
+            }
+
             clickElement(By.id("btn_skip"));
 
             wait.until((WebDriver driver) -> {


### PR DESCRIPTION
Tired of errors... trying to fix.

Fix in AbstractOpenNMSSeleniumHelper: park on about:blank after cookie deletion, retry the login if it lands on accessDenied.jsp, and make skipPasswordGate() a no-op when not on the gate page.

Assisted by Anthropic Claude Fable 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20049

