### PR TITLE
NMS-19961: Prevent old bcprov-jdk18on version from being included

### DIFF
--- a/features/minion/core/repository/src/assembly/repo.xml
+++ b/features/minion/core/repository/src/assembly/repo.xml
@@ -17,6 +17,8 @@
         <exclude>io/netty/netty-*/4.1.22.Final/*</exclude>
         <exclude>io/netty/netty-*/4.1.77.Final</exclude>
         <exclude>io/netty/netty-*/4.1.77.Final/*</exclude>
+        <exclude>org/bouncycastle/bcprov-jdk18on/1.75</exclude>
+        <exclude>org/bouncycastle/bcprov-jdk18on/1.75/*</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/features/minion/repository/src/assembly/repo.xml
+++ b/features/minion/repository/src/assembly/repo.xml
@@ -21,6 +21,8 @@
         <exclude>io/netty/netty-*/4.1.22.Final/*</exclude>
         <exclude>io/netty/netty-*/4.1.77.Final</exclude>
         <exclude>io/netty/netty-*/4.1.77.Final/*</exclude>
+        <exclude>org/bouncycastle/bcprov-jdk18on/1.75</exclude>
+        <exclude>org/bouncycastle/bcprov-jdk18on/1.75/*</exclude>
       </excludes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
* JIRA: https://opennms.atlassian.net/browse/NMS-19961