### PR TITLE
Docs: Add Architecture and Deployment Planning docs chapter

### DIFF
--- a/docs/modules/deployment/images/deployment/architecture/dedicated-timeseries.svg
+++ b/docs/modules/deployment/images/deployment/architecture/dedicated-timeseries.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 450" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="820" height="450" fill="#ffffff"/>
+  <!-- connections -->
+  <line x1="410" y1="120" x2="410" y2="175" stroke="#555555" stroke-width="2"/>
+  <line x1="360" y1="265" x2="240" y2="325" stroke="#555555" stroke-width="2"/>
+  <line x1="460" y1="265" x2="600" y2="325" stroke="#555555" stroke-width="2"/>
+  <!-- Distributed Minions -->
+  <rect x="300" y="40" width="220" height="80" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="410" y="86" text-anchor="middle" font-size="18" font-weight="bold" fill="#ffffff">OpenNMS Minions</text>
+  <!-- OpenNMS Core -->
+  <rect x="300" y="175" width="220" height="90" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="410" y="226" text-anchor="middle" font-size="20" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+  <!-- PostgreSQL -->
+  <rect x="110" y="325" width="230" height="90" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="225" y="376" text-anchor="middle" font-size="19" font-weight="bold" fill="#222222">PostgreSQL</text>
+  <!-- Dedicated time series storage -->
+  <rect x="470" y="325" width="260" height="90" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="600" y="366" text-anchor="middle" font-size="18" font-weight="bold" fill="#222222">Dedicated time series</text>
+  <text x="600" y="391" text-anchor="middle" font-size="18" font-weight="bold" fill="#222222">storage</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/distributed.svg
+++ b/docs/modules/deployment/images/deployment/architecture/distributed.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 570" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="1000" height="570" fill="#ffffff"/>
+
+  <!-- connections -->
+  <!-- Minions to Kafka -->
+  <line x1="275" y1="95" x2="500" y2="150" stroke="#555555" stroke-width="1.5"/>
+  <line x1="500" y1="95" x2="500" y2="150" stroke="#555555" stroke-width="1.5"/>
+  <line x1="725" y1="95" x2="500" y2="150" stroke="#555555" stroke-width="1.5"/>
+  <!-- Kafka to Core -->
+  <line x1="450" y1="220" x2="215" y2="285" stroke="#555555" stroke-width="1.5"/>
+  <!-- Kafka to Sentinels -->
+  <line x1="560" y1="220" x2="597" y2="295" stroke="#555555" stroke-width="1.5"/>
+  <line x1="560" y1="220" x2="757" y2="295" stroke="#555555" stroke-width="1.5"/>
+  <line x1="560" y1="220" x2="917" y2="295" stroke="#555555" stroke-width="1.5"/>
+  <!-- Core to storage -->
+  <line x1="185" y1="365" x2="140" y2="450" stroke="#555555" stroke-width="1.5"/>
+  <line x1="250" y1="365" x2="345" y2="450" stroke="#555555" stroke-width="1.5"/>
+  <!-- Sentinels to PostgreSQL -->
+  <line x1="560" y1="358" x2="400" y2="452" stroke="#555555" stroke-width="1.5"/>
+  <!-- Sentinels to Elasticsearch -->
+  <line x1="597" y1="360" x2="757" y2="450" stroke="#555555" stroke-width="1.5"/>
+  <line x1="757" y1="360" x2="757" y2="450" stroke="#555555" stroke-width="1.5"/>
+  <line x1="917" y1="360" x2="757" y2="450" stroke="#555555" stroke-width="1.5"/>
+
+  <!-- Minions (blue) -->
+  <rect x="200" y="30" width="150" height="65" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="275" y="69" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="425" y="30" width="150" height="65" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="500" y="69" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="650" y="30" width="150" height="65" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="725" y="69" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+
+  <!-- Apache Kafka cluster -->
+  <rect x="350" y="150" width="300" height="70" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="500" y="192" text-anchor="middle" font-size="17" font-weight="bold" fill="#222222">Apache Kafka cluster</text>
+
+  <!-- OpenNMS Core -->
+  <rect x="100" y="285" width="230" height="80" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="215" y="331" text-anchor="middle" font-size="18" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+
+  <!-- OpenNMS Sentinels (lighter blue) -->
+  <rect x="530" y="295" width="135" height="65" rx="10" fill="#5b9bd5" stroke="#2f6db3" stroke-width="2"/>
+  <text x="597" y="322" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">OpenNMS</text>
+  <text x="597" y="340" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">Sentinel</text>
+  <rect x="690" y="295" width="135" height="65" rx="10" fill="#5b9bd5" stroke="#2f6db3" stroke-width="2"/>
+  <text x="757" y="322" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">OpenNMS</text>
+  <text x="757" y="340" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">Sentinel</text>
+  <rect x="850" y="295" width="135" height="65" rx="10" fill="#5b9bd5" stroke="#2f6db3" stroke-width="2"/>
+  <text x="917" y="322" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">OpenNMS</text>
+  <text x="917" y="340" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">Sentinel</text>
+
+  <!-- Dedicated time series storage (under Core, left) -->
+  <rect x="40" y="450" width="200" height="80" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="140" y="485" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">Dedicated time series</text>
+  <text x="140" y="505" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">storage</text>
+
+  <!-- PostgreSQL (under Core, right) -->
+  <rect x="270" y="450" width="150" height="80" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="345" y="497" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">PostgreSQL</text>
+
+  <!-- Elasticsearch / OpenSearch (under Sentinels) -->
+  <rect x="637" y="450" width="240" height="80" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="757" y="485" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">Elasticsearch or</text>
+  <text x="757" y="505" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">OpenSearch</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/example-enterprise.svg
+++ b/docs/modules/deployment/images/deployment/architecture/example-enterprise.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 420" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="940" height="420" fill="#ffffff"/>
+  <!-- Headquarters boundary -->
+  <rect x="30" y="30" width="520" height="360" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="50" y="62" font-size="17" font-weight="bold" fill="#666666">Central office</text>
+  <!-- Branch offices boundary -->
+  <rect x="615" y="50" width="295" height="320" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="635" y="82" font-size="17" font-weight="bold" fill="#666666">Branch offices</text>
+
+  <!-- connections -->
+  <line x1="170" y1="175" x2="170" y2="255" stroke="#555555" stroke-width="2"/>
+  <line x1="270" y1="175" x2="405" y2="255" stroke="#555555" stroke-width="2"/>
+  <line x1="665" y1="130" x2="320" y2="120" stroke="#555555" stroke-width="1.5"/>
+  <line x1="665" y1="215" x2="320" y2="135" stroke="#555555" stroke-width="1.5"/>
+  <line x1="665" y1="300" x2="320" y2="150" stroke="#555555" stroke-width="1.5"/>
+
+  <!-- OpenNMS Core -->
+  <rect x="90" y="85" width="230" height="90" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="205" y="138" text-anchor="middle" font-size="20" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+  <!-- PostgreSQL -->
+  <rect x="70" y="255" width="200" height="90" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="170" y="308" text-anchor="middle" font-size="19" font-weight="bold" fill="#222222">PostgreSQL</text>
+  <!-- Grafana -->
+  <rect x="310" y="255" width="190" height="90" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="405" y="308" text-anchor="middle" font-size="19" font-weight="bold" fill="#222222">Grafana</text>
+
+  <!-- Minions (one per branch) -->
+  <rect x="665" y="100" width="195" height="60" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="762" y="138" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="665" y="185" width="195" height="60" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="762" y="223" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="665" y="270" width="195" height="60" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="762" y="308" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/example-flow-heavy.svg
+++ b/docs/modules/deployment/images/deployment/architecture/example-flow-heavy.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1050 580" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="1050" height="580" fill="#ffffff"/>
+
+  <!-- Points of presence boundary -->
+  <rect x="30" y="40" width="210" height="290" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="50" y="72" font-size="15" font-weight="bold" fill="#666666">Points of presence</text>
+
+  <!-- connections -->
+  <line x1="215" y1="117" x2="340" y2="120" stroke="#555555" stroke-width="1.5"/>
+  <line x1="215" y1="192" x2="340" y2="127" stroke="#555555" stroke-width="1.5"/>
+  <line x1="215" y1="267" x2="340" y2="135" stroke="#555555" stroke-width="1.5"/>
+  <line x1="580" y1="127" x2="700" y2="127" stroke="#999999" stroke-width="1.5" stroke-dasharray="7 6"/>
+  <line x1="450" y1="165" x2="445" y2="260" stroke="#555555" stroke-width="1.5"/>
+  <line x1="540" y1="165" x2="770" y2="260" stroke="#555555" stroke-width="1.5"/>
+  <line x1="390" y1="340" x2="180" y2="450" stroke="#555555" stroke-width="1.5"/>
+  <line x1="740" y1="340" x2="700" y2="450" stroke="#555555" stroke-width="1.5"/>
+  <line x1="450" y1="450" x2="445" y2="340" stroke="#555555" stroke-width="1.5"/>
+  <line x1="840" y1="495" x2="800" y2="495" stroke="#555555" stroke-width="1.5"/>
+
+  <!-- Minions -->
+  <rect x="65" y="90" width="150" height="55" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="140" y="124" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="65" y="165" width="150" height="55" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="140" y="199" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="65" y="240" width="150" height="55" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="140" y="274" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+
+  <!-- Apache Kafka cluster -->
+  <rect x="340" y="90" width="240" height="75" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="460" y="124" text-anchor="middle" font-size="16" font-weight="bold" fill="#222222">Apache Kafka cluster</text>
+  <text x="460" y="146" text-anchor="middle" font-size="11" fill="#444444">transport, buffering, integration bus</text>
+
+  <!-- Downstream consumers -->
+  <rect x="700" y="90" width="230" height="75" rx="10" fill="#fafafa" stroke="#8c8c8c" stroke-width="2" stroke-dasharray="7 6"/>
+  <text x="815" y="121" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">Downstream consumers</text>
+  <text x="815" y="143" text-anchor="middle" font-size="11" fill="#444444">service-impact tooling, data platform</text>
+
+  <!-- OpenNMS Core -->
+  <rect x="330" y="260" width="220" height="80" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="440" y="306" text-anchor="middle" font-size="18" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+
+  <!-- OpenNMS Sentinels -->
+  <rect x="680" y="260" width="230" height="80" rx="10" fill="#5b9bd5" stroke="#2f6db3" stroke-width="2"/>
+  <text x="795" y="294" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">OpenNMS Sentinels</text>
+  <text x="795" y="316" text-anchor="middle" font-size="11" fill="#eef4fb">scaled to flow rate</text>
+
+  <!-- PostgreSQL and time series storage -->
+  <rect x="60" y="450" width="240" height="90" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="180" y="488" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">PostgreSQL and dedicated</text>
+  <text x="180" y="510" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">time series storage</text>
+
+  <!-- Grafana -->
+  <rect x="350" y="450" width="200" height="90" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="450" y="488" text-anchor="middle" font-size="17" font-weight="bold" fill="#222222">Grafana</text>
+  <text x="450" y="510" text-anchor="middle" font-size="11" fill="#444444">OpenNMS data source</text>
+
+  <!-- Elasticsearch -->
+  <rect x="600" y="450" width="200" height="90" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="700" y="488" text-anchor="middle" font-size="16" font-weight="bold" fill="#222222">Elasticsearch</text>
+  <text x="700" y="510" text-anchor="middle" font-size="11" fill="#444444">flows</text>
+
+  <!-- Kibana -->
+  <rect x="840" y="450" width="170" height="90" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="925" y="488" text-anchor="middle" font-size="17" font-weight="bold" fill="#222222">Kibana</text>
+  <text x="925" y="510" text-anchor="middle" font-size="11" fill="#444444">flow exploration</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/external-postgres.svg
+++ b/docs/modules/deployment/images/deployment/architecture/external-postgres.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 740 260" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="740" height="260" fill="#ffffff"/>
+  <!-- OpenNMS host boundary -->
+  <rect x="20" y="30" width="320" height="200" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="40" y="62" font-size="16" font-weight="bold" fill="#666666">OpenNMS host</text>
+  <!-- Database host boundary -->
+  <rect x="400" y="30" width="320" height="200" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="420" y="62" font-size="16" font-weight="bold" fill="#666666">Database host</text>
+  <!-- connection -->
+  <line x1="300" y1="140" x2="440" y2="140" stroke="#555555" stroke-width="2"/>
+  <!-- OpenNMS Core -->
+  <rect x="60" y="90" width="240" height="100" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="180" y="147" text-anchor="middle" font-size="20" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+  <!-- PostgreSQL -->
+  <rect x="440" y="90" width="240" height="100" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="560" y="147" text-anchor="middle" font-size="20" font-weight="bold" fill="#222222">PostgreSQL</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/fault-management.svg
+++ b/docs/modules/deployment/images/deployment/architecture/fault-management.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 470" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="1020" height="470" fill="#ffffff"/>
+  <!-- Equipment sites boundary -->
+  <rect x="30" y="50" width="230" height="310" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="50" y="82" font-size="16" font-weight="bold" fill="#666666">Equipment sites</text>
+
+  <!-- connections -->
+  <line x1="240" y1="137" x2="410" y2="95" stroke="#555555" stroke-width="1.5"/>
+  <line x1="240" y1="222" x2="410" y2="110" stroke="#555555" stroke-width="1.5"/>
+  <line x1="240" y1="307" x2="410" y2="125" stroke="#555555" stroke-width="1.5"/>
+  <line x1="520" y1="150" x2="520" y2="250" stroke="#555555" stroke-width="1.5"/>
+  <line x1="630" y1="110" x2="770" y2="110" stroke="#555555" stroke-width="1.5"/>
+  <line x1="520" y1="330" x2="520" y2="370" stroke="#555555" stroke-width="1.5"/>
+
+  <!-- Minions -->
+  <rect x="70" y="110" width="170" height="55" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="155" y="145" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="70" y="195" width="170" height="55" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="155" y="230" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="70" y="280" width="170" height="55" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="155" y="315" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+
+  <!-- Apache Kafka cluster (hub) -->
+  <rect x="410" y="70" width="220" height="80" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="520" y="105" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">Apache Kafka cluster</text>
+  <text x="520" y="127" text-anchor="middle" font-size="11" fill="#444444">Minion transport, alarm topic</text>
+
+  <!-- Upstream system (black box) -->
+  <rect x="770" y="70" width="210" height="80" rx="10" fill="#fafafa" stroke="#8c8c8c" stroke-width="2" stroke-dasharray="7 6"/>
+  <text x="875" y="103" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">Upstream system</text>
+  <text x="875" y="126" text-anchor="middle" font-size="11" fill="#444444">notifications, correlation</text>
+
+  <!-- OpenNMS Core -->
+  <rect x="410" y="250" width="220" height="80" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="520" y="285" text-anchor="middle" font-size="17" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+  <text x="520" y="307" text-anchor="middle" font-size="11" fill="#e8f1e6">traps to correlated alarms</text>
+
+  <!-- PostgreSQL -->
+  <rect x="420" y="370" width="200" height="65" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="520" y="408" text-anchor="middle" font-size="16" font-weight="bold" fill="#222222">PostgreSQL</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/message-broker.svg
+++ b/docs/modules/deployment/images/deployment/architecture/message-broker.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 430" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="800" height="430" fill="#ffffff"/>
+  <!-- Single host boundary (top) -->
+  <rect x="200" y="30" width="400" height="150" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="220" y="62" font-size="16" font-weight="bold" fill="#666666">Single host</text>
+  <!-- OpenNMS Core -->
+  <rect x="230" y="80" width="180" height="80" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="320" y="126" text-anchor="middle" font-size="17" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+  <!-- PostgreSQL -->
+  <rect x="425" y="80" width="150" height="80" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="500" y="126" text-anchor="middle" font-size="16" font-weight="bold" fill="#222222">PostgreSQL</text>
+  <line x1="410" y1="120" x2="425" y2="120" stroke="#555555" stroke-width="2"/>
+  <!-- Kafka cluster (middle) -->
+  <rect x="285" y="220" width="230" height="70" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="400" y="262" text-anchor="middle" font-size="17" font-weight="bold" fill="#222222">Apache Kafka cluster</text>
+  <!-- connections -->
+  <line x1="400" y1="180" x2="400" y2="220" stroke="#555555" stroke-width="2"/>
+  <line x1="140" y1="330" x2="400" y2="290" stroke="#555555" stroke-width="2"/>
+  <line x1="400" y1="330" x2="400" y2="290" stroke="#555555" stroke-width="2"/>
+  <line x1="660" y1="330" x2="400" y2="290" stroke="#555555" stroke-width="2"/>
+  <!-- Minions (bottom) -->
+  <rect x="60" y="330" width="160" height="75" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="140" y="373" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="320" y="330" width="160" height="75" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="400" y="373" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="580" y="330" width="160" height="75" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="660" y="373" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/metrics-pipeline.svg
+++ b/docs/modules/deployment/images/deployment/architecture/metrics-pipeline.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 540" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="1200" height="540" fill="#ffffff"/>
+
+  <!-- Collection networks boundary -->
+  <rect x="25" y="60" width="175" height="320" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="45" y="92" font-size="15" font-weight="bold" fill="#666666">Collection networks</text>
+
+  <!-- Prometheus-compatible stack boundary -->
+  <rect x="690" y="40" width="485" height="360" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="710" y="72" font-size="15" font-weight="bold" fill="#666666">Prometheus-compatible stack</text>
+
+  <!-- connections -->
+  <line x1="175" y1="145" x2="240" y2="195" stroke="#555555" stroke-width="1.5"/>
+  <line x1="175" y1="220" x2="240" y2="210" stroke="#555555" stroke-width="1.5"/>
+  <line x1="175" y1="295" x2="240" y2="225" stroke="#555555" stroke-width="1.5"/>
+  <line x1="405" y1="210" x2="445" y2="185" stroke="#555555" stroke-width="1.5"/>
+  <line x1="537" y1="220" x2="537" y2="270" stroke="#555555" stroke-width="1.5"/>
+  <line x1="630" y1="175" x2="720" y2="128" stroke="#555555" stroke-width="1.5"/>
+  <line x1="900" y1="128" x2="970" y2="128" stroke="#555555" stroke-width="1.5"/>
+  <line x1="810" y1="165" x2="810" y2="250" stroke="#555555" stroke-width="1.5"/>
+  <line x1="810" y1="325" x2="810" y2="440" stroke="#555555" stroke-width="1.5"/>
+
+  <!-- Minions -->
+  <rect x="50" y="120" width="125" height="50" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="112" y="151" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="50" y="195" width="125" height="50" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="112" y="226" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="50" y="270" width="125" height="50" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="112" y="301" text-anchor="middle" font-size="13" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+
+  <!-- Apache Kafka cluster -->
+  <rect x="240" y="170" width="165" height="80" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="322" y="205" text-anchor="middle" font-size="13" font-weight="bold" fill="#222222">Apache Kafka cluster</text>
+  <text x="322" y="226" text-anchor="middle" font-size="10" fill="#444444">Minion transport</text>
+
+  <!-- OpenNMS Core -->
+  <rect x="445" y="140" width="185" height="80" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="537" y="177" text-anchor="middle" font-size="16" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+  <text x="537" y="199" text-anchor="middle" font-size="10" fill="#e8f1e6">inventory-driven collection</text>
+
+  <!-- PostgreSQL -->
+  <rect x="455" y="270" width="165" height="65" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="537" y="308" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">PostgreSQL</text>
+
+  <!-- Thanos -->
+  <rect x="720" y="90" width="180" height="75" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="810" y="124" text-anchor="middle" font-size="16" font-weight="bold" fill="#222222">Thanos</text>
+  <text x="810" y="146" text-anchor="middle" font-size="10" fill="#444444">metrics storage</text>
+
+  <!-- Grafana -->
+  <rect x="970" y="90" width="175" height="75" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="1057" y="124" text-anchor="middle" font-size="16" font-weight="bold" fill="#222222">Grafana</text>
+  <text x="1057" y="146" text-anchor="middle" font-size="10" fill="#444444">PromQL</text>
+
+  <!-- Alertmanager -->
+  <rect x="720" y="250" width="180" height="75" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="810" y="284" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">Alertmanager</text>
+  <text x="810" y="306" text-anchor="middle" font-size="10" fill="#444444">rule evaluation, routing</text>
+
+  <!-- Slack (external messaging) -->
+  <rect x="720" y="440" width="180" height="65" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="810" y="478" text-anchor="middle" font-size="16" font-weight="bold" fill="#222222">Slack</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/minions.svg
+++ b/docs/modules/deployment/images/deployment/architecture/minions.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 390" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="800" height="390" fill="#ffffff"/>
+  <!-- Single host boundary (top) -->
+  <rect x="200" y="30" width="400" height="150" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="220" y="62" font-size="16" font-weight="bold" fill="#666666">Single host</text>
+  <!-- OpenNMS Core -->
+  <rect x="230" y="80" width="180" height="80" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="320" y="126" text-anchor="middle" font-size="17" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+  <!-- PostgreSQL -->
+  <rect x="425" y="80" width="150" height="80" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="500" y="126" text-anchor="middle" font-size="16" font-weight="bold" fill="#222222">PostgreSQL</text>
+  <!-- Core-PostgreSQL connection -->
+  <line x1="410" y1="120" x2="425" y2="120" stroke="#555555" stroke-width="2"/>
+  <!-- connections: each Minion to the host/core -->
+  <line x1="140" y1="290" x2="400" y2="180" stroke="#555555" stroke-width="2"/>
+  <line x1="400" y1="290" x2="400" y2="180" stroke="#555555" stroke-width="2"/>
+  <line x1="660" y1="290" x2="400" y2="180" stroke="#555555" stroke-width="2"/>
+  <!-- Minions (bottom, in remote networks) -->
+  <rect x="60" y="290" width="160" height="75" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="140" y="333" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="320" y="290" width="160" height="75" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="400" y="333" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+  <rect x="580" y="290" width="160" height="75" rx="10" fill="#1f6db3" stroke="#134a7c" stroke-width="2"/>
+  <text x="660" y="333" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">OpenNMS Minion</text>
+</svg>

--- a/docs/modules/deployment/images/deployment/architecture/single-host.svg
+++ b/docs/modules/deployment/images/deployment/architecture/single-host.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 260" font-family="Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="700" height="260" fill="#ffffff"/>
+  <!-- Host boundary -->
+  <rect x="20" y="20" width="660" height="220" rx="12" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <text x="40" y="52" font-size="17" font-weight="bold" fill="#666666">Single host</text>
+  <!-- connection -->
+  <line x1="320" y1="140" x2="400" y2="140" stroke="#555555" stroke-width="2"/>
+  <!-- OpenNMS Core -->
+  <rect x="70" y="85" width="250" height="110" rx="10" fill="#4c9a41" stroke="#2e6b28" stroke-width="2"/>
+  <text x="195" y="147" text-anchor="middle" font-size="21" font-weight="bold" fill="#ffffff">OpenNMS Core</text>
+  <!-- PostgreSQL -->
+  <rect x="400" y="85" width="230" height="110" rx="10" fill="#f2f2f2" stroke="#8c8c8c" stroke-width="2"/>
+  <text x="515" y="147" text-anchor="middle" font-size="21" font-weight="bold" fill="#222222">PostgreSQL</text>
+</svg>

--- a/docs/modules/deployment/nav.adoc
+++ b/docs/modules/deployment/nav.adoc
@@ -1,5 +1,10 @@
 
 .Deployment
+* xref:architecture/introduction.adoc[]
+** xref:architecture/data-domains.adoc[]
+** xref:architecture/deployment-scenarios.adoc[]
+** xref:architecture/deployments-in-practice.adoc[]
+
 * xref:core/introduction.adoc[]
 ** xref:core/system-requirements.adoc[]
 ** xref:core/install.adoc[]

--- a/docs/modules/deployment/pages/architecture/data-domains.adoc
+++ b/docs/modules/deployment/pages/architecture/data-domains.adoc
@@ -1,0 +1,90 @@
+
+[[arch-data-domains]]
+= Data Domains and Processing
+:description: The kinds of data OpenNMS ingests, the difference between pull and push ingestion, where each kind of data is stored, and the paths for exporting data to other systems.
+
+This page describes how data moves through {page-component-title}: what comes in, where it is stored, and how it leaves.
+Configuration details are covered in the linked references.
+
+== Inventory
+
+Data in {page-component-title} attaches to inventory: the nodes, interfaces, and services defined through xref:operation:deep-dive/provisioning/introduction.adoc[provisioning].
+An SNMP trap is enriched with the node that sent it, collected metrics are stored against a node's resources, flows are tagged with the exporting node, and topology links connect nodes to each other.
+This shared anchor is what unifies monitoring across the data domains: fault, performance, and traffic data all describe the same nodes.
+Nodes, interfaces, and services can also carry arbitrary xref:operation:deep-dive/meta-data.adoc[metadata], which can be referenced to configure service monitoring, data collection, service detection, and thresholds.
+
+Data from devices that are not in the inventory is of limited use: flows or traps from an unknown source cannot be fully enriched or correlated.
+Nodes should enter inventory through requisitions, which define the entities to monitor from an authoritative source such as a CMDB, IPAM system, or cloud inventory, and which {page-component-title} imports and keeps in sync.
+Provisioning is usually the right place to start when adopting the platform, because the other data domains depend on it.
+
+== Events and alarms
+
+Most activity in {page-component-title} is represented as events: a poller detects a service outage, a trap arrives, a threshold is exceeded, a configuration is reloaded.
+External sources such as xref:operation:deep-dive/events/sources/snmp-traps.adoc[SNMP traps], xref:operation:deep-dive/events/sources/syslog.adoc[syslog messages], and the xref:operation:deep-dive/events/sources/rest.adoc[REST API] are normalized into the same event stream as internally generated events.
+
+Events that indicate problems are raised as alarms, with repeated occurrences reduced onto a single alarm; related alarms can be grouped further through correlation.
+Alarms carry state (they can be acknowledged, escalated, and cleared) and drive notifications and ticketing integrations.
+The xref:operation:deep-dive/events/introduction.adoc[Events] documentation covers this pipeline in depth.
+
+== Pull and push ingestion
+
+Ingestion paths fall into two families, and the two families load a deployment differently.
+
+With *pull* ingestion, {page-component-title} initiates the request:
+
+* The poller runs xref:reference:service-assurance/introduction.adoc[service monitors] to test service availability on a schedule.
+* xref:reference:performance-data-collection/introduction.adoc[Collectors] gather performance metrics (SNMP, HTTPS, JMX, and others) on a schedule.
+
+Pull workloads are driven by configuration: the load depends on the number of nodes, the metrics collected from each, and the collection interval.
+
+With *push* ingestion, network devices initiate the transmission:
+
+* SNMP traps and syslog messages arrive as devices send them.
+* Flows and xref:operation:deep-dive/telemetryd/introduction.adoc[streaming telemetry] arrive continuously, at rates influenced by both network traffic and device configuration, such as export and sampling settings.
+
+Push workloads vary with conditions on the network; a routing incident or a traffic spike can multiply them.
+The scaling components (Sentinel, external flow storage) are aimed primarily at the push side for this reason.
+Minions serve both families: they run pollers and collectors remotely, and they act as listeners that receive push data close to its source.
+
+== Where data is stored
+
+[caption=]
+.Data domains and their default storage
+[cols="1,2,3"]
+|===
+| Data | Storage | Notes
+
+| Inventory, events, alarms
+| PostgreSQL
+| Required in every deployment.
+The system of record for platform state.
+
+| Performance metrics
+| Time series storage on the core's local disk (RRDtool by default)
+| Pluggable: a xref:time-series-storage/timeseries/ts-integration-layer.adoc[time series integration plugin] fits scenarios where metric volume outgrows the local disk.
+
+| Flows
+| An Elasticsearch or OpenSearch cluster
+| Flows are persisted to an xref:operation:deep-dive/flows/basic.adoc[Elasticsearch or OpenSearch] cluster.
+
+| Topology
+| PostgreSQL
+| Discovered by enlinkd from LLDP, CDP, bridge, and routing data.
+|===
+
+State and metadata are stored in PostgreSQL.
+The two high-volume domains, metrics and flows, have pluggable storage because they are typically the first to outgrow a single host.
+
+== Exporting data
+
+{page-component-title} provides several paths for other systems to consume its data:
+
+* *REST APIs*: These expose inventory, events, alarms, measurements, and flow summaries.
+Most integrations start here.
+* *Kafka Producer*: The xref:operation:deep-dive/kafka-producer/kafka-producer.adoc[Kafka Producer] streams events, alarms, metrics, and topology updates to Kafka topics, and a separate xref:operation:deep-dive/flows/basic.adoc#kafka-forwarder-config[flow forwarder] streams enriched flows to Kafka as well.
+This suits continuous consumers, such as data lakes or correlation engines, better than polling the REST APIs.
+* *Prometheus RemoteWrite plugin*: The xref:time-series-storage/timeseries/prometheus-remotewrite.adoc[plugin] persists time series data to a Prometheus remote-write compatible store, where other tools in the stack can query it.
+* *OpenNMS Plugin for Grafana*: The https://docs.opennms.com/grafana-plugin/latest/index.html[plugin] queries the REST APIs so dashboards can be built in Grafana.
+* *Notifications and ticketing integrations*: These forward alarms to people and workflow systems.
+
+The examples in xref:architecture/deployments-in-practice.adoc[] show these paths in use.

--- a/docs/modules/deployment/pages/architecture/deployment-scenarios.adoc
+++ b/docs/modules/deployment/pages/architecture/deployment-scenarios.adoc
@@ -1,0 +1,114 @@
+
+[[arch-deployment-scenarios]]
+= Deployment Scenarios
+:description: Common OpenNMS deployment scenarios, from a single host to a distributed deployment with Minions, external storage, Kafka, and Sentinel, with the triggers for each.
+
+A deployment can start with the smallest system that meets current needs and add components when a specific limit appears.
+Every additional component is another system to install, secure, monitor, and upgrade, so there is a cost to deploying ahead of need.
+The scenarios below are ordered by growth and scaling needs, reflecting common patterns of growth and change we see across deployments; each scenario builds on the previous one, and each lists the trigger that usually motivates it.
+Each scenario describes a single expansion step; xref:architecture/deployments-in-practice.adoc[] shows complete environments that combine several of them.
+
+NOTE: The sizing figures on this page are rough orders of magnitude, not benchmarks or guarantees, and actual capacity varies widely with hardware, collection intervals, retention, and the mix of monitored services.
+The figures can help judge whether a scenario is plausible for an environment, but you should verify them against your own workload.
+
+[[arch-single-host]]
+== Everything on one host
+
+A single server runs the core, PostgreSQL, and time series storage (RRDtool by default) on local disk, with the embedded ActiveMQ broker.
+This is the deployment the xref:core/install.adoc[installation guide] produces, and it is suitable for production use as well as evaluation.
+
+.Single-host deployment
+image::deployment/architecture/single-host.svg["Architecture diagram of a single-host deployment: OpenNMS Core and PostgreSQL on one server", 620]
+
+As a rough guide, a single well-resourced host can handle hundreds to a few thousand nodes with default collection intervals.
+Because the core, PostgreSQL, and time series storage share one machine, the limit is usually contention for its CPU, memory, and disk I/O rather than any single component.
+Database I/O is often the first pressure point, as inventory and event data grow.
+
+Many organizations never need more than this scenario.
+It is also the recommended starting point for evaluations, regardless of the expected final size: the later scenarios build on this one without reinstallation.
+
+[[arch-minions]]
+== Minions for reach
+
+*Trigger*: Parts of the network that the core cannot reach directly, such as remote sites, networks behind firewalls or NAT, or overlapping RFC 1918 address space; or monitoring that should happen from a remote user's perspective.
+
+.Single-host deployment with Minions
+image::deployment/architecture/minions.svg["Architecture diagram of a single-host deployment (OpenNMS Core and PostgreSQL) with three Minions in remote networks connecting back to the core", 640]
+
+A xref:minion/introduction.adoc[Minion] is a lightweight component deployed inside the remote network.
+It runs xref:reference:service-assurance/introduction.adoc[pollers] and xref:reference:performance-data-collection/introduction.adoc[collectors] locally, receives traps, syslog, and flows close to their source, and communicates with the core over a single authenticated connection.
+
+Reach is the primary reason to add Minions, but they also relieve capacity.
+A Minion executes the polls and collections for its location, so the network I/O and the worst-case timeout and retry load described in <<arch-knowing-limits, Knowing the limits>> fall on the Minion rather than the core.
+The core still schedules that work and persists and correlates the results, so a busy Minion site adds to the core's central load, and Minions do not scale out correlation or persistence.
+At small Minion counts, the embedded ActiveMQ broker is typically sufficient.
+A growing Minion fleet is one of the triggers for the <<arch-message-broker, external message broker>>.
+
+[[arch-external-postgres]]
+== External PostgreSQL
+
+*Trigger*: The database competing with the core for I/O and memory, or organizational requirements such as existing backup and high-availability practices or a DBA team that manages PostgreSQL as a service.
+
+.Deployment with external PostgreSQL
+image::deployment/architecture/external-postgres.svg["Architecture diagram with PostgreSQL moved to a dedicated database server", 620]
+
+Moving PostgreSQL to dedicated hardware or a managed instance is usually a small operational change, and it is often done from the start when a database platform already exists.
+It also enables standard PostgreSQL replication and backup tooling without any {page-component-title}-specific work.
+
+[[arch-message-broker]]
+== External message broker
+
+*Trigger*: A Minion fleet that has outgrown the embedded ActiveMQ broker, a need for a more resilient transport between Minions and the core, or a plan to use the broker as an integration bus for other systems.
+
+.Deployment with an external message broker
+image::deployment/architecture/message-broker.svg["Architecture diagram with an external Apache Kafka cluster carrying traffic between Minions and the single host", 640]
+
+The embedded ActiveMQ broker is convenient for a small number of Minions but is not intended for production workloads at scale.
+An external xref:core/setup-message-broker.adoc[Apache Kafka cluster] replaces it as the transport between Minions and the core, handling higher message volumes and buffering traffic when connectivity is interrupted.
+The same cluster can later carry flow and telemetry data to Sentinel (see <<arch-sentinel-flows>>) and serve as an integration point for other systems.
+
+[[arch-dedicated-tss]]
+== Dedicated time series storage
+
+*Trigger*: A need for capabilities that local RRD storage does not provide.
+Common reasons are finer control over retention and downsampling, consolidating metrics into a time series database already used elsewhere, querying the metrics directly from other tools, and data availability, since a clustered time series database provides redundancy that local storage on a single host does not.
+
+.Deployment with dedicated time series storage
+image::deployment/architecture/dedicated-timeseries.svg["Architecture diagram with time series storage moved off the core onto a dedicated system", 680]
+
+The xref:time-series-storage/timeseries/time-series-storage.adoc[time series layer] is pluggable; xref:time-series-storage/timeseries/ts-integration-layer.adoc[time series integration plugins] connect dedicated backends such as VictoriaMetrics.
+Migrating existing time series data between storage technologies is difficult and usually lossy, so this choice is harder to revisit than the others on this page.
+
+Local RRD storage is comparatively lightweight and handles substantial workloads, so this step is usually driven by these capability needs rather than by disk pressure.
+
+[[arch-sentinel-flows]]
+== Sentinel and scale-out flows
+
+*Trigger*: Flow or streaming telemetry volumes competing with the core's other work.
+
+.Distributed deployment with Kafka, Sentinel, and Elasticsearch
+image::deployment/architecture/distributed.svg["Architecture diagram of a fully distributed deployment: three Minions feeding a Kafka cluster, the OpenNMS Core with PostgreSQL and time series storage beneath it, and three OpenNMS Sentinels feeding an Elasticsearch or OpenSearch cluster", 820]
+
+This scenario builds on the <<arch-message-broker, external message broker>>, which carries flow and telemetry data alongside Minion traffic:
+
+* xref:sentinel/introduction.adoc[Sentinel] instances consume flow and telemetry data from Kafka and process it in place of the core.
+Sentinel scales horizontally: additional instances add processing capacity.
+* An xref:operation:deep-dive/flows/sentinel/sentinel.adoc[Elasticsearch or OpenSearch] cluster stores flows at high volumes; as a rough order of magnitude, this means sustained rates in the tens of thousands of flows per second.
+
+[[arch-knowing-limits]]
+== Knowing the limits
+
+The scenarios above extend reach, storage, and data processing, but they share one core instance, and the core does not cluster: polling and collection scheduling, event and alarm correlation, provisioning, and the web application all run there.
+Even so, a single core with the supporting components in place scales to very large environments, and deployments monitoring hundreds of thousands of nodes from one core exist.
+
+Node count alone is a weak measure of load.
+What a deployment sustains depends on the mix of work behind those nodes: the services and metrics collected per node, the polling and collection intervals, the volume of flows and events, and how the deployment is tuned.
+A few nodes polled frequently across many services can outweigh many lightly monitored ones.
+
+Size for the worst case, not the steady state.
+An unreachable service holds a poller thread for the full timeout on each attempt and retries according to its configuration, and the xref:operation:deep-dive/service-assurance/downtime-model.adoc[downtime model] polls a down service frequently at first, then backs off for prolonged outages.
+A large outage makes many services time out at once, generating far more concurrent polling work than normal operation, so leave headroom for it.
+For a deeper discussion, see the community post on https://opennms.discourse.group/t/opennms-in-large-environments/3587[OpenNMS in large environments].
+
+If requirements exceed what one fully expanded core can do, the usual approach is more than one deployment, split by region, business unit, or function, with a shared layer above them: a dashboard tool such as Grafana that queries several instances, or a Kafka pipeline that aggregates their events and alarms.
+High availability likewise uses standby instances and infrastructure-level failover rather than active-active clustering, and either is easier when the split follows a boundary that already exists in the organization.

--- a/docs/modules/deployment/pages/architecture/deployments-in-practice.adoc
+++ b/docs/modules/deployment/pages/architecture/deployments-in-practice.adoc
@@ -1,0 +1,89 @@
+
+[[arch-deployments-in-practice]]
+= Deployments in Practice
+:description: Worked examples of OpenNMS in a complete Operational Support System (OSS) stack, ranging from a mid-size enterprise to a flow-heavy service provider.
+
+The examples below are composites of common real-world deployments; they are not intended as templates to copy.
+They show how {page-component-title} fits into an Operational Support System (OSS) stack, and how the xref:architecture/deployment-scenarios.adoc[deployment scenarios] combine in practice.
+Few deployments start in their final form: most grow iteratively, adding components as specific needs appear rather than being built out all at once.
+
+== Availability and performance monitoring for an enterprise
+
+An organization with a campus network and a dozen branch offices: roughly 1,500 nodes, mostly switches, routers, wireless controllers, and servers.
+The requirements are availability monitoring, SNMP performance data, and alerting.
+
+.Enterprise deployment: single core, one Minion per branch, Grafana for dashboards
+image::deployment/architecture/example-enterprise.svg["Architecture diagram of an enterprise deployment with a core at the central office, PostgreSQL, and Grafana, and a Minion in each of several branch offices connecting back to the core", 800]
+
+The deployment:
+
+* A single core host at the central office (<<arch-single-host, single-host scenario>>) stores time series data on local SSD storage.
+* PostgreSQL runs on the organization's existing database infrastructure (<<arch-external-postgres, external PostgreSQL scenario>>), which already provides backups and DBA support.
+* One Minion runs in each branch office (<<arch-minions, Minion scenario>>).
+The branches sit behind firewalls, and each Minion makes a single outbound connection.
+* Grafana provides the dashboards through the https://docs.opennms.com/grafana-plugin/latest/index.html[OpenNMS Plugin for Grafana]; the {page-component-title} UI handles alarms, provisioning, and troubleshooting.
+* Notifications feed the team's existing on-call tooling.
+
+This deployment uses only the first three scenarios, matching components to the requirements it has.
+It can grow along the same path as needs change.
+
+== Collection and fault management for an upstream OSS
+
+A network operator with equipment in many unstaffed locations, such as fiber exchanges and other equipment sites.
+The equipment reports faults primarily through SNMP traps, and an upstream system owns notifications and cross-domain correlation.
+{page-component-title} serves as the collection and fault management layer between the two: it turns raw traps into alarms, correlates them, and streams them to the upstream system.
+
+.Collection and fault management: Minions collect traps, the core correlates alarms, and Kafka carries both Minion traffic and the alarm topic to an upstream system
+image::deployment/architecture/fault-management.svg["Architecture diagram: Minions at equipment sites connect through a Kafka cluster to the OpenNMS core, which correlates alarms; the same Kafka cluster carries the alarm topic to an upstream system", 900]
+
+The deployment:
+
+* A Minion at each equipment location receives traps close to the source (<<arch-minions, Minion scenario>>) and reaches the core through an external Kafka cluster (<<arch-message-broker, external message broker scenario>>).
+* The core normalizes traps into events and raises alarms from them.
+Custom xref:operation:deep-dive/alarms/advanced-alarm-handling.adoc[Drools rules] extend the default correlation to match the operator's alarm lifecycle, such as clearing, deduplication, and grouping of related alarms.
+* The xref:operation:deep-dive/kafka-producer/kafka-producer.adoc[Kafka Producer] streams all alarms, and their subsequent updates, to a topic on the same Kafka cluster.
+* An upstream system consumes the alarm topic and handles notifications and further correlation.
+To {page-component-title} it is a black box: no notification or ticketing configuration exists in {page-component-title} itself.
+
+In this stack, {page-component-title} owns trap ingestion, event normalization, and alarm correlation; everything user-facing happens upstream.
+The operator's concern here is faults, not performance data.
+
+== Metrics collection for a Prometheus-compatible stack
+
+An organization that uses {page-component-title} solely as a metrics collection engine, feeding a monitoring stack built on Prometheus-compatible tooling.
+This deployment is the opposite of the previous example: the concern is performance data, not faults.
+
+.Metrics pipeline: Minions collect SNMP metrics and reach the core through Kafka; the core writes them to a Prometheus-compatible stack for storage, dashboards, and alerting
+image::deployment/architecture/metrics-pipeline.svg["Architecture diagram: Minions collect SNMP metrics and reach the OpenNMS core through a Kafka cluster; the core writes metrics to Thanos in a Prometheus-compatible stack that feeds Grafana dashboards and Alertmanager notifications to Slack", 980]
+
+The deployment:
+
+* Minions in the collection networks (<<arch-minions, Minion scenario>>) gather SNMP metrics on a one-minute collection interval, faster than the default five-minute interval, and reach the core through an external Kafka cluster (<<arch-message-broker, external message broker scenario>>).
+* The xref:time-series-storage/timeseries/prometheus-remotewrite.adoc[Prometheus RemoteWrite plugin] persists all collected metrics to Thanos (<<arch-dedicated-tss, dedicated time series storage scenario>>); nothing is written to local RRD files.
+The fast collection interval multiplies write volume, which is the trigger for dedicated storage here.
+* Alerting on the metrics runs in the Prometheus ecosystem: an alerting component evaluates threshold rules, and Alertmanager routes notifications to a messaging tool such as Slack.
+* Grafana queries Thanos directly with PromQL through its Prometheus data source; the OpenNMS Plugin for Grafana is not needed in this pipeline.
+
+In this stack, {page-component-title} contributes inventory-driven collection at scale; metric storage, alerting, and dashboards live in the Prometheus ecosystem.
+
+== Flow monitoring for a service provider
+
+A regional service provider: a few thousand nodes across several points of presence, with NetFlow and IPFIX exported from edge and core routers at sustained rates in the tens of thousands of flows per second.
+Traffic visibility is a primary product requirement.
+
+.Service provider deployment: Minions in each POP feed Kafka; Sentinels process flows into Elasticsearch, with Grafana and Kibana for visualization
+image::deployment/architecture/example-flow-heavy.svg["Architecture diagram of a service provider deployment: Minions in points of presence feed a Kafka cluster; the core and Sentinels process data; Sentinels write flows to Elasticsearch; Grafana queries the core and Kibana queries Elasticsearch directly; the Kafka Producer feeds downstream consumers", 860]
+
+The deployment:
+
+* Minions in each POP receive flows and telemetry close to the exporters and handle polling within the POP (<<arch-minions, Minion scenario>>).
+* An Apache Kafka cluster carries Minion traffic and buffers flow data (<<arch-message-broker, external message broker scenario>>).
+Buffering is relevant here because flow volume spikes during network incidents, when visibility is most needed.
+* Sentinel instances consume and process the flow stream, with the instance count scaled to the flow rate.
+Raw flow processing does not reach the core.
+* An Elasticsearch cluster stores flows; PostgreSQL and dedicated time series storage hold the rest.
+* Grafana provides operational dashboards through the OpenNMS data source, and Kibana queries the Elasticsearch cluster directly for flow exploration.
+* The xref:operation:deep-dive/kafka-producer/kafka-producer.adoc[Kafka Producer] streams alarms and events to Kafka topics consumed by the provider's service-impact tooling and data platform.
+The same Kafka cluster serves the internal pipeline and the integration bus.
+
+Even at this scale there is still one core; what scales out is reach (Minions), data processing (Sentinels), and storage (Elasticsearch, Kafka).

--- a/docs/modules/deployment/pages/architecture/introduction.adoc
+++ b/docs/modules/deployment/pages/architecture/introduction.adoc
@@ -1,0 +1,64 @@
+
+[[arch-planning]]
+= Architecture and Deployment Planning
+:description: How OpenNMS is structured as a data ingestion platform, which components are optional, and how to plan a deployment that starts small and grows.
+
+{page-component-title} is a unified platform for ingesting, correlating, and acting on network monitoring data.
+This section describes the architecture at a conceptual level: what a deployment consists of, which components are optional, and what each component is for.
+It does not replace the installation instructions in the rest of the Deployment section; it provides context for deciding which components you need.
+
+== Data domains
+
+{page-component-title} ingests several kinds of network data and correlates them around a shared inventory:
+
+* *Inventory*: The nodes, interfaces, and services you monitor, populated through xref:operation:deep-dive/provisioning/introduction.adoc[provisioning].
+* *Events and alarms*: State changes, faults, and messages from the network and from {page-component-title} itself.
+* *Performance metrics*: Numeric time series gathered by collectors and pollers, or pushed to {page-component-title} through streaming telemetry.
+* *Flows*: Traffic summaries (NetFlow, IPFIX, sFlow) exported by network devices.
+* *Topology*: Layer 2 and layer 3 relationships discovered from the network.
+
+Each kind of data arrives through its own ingestion path, but all of them attach to the same inventory.
+An alarm, a graph, a flow record, and a topology map can therefore refer to the same node.
+xref:architecture/data-domains.adoc[] describes these paths in more detail.
+
+== One core, optional components
+
+Every deployment is built around a single core instance and a PostgreSQL database.
+The core runs the ingestion, correlation, and web components; PostgreSQL holds inventory, events, alarms, and most other state.
+In many environments, these two components are the entire deployment, and can even co-locate on the same system.
+
+Two optional {page-component-title} components distribute work beyond the core, and each addresses a specific problem:
+
+* *Minion*: Minions extend the core's reach into networks it cannot address directly, such as remote sites, overlapping address space, or networks behind firewalls.
+* *Sentinel*: Sentinels process high-volume push data (flows and streaming telemetry) in place of the core.
+
+Third-party components can take over storage and transport roles as a deployment grows:
+
+* *Time series storage*: By default, the core writes performance metrics as RRD files on its local disk.
+Through a pluggable time series layer, xref:time-series-storage/timeseries/time-series-storage.adoc[alternative time series backends] fit deployment scenarios where metric volume outgrows the local disk.
+* *Search and analytics storage*: An Elasticsearch or OpenSearch cluster stores flows, and can also store historical events and alarms.
+* *Message broker*: The core includes an embedded ActiveMQ broker for communication with distributed components.
+An external broker (typically Apache Kafka) replaces it as a deployment grows, and can also serve as an integration point for other systems.
+
+{page-component-title} does not provide clustering of the core itself.
+A deployment scales by giving the core a larger host, by adding Minions and Sentinels around it, and by moving storage onto dedicated systems.
+xref:architecture/deployment-scenarios.adoc[] discusses the practical limits.
+
+== {page-component-title} in an Operational Support System (OSS) stack
+
+{page-component-title} provides the ingestion, inventory, and fault management layers of an OSS stack, and offers several paths for passing data to other tools:
+
+* REST APIs expose inventory, measurements, events, alarms, and flows.
+* The xref:operation:deep-dive/kafka-producer/kafka-producer.adoc[Kafka Producer] streams events, alarms, metrics, and topology to Kafka for downstream consumers, and enriched flows can be forwarded to Kafka as well.
+* The xref:time-series-storage/timeseries/prometheus-remotewrite.adoc[Prometheus RemoteWrite plugin] persists time series data to a Prometheus remote-write compatible store (such as VictoriaMetrics, Mimir, or Cortex), where other tools in the stack can query it.
+* The https://docs.opennms.com/grafana-plugin/latest/index.html[OpenNMS Plugin for Grafana] supports building dashboards in Grafana, outside the {page-component-title} UI.
+* Built-in xref:operation:deep-dive/notifications/introduction.adoc[notifications] (email, SMS, chat, and webhooks) and xref:operation:deep-dive/ticketing/introduction.adoc[ticketing integrations] push alarms and events to people and workflow systems such as Jira or ServiceNow.
+
+A complete stack often pairs {page-component-title} with a visualization tool such as Grafana and an external ticketing or notification system fed from alarms or events.
+Many other combinations fit different usage scenarios; xref:architecture/deployments-in-practice.adoc[] describes some of them.
+
+== In this section
+
+* xref:architecture/data-domains.adoc[]: How data enters, where it is stored, and how it leaves.
+* xref:architecture/deployment-scenarios.adoc[]: When to add each component, in the order deployments commonly grow.
+* xref:architecture/deployments-in-practice.adoc[]: Complete example environments that combine several scenarios into an OSS stack.

--- a/docs/modules/deployment/pages/architecture/introduction.adoc
+++ b/docs/modules/deployment/pages/architecture/introduction.adoc
@@ -30,7 +30,7 @@ In many environments, these two components are the entire deployment, and can ev
 Two optional {page-component-title} components distribute work beyond the core, and each addresses a specific problem:
 
 * *Minion*: Minions extend the core's reach into networks it cannot address directly, such as remote sites, overlapping address space, or networks behind firewalls.
-* *Sentinel*: Sentinels process high-volume push data (flows and streaming telemetry) in place of the core.
+* *Sentinel*: Sentinels process and persist high-volume push data (flows and streaming telemetry) in place of the core.
 
 Third-party components can take over storage and transport roles as a deployment grows:
 


### PR DESCRIPTION
Add a four-page chapter to the Deployment module that frames OpenNMS as a platform for data ingestion. It covers the data domains and ingestion, a scenario-based growth path from a single host to a distributed deployment, and some worked example deployments... all with diagrams.  I feel like this has been missing so I'm hoping it's helpful.

Assisted by Anthropic Claude Opus 4.8 - though in this case it honestly felt more like I had to do a lot of editing and trimming.

Feedback welcome.