### PR TITLE
NMS-20033: UI styling, behavior and pr review issues (post-PrimeVue migration)

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/userGroupView/groups/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/userGroupView/groups/list.jsp
@@ -119,7 +119,7 @@
                 <a id="${group.name}.doDelete" href="javascript:deleteGroup('${fn:escapeXml(group.name)}')" onclick="return confirm('Are you sure you want to delete the group ${fn:escapeXml(group.name)}?')"><i class="fas fa-trash-can fa-2x"></i></a>
               </c:when>
               <c:otherwise>
-                <i class="fas fa-trash-can fa-2x" style="color: var(--feather-clickable-normal);" onclick="alert('Sorry, the ${fn:escapeXml(group.name)} group cannot be deleted.')"></i>
+                <i class="fas fa-trash-can fa-2x" onclick="alert('Sorry, the ${fn:escapeXml(group.name)} group cannot be deleted.')"></i>
               </c:otherwise>
             </c:choose>
           </td>

--- a/opennms-webapp/src/main/webapp/admin/userGroupView/users/list.jsp
+++ b/opennms-webapp/src/main/webapp/admin/userGroupView/users/list.jsp
@@ -159,7 +159,7 @@
             <a id="<%= "users("+sanitizedUserId+").doDelete" %>" href="javascript:deleteUser('<%=sanitizedUserId%>')" onclick="return confirm('Are you sure you want to delete the user <%=sanitizedUserId%>?')"><i class="fas fa-trash-can fa-2x"></i></a>
           </td>
           <% } else { %>
-          <td rowspan="2" class="text-center" style="color: var(--feather-clickable-normal);">
+          <td rowspan="2" class="text-center">
             <i class="fas fa-trash-can fa-2x" onclick="alert('Sorry, the admin user cannot be deleted.')"></i>
           </td>
           <% } %>

--- a/ui/src/components/Common/FormField.vue
+++ b/ui/src/components/Common/FormField.vue
@@ -86,17 +86,11 @@ watch(errorId, () => nextTick(syncAriaDescribedby))
   display: flex;
   flex-direction: column;
 
-  // Pilot-only: shorter controls inside FormField. Once every screen is
-  // converted off IftaLabel/FloatLabel, promote 3rem to the global
-  // .p-inputtext / .p-select rule in primevue-overrides.scss and delete
-  // this block.
-  :deep(.p-inputtext),
-  :deep(.p-select) {
-    height: 3rem;
-  }
-
-  // MultiSelect grows with its chip display, so normalize via min-height to
-  // match the other controls when empty while still allowing it to grow.
+  // Input/Select height (3rem) is now the global default (see
+  // primevue-overrides.scss .p-inputtext / .p-select), so no per-field height
+  // override is needed here. MultiSelect grows with its chip display, so
+  // normalize via min-height to match the other controls when empty while
+  // still allowing it to grow.
   :deep(.p-multiselect) {
     min-height: 3rem;
   }

--- a/ui/src/components/Common/OnmsIconButton.vue
+++ b/ui/src/components/Common/OnmsIconButton.vue
@@ -1,0 +1,42 @@
+<template>
+  <Button :title="title">
+    <span
+      class="onms-icon-button__icon"
+      :style="{ fontSize: iconSize }"
+    >
+      <OnmsIcon
+        :icon="icon"
+        :title="title"
+      />
+    </span>
+  </Button>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button'
+import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+
+// Seam wrapper around a PrimeVue Button + OnmsIcon for icon-only buttons.
+// Bakes in consistent icon sizing (default 1.5rem). Button is the single
+// template root, so @click, data-test, aria-label and all PrimeVue Button
+// props (text, outlined, rounded, severity, disabled, ...) fall through to it.
+// `title` is applied both to the button (native hover tooltip) and forwarded
+// to OnmsIcon as its accessible name; when undefined it renders no attribute.
+withDefaults(defineProps<{
+  icon: object
+  iconSize?: string
+  title?: string
+}>(), {
+  iconSize: '1.5rem',
+  title: undefined
+})
+</script>
+
+<style lang="scss" scoped>
+.onms-icon-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+</style>

--- a/ui/src/components/Configuration/ConfigurationAdvancedPanel.vue
+++ b/ui/src/components/Configuration/ConfigurationAdvancedPanel.vue
@@ -30,17 +30,14 @@
         <FormField label="Value" class="value-field" :hint="item.hint || ' '">
           <PInputText v-model="item.value" />
         </FormField>
-        <PButton
+        <OnmsIconButton
           text
+          class="delete-icon"
           aria-label="Delete"
           v-tooltip="'Delete'"
+          :icon="Delete"
           @click="() => deleteAdvancedOption(index)"
-        >
-          <OnmsIcon
-            class="delete-icon"
-            :icon="Delete"
-          ></OnmsIcon>
-        </PButton>
+        />
       </div>
       <div class="button-wrapper">
         <PButton
@@ -60,7 +57,7 @@ import { PropType, computed, reactive, ref } from 'vue'
 import AutoComplete from 'primevue/autocomplete'
 import Button from 'primevue/button'
 import InputText from 'primevue/inputtext'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Delete from '@/components/icons/action/Delete.vue'
 import TogglePanel from '@/components/Common/TogglePanel.vue'
 import FormField from '@/components/Common/FormField.vue'
@@ -247,6 +244,5 @@ const search = (searchVal: string, type: string, subType: string, index: number)
 }
 .delete-icon {
   color: var(--p-red-500);
-  font-size: 1.5rem;
 }
 </style>

--- a/ui/src/components/Configuration/ConfigurationCopyPasteDisplay.vue
+++ b/ui/src/components/Configuration/ConfigurationCopyPasteDisplay.vue
@@ -17,17 +17,14 @@
         class="button"
         v-if="showCopyBtn"
       >
-        <PButton
+        <OnmsIconButton
           text
+          class="edit-icon"
           aria-label="Copy to clipboard"
           v-tooltip="'Copy to clipboard'"
+          :icon="ContentCopy"
           @click="copyURLToClipboard"
-        >
-          <OnmsIcon
-            :icon="ContentCopy"
-            class="edit-icon"
-          ></OnmsIcon>
-        </PButton>
+        />
       </div>
     </div>
   </div>
@@ -39,13 +36,10 @@
 >
 import { computed, reactive, ref } from 'vue'
 
-import Button from 'primevue/button'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import ContentCopy from '@/components/icons/action/ContentCopy.vue'
 import useSnackbar from '@/composables/useSnackbar'
 import { ConfigurationHelper } from './ConfigurationHelper'
-
-const PButton = Button
 
 /**
  * Props

--- a/ui/src/components/Configuration/ConfigurationCronSelector.vue
+++ b/ui/src/components/Configuration/ConfigurationCronSelector.vue
@@ -158,6 +158,11 @@ const hasCronValidationError = computed(() => props.errors.occuranceAdvanced || 
 @import "@/styles/onms-tokens";
 @import '@/styles/onms-typography';
 
+// Local replacement for the removed FeatherDS global spacing utility
+// (--onms-spacing-m mirrors the original FeatherDS value).
+.mb-m {
+    margin-bottom: var(--onms-spacing-m);
+}
 .input-hint-custom {
     flex: 1;
     @include onms-caption();

--- a/ui/src/components/Configuration/ConfigurationDrawer.vue
+++ b/ui/src/components/Configuration/ConfigurationDrawer.vue
@@ -22,16 +22,12 @@
             Requisition
           </div>
           <div class="icon">
-            <PButton
+            <OnmsIconButton
               text
               aria-label="Cancel"
+              :icon="cancelIcon"
               @click="props.closePanel"
-            >
-              <OnmsIcon
-                class="close-icon"
-                :icon="cancelIcon"
-              />
-            </PButton>
+            />
           </div>
         </div>
       </div>
@@ -83,7 +79,7 @@
 import { PropType, computed, ref, watch } from 'vue'
 
 import Button from 'primevue/button'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 
 import Cancel from '@/components/icons/navigation/Cancel.vue'
 
@@ -274,9 +270,6 @@ const toggleHelp = () => {
   :deep(.p-button) {
     margin: 0;
   }
-}
-.close-icon {
-  font-size: 32px;
 }
 .sideshared {
   z-index: 2;

--- a/ui/src/components/Configuration/ConfigurationHelpPanel.vue
+++ b/ui/src/components/Configuration/ConfigurationHelpPanel.vue
@@ -4,17 +4,13 @@
     :class="props?.active ? 'config-help-panel-open' : ''"
   >
     <div class="config-help-close">
-      <PButton
-        class="button"
+      <OnmsIconButton
         text
+        class="button"
         aria-label="Close help"
+        :icon="chevronRight"
         @click="onClose"
-      >
-        <OnmsIcon
-          class="buttonIcon"
-          :icon="chevronRight"
-        />
-      </PButton>
+      />
     </div>
     <div class="config-help-header">
       <div class="config-help-title">
@@ -43,14 +39,11 @@
 >
 import { PropType, computed } from 'vue'
 
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
-import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 
 import ChevronRight from '@/components/icons/navigation/ChevronRight.vue'
 import { RequisitionPluginSubTypes, RequisitionTypes } from './copy/requisitionTypes'
 import { LocalConfiguration } from './configuration.types'
-
-const PButton = Button
 
 /**
  * Props
@@ -192,7 +185,6 @@ const helpText = computed(() => {
   padding-top: 12px;
   height: 50px;
   .button {
-    font-size: 42px;
     color: var(--p-primary-color);
     display: flex;
     align-items: center;

--- a/ui/src/components/Configuration/ConfigurationTable.vue
+++ b/ui/src/components/Configuration/ConfigurationTable.vue
@@ -37,26 +37,22 @@
       <PColumn :pt="columnHeaderPt">
         <template #body="{ data }">
           <div class="flex">
-            <PButton
+            <OnmsIconButton
               aria-label="Edit"
               v-tooltip="'Edit'"
-              @click="() => props.editClicked(data.originalIndex)"
               :disabled="Boolean(data[RequisitionData.ImportURL].startsWith('requisition://'))"
               data-test="edit-btn"
-            >
-              <OnmsIcon :icon="Edit" />
-            </PButton>
-            <PButton
+              :icon="Edit"
+              @click="() => props.editClicked(data.originalIndex)"
+            />
+            <OnmsIconButton
               text
+              class="delete-icon"
               aria-label="Delete"
               v-tooltip="'Delete'"
+              :icon="Delete"
               @click="() => props.deleteClicked(data.originalIndex)"
-            >
-              <OnmsIcon
-                class="delete-icon"
-                :icon="Delete"
-              />
-            </PButton>
+            />
           </div>
         </template>
       </PColumn>
@@ -71,8 +67,7 @@
 import { computed, PropType } from 'vue'
 import DataTable, { DataTablePageEvent } from 'primevue/datatable'
 import Column from 'primevue/column'
-import Button from 'primevue/button'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 
 import Edit from '@/components/icons/action/Edit.vue'
 import Delete from '@/components/icons/action/Delete.vue'
@@ -85,7 +80,6 @@ import { rescanCopy } from './copy/rescanItems'
 
 const PDataTable = DataTable
 const PColumn = Column
-const PButton = Button
 
 // PrimeVue Column doesn't emit scope="col" on the header <th>; restore it via the
 // passthrough so header cells stay associated with their columns for screen readers.
@@ -137,11 +131,6 @@ const rescanToEnglish = (rescanVal: string) => {
 }
 .flex {
   display: flex;
-
-  // Enlarge the edit/delete glyphs (OnmsIcon scales with font-size)
-  :deep(svg) {
-    font-size: 1.25em;
-  }
 }
 .delete-icon {
   color: var(--p-red-500);

--- a/ui/src/components/Configuration/ConfigurationThreadPools.vue
+++ b/ui/src/components/Configuration/ConfigurationThreadPools.vue
@@ -216,6 +216,11 @@ const getError = (key: string) => {
 >
 @import '@/styles/onms-typography';
 
+// Local replacement for the removed FeatherDS global spacing utility
+// (--onms-spacing-xl mirrors the original FeatherDS value).
+.pb-xl {
+  padding-bottom: var(--onms-spacing-xl);
+}
 .title {
   @include onms-headline3();
   margin-right: 16px;

--- a/ui/src/components/Configuration/ProvisionDForm.vue
+++ b/ui/src/components/Configuration/ProvisionDForm.vue
@@ -189,6 +189,14 @@ const updateCronValue = (type: string, val: string) => {
 .side-input {
     padding-bottom: 0;
 }
+// Local replacements for the removed FeatherDS global spacing utilities
+// (--onms-spacing-* mirror the original FeatherDS values).
+.mb-m {
+    margin-bottom: var(--onms-spacing-m);
+}
+.mr-m {
+    margin-right: var(--onms-spacing-m);
+}
 .occurance {
     width: 100%;
 }

--- a/ui/src/components/Configuration/ProvisionDForm.vue
+++ b/ui/src/components/Configuration/ProvisionDForm.vue
@@ -20,17 +20,13 @@
         />
       </FormField>
       <div class="icon">
-        <PButton
+        <OnmsIconButton
           text
           aria-label="Help"
           v-tooltip="'Help'"
+          :icon="Help"
           @click="() => props.toggleHelp()"
-        >
-          <OnmsIcon
-            class="help-icon"
-            :icon="Help"
-          ></OnmsIcon>
-        </PButton>
+        />
       </div>
     </div>
     <div v-if="RequsitionTypesUsingHost.includes(config.type.name)">
@@ -138,12 +134,11 @@
 >
 import Select from 'primevue/select'
 import InputText from 'primevue/inputtext'
-import Button from 'primevue/button'
 import RadioButton from 'primevue/radiobutton'
 import FormField from '@/components/Common/FormField.vue'
 import { requisitionSubTypes, RequsitionTypesUsingHost, RequisitionTypes, requisitionTypeList, RequisitionHTTPTypes } from './copy/requisitionTypes'
 import { rescanItems } from './copy/rescanItems'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import { PropType, computed, ref, watch } from 'vue'
 import Help from '@/components/icons/action/Help.vue'
 import { LocalConfigurationWrapper } from './configuration.types'
@@ -153,7 +148,6 @@ import { UpdateModelFunction } from '@/types'
 
 const PSelect = Select
 const PInputText = InputText
-const PButton = Button
 const PRadioButton = RadioButton
 
 const firstInput = ref()
@@ -213,9 +207,6 @@ const updateCronValue = (type: string, val: string) => {
     // hint/error rendered below it.
     height: 3rem;
     margin-top: 1.6875rem;
-    .help-icon {
-        font-size: 1.5rem;
-    }
 }
 .side-label {
     margin-top: 1rem;

--- a/ui/src/components/Device/DCBModalConfigDiffContent.vue
+++ b/ui/src/components/Device/DCBModalConfigDiffContent.vue
@@ -1,37 +1,34 @@
 <template>
-  <PButton
+  <OnmsIconButton
     text
     class="compare-btn"
     aria-label="Compare configs"
     v-tooltip="'Compare configs'"
-    @click="onCompare"
     v-if="!isCompareView"
     :disabled="!config1 || !config2"
-  >
-    <OnmsIcon :icon="Compare" />
-  </PButton>
+    :icon="Compare"
+    @click="onCompare"
+  />
 
-  <PButton
+  <OnmsIconButton
     text
     class="return-btn"
     aria-label="Return"
     v-tooltip="'Return'"
-    @click="onReturn"
     v-if="isCompareView"
-  >
-    <OnmsIcon :icon="Restore" />
-  </PButton>
+    :icon="Restore"
+    @click="onReturn"
+  />
 
-  <PButton
+  <OnmsIconButton
     text
     class="dwnld-btn"
     aria-label="Download configs"
     v-tooltip="'Download configs'"
-    @click="onDownload"
     v-if="isCompareView"
-  >
-    <OnmsIcon :icon="Download" />
-  </PButton>
+    :icon="Download"
+    @click="onDownload"
+  />
 
   <p class="select-msg" v-if="numberOfSelectedConfigs < 2">Select two dates to compare.</p>
   <p
@@ -88,10 +85,9 @@ import { computed, onMounted, ref } from 'vue'
 
 import { diffLines } from 'diff'
 import { orderBy } from 'lodash'
-import Button from 'primevue/button'
 import Checkbox from 'primevue/checkbox'
 import Chip from 'primevue/chip'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Restore from '@/components/icons/action/Restore.vue'
 import Download from '@/components/icons/action/DownloadFile.vue'
 import DCBDiff from './DCBDiff.vue'
@@ -99,7 +95,6 @@ import Compare from '@/assets/Compare.vue'
 import { useDeviceStore } from '@/stores/deviceStore'
 import { DeviceConfigBackup } from '@/types/deviceConfig'
 
-const PButton = Button
 const PCheckbox = Checkbox
 const PChip = Chip
 

--- a/ui/src/components/Device/DCBModalViewHistoryContent.vue
+++ b/ui/src/components/Device/DCBModalViewHistoryContent.vue
@@ -1,23 +1,21 @@
 <template>
-  <PButton
+  <OnmsIconButton
     text
     class="compare-btn"
     aria-label="Compare configs"
     v-tooltip="'Compare configs'"
+    :icon="Compare"
     @click="emit('onCompare')"
-  >
-    <OnmsIcon :icon="Compare" />
-  </PButton>
+  />
 
-  <PButton
+  <OnmsIconButton
     text
     class="dwnld-btn"
     aria-label="Download config"
     v-tooltip="'Download config'"
+    :icon="Download"
     @click="onDownload"
-  >
-    <OnmsIcon :icon="Download" />
-  </PButton>
+  />
 
   <span class="title">
     {{ selectedConfig?.configName }}
@@ -47,15 +45,12 @@
 import { onMounted, ref, watch } from 'vue'
 
 import { storeToRefs } from 'pinia'
-import Button from 'primevue/button'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Download from '@/components/icons/action/DownloadFile.vue'
 import Compare from '@/assets/Compare.vue'
 import DCBDiff from './DCBDiff.vue'
 import { DeviceConfigBackup } from '@/types/deviceConfig'
 import { useDeviceStore } from '@/stores/deviceStore'
-
-const PButton = Button
 
 const emit = defineEmits(['onCompare'])
 

--- a/ui/src/components/Device/DCBSearch.vue
+++ b/ui/src/components/Device/DCBSearch.vue
@@ -68,12 +68,5 @@ const getDeviceConfigBackupsOnDebounce = useDebounceFn(() => deviceStore.getDevi
     width: 100%;
     padding-right: 2.75rem;
   }
-
-  // enlarge the search glyph and keep it near the right edge
-  :deep(.p-inputicon) {
-    font-size: 1.75rem;
-    right: 0.625rem;
-    margin-top: -0.875rem;
-  }
 }
 </style>

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -378,9 +378,30 @@ onMounted(() => {
   }
 }
 
-.dcb-action-btn {
+.btn-container {
+  .dcb-action-btn {
+    // PrimeVue buttons are inline-flex; keep the icon centered against its label.
+    align-items: center;
+  }
+
+  // Normalize every action-button icon to 1.5em and strip the per-asset sizing
+  // and margin quirks: assets/Compare.vue hardcodes 24px + margin-top: -10px and
+  // assets/Backup.vue adds margin-top: -10px, which broke both size parity (the
+  // Compare icon rendered 24px vs the others' ~18px) and vertical alignment.
+  // Handles OnmsIcon SVGs rendered directly and the asset wrappers nesting an <svg>.
   .btn-icon {
-    margin-right: 0.4rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5em;
+    height: 1.5em;
+    margin: 0 0.4rem 0 0;
+
+    :deep(svg) {
+      width: 1.5em;
+      height: 1.5em;
+      margin: 0;
+    }
   }
 }
 

--- a/ui/src/components/EventConfigEventCreate/BasicInformation.vue
+++ b/ui/src/components/EventConfigEventCreate/BasicInformation.vue
@@ -281,6 +281,7 @@
       <template #footer>
         <Button
           text
+          outlined
           label="Cancel"
           @click="handleSourceCreationCancel"
           data-test="cancel-source-button"

--- a/ui/src/components/EventConfiguration/Dialog/CreateEventConfigurationDialog.vue
+++ b/ui/src/components/EventConfiguration/Dialog/CreateEventConfigurationDialog.vue
@@ -51,6 +51,7 @@
     <template #footer>
       <Button
         text
+        outlined
         label="Cancel"
         @click="handleCancel"
       />

--- a/ui/src/components/EventConfiguration/Dialog/UploadedFileRenameDialog.vue
+++ b/ui/src/components/EventConfiguration/Dialog/UploadedFileRenameDialog.vue
@@ -68,6 +68,7 @@
         />
         <Button
           text
+          outlined
           label="Cancel"
           @click="onCancel"
         />

--- a/ui/src/components/EventConfiguration/EventConfigSourceTable.vue
+++ b/ui/src/components/EventConfiguration/EventConfigSourceTable.vue
@@ -269,24 +269,10 @@ onMounted(async () => {
             width: 100%;
             padding-right: 2.75rem;
           }
-
-          // enlarge the search glyph (OnmsIcon scales with font-size) and
-          // keep it near the right edge, vertically centered
-          :deep(.p-inputicon) {
-            font-size: 1.75rem;
-            right: 0.625rem;
-            margin-top: -0.875rem;
-          }
         }
 
         .refresh {
           display: flex;
-
-          :deep(.p-inputicon) {
-            font-size: 1.75rem;
-            right: 0.625rem;
-            margin-top: -0.875rem;
-          }
         }
       }
     }

--- a/ui/src/components/EventConfiguration/EventConfigSourceTable.vue
+++ b/ui/src/components/EventConfiguration/EventConfigSourceTable.vue
@@ -23,14 +23,13 @@
           </FormField>
         </div>
         <div class="refresh">
-          <Button
+          <OnmsIconButton
             text
             title="Refresh"
             data-test="refresh-button"
+            :icon="Refresh"
             @click="store.refreshSourcesFilters()"
-          >
-            <OnmsIcon :icon="Refresh" />
-          </Button>
+          />
         </div>
       </div>
     </div>
@@ -79,32 +78,29 @@
       <Column header="Actions">
         <template #body="{ data }">
           <div class="action-container">
-            <Button
+            <OnmsIconButton
               text
               :title="`View ${data.name}`"
               data-test="view-button"
+              :icon="ViewDetails"
               @click="onEventClick(data)"
-            >
-              <OnmsIcon :icon="ViewDetails" />
-            </Button>
-            <Button
+            />
+            <OnmsIconButton
               text
               :title="`Download ${data.name} XML`"
               data-test="download-button"
+              :icon="Download"
               @click="downloadEventConfXmlBySourceId(data.id)"
-            >
-              <OnmsIcon :icon="Download" />
-            </Button>
-            <Button
+            />
+            <OnmsIconButton
               text
               aria-haspopup="true"
               aria-controls="event-source-row-menu"
               :title="`More actions for ${data.name}`"
               data-test="row-menu-button"
+              :icon="MenuIcon"
               @click="toggleRowMenu($event, data)"
-            >
-              <OnmsIcon :icon="MenuIcon" />
-            </Button>
+            />
           </div>
         </template>
       </Column>
@@ -142,7 +138,6 @@ import Search from '@/components/icons/action/Search.vue'
 import ViewDetails from '@/components/icons/action/ViewDetails.vue'
 import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'
 import Refresh from '@/components/icons/navigation/Refresh.vue'
-import Button from 'primevue/button'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import type { DataTablePageEvent, DataTableSortEvent } from 'primevue/datatable'
@@ -155,6 +150,7 @@ import Tag from 'primevue/tag'
 import { debounce } from 'lodash'
 import EmptyList from '../Common/EmptyList.vue'
 import FormField from '@/components/Common/FormField.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import TableCard from '../Common/TableCard.vue'
 import ChangeEventConfigSourceStatusDialog from './Dialog/ChangeEventConfigSourceStatusDialog.vue'
 import DeleteEventConfigSourceDialog from './Dialog/DeleteEventConfigSourceDialog.vue'

--- a/ui/src/components/EventConfiguration/EventConfigUploadFilesTab.vue
+++ b/ui/src/components/EventConfiguration/EventConfigUploadFilesTab.vue
@@ -41,23 +41,19 @@
                       v-tooltip="element.errors.map((error: string) => `${error}. `).join('\n')"
                       class="error-icon"
                     />
-                    <Button
+                    <OnmsIconButton
                       text
                       title="Reorder"
-                    >
-                      <OnmsIcon
-                        class="close-icon drag-handle"
-                        :icon="Apps"
-                      />
-                    </Button>
-                    <Button
+                      class="close-icon drag-handle"
+                      :icon="Apps"
+                    />
+                    <OnmsIconButton
                       text
                       title="Remove"
                       data-test="remove-files-button"
+                      :icon="Delete"
                       @click="removeFile(index)"
-                    >
-                      <OnmsIcon :icon="Delete" />
-                    </Button>
+                    />
                   </div>
                 </div>
               </template>
@@ -170,6 +166,7 @@ import Warning from '@/components/icons/notification/Warning.vue'
 import Button from 'primevue/button'
 import Draggable from 'vuedraggable'
 import EventConfigFilesUploadReportDialog from './Dialog/EventConfigFilesUploadReportDialog.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import UploadedFileRenameDialog from './Dialog/UploadedFileRenameDialog.vue'
 import { isDuplicateFile, MAX_FILES_UPLOAD, validateEventConfigFile } from './eventConfigXmlValidator'
 

--- a/ui/src/components/EventConfigurationDetail/EventConfigEventTable.vue
+++ b/ui/src/components/EventConfigurationDetail/EventConfigEventTable.vue
@@ -23,14 +23,13 @@
           </FormField>
         </div>
         <div class="refresh">
-          <Button
+          <OnmsIconButton
             text
             title="Refresh"
             data-test="refresh-button"
+            :icon="Refresh"
             @click="store.refreshEventConfigEvents()"
-          >
-            <OnmsIcon :icon="Refresh" />
-          </Button>
+          />
         </div>
       </div>
     </div>
@@ -95,24 +94,22 @@
       <Column header="Actions">
         <template #body="{ data }">
           <div class="action-container">
-            <Button
+            <OnmsIconButton
               text
               :title="`Edit ${data.eventLabel}`"
               data-test="edit-button"
+              :icon="Edit"
               @click="onEditEvent(data)"
-            >
-              <OnmsIcon :icon="Edit" />
-            </Button>
-            <Button
+            />
+            <OnmsIconButton
               text
               aria-haspopup="true"
               aria-controls="event-row-menu"
               title="More Options"
               data-test="row-menu-button"
+              :icon="MenuIcon"
               @click="toggleRowMenu($event, data)"
-            >
-              <OnmsIcon :icon="MenuIcon" />
-            </Button>
+            />
           </div>
         </template>
       </Column>
@@ -159,7 +156,6 @@ import Edit from '@/components/icons/action/Edit.vue'
 import Search from '@/components/icons/action/Search.vue'
 import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'
 import Refresh from '@/components/icons/navigation/Refresh.vue'
-import Button from 'primevue/button'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import type { DataTablePageEvent, DataTableSortEvent } from 'primevue/datatable'
@@ -172,6 +168,7 @@ import Tag from 'primevue/tag'
 import { debounce } from 'lodash'
 import EmptyList from '../Common/EmptyList.vue'
 import FormField from '@/components/Common/FormField.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import TableCard from '../Common/TableCard.vue'
 import ChangeEventConfigEventStatusDialog from './Dialog/ChangeEventConfigEventStatusDialog.vue'
 import DeleteEventConfigEventDialog from './Dialog/DeleteEventConfigEventDialog.vue'

--- a/ui/src/components/FileEditor/FileSidebar.vue
+++ b/ui/src/components/FileEditor/FileSidebar.vue
@@ -2,51 +2,48 @@
   <Search />
   <div class="sidebar-relative-container">
     <div class="file-tools">
-     <PButton
+     <OnmsIconButton
         v-if="changedFilesOnly"
         text
         class="btn"
         aria-label="Click to show all files."
         v-tooltip="'Click to show all files.'"
+        :icon="FilterAlt"
+        :icon-size="'2em'"
         @click="getFiles(false)"
-      >
-        <OnmsIcon :icon="FilterAlt" />
-      </PButton>
+      />
 
-      <PButton
+      <OnmsIconButton
         v-if="!changedFilesOnly"
         text
         class="btn unfiltered"
         aria-label="Click to show modified files only."
         v-tooltip="'Click to show modified files only.'"
+        :icon="FilterAlt"
+        :icon-size="'2em'"
         @click="getFiles(true)"
-      >
-        <OnmsIcon :icon="FilterAlt" />
-      </PButton>
+      />
 
-      <PButton
+      <OnmsIconButton
         text
         class="btn"
         :disabled="!selectedFileName"
         aria-label="Scroll to selected file."
         v-tooltip="'Scroll to selected file.'"
+        :icon="SupportCenter"
+        :icon-size="'2em'"
         @click="scrollToSelectedFile"
-      >
-        <OnmsIcon :icon="SupportCenter" />
-      </PButton>
+      />
 
-      <PButton
+      <OnmsIconButton
         text
-        class="btn"
+        class="btn info-icon"
         aria-label="Click for info."
         v-tooltip="'Click for info.'"
+        :icon="InfoIcon"
+        :icon-size="'2em'"
         @click="showInfo"
-      >
-        <OnmsIcon
-          :icon="InfoIcon"
-          class="info-icon"
-        />
-      </PButton>
+      />
     </div>
     <div class="file-sidebar">
       <ul>
@@ -82,17 +79,14 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import FilterAlt from '@/components/icons/action/FilterAlt.vue'
 import SupportCenter from '@/components/icons/action/SupportCenter.vue'
 import InfoIcon from '@/components/icons/action/Info.vue'
-import Button from 'primevue/button'
 import MessageDialog from '../Common/MessageDialog.vue'
 import { useFileEditorStore } from '@/stores/fileEditorStore'
 import FileTreeItem from './FileTreeItem.vue'
 import Search from './Search.vue'
-
-const PButton = Button
 
 const isMessageDialogVisible = ref(false)
 const fileEditorStore = useFileEditorStore()
@@ -150,9 +144,6 @@ const scrollToSelectedFile = () => {
       width: 2.8em !important;
       min-width: 2.8em !important;
       margin-top: 2px;
-      svg {
-        font-size: 2em !important;
-      }
 
       &.unfiltered {
         color: var(--p-text-muted-color);
@@ -162,7 +153,6 @@ const scrollToSelectedFile = () => {
 
   .info-icon {
     cursor: pointer;
-    font-size: 1.5em;
     margin-left: 0.5em;
 
     &:hover {

--- a/ui/src/components/FileEditor/Search.vue
+++ b/ui/src/components/FileEditor/Search.vue
@@ -73,13 +73,6 @@ const save = () => fileEditorStore.saveModifiedFile()
         width: 100%;
         padding-right: 2.75rem;
       }
-
-      // enlarge the search glyph and keep it near the right edge
-      :deep(.p-inputicon) {
-        font-size: 1.75rem;
-        right: 0.625rem;
-        margin-top: -0.875rem;
-      }
     }
   }
   .save,

--- a/ui/src/components/Layout/Footer.vue
+++ b/ui/src/components/Layout/Footer.vue
@@ -27,17 +27,10 @@ const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 .footer {
   display: block;
   text-align: center;
-  margin-left: -15px;
-  margin-right: -15px;
-  padding: 0.25rem 0.42rem;
-  background-color: #e9ecef;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding: 0.5rem 0.5rem;
   border-top: 1px solid rgba(0, 0, 0, .125);
-}
-
-// The hardcoded light gray above stays light in dark mode; use the (dark)
-// content background and a theme-aware border so the footer reads correctly on
-// the Vue SPA pages (JSP pages are unaffected).
-.open-dark .footer {
   background-color: var(--p-content-background);
   border-top-color: var(--p-content-border-color);
 }

--- a/ui/src/components/Layout/Footer.vue
+++ b/ui/src/components/Layout/Footer.vue
@@ -33,4 +33,12 @@ const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
   background-color: #e9ecef;
   border-top: 1px solid rgba(0, 0, 0, .125);
 }
+
+// The hardcoded light gray above stays light in dark mode; use the (dark)
+// content background and a theme-aware border so the footer reads correctly on
+// the Vue SPA pages (JSP pages are unaffected).
+.open-dark .footer {
+  background-color: var(--p-content-background);
+  border-top-color: var(--p-content-border-color);
+}
 </style>

--- a/ui/src/components/Logs/Editor.vue
+++ b/ui/src/components/Logs/Editor.vue
@@ -1,27 +1,25 @@
 <template>
   <div class="editor">
     <div class="toolbar">
-      <PButton
+      <OnmsIconButton
         v-if="reverseLog"
         text
         :disabled="!selectedLog"
         class="btn"
         aria-label="Display oldest first."
+        :icon="KeyboardArrowDown"
         @click="getLog(false)"
-      >
-        <OnmsIcon :icon="KeyboardArrowDown" />
-      </PButton>
+      />
 
-      <PButton
+      <OnmsIconButton
         v-if="!reverseLog"
         text
         :disabled="!selectedLog"
         class="btn"
         aria-label="Display newest first."
+        :icon="KeyboardArrowUp"
         @click="getLog(true)"
-      >
-        <OnmsIcon :icon="KeyboardArrowUp" />
-      </PButton>
+      />
     </div>
     <VAceEditor
       v-model:value="content"
@@ -38,8 +36,7 @@
 import { computed, ref, watchEffect } from 'vue'
 
 import { VAceEditor } from 'vue3-ace-editor'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
-import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import { onKeyStroke } from '@vueuse/core'
 import KeyboardArrowUp from '@/components/icons/hardware/KeyboardArrowUp.vue'
 import KeyboardArrowDown from '@/components/icons/hardware/KeyboardArrowDown.vue'
@@ -50,8 +47,6 @@ import 'ace-builds/src-noconflict/theme-dracula'
 import 'ace-builds/src-noconflict/ext-searchbox'
 import { useAppStore } from '@/stores/appStore'
 import { useLogStore } from '@/stores/logStore'
-
-const PButton = Button
 
 const appStore = useAppStore()
 const logStore = useLogStore()
@@ -120,9 +115,6 @@ const init = (editor: any) => {
       min-width: 25px !important;
       margin-right: 5px;
       margin-top: 2px;
-      :deep(svg) {
-        font-size: 20px !important;
-      }
     }
   }
 }

--- a/ui/src/components/Map/LeafletMap.vue
+++ b/ui/src/components/Map/LeafletMap.vue
@@ -313,6 +313,11 @@ const onPopupEscapeKeydown = (e: KeyboardEvent) => {
   leafletObject.value.closePopup()
 }
 
+// Whether a marker popup is currently open (set by popupopen/popupclose).
+// Needed on keep-alive reactivation to know if the Esc listener — removed on
+// deactivate — must be reattached for a popup left open while away.
+let popupOpen = false
+
 // Leaflet caches its pixel size and only re-reads it on invalidateSize(). The
 // map container reflows when the side menu is pinned (it sets padding-left on
 // .app-layout) or on any other layout change, but Leaflet won't repaint to the
@@ -339,9 +344,14 @@ onDeactivated(() => {
 })
 
 // Returning to the cached map: its container may have resized while away (e.g.
-// the side menu was pinned on another page), so revalidate Leaflet's size.
+// the side menu was pinned on another page), so revalidate Leaflet's size. And
+// if the map was left with a popup open, reattach the Esc listener that
+// onDeactivated removed (popupopen won't re-fire for an already-open popup).
 onActivated(() => {
   debouncedInvalidateSize()
+  if (popupOpen) {
+    document.addEventListener('keydown', onPopupEscapeKeydown)
+  }
 })
 
 const onLeafletReady = async () => {
@@ -403,10 +413,12 @@ const onLeafletReady = async () => {
         leafletObject.value.panBy([dx, dy], { animate: true })
       }
 
+      popupOpen = true
       document.addEventListener('keydown', onPopupEscapeKeydown)
     })
 
     leafletObject.value.on('popupclose', () => {
+      popupOpen = false
       document.removeEventListener('keydown', onPopupEscapeKeydown)
     })
 

--- a/ui/src/components/Map/LeafletMap.vue
+++ b/ui/src/components/Map/LeafletMap.vue
@@ -75,8 +75,9 @@
 </template>
 
 <script setup lang ="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
+import { debounce } from 'lodash'
 
 import 'leaflet/dist/leaflet.css'
 import { Map as LeafletMap, divIcon, LatLngTuple, MarkerCluster as Cluster, PopupOptions } from 'leaflet'
@@ -299,13 +300,48 @@ const getNodeCoordinateMap = computed(() => {
 // bubble phase, so the menu search's Esc handler — which stopImmediatePropagation()s
 // before the event reaches document — always takes precedence and is unaffected.
 const onPopupEscapeKeydown = (e: KeyboardEvent) => {
-  if (e.key === 'Escape') {
-    leafletObject.value.closePopup()
+  if (e.key !== 'Escape') {
+    return
   }
+  // The map search (PrimeVue AutoComplete) also uses Esc to dismiss its own
+  // suggestions but doesn't stopPropagation, so its Esc bubbles to this
+  // document listener. Don't let dismissing search suggestions also close the
+  // open marker popup.
+  if ((e.target as HTMLElement | null)?.closest('.map-search')) {
+    return
+  }
+  leafletObject.value.closePopup()
 }
+
+// Leaflet caches its pixel size and only re-reads it on invalidateSize(). The
+// map container reflows when the side menu is pinned (it sets padding-left on
+// .app-layout) or on any other layout change, but Leaflet won't repaint to the
+// new size on its own, so observe the container and revalidate on resize.
+const debouncedInvalidateSize = debounce(() => {
+  if (typeof leafletObject.value?.invalidateSize === 'function') {
+    leafletObject.value.invalidateSize()
+  }
+}, 150)
+let containerResizeObserver: ResizeObserver | null = null
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', onPopupEscapeKeydown)
+  containerResizeObserver?.disconnect()
+  debouncedInvalidateSize.cancel()
+})
+
+// Map.vue is <keep-alive>'d (name: MapKeepAlive), so navigating away deactivates
+// rather than unmounts and onBeforeUnmount never fires. Remove the document Esc
+// listener here too — otherwise, leaving with a popup open keeps it installed
+// app-wide and a stray Esc later closes the popup on the cached map.
+onDeactivated(() => {
+  document.removeEventListener('keydown', onPopupEscapeKeydown)
+})
+
+// Returning to the cached map: its container may have resized while away (e.g.
+// the side menu was pinned on another page), so revalidate Leaflet's size.
+onActivated(() => {
+  debouncedInvalidateSize()
 })
 
 const onLeafletReady = async () => {
@@ -338,13 +374,33 @@ const onLeafletReady = async () => {
       e.popup.options.offset = [0, el.offsetHeight + 40]
       e.popup.update()
 
-      // autoPan is off (a popup opening below never needs the map shifted for
-      // top markers), but a below-popup on a bottom-edge marker can run past
-      // the map's lower edge. In that one case, pan up just enough to reveal it.
-      const overflowBottom = el.getBoundingClientRect().bottom -
-        leafletObject.value.getContainer().getBoundingClientRect().bottom
-      if (overflowBottom > 0) {
-        leafletObject.value.panBy([0, overflowBottom + 16], { animate: true })
+      // autoPan is off, so a below-popup can spill past any edge of the map
+      // pane: bottom for low markers, left/right for the east/west-most markers,
+      // top for a popup taller than the pane. Pan just enough on each axis to
+      // bring it into view, biasing toward keeping the popup's top (its header
+      // and close button) visible when it is taller than the pane.
+      const pad = 16
+      const popupRect = el.getBoundingClientRect()
+      const mapRect = leafletObject.value.getContainer().getBoundingClientRect()
+
+      let dx = 0
+      if (popupRect.right > mapRect.right) {
+        dx = popupRect.right - mapRect.right + pad
+      } else if (popupRect.left < mapRect.left) {
+        dx = popupRect.left - mapRect.left - pad
+      }
+
+      let dy = 0
+      if (popupRect.bottom > mapRect.bottom) {
+        // Don't pan so far down that the popup's top scrolls off the pane.
+        const maxPanKeepingTopVisible = Math.max(0, popupRect.top - mapRect.top - pad)
+        dy = Math.min(popupRect.bottom - mapRect.bottom + pad, maxPanKeepingTopVisible)
+      } else if (popupRect.top < mapRect.top) {
+        dy = popupRect.top - mapRect.top - pad
+      }
+
+      if (dx !== 0 || dy !== 0) {
+        leafletObject.value.panBy([dx, dy], { animate: true })
       }
 
       document.addEventListener('keydown', onPopupEscapeKeydown)
@@ -355,6 +411,15 @@ const onLeafletReady = async () => {
     })
 
     leafletReady.value = true
+
+    // Revalidate Leaflet's cached size whenever its container resizes (side-menu
+    // pin, window resize, splitter drag). See debouncedInvalidateSize above.
+    const container = leafletObject.value.getContainer()
+    if (container && typeof ResizeObserver !== 'undefined') {
+      containerResizeObserver?.disconnect()
+      containerResizeObserver = new ResizeObserver(() => debouncedInvalidateSize())
+      containerResizeObserver.observe(container)
+    }
 
     await nextTick()
 
@@ -423,6 +488,10 @@ defineExpose({ invalidateSizeFn })
   z-index: 1020;
 }
 .geo-map {
+  // Positioning context for the absolutely-positioned overlays (search bar,
+  // Show Severity) so they anchor to the map area, not the viewport — otherwise
+  // they slide under the pinned side-menu rail.
+  position: relative;
   height: 100%;
 }
 .marker-cluster-popup-hide {
@@ -475,10 +544,24 @@ defineExpose({ invalidateSizeFn })
   right: 0;
   min-width: 20em;
   padding: 6px 10px;
-  background: #fff;
-  color: #333;
+  // Theme-aware, matching the sibling controls and the popup wrapper — was
+  // hardcoded #fff/#333, the one white element left in dark mode.
+  background: var(--p-content-background);
+  color: var(--p-text-color);
   border-radius: 5px;
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
+}
+// Bridge the 5px gap between the toggle and the dropped-down list. Leaflet
+// collapses the control on mouseleave of its DOM subtree; a bare gap lets the
+// pointer sample outside the control mid-traverse and collapse the list before
+// it's reached. A transparent strip filling the gap keeps the pointer inside.
+.geo-map .leaflet-control-layers-expanded .leaflet-control-layers-list::before {
+  content: "";
+  position: absolute;
+  top: -5px;
+  left: 0;
+  right: 0;
+  height: 5px;
 }
 
 .leaflet-marker-pane {

--- a/ui/src/components/Map/LeafletMap.vue
+++ b/ui/src/components/Map/LeafletMap.vue
@@ -481,10 +481,10 @@ defineExpose({ invalidateSizeFn })
 <style lang="scss" scoped>
 .search-bar {
   position: absolute;
-  // Top-left overlay, clearing the fixed top menu bar; mirrors the
-  // Show Severity control on the right (right: 80px; top: 80px).
-  top: 80px;
-  left: 80px;
+  // Top-left overlay inset from the map corner; mirrors the Show Severity
+  // control on the right (right: 80px; top: 2em).
+  top: 2em;
+  left: 2em;
   z-index: 1020;
 }
 .geo-map {
@@ -502,12 +502,12 @@ defineExpose({ invalidateSizeFn })
 <style lang="scss">
 @import "@/styles/onms-tokens";
 
-// The map is full-bleed under the fixed top menu bar, so push Leaflet's top
-// controls (zoom + layers, both top-right) down to clear it. A stable CSS
-// offset also survives Leaflet's invalidateSize() re-layout on interaction
-// (which otherwise lets the controls settle back under the menu bar).
+// Inset Leaflet's top controls (zoom + layers, both top-right) to line up with
+// the Search / Show Severity overlays. A stable CSS offset also survives
+// Leaflet's invalidateSize() re-layout on interaction (which otherwise lets the
+// controls settle back to the container's top edge).
 .geo-map .leaflet-top {
-  top: 70px;
+  top: 2em;
 }
 
 // Leaflet focuses the container on click; the browser then scrolls it into

--- a/ui/src/components/Map/SeverityFilter.vue
+++ b/ui/src/components/Map/SeverityFilter.vue
@@ -37,7 +37,7 @@ const onSeveritySelect = () => mapStore.setSelectedSeverity(selectedSeverity.val
   position: absolute;
   width: 250px;
   right: 80px;
-  top: 80px;
+  top: 2em;
   /* below the app bar's z-index (1030) */
   z-index: 1020;
   /* Translucent panel so the control reads clearly over the map. Follows the

--- a/ui/src/components/Nodes/AssetFilterPanel.vue
+++ b/ui/src/components/Nodes/AssetFilterPanel.vue
@@ -50,13 +50,13 @@
       </PColumn>
       <PColumn header="" style="width: 3.5rem">
         <template #body="{ data }">
-          <Button
+          <OnmsIconButton
             text
             data-test="delete-asset-filter-button"
+            title="Remove asset filter"
+            :icon="DeleteIcon"
             @click="removeGridItem(data.column)"
-          >
-            <OnmsIcon :icon="DeleteIcon" />
-          </Button>
+          />
         </template>
       </PColumn>
     </PDataTable>
@@ -75,6 +75,7 @@ import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import Add from '@/components/icons/action/Add.vue'
 import DeleteIcon from '@/components/icons/action/Delete.vue'
 import FormField from '@/components/Common/FormField.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import { ASSET_COLUMN_OPTIONS } from '@/components/Nodes/hooks/queryStringParser'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 

--- a/ui/src/components/Nodes/ColumnSelectionDrawer.vue
+++ b/ui/src/components/Nodes/ColumnSelectionDrawer.vue
@@ -19,9 +19,12 @@
       >
         <template #item="{ element, index }">
           <div class="column-row">
-            <Button text class="drag-btn">
-              <OnmsIcon class="close-icon drag-handle" :icon="Apps" />
-            </Button>
+            <OnmsIconButton
+              text
+              class="drag-btn close-icon drag-handle"
+              aria-label="Reorder column"
+              :icon="Apps"
+            />
             <Select
               v-model="element.value"
               :options="getAvailableOptions(index)"
@@ -30,13 +33,14 @@
               :placeholder="`Column ${index + 1}`"
               class="columns-selector"
             />
-            <Button
+            <OnmsIconButton
               text
               :data-test="`remove-column-${index}`"
+              title="Remove column"
+              class="close-icon"
+              :icon="Cancel"
               @click="removeColumn(index)"
-            >
-              <OnmsIcon class="close-icon" :icon="Cancel" />
-            </Button>
+            />
           </div>
         </template>
       </Draggable>
@@ -58,13 +62,13 @@
 <script lang="ts" setup>
 import { computed, ref, watch } from 'vue'
 
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import Apps from '@/components/icons/navigation/Apps.vue'
 import Cancel from '@/components/icons/navigation/Cancel.vue'
 import Draggable from 'vuedraggable'
 import Button from 'primevue/button'
 import Drawer from 'primevue/drawer'
 import Select from 'primevue/select'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import { saveNodePreferences } from '@/services/localStorageService'
 import { useNodeStructureStore } from '@/stores/nodeStructureStore'
 import { NodeColumnSelectionItem } from '@/types'

--- a/ui/src/components/Nodes/ExtendedSearchPanel.vue
+++ b/ui/src/components/Nodes/ExtendedSearchPanel.vue
@@ -50,13 +50,13 @@
       </PColumn>
       <PColumn header="" style="width: 3.5rem">
         <template #body="{ data }">
-          <Button
+          <OnmsIconButton
             text
+            :icon="DeleteIcon"
+            title="Remove search term"
             data-test="delete-search-term-button"
             @click="removeGridItem(data.key)"
-          >
-            <OnmsIcon :icon="DeleteIcon" />
-          </Button>
+          />
         </template>
       </PColumn>
     </PDataTable>
@@ -71,6 +71,7 @@ import ColumnComponent from 'primevue/column'
 import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import Add from '@/components/icons/action/Add.vue'
 import DeleteIcon from '@/components/icons/action/Delete.vue'

--- a/ui/src/components/Nodes/NodeActionsDropdown.vue
+++ b/ui/src/components/Nodes/NodeActionsDropdown.vue
@@ -1,18 +1,14 @@
 <template>
-  <Button
+  <OnmsIconButton
     text
     title="Node Actions"
     aria-label="Node Actions"
     aria-haspopup="true"
     :aria-controls="menuId"
     data-test="node-actions-button"
+    :icon="menuIcon"
     @click="toggle"
-  >
-    <OnmsIcon
-      :icon="menuIcon"
-      class="node-actions-icon"
-    />
-  </Button>
+  />
   <Menu
     :id="menuId"
     ref="menu"
@@ -22,11 +18,10 @@
 </template>
 
 <script setup lang="ts">
-import Button from 'primevue/button'
 import Menu from 'primevue/menu'
 import type { MenuItem } from 'primevue/menuitem'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import MoreVert from '@/components/icons/navigation/MoreVert.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import { markRaw, computed, ref, PropType } from 'vue'
 import { Node } from '@/types'
 
@@ -117,9 +112,3 @@ const mapLink = (name: string, node: Node) => {
 
 defineExpose({ items })
 </script>
-
-<style lang="scss" scoped>
-.node-actions-icon {
-  font-size: 1.1rem;
-}
-</style>

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -38,15 +38,14 @@
             @update:modelValue="(items) => updateFilter('categories', items)"
           />
         </FormField>
-        <Button
+        <OnmsIconButton
           v-if="!showSecondCategories"
           class="category-add-btn"
           text
+          :icon="AddIcon"
           aria-label="Add category group"
           @click="showSecondCategories = true"
-        >
-          <OnmsIcon :icon="AddIcon" />
-        </Button>
+        />
       </div>
       <div v-if="showSecondCategories" class="category-row">
         <FormField
@@ -65,14 +64,13 @@
             @update:modelValue="(items) => updateFilter('categories2', items)"
           />
         </FormField>
-        <Button
+        <OnmsIconButton
           class="category-add-btn"
           text
+          :icon="DeleteIcon"
           aria-label="Remove category group"
           @click="removeSecondCategories"
-        >
-          <OnmsIcon :icon="DeleteIcon" />
-        </Button>
+        />
       </div>
       <hr />
       <div class="spacer-large"></div>
@@ -292,6 +290,7 @@ import MultiSelect from 'primevue/multiselect'
 import InputText from 'primevue/inputtext'
 import ToggleSwitch from 'primevue/toggleswitch'
 import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import FormField from '@/components/Common/FormField.vue'
 import MessageDialog from '../Common/MessageDialog.vue'
 import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
@@ -505,10 +504,6 @@ defineExpose({
   margin-top: 1.25rem;
   height: 3rem;
   width: 3rem;
-
-  :deep(svg) {
-    font-size: 1.5rem;
-  }
 }
 
 .info-section {

--- a/ui/src/components/Nodes/NodeDownloadDropdown.vue
+++ b/ui/src/components/Nodes/NodeDownloadDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <Button
+  <OnmsIconButton
     text
     title="Download"
     aria-label="Download"
@@ -7,14 +7,9 @@
     aria-controls="node-download-menu"
     class="node-download-dropdown"
     data-test="download-button"
+    :icon="downloadIcon"
     @click="toggle"
-  >
-    <OnmsIcon
-      :icon="downloadIcon"
-      class="download-actions-icon"
-      title="Download"
-    />
-  </Button>
+  />
   <Menu
     id="node-download-menu"
     ref="menu"
@@ -24,11 +19,10 @@
 </template>
 
 <script setup lang="ts">
-import Button from 'primevue/button'
 import Menu from 'primevue/menu'
 import type { MenuItem } from 'primevue/menuitem'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import Download from '@/components/icons/action/DownloadFile.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import { markRaw, ref, PropType } from 'vue'
 
 const props = defineProps({
@@ -56,9 +50,3 @@ const toggle = (event: Event) => {
 
 defineExpose({ items })
 </script>
-
-<style lang="scss" scoped>
-.download-actions-icon {
-  font-size: 1.1rem;
-}
-</style>

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -541,12 +541,6 @@ defineExpose({ onSort, onPage, removeItem })
         width: 100%;
         padding-right: 2.75rem;
       }
-
-      :deep(.p-inputicon) {
-        font-size: 1.75rem;
-        right: 0.625rem;
-        margin-top: -0.875rem;
-      }
     }
   }
 

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -52,17 +52,13 @@
               />
             </div>
             <div>
-              <Button
+              <OnmsIconButton
                 text
                 title="Advanced Filters"
                 data-test="advanced-filters-button"
+                :icon="FilterAlt"
                 @click="nodeStructureStore.openInstancesDrawerModal()"
-              >
-                <OnmsIcon
-                  :icon="FilterAlt"
-                  class="advanced-filters-icon"
-                />
-              </Button>
+              />
             </div>
           </div>
           <div class="chip-container">
@@ -210,18 +206,13 @@
           >
             <template #body="{ data }">
               <div class="actions-cell-buttons">
-                <Button
+                <OnmsIconButton
                   text
                   title="View Details"
-                  class="view-details-icon"
                   data-test="view-details-button"
+                  :icon="ViewDetails"
                   @click="onNodeLinkClick(data.id)"
-                >
-                  <OnmsIcon
-                    :icon="ViewDetails"
-                    title="View Details"
-                  />
-                </Button>
+                />
                 <NodeActionsDropdown
                   :baseHref="mainMenu.baseHref"
                   :node="data"
@@ -300,6 +291,7 @@ import IconField from 'primevue/iconfield'
 import InputIcon from 'primevue/inputicon'
 import InputText from 'primevue/inputtext'
 import MessageDialog from '../Common/MessageDialog.vue'
+import OnmsIconButton from '../Common/OnmsIconButton.vue'
 import { computed, nextTick, ref, watch } from 'vue'
 import ColumnSelectionDrawer from './ColumnSelectionDrawer.vue'
 import FlowTooltipCell from './FlowTooltipCell.vue'
@@ -558,12 +550,6 @@ defineExpose({ onSort, onPage, removeItem })
     }
   }
 
-  // The Advanced Filters trigger icon read too small; bump it to ~1.5rem
-  // (OnmsIcon scales with font-size).
-  .advanced-filters-icon {
-    font-size: 1.5rem;
-  }
-
   .btn.btn-icon{
     border: 2px solid var(variables.$border-on-surface);
     border-radius: 3px;
@@ -616,14 +602,6 @@ defineExpose({ onSort, onPage, removeItem })
   align-items: center;
   justify-content: flex-end;
   gap: 0.5rem;
-}
-
-.actions-cell {
-  .view-details-icon {
-    svg {
-      font-size: 1.5rem !important;
-    }
-  }
 }
 
 // Keep the View Details + Node Actions buttons on a single line; never wrap

--- a/ui/src/components/Resources/Graph.vue
+++ b/ui/src/components/Resources/Graph.vue
@@ -340,6 +340,10 @@ onBeforeUnmount(() => {
 .graph-data-tabs {
   margin-top: 50px;
   margin-bottom: v-bind(legendHeight);
+
+  :deep(.p-tab) {
+    text-transform: uppercase;
+  }
 }
 .single-graph-btn {
   position: absolute;

--- a/ui/src/components/Resources/Graph.vue
+++ b/ui/src/components/Resources/Graph.vue
@@ -53,7 +53,7 @@ import TabList from 'primevue/tablist'
 import Tab from 'primevue/tab'
 import TabPanels from 'primevue/tabpanels'
 import TabPanel from 'primevue/tabpanel'
-import { PropType, computed, onMounted, ref, watch } from 'vue'
+import { PropType, computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 const PButton = Button
 const PTabs = Tabs
@@ -100,7 +100,7 @@ const convertedGraphDataRef = ref<ConvertedGraphData>({
   printStatements: [],
   properties: {}
 })
-let chart: any = {}
+let chart: any = null
 const legendRef = ref()
 const { height } = useElementSize(legendRef)
 const yAxisFormatter = format('.3s')
@@ -288,11 +288,17 @@ const render = async (update?: boolean) => {
     formattedGraphData = getFormattedLegendStatements(graphMetrics, rrdGraphConverterModel)
     graphData.value = formattedGraphData
 
-    if (update) {
+    if (update && chart) {
       chart.data = chartData.value
       chart.update()
     } else {
       const ctx: any = document.getElementById(`${props.label}-${props.definition}`)
+      // Chart.js throws "Canvas is already in use" if a chart still owns this
+      // canvas — e.g. a stale instance left on a reused canvas after navigating
+      // away and back. Destroy any prior chart on it before creating the new one.
+      if (ctx) {
+        Chart.getChart(ctx)?.destroy()
+      }
       chart = new Chart(ctx, {
         type: 'line',
         data: chartData.value,
@@ -310,6 +316,16 @@ const render = async (update?: boolean) => {
 watch(props.time, () => render(true))
 
 onMounted(() => render())
+
+// Release the canvas when the graph is torn down (navigation away, infinite-
+// scroll replacement) so Chart.js doesn't report it "already in use" on the
+// next render.
+onBeforeUnmount(() => {
+  if (chart && typeof chart.destroy === 'function') {
+    chart.destroy()
+    chart = null
+  }
+})
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/Resources/Graphs.vue
+++ b/ui/src/components/Resources/Graphs.vue
@@ -94,7 +94,23 @@ const resources = props.singleGraphResourceId ?
   computed<GraphDefinition[]>(() => graphStore.definitions)
 
 const definitionsList = computed<string[]>(() => graphStore.definitionsList)
-let definitionsListCopy: string[] = JSON.parse(JSON.stringify(graphStore.definitionsList))
+
+// Filled reactively (see seedInitialGraphs) rather than snapshotted at setup:
+// the definitions may still be loading when this view mounts.
+let definitionsListCopy: string[] = []
+let seeded = false
+
+// Seed the initial page of graphs once the definitions are available. Idempotent
+// and guarded so it runs a single time per mount (Graphs.vue is not kept-alive,
+// so `seeded` resets on every navigation back in).
+const seedInitialGraphs = () => {
+  if (seeded || props.singleGraphDefinition || !definitionsList.value.length) {
+    return
+  }
+  seeded = true
+  definitionsListCopy = [...definitionsList.value]
+  definitionsToDisplay.value = definitionsListCopy.splice(0, initNumOfGraphs)
+}
 
 const time = reactive<StartEndTime>({
   startTime: getUnixTime(sub(now, { hours: 24 })),
@@ -145,16 +161,16 @@ watch(arrivedState, () => {
   }
 })
 
+// Seed as soon as definitions are present — whether that's already true at mount
+// or arrives shortly after (e.g. a deep-link straight to /resource-graphs/graphs).
+watch(definitionsList, seedInitialGraphs, { immediate: true })
+
 onMounted(() => {
   // for displaying only selected graph
   if (props.singleGraphDefinition) {
     definitionsToDisplay.value = [props.singleGraphDefinition]
-    return
   }
-
-  [...Array(initNumOfGraphs)].forEach(() => {
-    addGraphDefinition()
-  })
+  // multi-graph seeding is handled reactively by the definitionsList watch above
 })
 
 onBeforeMount(() => {

--- a/ui/src/components/Resources/Graphs.vue
+++ b/ui/src/components/Resources/Graphs.vue
@@ -131,27 +131,25 @@ const addGraphDefinition = () => {
   }
 }
 
+// A single shared debounced function: creating it per keystroke (inside the
+// handler) would give every keystroke its own independent 1s timer, so the
+// search would run once per keystroke instead of once per pause.
+const debouncedSearch = useDebounceFn((val: string) => {
+  if (val) {
+    definitionsListCopy = definitionsList.value.filter(definition =>
+      definition.toLowerCase().includes(val.toLowerCase()))
+  } else {
+    definitionsListCopy = [...definitionsList.value]
+  }
+
+  definitionsToDisplay.value = definitionsListCopy.splice(0, 4)
+  stopSpinner()
+}, 1000)
+
 const searchHandler: UpdateModelFunction = (searchInputVal: string) => {
   startSpinner()
   searchVal.value = searchInputVal
-
-  const search = useDebounceFn((val: string) => {
-    if (val) {
-      definitionsListCopy = definitionsList.value.filter(definition =>
-        definition.toLowerCase().includes(val.toLowerCase()))
-
-      definitionsToDisplay.value = definitionsListCopy.splice(0, 4)
-    }
-
-    if (!val) {
-      definitionsListCopy = JSON.parse(JSON.stringify(definitionsList.value))
-      definitionsToDisplay.value = definitionsListCopy.splice(0, 4)
-    }
-
-    stopSpinner()
-  }, 1000)
-
-  search(searchInputVal)
+  debouncedSearch(searchInputVal)
 }
 
 watch(arrivedState, () => {

--- a/ui/src/components/Resources/NodeResourceList.vue
+++ b/ui/src/components/Resources/NodeResourceList.vue
@@ -83,7 +83,10 @@ const graphSelected = async () => {
 
 const graphAll = async () => {
   const resourceIds = resources.value.map(resource => resource.id)
-  graphStore.getGraphDefinitionsByResourceIds(resourceIds, resources.value)
+  // Await the definitions before navigating: Graphs.vue snapshots
+  // graphStore.definitionsList on mount, so if this fetch is still in flight
+  // the graph list is empty and nothing renders on the first attempt.
+  await graphStore.getGraphDefinitionsByResourceIds(resourceIds, resources.value)
   router.push('/resource-graphs/graphs')
 }
 </script>

--- a/ui/src/components/SCV/SCVAttribute.vue
+++ b/ui/src/components/SCV/SCVAttribute.vue
@@ -30,14 +30,13 @@
       />
     </FormField>
 
-    <PButton
+    <OnmsIconButton
       text
       aria-label="Remove attribute"
       data-test="rm-attr-btn"
+      :icon="Delete"
       @click="removeAttribute"
-    >
-      <OnmsIcon :icon="Delete" />
-    </PButton>
+    />
   </div>
 </template>
 
@@ -45,8 +44,7 @@
 import { computed, onMounted, ref } from 'vue'
 
 import InputText from 'primevue/inputtext'
-import Button from 'primevue/button'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Delete from '@/components/icons/action/Remove.vue'
 import FormField from '@/components/Common/FormField.vue'
 import { useScvStore } from '@/stores/scvStore'
@@ -54,7 +52,6 @@ import { SCVCredentials } from '@/types/scv'
 import { UpdateModelFunction } from '@/types'
 
 const PInputText = InputText
-const PButton = Button
 
 const scvStore = useScvStore()
 const emit = defineEmits(['set-key-error'])

--- a/ui/src/components/SCV/ScvInputIcon.vue
+++ b/ui/src/components/SCV/ScvInputIcon.vue
@@ -1,25 +1,18 @@
 <template>
-  <PButton
+  <OnmsIconButton
     text
-    :aria-label="title ?? tooltipTitle"
     class="scv-edit-icon"
+    :aria-label="title ?? tooltipTitle"
     :disabled="disabled"
     v-tooltip="title ?? tooltipTitle"
+    :icon="IconSecurity"
     @click="$emit('click')"
-  >
-    <OnmsIcon
-      :icon="IconSecurity"
-      class="scv-icon"
-    />
-  </PButton>
+  />
 </template>
 
 <script setup lang="ts">
-import Button from 'primevue/button'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import IconSecurity from '@/components/icons/network/Security.vue'
-
-const PButton = Button
 
 defineProps<{
   title?: string
@@ -41,12 +34,5 @@ const tooltipTitle = 'Use SCV to populate this field'
   width: 2rem;
   min-width: 2rem;
   padding: 0;
-
-  :deep(svg.scv-icon) {
-    cursor: pointer;
-    font-size: 1.25em !important;
-    width: 1.5em;
-    height: 1.5em;
-  }
 }
 </style>

--- a/ui/src/components/SCV/ScvSearchDrawer.vue
+++ b/ui/src/components/SCV/ScvSearchDrawer.vue
@@ -62,6 +62,7 @@
       <div class="scv-drawer-button-container">
         <PButton
           text
+          outlined
           :disabled="credentialsLoading"
           data-test="scv-drawer-cancel-button"
           label="Cancel"

--- a/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionsTable.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionsTable.vue
@@ -66,23 +66,21 @@
         <PColumn header="Actions">
           <template #body="{ data }">
             <div class="action-container">
-              <PButton
+              <OnmsIconButton
                 text
                 aria-label="Edit"
                 data-test="edit-button"
+                :icon="IconEdit"
                 @click="onDefinitionEdit(data.original)"
-              >
-                <OnmsIcon :icon="IconEdit" />
-              </PButton>
-              <PButton
+              />
+              <OnmsIconButton
                 v-if="data.original.id !== 0"
                 text
                 aria-label="Delete"
                 data-test="delete-button"
+                :icon="IconDelete"
                 @click="onDefinitionDelete(data.original)"
-              >
-                <OnmsIcon :icon="IconDelete" />
-              </PButton>
+              />
             </div>
           </template>
         </PColumn>
@@ -161,6 +159,7 @@ import { SnmpDefinition } from '@/types/snmpConfig'
 import ConfirmationDialog from '../Common/ConfirmationDialog.vue'
 import EmptyList from '../Common/EmptyList.vue'
 import FormField from '@/components/Common/FormField.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import TableCard from '../Common/TableCard.vue'
 
 const PButton = Button
@@ -375,11 +374,6 @@ const onSearchChange = (value: string | number | undefined) => {
       display: flex;
       align-items: center;
       gap: 5px;
-
-      // enlarge the edit/delete icons (OnmsIcon scales with font-size)
-      :deep(.p-button) {
-        font-size: 1.3rem;
-      }
     }
   }
 

--- a/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionsTable.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigDefinitionsTable.vue
@@ -359,14 +359,6 @@ const onSearchChange = (value: string | number | undefined) => {
             width: 100%;
             padding-right: 2.75rem;
           }
-
-          // enlarge the search glyph (OnmsIcon scales with font-size) and
-          // keep it near the right edge, vertically centered
-          :deep(.p-inputicon) {
-            font-size: 1.75rem;
-            right: 0.625rem;
-            margin-top: -0.875rem;
-          }
         }
       }
     }

--- a/ui/src/components/SnmpConfiguration/SnmpConfigProfilesTable.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigProfilesTable.vue
@@ -259,14 +259,6 @@ const onSearchChange = (value: string | number | undefined) => {
             width: 100%;
             padding-right: 2.75rem;
           }
-
-          // enlarge the search glyph (OnmsIcon scales with font-size) and
-          // keep it near the right edge, vertically centered
-          :deep(.p-inputicon) {
-            font-size: 1.75rem;
-            right: 0.625rem;
-            margin-top: -0.875rem;
-          }
         }
       }
     }

--- a/ui/src/components/SnmpConfiguration/SnmpConfigProfilesTable.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigProfilesTable.vue
@@ -51,22 +51,20 @@
         <PColumn header="Actions">
           <template #body="{ data }">
             <div class="action-container">
-              <PButton
+              <OnmsIconButton
                 text
                 aria-label="Edit"
                 data-test="edit-button"
+                :icon="IconEdit"
                 @click="onProfileEdit(data.label)"
-              >
-                <OnmsIcon :icon="IconEdit" />
-              </PButton>
-              <PButton
+              />
+              <OnmsIconButton
                 text
                 aria-label="Delete"
                 data-test="delete-button"
+                :icon="IconDelete"
                 @click="onConfirmProfileDelete(data.label)"
-              >
-                <OnmsIcon :icon="IconDelete" />
-              </PButton>
+              />
             </div>
           </template>
         </PColumn>
@@ -114,6 +112,7 @@ import IconSearch from '@/components/icons/action/Search.vue'
 import ConfirmationDialog from '../Common/ConfirmationDialog.vue'
 import EmptyList from '../Common/EmptyList.vue'
 import FormField from '@/components/Common/FormField.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import TableCard from '../Common/TableCard.vue'
 
 import { useSnmpConfigStore, ActiveTabs, AdvancedSubtabs, SnmpConfigEditMode } from '@/stores/snmpConfigStore'
@@ -269,11 +268,6 @@ const onSearchChange = (value: string | number | undefined) => {
       display: flex;
       align-items: center;
       gap: 5px;
-
-      // enlarge the edit/delete icons (OnmsIcon scales with font-size)
-      :deep(.p-button) {
-        font-size: 1.3rem;
-      }
     }
   }
 

--- a/ui/src/components/SnmpDataCollection/Dialog/UploadedFileRenameDialog.vue
+++ b/ui/src/components/SnmpDataCollection/Dialog/UploadedFileRenameDialog.vue
@@ -68,6 +68,7 @@
         />
         <Button
           text
+          outlined
           label="Cancel"
           @click="onCancel"
         />

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileRrdSettingsTab.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileRrdSettingsTab.vue
@@ -109,13 +109,13 @@
           style="width: 4rem"
         >
           <template #body="{ data }">
-            <PButton
+            <OnmsIconButton
               text
+              title="Delete RRA"
               data-test="delete-rra-button"
+              :icon="Delete"
               @click="deleteRRA(data._id)"
-            >
-              <OnmsIcon :icon="Delete" />
-            </PButton>
+            />
           </template>
         </PColumn>
         <PColumn
@@ -152,6 +152,7 @@ import ColumnComponent from 'primevue/column'
 import InputNumberComponent from 'primevue/inputnumber'
 import SelectComponent from 'primevue/select'
 import FormField from '@/components/Common/FormField.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 
 const PButton = ButtonComponent
 const PDataTable = DataTableComponent

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileSourcesTab.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileSourcesTab.vue
@@ -32,13 +32,13 @@
         <PColumn field="name" style="width: 20%; height: 44px"></PColumn>
         <PColumn style="width: 4rem">
           <template #body="{ data }">
-            <PButton
+            <OnmsIconButton
               text
+              title="Delete source"
               data-test="delete-source-button"
+              :icon="Delete"
               @click="removeSource(data.name)"
-            >
-              <OnmsIcon :icon="Delete" />
-            </PButton>
+            />
           </template>
         </PColumn>
       </PDataTable>
@@ -50,15 +50,13 @@
 import { computed, ref } from 'vue'
 
 import { useSnmpDataCollectionStore } from '@/stores/snmpDataCollectionStore'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import Delete from '@/components/icons/action/Delete.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import AutoCompleteComponent from 'primevue/autocomplete'
-import ButtonComponent from 'primevue/button'
 import DataTableComponent from 'primevue/datatable'
 import ColumnComponent from 'primevue/column'
 
 const PAutoComplete = AutoCompleteComponent
-const PButton = ButtonComponent
 const PDataTable = DataTableComponent
 const PColumn = ColumnComponent
 

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileSourcesTab.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/ProfileSourcesTab.vue
@@ -6,19 +6,21 @@
     <div class="section-header">Sources</div>
     <div>Add or remove sources from this profile.</div>
     <div class="autocomplete-row">
-      <PAutoComplete
-        v-model="autocompleteQuery"
-        :suggestions="sourceSearchResults"
-        optionLabel="name"
-        @complete="onSourceSearch"
-        @option-select="onSourceSelected($event.value)"
-        placeholder="Add Source"
-        :forceSelection="true"
-        data-test="add-source-autocomplete"
-        dropdown
-        completeOnFocus
-        fluid
-      />
+      <FormField label="Add Source">
+        <PAutoComplete
+          v-model="autocompleteQuery"
+          :suggestions="sourceSearchResults"
+          optionLabel="name"
+          @complete="onSourceSearch"
+          @option-select="onSourceSelected($event.value)"
+          placeholder="Search sources..."
+          :forceSelection="true"
+          data-test="add-source-autocomplete"
+          dropdown
+          completeOnFocus
+          fluid
+        />
+      </FormField>
     </div>
     <div class="sources-card">
       <PDataTable
@@ -51,6 +53,7 @@ import { computed, ref } from 'vue'
 
 import { useSnmpDataCollectionStore } from '@/stores/snmpDataCollectionStore'
 import Delete from '@/components/icons/action/Delete.vue'
+import FormField from '@/components/Common/FormField.vue'
 import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import AutoCompleteComponent from 'primevue/autocomplete'
 import DataTableComponent from 'primevue/datatable'

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/SnmpDataCollectionProfileDetails.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfile/SnmpDataCollectionProfileDetails.vue
@@ -365,13 +365,13 @@ onMounted(async () => {
 
 .snmp-data-collection-profile-details {
   margin: 0 auto;
-  padding: 45px;
+  padding: 0.5rem;
 
   .header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin: 20px 0px;
+    margin: 1.25rem 0;
 
     .title-container {
       display: flex;

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfilesTable.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionProfilesTable.vue
@@ -64,24 +64,22 @@
       <Column header="Actions">
         <template #body="{ data }">
           <div class="action-container">
-            <Button
+            <OnmsIconButton
               text
               :title="`View ${data.name}`"
               data-test="view-button"
+              :icon="ViewDetails"
               @click="onProfileClick(data)"
-            >
-              <OnmsIcon :icon="ViewDetails" />
-            </Button>
-            <Button
+            />
+            <OnmsIconButton
               text
               aria-haspopup="true"
               aria-controls="profile-row-menu"
               :title="`More actions for ${data.name}`"
               data-test="row-menu-button"
+              :icon="MenuIcon"
               @click="toggleRowMenu($event, data)"
-            >
-              <OnmsIcon :icon="MenuIcon" />
-            </Button>
+            />
           </div>
         </template>
       </Column>
@@ -122,6 +120,7 @@ import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'
 import Search from '@/components/icons/action/Search.vue'
 import ViewDetails from '@/components/icons/action/ViewDetails.vue'
 import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import IconField from 'primevue/iconfield'

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/MibGroupCreationDrawer.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/MibGroupCreationDrawer.vue
@@ -94,22 +94,20 @@
             <Column header="Action">
               <template #body="{ data }">
                 <div class="action-container">
-                  <Button
+                  <OnmsIconButton
                     text
                     title="Edit MIB Object"
                     data-test="edit-mib-object-button"
+                    :icon="Edit"
                     @click="openMibObjectDrawer(mibObjects.indexOf(data), data, CreateEditMode.Edit)"
-                  >
-                    <OnmsIcon :icon="Edit" />
-                  </Button>
-                  <Button
+                  />
+                  <OnmsIconButton
                     text
                     title="Delete MIB Object"
                     data-test="delete-mib-object-button"
+                    :icon="Delete"
                     @click="deleteMibObject(mibObjects.indexOf(data))"
-                  >
-                    <OnmsIcon :icon="Delete" />
-                  </Button>
+                  />
                 </div>
               </template>
             </Column>
@@ -241,11 +239,11 @@ import { createMibGroup, updateMibGroup } from '@/services/snmpDataCollectionSer
 import { useSnmpDataCollectionDetailStore } from '@/stores/snmpDataCollectionDetailStore'
 import { CreateEditMode } from '@/types'
 import { MibGroupErrors, MibGroupObjectForm, MibGroupObjectFormErrors } from '@/types/snmpDataCollection'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import Delete from '@/components/icons/action/Delete.vue'
 import Edit from '@/components/icons/action/Edit.vue'
 import { ISelectItemType } from '@/types'
 import FormField from '@/components/Common/FormField.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Button from 'primevue/button'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/MibGroupCreationDrawer.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/MibGroupCreationDrawer.vue
@@ -195,6 +195,7 @@
         <div class="footer">
           <Button
             text
+            outlined
             label="Cancel"
             data-test="cancel-mib-object-button"
             @click="closeMibObjectDrawer"
@@ -213,6 +214,7 @@
       >
         <Button
           text
+          outlined
           label="Cancel"
           data-test="cancel-mib-group"
           @click="closeMibGroupDrawer"

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/ResourceTypeCreationDrawer.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/ResourceTypeCreationDrawer.vue
@@ -116,22 +116,20 @@
             <Column header="Action">
               <template #body="{ data }">
                 <div class="action-container">
-                  <Button
+                  <OnmsIconButton
                     text
                     title="Edit Storage Strategy Parameter"
                     data-test="edit-storage-strategy-button"
+                    :icon="Edit"
                     @click="openStorageStrategyDrawer(CreateEditMode.Edit, storageStrategyParams.indexOf(data), data)"
-                  >
-                    <OnmsIcon :icon="Edit" />
-                  </Button>
-                  <Button
+                  />
+                  <OnmsIconButton
                     text
                     title="Delete Storage Strategy Parameter"
                     data-test="delete-storage-strategy-button"
+                    :icon="Delete"
                     @click="deleteStorageStrategy(storageStrategyParams.indexOf(data))"
-                  >
-                    <OnmsIcon :icon="Delete" />
-                  </Button>
+                  />
                 </div>
               </template>
             </Column>
@@ -193,22 +191,20 @@
             <Column header="Action">
               <template #body="{ data }">
                 <div class="action-container">
-                  <Button
+                  <OnmsIconButton
                     text
                     title="Edit Persistence Selector Strategy Parameter"
                     data-test="edit-persistence-selector-strategy-button"
+                    :icon="Edit"
                     @click="openPersistenceSelectorStrategyDrawer(CreateEditMode.Edit, persistenceSelectorStrategyParams.indexOf(data), data)"
-                  >
-                    <OnmsIcon :icon="Edit" />
-                  </Button>
-                  <Button
+                  />
+                  <OnmsIconButton
                     text
                     title="Delete Persistence Selector Strategy Parameter"
                     data-test="delete-persistence-selector-strategy-button"
+                    :icon="Delete"
                     @click="deletePersistenceSelectorStrategy(persistenceSelectorStrategyParams.indexOf(data))"
-                  >
-                    <OnmsIcon :icon="Delete" />
-                  </Button>
+                  />
                 </div>
               </template>
             </Column>
@@ -306,9 +302,9 @@ import { useSnmpDataCollectionDetailStore } from '@/stores/snmpDataCollectionDet
 import { CreateEditMode } from '@/types'
 import { PersistSelectorStrategyForm, ResourceTypeErrors, StorageStrategyForm } from '@/types/snmpDataCollection'
 import { IAutocompleteItemType } from '@/types'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
 import Delete from '@/components/icons/action/Delete.vue'
 import Edit from '@/components/icons/action/Edit.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import AutoComplete from 'primevue/autocomplete'
 import Button from 'primevue/button'
 import Column from 'primevue/column'

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/ResourceTypeCreationDrawer.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/ResourceTypeCreationDrawer.vue
@@ -256,6 +256,7 @@
         <div class="footer">
           <Button
             text
+            outlined
             label="Cancel"
             data-test="cancel-resource-type-parameter-button"
             @click="closeParameterDrawer"
@@ -274,6 +275,7 @@
       >
         <Button
           text
+          outlined
           label="Cancel"
           data-test="cancel-resource-type"
           @click="closeResourceTypeDrawer"

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/SnmpDataCollectionSourceProfilesDrawer.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/SnmpDataCollectionSourceProfilesDrawer.vue
@@ -179,4 +179,11 @@ watch(() => props.visible, async (visible) => {
     margin-left: 0 !important;
   }
 }
+
+// This AutoComplete isn't wrapped in a FormField, so its input inherits the
+// global 3.75rem .p-inputtext height and reads too tall. Match the app-standard
+// field height (3rem, the value FormField applies) instead.
+:deep(.p-autocomplete-input) {
+  height: 3rem;
+}
 </style>

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/SnmpDataCollectionSourceProfilesDrawer.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/SnmpDataCollectionSourceProfilesDrawer.vue
@@ -25,19 +25,21 @@
         >No profiles assigned</span>
       </div>
       <div class="spacer" />
-      <div class="section-label">Add Profile</div>
-      <PAutoComplete
-        v-model="autocompleteQuery"
-        :suggestions="filteredSuggestions"
-        optionLabel="name"
-        @complete="onSearch"
-        @option-select="addProfile($event.value)"
-        placeholder="Search profiles..."
-        :forceSelection="true"
-        data-test="profile-autocomplete"
-        dropdown
-        completeOnFocus
-      />
+      <FormField label="Add Profile">
+        <PAutoComplete
+          v-model="autocompleteQuery"
+          :suggestions="filteredSuggestions"
+          optionLabel="name"
+          @complete="onSearch"
+          @option-select="addProfile($event.value)"
+          placeholder="Search profiles..."
+          :forceSelection="true"
+          data-test="profile-autocomplete"
+          dropdown
+          completeOnFocus
+          fluid
+        />
+      </FormField>
       <div class="button-row">
         <Button
           text
@@ -64,6 +66,7 @@ import AutoCompleteComponent from 'primevue/autocomplete'
 import Button from 'primevue/button'
 import ChipComponent from 'primevue/chip'
 import Drawer from 'primevue/drawer'
+import FormField from '@/components/Common/FormField.vue'
 
 const PChip = ChipComponent
 const PAutoComplete = AutoCompleteComponent
@@ -180,10 +183,4 @@ watch(() => props.visible, async (visible) => {
   }
 }
 
-// This AutoComplete isn't wrapped in a FormField, so its input inherits the
-// global 3.75rem .p-inputtext height and reads too tall. Match the app-standard
-// field height (3rem, the value FormField applies) instead.
-:deep(.p-autocomplete-input) {
-  height: 3rem;
-}
 </style>

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/SnmpDataCollectionSourceProfilesDrawer.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/Drawer/SnmpDataCollectionSourceProfilesDrawer.vue
@@ -41,6 +41,7 @@
       <div class="button-row">
         <Button
           text
+          outlined
           label="Cancel"
           @click="close"
         />

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/MibGroupsTable.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/MibGroupsTable.vue
@@ -20,14 +20,13 @@
           </FormField>
         </div>
         <div class="refresh">
-          <Button
+          <OnmsIconButton
             text
             title="Refresh"
             data-test="refresh-button"
+            :icon="Refresh"
             @click="store.resetMibGroupsFilters"
-          >
-            <OnmsIcon :icon="Refresh" />
-          </Button>
+          />
         </div>
       </div>
       <div class="section-right">
@@ -93,24 +92,23 @@
       <Column header="Actions">
         <template #body="{ data }">
           <div class="action-container">
-            <Button
+            <OnmsIconButton
               v-if="!isPluginSourced(store.selectedCollectionSource)"
               text
               :title="`Edit ${data.name}`"
               data-test="edit-button"
+              :icon="Edit"
               @click="onMibGroupEditClicked(data)"
-            >
-              <OnmsIcon :icon="Edit" />
-            </Button>
-            <Button
+            />
+            <OnmsIconButton
               text
               aria-haspopup="true"
               :aria-controls="`mib-group-row-menu`"
+              title="More actions"
               data-test="row-menu-button"
+              :icon="MenuIcon"
               @click="toggleRowMenu($event, data)"
-            >
-              <OnmsIcon :icon="MenuIcon" />
-            </Button>
+            />
           </div>
         </template>
       </Column>
@@ -177,6 +175,7 @@ import Search from '@/components/icons/action/Search.vue'
 import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'
 import Refresh from '@/components/icons/navigation/Refresh.vue'
 import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import type { DataTablePageEvent, DataTableSortEvent } from 'primevue/datatable'

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/ResourceTypesTable.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/ResourceTypesTable.vue
@@ -20,14 +20,13 @@
           </FormField>
         </div>
         <div class="refresh">
-          <Button
+          <OnmsIconButton
             text
             title="Refresh"
             data-test="refresh-button"
+            :icon="Refresh"
             @click="store.resetResourceTypesFilters"
-          >
-            <OnmsIcon :icon="Refresh" />
-          </Button>
+          />
         </div>
       </div>
       <div class="section-right">
@@ -98,24 +97,23 @@
       <Column header="Actions">
         <template #body="{ data }">
           <div class="action-container">
-            <Button
+            <OnmsIconButton
               v-if="!isPluginSourced(store.selectedCollectionSource)"
               text
               :title="`Edit ${data.name}`"
               data-test="edit-button"
+              :icon="Edit"
               @click="onResourceTypeEditClicked(data)"
-            >
-              <OnmsIcon :icon="Edit" />
-            </Button>
-            <Button
+            />
+            <OnmsIconButton
               text
               aria-haspopup="true"
               aria-controls="resource-type-row-menu"
+              title="More actions"
               data-test="row-menu-button"
+              :icon="MenuIcon"
               @click="toggleRowMenu($event, data)"
-            >
-              <OnmsIcon :icon="MenuIcon" />
-            </Button>
+            />
           </div>
         </template>
       </Column>
@@ -174,6 +172,7 @@ import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'
 import Refresh from '@/components/icons/navigation/Refresh.vue'
 import { debounce } from 'lodash'
 import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import type { DataTablePageEvent, DataTableSortEvent } from 'primevue/datatable'

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/SystemDefinitionsTable.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceDetail/SystemDefinitionsTable.vue
@@ -20,14 +20,13 @@
           </FormField>
         </div>
         <div class="refresh">
-          <Button
+          <OnmsIconButton
             text
             title="Refresh"
             data-test="refresh-button"
+            :icon="Refresh"
             @click="store.resetSystemDefinitionsFilters"
-          >
-            <OnmsIcon :icon="Refresh" />
-          </Button>
+          />
         </div>
       </div>
       <div class="section-right">
@@ -98,24 +97,23 @@
       <Column header="Actions">
         <template #body="{ data }">
           <div class="action-container">
-            <Button
+            <OnmsIconButton
               v-if="!isPluginSourced(store.selectedCollectionSource)"
               text
               :title="`Edit ${data.name}`"
               data-test="edit-button"
+              :icon="Edit"
               @click="onSystemDefEditClicked(data)"
-            >
-              <OnmsIcon :icon="Edit" />
-            </Button>
-            <Button
+            />
+            <OnmsIconButton
               text
               aria-haspopup="true"
               aria-controls="system-definition-row-menu"
+              title="More actions"
               data-test="row-menu-button"
+              :icon="MenuIcon"
               @click="toggleRowMenu($event, data)"
-            >
-              <OnmsIcon :icon="MenuIcon" />
-            </Button>
+            />
           </div>
         </template>
       </Column>
@@ -172,6 +170,7 @@ import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'
 import Refresh from '@/components/icons/navigation/Refresh.vue'
 import { debounce } from 'lodash'
 import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import type { DataTablePageEvent, DataTableSortEvent } from 'primevue/datatable'

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceImport.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourceImport.vue
@@ -193,14 +193,13 @@
         </Column>
         <Column header="Action">
           <template #body="{ data }">
-            <Button
+            <OnmsIconButton
               text
               title="Remove"
               data-test="remove-files-button"
+              :icon="Delete"
               @click="removeFile(data)"
-            >
-              <OnmsIcon :icon="Delete" />
-            </Button>
+            />
           </template>
         </Column>
       </DataTable>
@@ -279,6 +278,7 @@ import Refresh from '@/components/icons/navigation/Refresh.vue'
 import Error from '@/components/icons/notification/Error.vue'
 import Warning from '@/components/icons/notification/Warning.vue'
 import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Checkbox from 'primevue/checkbox'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'

--- a/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourcesTable.vue
+++ b/ui/src/components/SnmpDataCollection/SnmpDataCollectionSourcesTable.vue
@@ -91,35 +91,32 @@
       <Column header="Actions">
         <template #body="{ data }">
           <div class="action-container">
-            <Button
+            <OnmsIconButton
               text
               :title="`View ${data.name}`"
               data-test="view-button"
+              :icon="ViewDetails"
               @click="onSourceClick(data)"
-            >
-              <OnmsIcon :icon="ViewDetails" />
-            </Button>
+            />
             <!-- Quick-download in XML (the round-trippable format the
                  /upload endpoint accepts). JSON is still reachable via
                  the row menu below for users who want it. -->
-            <Button
+            <OnmsIconButton
               text
               :title="`Download ${data.name} XML`"
               data-test="download-xml-button"
+              :icon="DownloadIcon"
               @click="downloadCollectionSource(data, 'xml')"
-            >
-              <OnmsIcon :icon="DownloadIcon" />
-            </Button>
-            <Button
+            />
+            <OnmsIconButton
               text
               aria-haspopup="true"
               aria-controls="source-row-menu"
               :title="`More actions for ${data.name}`"
               data-test="row-menu-button"
+              :icon="MenuIcon"
               @click="toggleRowMenu($event, data)"
-            >
-              <OnmsIcon :icon="MenuIcon" />
-            </Button>
+            />
           </div>
         </template>
       </Column>
@@ -167,6 +164,7 @@ import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'
 import Search from '@/components/icons/action/Search.vue'
 import ViewDetails from '@/components/icons/action/ViewDetails.vue'
 import Button from 'primevue/button'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Chip from 'primevue/chip'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
@@ -494,11 +492,6 @@ onMounted(async () => {
     display: flex;
     align-items: center;
     gap: 5px;
-
-    // enlarge the button icons (OnmsIcon scales with font-size)
-    :deep(.p-button) {
-      font-size: 1.3rem;
-    }
   }
 }
 </style>

--- a/ui/src/components/TrapdConfiguration/CreateSnmpV3User.vue
+++ b/ui/src/components/TrapdConfiguration/CreateSnmpV3User.vue
@@ -7,14 +7,13 @@
     <div class="header">
       <div class="section-left">
         <div class="title">
-          <PButton
+          <OnmsIconButton
             text
             aria-label="Back"
             data-test="text-button"
+            :icon="ChevronLeft"
             @click="store.closeCreateUserDrawer"
-          >
-            <OnmsIcon :icon="ChevronLeft" />
-          </PButton>
+          />
           <h3 v-if="store.createUserDrawerState.mode === CreateEditMode.Create">New SNMPv3 User</h3>
           <h3 v-else-if="store.createUserDrawerState.mode === CreateEditMode.Edit">Edit SNMPv3 User {{ securityName }}</h3>
         </div>
@@ -208,7 +207,7 @@ import FormField from '../Common/FormField.vue'
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
 import Select from 'primevue/select'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import ChevronLeft from '@/components/icons/navigation/ChevronLeft.vue'
 import { ISelectItemType } from '@/types'
 import TableCard from '../Common/TableCard.vue'
@@ -424,11 +423,6 @@ onMounted(() => {
         display: flex;
         align-items: center;
         gap: 10px;
-
-        // enlarge the back-button icon (OnmsIcon scales with font-size)
-        :deep(.p-button) {
-          font-size: 1.3rem;
-        }
 
         h3 {
           @include onms-headline3;

--- a/ui/src/components/TrapdConfiguration/CreateSnmpV3User.vue
+++ b/ui/src/components/TrapdConfiguration/CreateSnmpV3User.vue
@@ -165,6 +165,7 @@
     <div class="footer">
       <PButton
         text
+        outlined
         data-test="cancel-button"
         label="Cancel"
         @click="store.closeCreateUserDrawer"

--- a/ui/src/components/TrapdConfiguration/SnmpV3UserManagement.vue
+++ b/ui/src/components/TrapdConfiguration/SnmpV3UserManagement.vue
@@ -60,22 +60,20 @@
         <PColumn header="Action">
           <template #body="{ data }">
             <div class="action-container">
-              <PButton
+              <OnmsIconButton
                 text
                 aria-label="Edit User"
                 data-test="edit-user-button"
+                :icon="Edit"
                 @click="store.openCreateUserDrawer(CreateEditMode.Edit, userIndex(data))"
-              >
-                <OnmsIcon :icon="Edit" />
-              </PButton>
-              <PButton
+              />
+              <OnmsIconButton
                 text
                 aria-label="Delete User"
                 data-test="delete-user-button"
+                :icon="Delete"
                 @click="openDeleteUserDialog(userIndex(data))"
-              >
-                <OnmsIcon :icon="Delete" />
-              </PButton>
+              />
             </div>
           </template>
         </PColumn>
@@ -126,6 +124,7 @@ import Button from 'primevue/button'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import Delete from '@/components/icons/action/Delete.vue'
 import Edit from '@/components/icons/action/Edit.vue'
 import InfoIcon from '@/components/icons/action/Info.vue'
@@ -265,11 +264,6 @@ watch(
       display: flex;
       align-items: center;
       gap: 5px;
-
-      // enlarge the edit/delete icons (OnmsIcon scales with font-size)
-      :deep(.p-button) {
-        font-size: 1.3rem;
-      }
     }
   }
 }

--- a/ui/src/components/ZenithConnect/ZenithConnectRegisterResult.vue
+++ b/ui/src/components/ZenithConnect/ZenithConnectRegisterResult.vue
@@ -44,23 +44,21 @@
                 <PColumn header="Access Token">
                   <template #body="{ data }">
                     {{ ellipsify(data.accessToken ?? '', 30) }}
-                    <PButton
+                    <OnmsIconButton
                       aria-label="Copy Access Token"
+                      :icon="icons.ContentCopy"
                       @click.prevent="() => onCopyToken(true)"
-                    >
-                      <OnmsIcon :icon="icons.ContentCopy" />
-                    </PButton>
+                    />
                   </template>
                 </PColumn>
                 <PColumn header="Refresh Token">
                   <template #body="{ data }">
                     {{ ellipsify(data.refreshToken ?? '', 30) }}
-                    <PButton
+                    <OnmsIconButton
                       aria-label="Copy Refresh Token"
+                      :icon="icons.ContentCopy"
                       @click.prevent="() => onCopyToken(false)"
-                    >
-                      <OnmsIcon :icon="icons.ContentCopy" />
-                    </PButton>
+                    />
                   </template>
                 </PColumn>
               </PDataTable>
@@ -85,7 +83,7 @@ import { computed, markRaw, onMounted, ref } from 'vue'
 import Button from 'primevue/button'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import ContentCopy from '@/components/icons/action/ContentCopy.vue'
 import { useRoute, useRouter } from 'vue-router'
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'

--- a/ui/src/components/ZenithConnect/ZenithConnectView.vue
+++ b/ui/src/components/ZenithConnect/ZenithConnectView.vue
@@ -54,23 +54,21 @@
               <PColumn header="Access Token">
                 <template #body="{ data }">
                   {{ ellipsify(data.accessToken ?? '', 30) }}
-                  <PButton
+                  <OnmsIconButton
                     aria-label="Copy Access Token"
+                    :icon="icons.ContentCopy"
                     @click.prevent="() => onCopyToken(data.accessToken ?? '')"
-                  >
-                    <OnmsIcon :icon="icons.ContentCopy" />
-                  </PButton>
+                  />
                 </template>
               </PColumn>
               <PColumn header="Refresh Token">
                 <template #body="{ data }">
                   {{ ellipsify(data.refreshToken ?? '', 30) }}
-                  <PButton
+                  <OnmsIconButton
                     aria-label="Copy Refresh Token"
+                    :icon="icons.ContentCopy"
                     @click.prevent="() => onCopyToken(data.refreshToken ?? '')"
-                  >
-                    <OnmsIcon :icon="icons.ContentCopy" />
-                  </PButton>
+                  />
                 </template>
               </PColumn>
               <PColumn header="Actions">
@@ -108,7 +106,7 @@ import { format as fnsFormat } from 'date-fns'
 import Button from 'primevue/button'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
-import OnmsIcon from '@/components/icons/OnmsIcon.vue'
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
 import useSnackbar from '@/composables/useSnackbar'
 import { ellipsify } from '@/lib/utils'

--- a/ui/src/containers/DeviceConfigBackup.vue
+++ b/ui/src/containers/DeviceConfigBackup.vue
@@ -89,7 +89,7 @@ onMounted(() => deviceStore.getDeviceConfigBackups(true))
         }
 
         .dcb-search {
-          width: 250px;
+          width: 30rem;
           margin-top: 16px;
         }
       }

--- a/ui/src/containers/SnmpDataCollection.vue
+++ b/ui/src/containers/SnmpDataCollection.vue
@@ -124,14 +124,14 @@ const downloadConfig = async (format: 'xml' | 'json') => {
 
 <style lang="scss" scoped>
 .snmp-data-collection-container {
-  padding: 20px;
+  padding: 1.5rem;
 
   .header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 20px;
-    padding: 60px 40px 25px 40px;
+    margin-bottom: 1.25rem;
+    padding: 0.5rem 0;
 
     .header-actions {
       display: flex;
@@ -141,7 +141,7 @@ const downloadConfig = async (format: 'xml' | 'json') => {
   }
 
   .tab-container {
-    padding: 0px 40px 0px 40px;
+    padding: 0.5rem;
 
     .tabs {
       :deep(.p-tab) {

--- a/ui/src/styles/primevue-overrides.scss
+++ b/ui/src/styles/primevue-overrides.scss
@@ -42,21 +42,20 @@
   text-transform: uppercase;
 }
 
-// Taller text inputs across the app (matches the roomier FeatherDS field feel
-// and gives IftaLabel's in-field label space above the value). Height is not a
-// PrimeVue theme token, so it lives here. Applies to InputText and the inner
-// input of InputNumber (both render .p-inputtext).
+// Standard field height across the app. Height is not a PrimeVue theme token,
+// so it lives here. Applies to InputText and the inner input of InputNumber
+// (both render .p-inputtext). Formerly 3.75rem with FormField overriding to
+// 3rem; promoted to 3rem here so controls in and out of FormField match.
 .p-inputtext {
-  height: 3.75rem;
+  height: 3rem;
 }
 
-// Match Select height to the taller inputs so they line up in shared rows.
-// The root is inline-flex with the default `align-items: stretch`, so at the
-// taller height the label stretches full-height and its text pins to the top;
-// center it so the value/placeholder sits vertically centered (same fix as
-// .p-multiselect below).
+// Match Select height to the inputs so they line up in shared rows. The root is
+// inline-flex with the default `align-items: stretch`, so the label otherwise
+// stretches full-height and its text pins to the top; center it so the
+// value/placeholder sits vertically centered (same fix as .p-multiselect).
 .p-select {
-  height: 3.75rem;
+  height: 3rem;
   align-items: center;
 }
 

--- a/ui/src/styles/primevue-overrides.scss
+++ b/ui/src/styles/primevue-overrides.scss
@@ -111,6 +111,16 @@
   border-color: currentColor;
 }
 
+// Search-input (IconField / InputIcon) glyph. The icon is an OnmsIcon whose SVG
+// is 1em, so its size tracks the .p-inputicon font-size. PrimeVue's default is
+// too small and several screens overrode it inconsistently (1.75rem). Normalize
+// to 1.5rem everywhere. PrimeVue positions .p-inputicon at top: 50%, so the icon
+// is centered on the input mid-line with a margin-top of -½ its height.
+.p-inputicon {
+  font-size: 1.5rem;
+  margin-top: -0.75rem;
+}
+
 // Helper/hint text shown under a form field (the small sibling of an
 // IftaLabel/FloatLabel input). Global so every converted field is consistent:
 // indent to line up with the IftaLabel label/value text (the input's left

--- a/ui/src/styles/primevue-overrides.scss
+++ b/ui/src/styles/primevue-overrides.scss
@@ -100,6 +100,17 @@
   border-width: 2px;
 }
 
+// A Button given both `outlined` and `text` (e.g. the text-variant Cancel
+// buttons) shows no visible border on its own: both p-button-outlined and
+// p-button-text classes are applied, and .p-button-text sets a transparent
+// border-color that wins over the outlined border — leaving the 2px border
+// above invisible. Reassert a visible border color for that combination (this
+// two-class selector outranks .p-button-text). currentColor matches the
+// preset's intent that an outlined border use the button's own text color.
+.p-button-outlined.p-button-text {
+  border-color: currentColor;
+}
+
 // Helper/hint text shown under a form field (the small sibling of an
 // IftaLabel/FloatLabel input). Global so every converted field is consistent:
 // indent to line up with the IftaLabel label/value text (the input's left

--- a/ui/tests/components/Common/OnmsIconButton.test.ts
+++ b/ui/tests/components/Common/OnmsIconButton.test.ts
@@ -1,0 +1,58 @@
+import OnmsIconButton from '@/components/Common/OnmsIconButton.vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+// Minimal stand-in for a vendored OnmsIcon svg component.
+const StubIcon = defineComponent({
+  name: 'StubIcon',
+  render() {
+    return h('svg', { 'data-test': 'stub-icon' })
+  }
+})
+
+describe('OnmsIconButton.vue', () => {
+  it('renders a button containing the icon', () => {
+    const wrapper = mount(OnmsIconButton, { props: { icon: StubIcon }})
+    expect(wrapper.find('button').exists()).toBe(true)
+    expect(wrapper.find('svg[data-test="stub-icon"]').exists()).toBe(true)
+  })
+
+  it('applies the default 1.5rem icon size', () => {
+    const wrapper = mount(OnmsIconButton, { props: { icon: StubIcon }})
+    const iconWrap = wrapper.find('.onms-icon-button__icon')
+    expect(iconWrap.attributes('style')).toContain('font-size: 1.5rem')
+  })
+
+  it('applies a custom icon size', () => {
+    const wrapper = mount(OnmsIconButton, { props: { icon: StubIcon, iconSize: '2rem' }})
+    const iconWrap = wrapper.find('.onms-icon-button__icon')
+    expect(iconWrap.attributes('style')).toContain('font-size: 2rem')
+  })
+
+  it('forwards title to the icon as its accessible name', () => {
+    const wrapper = mount(OnmsIconButton, { props: { icon: StubIcon, title: 'Remove search term' }})
+    expect(wrapper.find('svg').attributes('aria-label')).toBe('Remove search term')
+  })
+
+  it('applies title to the button as a native tooltip', () => {
+    const wrapper = mount(OnmsIconButton, { props: { icon: StubIcon, title: 'Refresh' }})
+    expect(wrapper.find('button').attributes('title')).toBe('Refresh')
+  })
+
+  it('renders no title attribute on the button when title is not provided', () => {
+    const wrapper = mount(OnmsIconButton, { props: { icon: StubIcon }})
+    expect(wrapper.find('button').attributes('title')).toBeUndefined()
+  })
+
+  it('forwards click and data-test to the button', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(OnmsIconButton, {
+      props: { icon: StubIcon },
+      attrs: { 'data-test': 'my-btn', onClick }
+    })
+    expect(wrapper.find('button').attributes('data-test')).toBe('my-btn')
+    await wrapper.find('button').trigger('click')
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
# NMS-20033: UI styling & behavior fixes (post-PrimeVue migration)

Follow-up fixes and polish from PR review of the FeatherDS → PrimeVue migration. This branch introduces a small reusable seam component, migrates all icon-only buttons onto it, and resolves a batch of styling and behavior issues across the Vue SPA (icons, buttons, inputs, spacing, the geographical map, resource graphs, and dark mode).

## Highlights

- **New `OnmsIconButton` seam component** and migration of every icon-only button to it.
- Consistent **icon sizing** (icon buttons and search-field glyphs).
- **Form-control consistency**: outlined Cancel buttons, a single global input height, `FormField` adoption.
- **Geographical map** fixes (popup clipping, control positioning, layers dropdown, Esc handling, keep-alive cleanup, resize reflow).
- **Resource Graphs** reliability fixes (Chart.js lifecycle, "Graph All" race, reactive seeding).
- **Dark-mode footer** background.

---

## Changes

### `OnmsIconButton` seam component + migration
- Added `components/Common/OnmsIconButton.vue` — a thin wrapper around a PrimeVue `Button` + the vendored `OnmsIcon`, part of the `onms-` seam layer that insulates the app from PrimeVue. It bakes in consistent icon sizing (default `1.5rem`, overridable via `iconSize`), forwards `title` as the icon's accessible name **and** as the button's native tooltip, and lets all other attributes/`Button` props fall through. Unit tests added.
- Migrated **~65 icon-only buttons across ~33 files** (Configuration, EventConfiguration, Nodes, SnmpDataCollection, Trapd, Logs, Device, SCV, ZenithConnect, FileEditor) from the raw `<Button><OnmsIcon/></Button>` pattern to `OnmsIconButton`.
  - Normalized icon size to `1.5rem` (fixing under- and over-sized glyphs) and removed the scattered per-file `font-size` overrides; `FileSidebar` keeps its intentionally larger `2em` toolbar icons via the `iconSize` prop.
  - Added **accessible names** to 8 previously-unlabeled icon buttons.
  - Refactored the `ScvInputIcon` wrapper to build on `OnmsIconButton` while preserving its public API and circular-badge look.
  - Removed now-dead CSS classes left behind after the migration.

### Buttons
- **Cancel buttons**: added the `outlined` prop to every text-variant Cancel button so they read as bordered.
- **Outlined + text border fix**: a `Button` with both `outlined` and `text` rendered no visible border (PrimeVue's `p-button-text` sets a transparent border-color that won over the outlined border). Added a global rule so the outline shows for that combination.
- **DCB action buttons**: normalized the mixed-source action-button icons (`View History` / `Download` / `Backup` / `Compare`) to a single `1.5em` size and vertically centered icon + label (the `Compare` asset had hardcoded `24px` + a `-10px` margin hack that broke alignment).

### Inputs & form controls
- **Search-field icons**: the IconField magnifying-glass glyph (an `OnmsIcon`) was inconsistently sized (too small on most screens, `1.75rem` on a few). Normalized to `1.5rem` via one global `.p-inputicon` rule and removed the per-screen overrides.
- **Global input height**: promoted `height: 3rem` to the global `.p-inputtext` / `.p-select` rule (was `3.75rem`, with `FormField` overriding to `3rem`). ~92% of controls were already `3rem` via `FormField`; this brings the remaining non-`FormField` controls into line and retires the vestigial `3.75rem` default. `FormField`'s pilot height override was removed.
- **`FormField` adoption**: wrapped the "Add Profile" and "Add Source" autocompletes in `FormField` for label/structure consistency.

### Spacing
- Restored spacing lost to **orphaned FeatherDS spacing utility classes** (`mb-m`, `mr-m`, `pb-xl`) — the last unresolved Feather utilities — by defining local scoped equivalents backed by the `--onms-spacing-*` tokens (verified equal to the original FeatherDS values). Fixes the External Requisitions form rendering its fields flush.

### Geographical map (Leaflet)
- **Popup clipping**: extended the `popupopen` overflow handling to all edges (left/right/top/bottom), so popups on edge-most markers no longer render half outside the map.
- **Control positioning**: gave `.geo-map` a positioning context so the Search / Show Severity overlays anchor to the map area (not the viewport, where they slid under the pinned side-menu rail); reduced the Search / Severity / nav-control top inset from `80px` to `2em`.
- **Layers control**: bridged the hover dead-gap that let the layers dropdown collapse before you reached it, and made the dropdown theme-aware (was hardcoded white in dark mode).
- **Esc handling**: the map-search AutoComplete's Esc no longer also closes an open marker popup.
- **keep-alive cleanup**: the document Esc listener is now removed on `deactivated` (the map is `<keep-alive>`'d and never unmounts).
- **Resize reflow**: a `ResizeObserver` calls `invalidateSize()` so the map reflows when the side menu is pinned (or on any container resize).

### Resource Graphs
- **Chart.js lifecycle**: destroy chart instances before reusing a canvas and on unmount — fixes the console error `Canvas is already in use…` and graphs silently failing to render.
- **"Graph All" race**: await the graph-definitions fetch before navigating, so the graphs view no longer mounts before its data is ready (graphs failing to appear on the first try).
- **Reactive seeding**: the graphs view now seeds its initial graphs reactively from the store rather than a setup-time snapshot, so the first render depends on data availability rather than mount timing.
- **Tabs**: uppercased the `Graph` / `Data` tab labels.

### Dark mode
- **Footer**: the footer hardcoded a light background and stayed light in dark mode on Vue SPA pages. It now uses `var(--p-content-background)` (and a theme-aware top border).

---

Most changes are CSS/behavior on screens without unit-test coverage; these were verified visually in the running app (light and dark themes).

## Notes for reviewers

- `OnmsIconButton` is the recommended pattern for future icon-only buttons.
- `text` + `outlined` on a Button is a slightly contradictory combination we chose to keep for now (the global border rule makes it render correctly); revisit if/when Cancel buttons move to a dedicated seam/wrapper component.
- `SnmpDataCollectionSourceDetail`'s "Source" field was intentionally left as an inline detail row (not wrapped in `FormField`) so it stays consistent with its sibling read-only fields; the global 3rem height already applies to it.


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20033
