### PR TITLE
NMS-20055: Fix rest endpoints that expose protected fields

### DIFF
--- a/opennms-web-api/src/main/java/org/opennms/web/api/RestUtils.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/RestUtils.java
@@ -30,7 +30,11 @@ package org.opennms.web.api;
 
 import java.beans.PropertyEditor;
 import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -49,6 +53,15 @@ import org.springframework.beans.PropertyAccessorFactory;
 public abstract class RestUtils {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RestUtils.class);
+
+	/**
+	 * Properties that must never be set from client-supplied request parameters via a blind
+	 * bean-property copy: primary keys and the category access-control collection. Setting
+	 * these through a generic update is a mass-assignment / privilege-escalation vector, so
+	 * they are always ignored here regardless of the caller.
+	 */
+	public static final Set<String> IMMUTABLE_PROPERTIES = Collections.unmodifiableSet(
+	        new HashSet<>(Arrays.asList("id", "nodeId", "authorizedGroups")));
 
 	/**
 	 * <p>Use Spring's {@link PropertyAccessorFactory} to set values on the specified bean.
@@ -75,6 +88,10 @@ public abstract class RestUtils {
 	    wrapper.registerCustomEditor(PrimaryType.class, new PrimaryTypeEditor());
 	    for(final String key : properties.keySet()) {
 	        final String propertyName = convertNameToPropertyName(key);
+	        if (IMMUTABLE_PROPERTIES.contains(propertyName)) {
+	            LOG.warn("Ignoring attempt to set protected property '{}' from request parameters", propertyName);
+	            continue;
+	        }
 	        if (wrapper.isWritableProperty(propertyName)) {
 	            final String stringValue = properties.getFirst(key);
 	            Object value = convertIfNecessary(wrapper, propertyName, stringValue);

--- a/opennms-web-api/src/main/java/org/opennms/web/api/RestUtils.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/RestUtils.java
@@ -55,10 +55,8 @@ public abstract class RestUtils {
 	private static final Logger LOG = LoggerFactory.getLogger(RestUtils.class);
 
 	/**
-	 * Properties that must never be set from client-supplied request parameters via a blind
-	 * bean-property copy: primary keys and the category access-control collection. Setting
-	 * these through a generic update is a mass-assignment / privilege-escalation vector, so
-	 * they are always ignored here regardless of the caller.
+	 * Primary keys and the category access-control collection: never settable from request
+	 * parameters, for any caller.
 	 */
 	public static final Set<String> IMMUTABLE_PROPERTIES = Collections.unmodifiableSet(
 	        new HashSet<>(Arrays.asList("id", "nodeId", "authorizedGroups")));
@@ -80,6 +78,15 @@ public abstract class RestUtils {
 	 * @param properties
 	 */
 	public static void setBeanProperties(final Object bean, final MultivaluedMap<String,String> properties) {
+	    setBeanProperties(bean, properties, Collections.emptySet());
+	}
+
+	/**
+	 * As {@link #setBeanProperties(Object, MultivaluedMap)}, with additional protected property
+	 * names. Matching is done on the normalized name, so key variants such as
+	 * {@code foreign_source} are covered, not just the exact spelling.
+	 */
+	public static void setBeanProperties(final Object bean, final MultivaluedMap<String,String> properties, final Set<String> additionalProtectedProperties) {
 	    final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(bean);
 	    wrapper.registerCustomEditor(XMLGregorianCalendar.class, new StringXmlCalendarPropertyEditor());
 	    wrapper.registerCustomEditor(Date.class, new ISO8601DateEditor());
@@ -88,7 +95,7 @@ public abstract class RestUtils {
 	    wrapper.registerCustomEditor(PrimaryType.class, new PrimaryTypeEditor());
 	    for(final String key : properties.keySet()) {
 	        final String propertyName = convertNameToPropertyName(key);
-	        if (IMMUTABLE_PROPERTIES.contains(propertyName)) {
+	        if (IMMUTABLE_PROPERTIES.contains(propertyName) || additionalProtectedProperties.contains(propertyName)) {
 	            LOG.warn("Ignoring attempt to set protected property '{}' from request parameters", propertyName);
 	            continue;
 	        }

--- a/opennms-web-api/src/main/java/org/opennms/web/api/RestUtils.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/RestUtils.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -54,12 +55,66 @@ public abstract class RestUtils {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RestUtils.class);
 
-	/**
-	 * Primary keys and the category access-control collection: never settable from request
-	 * parameters, for any caller.
-	 */
+	/** Nested ('.') and indexed ('[', ']') separators in a Spring bean property path. */
+	private static final Pattern PROPERTY_PATH_SEPARATOR = Pattern.compile("[.\\[\\]]");
+
+	/** Primary keys and the category ACL collection: never settable from request parameters. */
 	public static final Set<String> IMMUTABLE_PROPERTIES = Collections.unmodifiableSet(
 	        new HashSet<>(Arrays.asList("id", "nodeId", "authorizedGroups")));
+
+	/** Node identity and provisioning-ownership properties. */
+	public static final Set<String> PROTECTED_NODE_PROPERTIES = Collections.unmodifiableSet(
+	        new HashSet<>(Arrays.asList("foreignSource", "foreignId", "type")));
+
+	/** Applied unless a caller opts out, so a new endpoint is covered without wiring a guard. */
+	private static final Set<String> DEFAULT_PROTECTED_PROPERTIES;
+	static {
+	    final Set<String> defaults = new HashSet<>(IMMUTABLE_PROPERTIES);
+	    defaults.addAll(PROTECTED_NODE_PROPERTIES);
+	    DEFAULT_PROTECTED_PROPERTIES = Collections.unmodifiableSet(defaults);
+	}
+
+	/**
+	 * Whether a request parameter name resolves to a property protected by default, including via
+	 * a key variant ({@code foreign_source}) or traversal ({@code asset_record.node.foreign_source}).
+	 */
+	public static boolean isProtectedProperty(final String key) {
+	    return pathReachesProperty(key, DEFAULT_PROTECTED_PROPERTIES);
+	}
+
+	/** As {@link #isProtectedProperty(String)}, plus names protected for this endpoint only. */
+	public static boolean isProtectedProperty(final String key, final Set<String> additionalProtectedProperties) {
+	    return isProtectedProperty(key) || pathReachesProperty(key, additionalProtectedProperties);
+	}
+
+	/** As {@link #isProtectedProperty}, for endpoints that reject the request outright. */
+	public static boolean containsProperty(final MultivaluedMap<String,String> properties, final String propertyName) {
+	    final Set<String> wanted = Collections.singleton(propertyName);
+	    for (final String key : properties.keySet()) {
+	        if (pathReachesProperty(key, wanted)) {
+	            return true;
+	        }
+	    }
+	    return false;
+	}
+
+	/**
+	 * Callers bind either the raw key or the normalized one, and normalization is not
+	 * case-preserving, so both spellings are compared ignoring case. BeanWrapper resolves nested
+	 * and indexed paths, hence the per-segment check.
+	 */
+	private static boolean pathReachesProperty(final String key, final Set<String> propertyNames) {
+	    for (final String path : new String[] { key, convertNameToPropertyName(key) }) {
+	        for (final String segment : PROPERTY_PATH_SEPARATOR.split(path)) {
+	            for (final String propertyName : propertyNames) {
+	                if (propertyName.equalsIgnoreCase(segment)) {
+	                    return true;
+	                }
+	            }
+	        }
+	    }
+	    return false;
+	}
 
 	/**
 	 * <p>Use Spring's {@link PropertyAccessorFactory} to set values on the specified bean.
@@ -74,19 +129,32 @@ public abstract class RestUtils {
 	 * <li>{@link PrimaryTypeEditor}</li>
 	 * </ul>
 	 * 
+	 * <p>Properties protected by {@link #isProtectedProperty(String)} are ignored.</p>
+	 *
 	 * @param bean
 	 * @param properties
 	 */
 	public static void setBeanProperties(final Object bean, final MultivaluedMap<String,String> properties) {
-	    setBeanProperties(bean, properties, Collections.emptySet());
+	    applyProperties(bean, properties, DEFAULT_PROTECTED_PROPERTIES);
+	}
+
+	/** As {@link #setBeanProperties(Object, MultivaluedMap)}, plus endpoint-specific names. */
+	public static void setBeanProperties(final Object bean, final MultivaluedMap<String,String> properties, final Set<String> additionalProtectedProperties) {
+	    final Set<String> protectedProperties = new HashSet<>(DEFAULT_PROTECTED_PROPERTIES);
+	    protectedProperties.addAll(additionalProtectedProperties);
+	    applyProperties(bean, properties, protectedProperties);
 	}
 
 	/**
-	 * As {@link #setBeanProperties(Object, MultivaluedMap)}, with additional protected property
-	 * names. Matching is done on the normalized name, so key variants such as
-	 * {@code foreign_source} are covered, not just the exact spelling.
+	 * For provisioning requisitions only, where {@code foreignSource}/{@code foreignId} identify
+	 * the requisition and so are legitimately settable. Enforces {@link #IMMUTABLE_PROPERTIES}
+	 * alone; use {@link #setBeanProperties(Object, MultivaluedMap)} for anything node-reachable.
 	 */
-	public static void setBeanProperties(final Object bean, final MultivaluedMap<String,String> properties, final Set<String> additionalProtectedProperties) {
+	public static void setRequisitionProperties(final Object bean, final MultivaluedMap<String,String> properties) {
+	    applyProperties(bean, properties, IMMUTABLE_PROPERTIES);
+	}
+
+	private static void applyProperties(final Object bean, final MultivaluedMap<String,String> properties, final Set<String> protectedProperties) {
 	    final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(bean);
 	    wrapper.registerCustomEditor(XMLGregorianCalendar.class, new StringXmlCalendarPropertyEditor());
 	    wrapper.registerCustomEditor(Date.class, new ISO8601DateEditor());
@@ -95,7 +163,7 @@ public abstract class RestUtils {
 	    wrapper.registerCustomEditor(PrimaryType.class, new PrimaryTypeEditor());
 	    for(final String key : properties.keySet()) {
 	        final String propertyName = convertNameToPropertyName(key);
-	        if (IMMUTABLE_PROPERTIES.contains(propertyName) || additionalProtectedProperties.contains(propertyName)) {
+	        if (pathReachesProperty(key, protectedProperties)) {
 	            LOG.warn("Ignoring attempt to set protected property '{}' from request parameters", propertyName);
 	            continue;
 	        }

--- a/opennms-web-api/src/main/java/org/opennms/web/api/RestUtils.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/RestUtils.java
@@ -60,13 +60,13 @@ public abstract class RestUtils {
 
 	/** Primary keys and the category ACL collection: never settable from request parameters. */
 	public static final Set<String> IMMUTABLE_PROPERTIES = Collections.unmodifiableSet(
-	        new HashSet<>(Arrays.asList("id", "nodeId", "authorizedGroups")));
+	        new HashSet<>(Arrays.asList("id", "dbId", "nodeId", "authorizedGroups")));
 
 	/** Node identity and provisioning-ownership properties. */
 	public static final Set<String> PROTECTED_NODE_PROPERTIES = Collections.unmodifiableSet(
 	        new HashSet<>(Arrays.asList("foreignSource", "foreignId", "type")));
 
-	/** Applied unless a caller opts out, so a new endpoint is covered without wiring a guard. */
+	/** Enforced for every caller that does not explicitly opt out. */
 	private static final Set<String> DEFAULT_PROTECTED_PROPERTIES;
 	static {
 	    final Set<String> defaults = new HashSet<>(IMMUTABLE_PROPERTIES);

--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultRequisitionAccessService.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultRequisitionAccessService.java
@@ -234,7 +234,7 @@ public class DefaultRequisitionAccessService implements RequisitionAccessService
             final Requisition req = getActiveRequisition(false);
             if (req != null) {
                 req.updateDateStamp();
-                RestUtils.setBeanProperties(req, params);
+                RestUtils.setRequisitionProperties(req, params);
                 save(req);
                 LOG.debug("updateRequisition: Requisition with foreign source {} updated", foreignSource);
             }
@@ -249,7 +249,7 @@ public class DefaultRequisitionAccessService implements RequisitionAccessService
                 final RequisitionNode node = req.getNode(foreignId);
                 if (node != null) {
                     req.updateDateStamp();
-                    RestUtils.setBeanProperties(node, params);
+                    RestUtils.setRequisitionProperties(node, params);
                     save(req);
                     LOG.debug("updateNode: Node with foreign source {} and foreign id {} updated", foreignSource, foreignId);
                 }
@@ -267,7 +267,7 @@ public class DefaultRequisitionAccessService implements RequisitionAccessService
                     final RequisitionInterface iface = node.getInterface(ipAddress);
                     if (iface != null) {
                         req.updateDateStamp();
-                        RestUtils.setBeanProperties(iface, params);
+                        RestUtils.setRequisitionProperties(iface, params);
                         save(req);
                         LOG.debug("updateInterface: Interface {} on node {}/{} updated", ipAddress, foreignSource, foreignId);
                     }

--- a/opennms-web-api/src/test/java/org/opennms/web/api/RestUtilsTest.java
+++ b/opennms-web-api/src/test/java/org/opennms/web/api/RestUtilsTest.java
@@ -79,7 +79,7 @@ public class RestUtilsTest {
         assertTrue(isProtected("metaData[foreign_source]"));
     }
 
-    /** Endpoints that never wire a guard are still covered, e.g. via a node back-reference. */
+    /** Node properties are protected even when the caller passes no extra names of its own. */
     @Test
     public void nodePropertiesAreProtectedByDefault() {
         assertTrue(RestUtils.isProtectedProperty("node.foreign_source"));

--- a/opennms-web-api/src/test/java/org/opennms/web/api/RestUtilsTest.java
+++ b/opennms-web-api/src/test/java/org/opennms/web/api/RestUtilsTest.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.junit.Test;
+
+public class RestUtilsTest {
+
+    private static boolean isProtected(final String key) {
+        return RestUtils.isProtectedProperty(key);
+    }
+
+    @Test
+    public void protectsExactPropertyNames() {
+        assertTrue(isProtected("id"));
+        assertTrue(isProtected("nodeId"));
+        assertTrue(isProtected("authorizedGroups"));
+        assertTrue(isProtected("foreignSource"));
+        assertTrue(isProtected("foreignId"));
+        assertTrue(isProtected("type"));
+    }
+
+    /** Request keys are normalized before binding, so separator forms must be covered. */
+    @Test
+    public void protectsSeparatorAndCaseVariants() {
+        assertTrue(isProtected("foreign_source"));
+        assertTrue(isProtected("foreign-source"));
+        assertTrue(isProtected("Foreign_Source"));
+        assertTrue(isProtected("FOREIGNSOURCE"));
+        assertTrue(isProtected("Type"));
+        assertTrue(isProtected("authorized_groups"));
+        assertTrue(isProtected("node_id"));
+    }
+
+    /** Spring's BeanWrapper resolves nested and indexed paths, which must not reach a protected property. */
+    @Test
+    public void protectsNestedAndIndexedPaths() {
+        assertTrue(isProtected("assetRecord.node.foreignSource"));
+        assertTrue(isProtected("asset_record.node.foreign_source"));
+        assertTrue(isProtected("node.foreignId"));
+        assertTrue(isProtected("assetRecord.id"));
+        assertTrue(isProtected("categories[0].authorizedGroups"));
+        assertTrue(isProtected("metaData[foreignSource]"));
+        assertTrue(isProtected("metaData[foreign_source]"));
+    }
+
+    /** Endpoints that never wire a guard are still covered, e.g. via a node back-reference. */
+    @Test
+    public void nodePropertiesAreProtectedByDefault() {
+        assertTrue(RestUtils.isProtectedProperty("node.foreign_source"));
+        assertTrue(RestUtils.isProtectedProperty("ipInterface.node.foreignId"));
+        assertTrue(RestUtils.isProtectedProperty("foreignSource"));
+    }
+
+    @Test
+    public void allowsOrdinaryProperties() {
+        assertFalse(isProtected("sysContact"));
+        assertFalse(isProtected("sys_contact"));
+        assertFalse(isProtected("label"));
+        assertFalse(isProtected("assetRecord.manufacturer"));
+        assertFalse(isProtected("asset_record.operating_system"));
+        assertFalse(isProtected("description"));
+    }
+
+    /** End-to-end: a protected property is refused while an ordinary one is written. */
+    @Test
+    public void setBeanPropertiesRefusesProtectedWrites() {
+        final Bean bean = new Bean();
+        final MultivaluedMap<String,String> params = new MultivaluedHashMap<>();
+        params.putSingle("label", "legit");
+        params.putSingle("foreign_source", "AttackerReq");
+        params.putSingle("id", "999");
+        RestUtils.setBeanProperties(bean, params);
+
+        assertEquals("legit", bean.getLabel());
+        assertNull("foreignSource must not be written", bean.getForeignSource());
+        assertNull("id must not be written", bean.getId());
+    }
+
+    /** Provisioning legitimately sets foreignSource/foreignId, so it opts out of those. */
+    @Test
+    public void requisitionPropertiesAllowForeignSourceButNotPrimaryKeys() {
+        final Bean bean = new Bean();
+        final MultivaluedMap<String,String> params = new MultivaluedHashMap<>();
+        params.putSingle("foreign_source", "MyRequisition");
+        params.putSingle("id", "999");
+        RestUtils.setRequisitionProperties(bean, params);
+
+        assertEquals("MyRequisition", bean.getForeignSource());
+        assertNull("id is immutable even for requisitions", bean.getId());
+    }
+
+    public static class Bean {
+        private String label;
+        private String foreignSource;
+        private Integer id;
+        public String getLabel() { return label; }
+        public void setLabel(String label) { this.label = label; }
+        public String getForeignSource() { return foreignSource; }
+        public void setForeignSource(String foreignSource) { this.foreignSource = foreignSource; }
+        public Integer getId() { return id; }
+        public void setId(Integer id) { this.id = id; }
+    }
+
+    @Test
+    public void containsPropertyMatchesVariantsAndPaths() {
+        assertTrue(RestUtils.containsProperty(params("ifIndex"), "ifIndex"));
+        assertTrue(RestUtils.containsProperty(params("if_index"), "ifIndex"));
+        assertTrue(RestUtils.containsProperty(params("IfIndex"), "ifIndex"));
+        assertTrue(RestUtils.containsProperty(params("node.ifIndex"), "ifIndex"));
+        assertTrue(RestUtils.containsProperty(params("Name"), "name"));
+        assertTrue(RestUtils.containsProperty(params("ip_address"), "ipAddress"));
+
+        assertFalse(RestUtils.containsProperty(params("ifDescr"), "ifIndex"));
+        assertFalse(RestUtils.containsProperty(params("description"), "name"));
+    }
+
+    private static MultivaluedMap<String,String> params(final String key) {
+        final MultivaluedMap<String,String> params = new MultivaluedHashMap<>();
+        params.putSingle(key, "value");
+        return params;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
@@ -52,6 +52,7 @@ import org.opennms.netmgt.model.OnmsGeolocation;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.web.api.ISO8601DateEditor;
+import org.opennms.web.api.RestUtils;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,6 +126,10 @@ public class AssetRecordResource extends OnmsRestService {
         BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(assetRecord);
         wrapper.registerCustomEditor(Date.class, new ISO8601DateEditor());
         for(String key : params.keySet()) {
+            if (RestUtils.isProtectedProperty(key)) {
+                LOG.warn("updateAssetRecord: ignoring attempt to set protected property '{}'", key);
+                continue;
+            }
             if (wrapper.isWritableProperty(key)) {
                 String stringValue = params.getFirst(key);
                 Object value = wrapper.convertIfNecessary(stringValue, (Class<?>)wrapper.getPropertyType(key));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
@@ -110,7 +110,7 @@ public class CategoryRestService extends OnmsRestService {
             BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(category);
             boolean modified = false;
             for(String key : params.keySet()) {
-                if (RestUtils.IMMUTABLE_PROPERTIES.contains(key)) {
+                if (RestUtils.isProtectedProperty(key)) {
                     LOG.warn("updateCategory: ignoring attempt to set protected property '{}'", key);
                     continue;
                 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.UriInfo;
 import org.opennms.netmgt.dao.api.CategoryDao;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsCategoryCollection;
+import org.opennms.web.api.RestUtils;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,6 +110,10 @@ public class CategoryRestService extends OnmsRestService {
             BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(category);
             boolean modified = false;
             for(String key : params.keySet()) {
+                if (RestUtils.IMMUTABLE_PROPERTIES.contains(key)) {
+                    LOG.warn("updateCategory: ignoring attempt to set protected property '{}'", key);
+                    continue;
+                }
                 if (wrapper.isWritableProperty(key)) {
                     String stringValue = params.getFirst(key);
                     Object value = wrapper.convertIfNecessary(stringValue, (Class<?>)wrapper.getPropertyType(key));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -97,8 +97,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class NodeRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
 
-    // Provisioning-ownership and identity fields that must not be reassigned through a
-    // generic property update (would allow requisition takeover / node detach / soft-delete).
     private static final Set<String> PROTECTED_NODE_PROPERTIES =
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList("foreignSource", "foreignId", "type")));
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -29,8 +29,10 @@
 package org.opennms.web.rest.v1;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -72,6 +74,7 @@ import org.opennms.netmgt.model.OnmsNodeList;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.netmgt.xml.event.Event;
+import org.opennms.web.api.RestUtils;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,6 +96,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Path("nodes")
 public class NodeRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
+
+    // Provisioning-ownership and identity fields that must not be reassigned through a
+    // generic property update (would allow requisition takeover / node detach / soft-delete).
+    private static final Set<String> PROTECTED_NODE_PROPERTIES =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("foreignSource", "foreignId", "type")));
 
     @Autowired
     private MonitoringLocationDao m_locationDao;
@@ -294,6 +302,10 @@ public class NodeRestService extends OnmsRestService {
             boolean modified = false;
             final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(node);
             for(final String key : params.keySet()) {
+                if (RestUtils.IMMUTABLE_PROPERTIES.contains(key) || PROTECTED_NODE_PROPERTIES.contains(key)) {
+                    LOG.warn("updateNode: ignoring attempt to set protected property '{}'", key);
+                    continue;
+                }
                 if (wrapper.isWritableProperty(key)) {
                     final String stringValue = params.getFirst(key);
                     final Object value = wrapper.convertIfNecessary(stringValue, (Class<?>)wrapper.getPropertyType(key));
@@ -467,6 +479,10 @@ public class NodeRestService extends OnmsRestService {
             BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(category);
             boolean updated = false;
             for(String key : params.keySet()) {
+                if (RestUtils.IMMUTABLE_PROPERTIES.contains(key) || "name".equals(key)) {
+                    LOG.warn("updateCategoryForNode: ignoring attempt to set protected property '{}'", key);
+                    continue;
+                }
                 if (wrapper.isWritableProperty(key)) {
                     String stringValue = params.getFirst(key);
                     Object value = wrapper.convertIfNecessary(stringValue, (Class<?>)wrapper.getPropertyType(key));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -29,10 +29,8 @@
 package org.opennms.web.rest.v1;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -96,9 +94,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Path("nodes")
 public class NodeRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
-
-    private static final Set<String> PROTECTED_NODE_PROPERTIES =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("foreignSource", "foreignId", "type")));
 
     @Autowired
     private MonitoringLocationDao m_locationDao;
@@ -300,7 +295,7 @@ public class NodeRestService extends OnmsRestService {
             boolean modified = false;
             final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(node);
             for(final String key : params.keySet()) {
-                if (RestUtils.IMMUTABLE_PROPERTIES.contains(key) || PROTECTED_NODE_PROPERTIES.contains(key)) {
+                if (RestUtils.isProtectedProperty(key)) {
                     LOG.warn("updateNode: ignoring attempt to set protected property '{}'", key);
                     continue;
                 }
@@ -477,7 +472,7 @@ public class NodeRestService extends OnmsRestService {
             BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(category);
             boolean updated = false;
             for(String key : params.keySet()) {
-                if (RestUtils.IMMUTABLE_PROPERTIES.contains(key) || "name".equals(key)) {
+                if (RestUtils.isProtectedProperty(key, Collections.singleton("name"))) {
                     LOG.warn("updateCategoryForNode: ignoring attempt to set protected property '{}'", key);
                     continue;
                 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsIpInterfaceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsIpInterfaceResource.java
@@ -59,6 +59,7 @@ import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.api.RestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanWrapper;
@@ -206,6 +207,10 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
             for(final String key : params.keySet()) {
                 // skip nodeId since we already know the node this is associated with and don't want to overwrite it
                 if ("nodeId".equals(key)) {
+                    continue;
+                }
+                if (RestUtils.isProtectedProperty(key)) {
+                    LOG.warn("Ignoring attempt to set protected property '{}'", key);
                     continue;
                 }
                 if (wrapper.isWritableProperty(key)) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsMonitoredServiceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsMonitoredServiceResource.java
@@ -59,6 +59,7 @@ import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.api.RestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanWrapper;
@@ -226,6 +227,10 @@ public class OnmsMonitoredServiceResource extends OnmsRestService {
             boolean modified = false;
             BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(service);
             for(String key : params.keySet()) {
+                if (RestUtils.isProtectedProperty(key)) {
+                    LOG.warn("Ignoring attempt to set protected property '{}'", key);
+                    continue;
+                }
                 if (wrapper.isWritableProperty(key)) {
                     String stringValue = params.getFirst(key);
                     Object value = wrapper.convertIfNecessary(stringValue, (Class<?>)wrapper.getPropertyType(key));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsSnmpInterfaceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsSnmpInterfaceResource.java
@@ -57,6 +57,7 @@ import org.opennms.netmgt.model.OnmsSnmpInterfaceList;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.api.RestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanWrapper;
@@ -232,6 +233,10 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
                 // don't try setting ipinterface data
                 if ("ipInterface".equals(key) || "ipInterfaces".equals(key)) continue;
 
+                if (RestUtils.isProtectedProperty(key)) {
+                    LOG.warn("Ignoring attempt to set protected property '{}'", key);
+                    continue;
+                }
                 if (wrapper.isWritableProperty(key)) {
                     final String stringValue = params.getFirst(key);
                     final Object value = wrapper.convertIfNecessary(stringValue, (Class<?>)wrapper.getPropertyType(key));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
@@ -80,7 +80,6 @@ import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.events.api.EventProxyException;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.web.api.ISO8601DateEditor;
-import org.opennms.web.api.RestUtils;
 import org.opennms.web.rest.support.CriteriaBehavior;
 import org.opennms.web.rest.support.CriteriaBuilderSearchVisitor;
 import org.opennms.web.rest.support.DateCollection;
@@ -475,8 +474,14 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
                 return Response.status(Status.NOT_FOUND).build();
             }
             for (T object : objects) {
-                RestUtils.setBeanProperties(object, params);
-                doUpdateProperties(securityContext, uriInfo, object, params);
+                // Delegate to the service's doUpdateProperties (the single-id path does the
+                // same). We must NOT blindly copy request params onto the entity here: that
+                // was a mass-assignment vector that mutated arbitrary fields even for
+                // services whose doUpdateProperties is not implemented.
+                final Response response = doUpdateProperties(securityContext, uriInfo, object, params);
+                if (response != null && response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+                    return response;
+                }
             }
             return Response.noContent().build();
         } finally {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
@@ -474,14 +474,9 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
                 return Response.status(Status.NOT_FOUND).build();
             }
             for (T object : objects) {
-                // Delegate to the service's doUpdateProperties (the single-id path does the
-                // same). We must NOT blindly copy request params onto the entity here: that
-                // was a mass-assignment vector that mutated arbitrary fields even for
-                // services whose doUpdateProperties is not implemented.
-                final Response response = doUpdateProperties(securityContext, uriInfo, object, params);
-                if (response != null && response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-                    return response;
-                }
+                // Applying the params is doUpdateProperties' responsibility; do not copy them
+                // onto the entity here.
+                doUpdateProperties(securityContext, uriInfo, object, params);
             }
             return Response.noContent().build();
         } finally {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
@@ -476,7 +476,15 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
             for (T object : objects) {
                 // Applying the params is doUpdateProperties' responsibility; do not copy them
                 // onto the entity here.
-                doUpdateProperties(securityContext, uriInfo, object, params);
+                final Response response = doUpdateProperties(securityContext, uriInfo, object, params);
+                // A non-error status such as 304 Not Modified just means this item was unchanged.
+                if (response != null) {
+                    final Response.Status.Family family = response.getStatusInfo().getFamily();
+                    if (family == Response.Status.Family.CLIENT_ERROR || family == Response.Status.Family.SERVER_ERROR) {
+                        // Throw, not return: transactional, and earlier items may be modified.
+                        throw new WebApplicationException(response);
+                    }
+                }
             }
             return Response.noContent().build();
         } finally {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
@@ -474,10 +474,9 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
                 return Response.status(Status.NOT_FOUND).build();
             }
             for (T object : objects) {
-                // Applying the params is doUpdateProperties' responsibility; do not copy them
-                // onto the entity here.
+                // Applying the params to the entity is doUpdateProperties' responsibility.
                 final Response response = doUpdateProperties(securityContext, uriInfo, object, params);
-                // A non-error status such as 304 Not Modified just means this item was unchanged.
+                // A non-error status such as 304 Not Modified means this item was unchanged.
                 if (response != null) {
                     final Response.Status.Family family = response.getStatusInfo().getFamily();
                     if (family == Response.Status.Family.CLIENT_ERROR || family == Response.Status.Family.SERVER_ERROR) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
@@ -144,7 +144,7 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
 
     @Override
     protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsCategory targetObject, MultivaluedMapImpl params) {
-        if (params.getFirst("name") != null) {
+        if (RestUtils.containsProperty(params, "name")) {
             throw getException(Status.BAD_REQUEST, "Cannot rename category.");
         }
         RestUtils.setBeanProperties(targetObject, params);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
@@ -149,7 +149,7 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
 
     @Override
     protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsIpInterface targetObject, MultivaluedMapImpl params) {
-        if (params.getFirst("ipAddress") != null) {
+        if (RestUtils.containsProperty(params, "ipAddress")) {
             throw getException(Status.BAD_REQUEST, "Cannot change the IP address.");
         }
         RestUtils.setBeanProperties(targetObject, params);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -94,8 +94,6 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
 
-    private static final Set<String> PROTECTED_NODE_PROPERTIES = Set.of("foreignSource", "foreignId", "type");
-
     @Autowired
     private MonitoringLocationDao m_locationDao;
 
@@ -237,7 +235,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
 
     @Override
     protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsNode targetObject, MultivaluedMapImpl params) {
-        RestUtils.setBeanProperties(targetObject, params, PROTECTED_NODE_PROPERTIES);
+        RestUtils.setBeanProperties(targetObject, params);
         getDao().update(targetObject);
         return Response.noContent().build();
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -94,6 +94,8 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
 
+    private static final Set<String> PROTECTED_NODE_PROPERTIES = Set.of("foreignSource", "foreignId", "type");
+
     @Autowired
     private MonitoringLocationDao m_locationDao;
 
@@ -235,13 +237,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
 
     @Override
     protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsNode targetObject, MultivaluedMapImpl params) {
-        // Provisioning-ownership / identity fields must not be reassigned through a generic
-        // property update (requisition takeover / node detach / soft-delete). Primary keys and
-        // ACL fields are additionally handled centrally by RestUtils.setBeanProperties.
-        params.remove("foreignSource");
-        params.remove("foreignId");
-        params.remove("type");
-        RestUtils.setBeanProperties(targetObject, params);
+        RestUtils.setBeanProperties(targetObject, params, PROTECTED_NODE_PROPERTIES);
         getDao().update(targetObject);
         return Response.noContent().build();
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -235,6 +235,12 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
 
     @Override
     protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsNode targetObject, MultivaluedMapImpl params) {
+        // Provisioning-ownership / identity fields must not be reassigned through a generic
+        // property update (requisition takeover / node detach / soft-delete). Primary keys and
+        // ACL fields are additionally handled centrally by RestUtils.setBeanProperties.
+        params.remove("foreignSource");
+        params.remove("foreignId");
+        params.remove("type");
         RestUtils.setBeanProperties(targetObject, params);
         getDao().update(targetObject);
         return Response.noContent().build();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeSnmpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeSnmpInterfacesRestService.java
@@ -110,7 +110,7 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
 
     @Override
     protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsSnmpInterface targetObject, MultivaluedMapImpl params) {
-        if (params.getFirst("ifIndex") != null) {
+        if (RestUtils.containsProperty(params, "ifIndex")) {
             throw getException(Status.BAD_REQUEST, "Cannot change ifIndex.");
         }
         RestUtils.setBeanProperties(targetObject, params);

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/CategoryRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/CategoryRestServiceIT.java
@@ -47,6 +47,7 @@ import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
 import org.opennms.core.xml.JaxbUtils;
+import org.opennms.netmgt.dao.api.CategoryDao;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsCategoryCollection;
 import org.opennms.test.JUnitConfigurationEnvironment;
@@ -55,6 +56,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @WebAppConfiguration
@@ -81,6 +83,31 @@ public class CategoryRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
     @Autowired
     private ServletContext m_servletContext;
+
+    @Autowired
+    private CategoryDao m_categoryDao;
+
+    /**
+     * Regression guard for the mass-assignment fix. updateCategory (PUT /categories/{name})
+     * must ignore the access-control field authorizedGroups (the field that drives the
+     * category ACL filter), while still allowing legitimate fields like description. A
+     * ROLE_REST user can no longer grant their own group access to a category.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    @Transactional
+    public void updateCategoryCannotWriteAuthorizedGroups() throws Exception {
+        createCategory("AclTest");
+        setUser("lowpriv", new String[]{ "ROLE_REST" });
+        // description (benign) alongside authorizedGroups (protected) in the same request
+        sendPut("/categories/AclTest", "description=legit&authorizedGroups=AttackerGroup", 204);
+
+        final OnmsCategory reloaded = m_categoryDao.findByName("AclTest");
+        assertNotNull(reloaded);
+        assertFalse("authorizedGroups must not be mass-assignable via updateCategory",
+                reloaded.getAuthorizedGroups().contains("AttackerGroup"));
+        assertEquals("legit", reloaded.getDescription());
+    }
 
     @Override
     protected void afterServletStart() throws Exception {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/CategoryRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/CategoryRestServiceIT.java
@@ -88,10 +88,8 @@ public class CategoryRestServiceIT extends AbstractSpringJerseyRestTestCase {
     private CategoryDao m_categoryDao;
 
     /**
-     * Regression guard for the mass-assignment fix. updateCategory (PUT /categories/{name})
-     * must ignore the access-control field authorizedGroups (the field that drives the
-     * category ACL filter), while still allowing legitimate fields like description. A
-     * ROLE_REST user can no longer grant their own group access to a category.
+     * updateCategory must ignore authorizedGroups (it drives the category ACL filter) while
+     * still applying ordinary fields.
      */
     @Test
     @JUnitTemporaryDatabase
@@ -99,7 +97,6 @@ public class CategoryRestServiceIT extends AbstractSpringJerseyRestTestCase {
     public void updateCategoryCannotWriteAuthorizedGroups() throws Exception {
         createCategory("AclTest");
         setUser("lowpriv", new String[]{ "ROLE_REST" });
-        // description (benign) alongside authorizedGroups (protected) in the same request
         sendPut("/categories/AclTest", "description=legit&authorizedGroups=AttackerGroup", 204);
 
         final OnmsCategory reloaded = m_categoryDao.findByName("AclTest");

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -320,6 +320,24 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         m_mockEventIpcManager.getEventAnticipator().verifyAnticipated();
     }
 
+    /**
+     * Regression guard for the mass-assignment fix. updateNode (PUT /nodes/{id}) must ignore
+     * provisioning-ownership fields (foreignSource/foreignId/type) while still allowing
+     * legitimate fields like sysContact. A ROLE_REST user can no longer reassign a node's
+     * provisioning ownership (requisition takeover / detach primitive).
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    public void updateNodeCannotReassignForeignSource() throws Exception {
+        createNode();
+        setUser("lowpriv", new String[]{ "ROLE_REST" });
+        // sysContact (benign) alongside foreignSource/foreignId (protected) in one request
+        sendPut("/nodes/1", "sysContact=LegitContact&foreignSource=AttackerReq&foreignId=999", 204);
+        final String xml = sendRequest(GET, "/nodes/1", 200);
+        assertFalse("foreignSource must not be reassignable via updateNode", xml.contains("AttackerReq"));
+        assertTrue("legitimate fields still update", xml.contains("LegitContact"));
+    }
+
     @Test
     @JUnitTemporaryDatabase
     public void testPutNodeAsset() throws Exception {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -341,6 +341,32 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     /**
+     * The v1 sub-resources bind the raw request key, so a camelCase nested path reaches the
+     * node. None of them may be a route to its protected properties or primary key.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    public void v1SubResourceUpdatesCannotReachNode() throws Exception {
+        createSnmpInterface(); // node 1 + ipInterface 10.10.10.10 + snmpInterface 6
+        final String service = "<service status=\"A\"><serviceType><name>ICMP</name></serviceType></service>";
+        sendPost("/nodes/1/ipinterfaces/10.10.10.10/services", service, 201,
+                "/nodes/1/ipinterfaces/10.10.10.10/services/ICMP");
+        setUser("lowpriv", new String[]{ "ROLE_REST" });
+
+        // each request carries one legitimate field, so a 204 shows the update ran and only the
+        // protected properties were dropped
+        final String attack = "&node.foreignSource=AttackerReq&node.id=999";
+        sendPut("/nodes/1/ipinterfaces/10.10.10.10", "isManaged=U" + attack, 204);
+        sendPut("/nodes/1/ipinterfaces/10.10.10.10/services/ICMP", "status=F" + attack, 204);
+        sendPut("/nodes/1/snmpinterfaces/6", "ifAlias=legit" + attack, 204);
+
+        final OnmsNode node = m_nodeDao.get(1);
+        assertNotNull("the node must still exist under its original id", node);
+        assertNull("foreignSource must not be reachable from a v1 sub-resource", node.getForeignSource());
+        assertEquals("the node's primary key must not be overwritten", Integer.valueOf(1), node.getId());
+    }
+
+    /**
      * The asset record holds a back-reference to its node, so the asset endpoint must not be a
      * route to the node's protected properties.
      */

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -328,10 +328,28 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     public void updateNodeCannotReassignForeignSource() throws Exception {
         createNode();
         setUser("lowpriv", new String[]{ "ROLE_REST" });
-        sendPut("/nodes/1", "sysContact=LegitContact&foreignSource=AttackerReq&foreignId=999", 204);
+        sendPut("/nodes/1", "sysContact=LegitContact&foreignSource=AttackerReq&foreignId=999"
+                + "&assetRecord.node.foreignSource=NestedReq", 204);
         final String xml = sendRequest(GET, "/nodes/1", 200);
         assertFalse("foreignSource must not be reassignable via updateNode", xml.contains("AttackerReq"));
+        assertFalse("foreignSource must not be reachable through a nested path", xml.contains("NestedReq"));
         assertTrue("legitimate fields still update", xml.contains("LegitContact"));
+    }
+
+    /**
+     * The asset record holds a back-reference to its node, so the asset endpoint must not be a
+     * route to the node's protected properties.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    public void updateAssetRecordCannotReachNodeForeignSource() throws Exception {
+        createNode();
+        setUser("lowpriv", new String[]{ "ROLE_REST" });
+        sendPut("/nodes/1/assetRecord", "description=LegitAsset&node.foreignSource=AttackerReq"
+                + "&node.foreign_source=AttackerReq2", 204);
+        assertTrue(sendRequest(GET, "/nodes/1/assetRecord", 200).contains("LegitAsset"));
+        final String xml = sendRequest(GET, "/nodes/1", 200);
+        assertFalse("node.foreignSource must not be settable via the asset endpoint", xml.contains("AttackerReq"));
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -321,17 +321,13 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     /**
-     * Regression guard for the mass-assignment fix. updateNode (PUT /nodes/{id}) must ignore
-     * provisioning-ownership fields (foreignSource/foreignId/type) while still allowing
-     * legitimate fields like sysContact. A ROLE_REST user can no longer reassign a node's
-     * provisioning ownership (requisition takeover / detach primitive).
+     * updateNode must ignore provisioning-ownership fields while still applying ordinary ones.
      */
     @Test
     @JUnitTemporaryDatabase
     public void updateNodeCannotReassignForeignSource() throws Exception {
         createNode();
         setUser("lowpriv", new String[]{ "ROLE_REST" });
-        // sysContact (benign) alongside foreignSource/foreignId (protected) in one request
         sendPut("/nodes/1", "sysContact=LegitContact&foreignSource=AttackerReq&foreignId=999", 204);
         final String xml = sendRequest(GET, "/nodes/1", 200);
         assertFalse("foreignSource must not be reassignable via updateNode", xml.contains("AttackerReq"));

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -31,6 +31,7 @@ package org.opennms.web.rest.v1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.opennms.core.test.xml.XmlTest.assertXpathMatches;
 
@@ -65,6 +66,7 @@ import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.core.xml.JaxbUtils;
+import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.model.OnmsCategory;
@@ -116,6 +118,9 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
     @Autowired
     private MockEventIpcManager m_mockEventIpcManager;
+
+    @Autowired
+    private NodeDao m_nodeDao;
 
     @Override
     protected void afterServletStart() throws Exception {
@@ -330,10 +335,9 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         setUser("lowpriv", new String[]{ "ROLE_REST" });
         sendPut("/nodes/1", "sysContact=LegitContact&foreignSource=AttackerReq&foreignId=999"
                 + "&assetRecord.node.foreignSource=NestedReq", 204);
-        final String xml = sendRequest(GET, "/nodes/1", 200);
-        assertFalse("foreignSource must not be reassignable via updateNode", xml.contains("AttackerReq"));
-        assertFalse("foreignSource must not be reachable through a nested path", xml.contains("NestedReq"));
-        assertTrue("legitimate fields still update", xml.contains("LegitContact"));
+        final OnmsNode updated = m_nodeDao.get(1);
+        assertNull("foreignSource must not be reassignable via updateNode", updated.getForeignSource());
+        assertEquals("legitimate fields still update", "LegitContact", updated.getSysContact());
     }
 
     /**
@@ -348,8 +352,8 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         sendPut("/nodes/1/assetRecord", "description=LegitAsset&node.foreignSource=AttackerReq"
                 + "&node.foreign_source=AttackerReq2", 204);
         assertTrue(sendRequest(GET, "/nodes/1/assetRecord", 200).contains("LegitAsset"));
-        final String xml = sendRequest(GET, "/nodes/1", 200);
-        assertFalse("node.foreignSource must not be settable via the asset endpoint", xml.contains("AttackerReq"));
+        assertNull("node.foreignSource must not be settable via the asset endpoint",
+                m_nodeDao.get(1).getForeignSource());
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/AlarmRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/AlarmRestServiceIT.java
@@ -688,21 +688,17 @@ public class AlarmRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     /**
-     * Regression guard for the mass-assignment fix. The inherited bulk-update endpoint
-     * (PUT /alarms -> updateMany in AbstractDaoRestServiceWithDTO) must NOT blindly copy
-     * request parameters onto matched entities; it now delegates only to doUpdateProperties.
-     * A ROLE_REST user sending a raw 'severity' field can no longer forge the alarm severity.
+     * The inherited bulk-update endpoint (PUT /alarms) must not let a raw 'severity' parameter
+     * forge the alarm severity.
      */
     @Test
     @JUnitTemporaryDatabase
     public void bulkUpdateCannotForgeAlarmSeverity() throws Exception {
         setUser("lowpriv", new String[]{ "ROLE_REST" });
-        // alarm1 was created MAJOR: no CLEARED alarm with this id
+        // alarm1 was created MAJOR
         executeQueryAndVerify("_s=alarm.id==" + alarm1.getId() + ";alarm.severity==CLEARED", 0);
-        // attempt to forge 'severity' via the bulk collection root
         sendRequest(PUT, "/alarms",
                 parseParamData("_s=alarm.id==" + alarm1.getId() + "&severity=CLEARED"), 204);
-        // severity is unchanged: the forged field was ignored
         executeQueryAndVerify("_s=alarm.id==" + alarm1.getId() + ";alarm.severity==CLEARED", 0);
     }
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/AlarmRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/AlarmRestServiceIT.java
@@ -687,6 +687,25 @@ public class AlarmRestServiceIT extends AbstractSpringJerseyRestTestCase {
         executeQueryAndVerify("_s=alarm.severity==CLEARED", 1);
     }
 
+    /**
+     * Regression guard for the mass-assignment fix. The inherited bulk-update endpoint
+     * (PUT /alarms -> updateMany in AbstractDaoRestServiceWithDTO) must NOT blindly copy
+     * request parameters onto matched entities; it now delegates only to doUpdateProperties.
+     * A ROLE_REST user sending a raw 'severity' field can no longer forge the alarm severity.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    public void bulkUpdateCannotForgeAlarmSeverity() throws Exception {
+        setUser("lowpriv", new String[]{ "ROLE_REST" });
+        // alarm1 was created MAJOR: no CLEARED alarm with this id
+        executeQueryAndVerify("_s=alarm.id==" + alarm1.getId() + ";alarm.severity==CLEARED", 0);
+        // attempt to forge 'severity' via the bulk collection root
+        sendRequest(PUT, "/alarms",
+                parseParamData("_s=alarm.id==" + alarm1.getId() + "&severity=CLEARED"), 204);
+        // severity is unchanged: the forged field was ignored
+        executeQueryAndVerify("_s=alarm.id==" + alarm1.getId() + ";alarm.severity==CLEARED", 0);
+    }
+
     private void anticipateEvent(EventBuilder eventBuilder) {
         m_eventMgr.getEventAnticipator().anticipateEvent(eventBuilder.getEvent());
     }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/MonitoringLocationRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/MonitoringLocationRestServiceIT.java
@@ -122,7 +122,7 @@ public class MonitoringLocationRestServiceIT extends AbstractSpringJerseyRestTes
 
     /**
      * This service does not implement a property update, so the bulk endpoint must report that
-     * rather than copying the parameters onto every matched row and answering 204.
+     * instead of reporting success.
      */
     @Test
     @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/MonitoringLocationRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/MonitoringLocationRestServiceIT.java
@@ -56,6 +56,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * TODO
@@ -117,6 +118,19 @@ public class MonitoringLocationRestServiceIT extends AbstractSpringJerseyRestTes
     public void testDelete() throws Exception {
         sendPost("/monitoringLocations", "<location location-name=\"Test\" monitoring-area=\"test\" priority=\"100\"/>", 201);
         sendRequest(DELETE, "/monitoringLocations/Test", 204);
+    }
+
+    /**
+     * This service does not implement a property update, so the bulk endpoint must report that
+     * rather than copying the parameters onto every matched row and answering 204.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    @Transactional
+    public void bulkUpdateDoesNotSilentlyReportSuccess() throws Exception {
+        sendPost("/monitoringLocations", "<location location-name=\"Test\" monitoring-area=\"test\" priority=\"100\"/>", 201);
+        sendRequest(PUT, "/monitoringLocations", parseParamData("monitoringArea=hijacked"), 501);
+        assertTrue(sendRequest(GET, "/monitoringLocations/Test", 200).contains("test"));
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -28,6 +28,7 @@
 
 package org.opennms.web.rest.v2;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -247,6 +248,33 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         category.put("name", "Production");
         sendData(POST, MediaType.APPLICATION_JSON, "/nodes/1/categories", category.toString(), 201);
         LOG.warn(sendRequest(GET, "/nodes/1/categories", 200));
+    }
+
+    /**
+     * The v2 node update must ignore provisioning-ownership fields, including key variants that
+     * a literal name check would miss.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    public void updateNodeCannotReassignProtectedFields() throws Exception {
+        final JSONObject node = new JSONObject();
+        node.put("type", "A");
+        node.put("label", "TestMachine1");
+        node.put("foreignSource", "JUnit");
+        node.put("foreignId", "TestMachine1");
+        node.put("location", "Default");
+        node.put("labelSource", "H");
+        node.put("sysName", "TestMachine1");
+        sendData(POST, MediaType.APPLICATION_JSON, "/nodes", node.toString(), 201);
+
+        // Keys are normalized before binding, so the separator form is what reaches a camelCase
+        // property (foreign_source -> foreignSource).
+        sendPut("/nodes/1", "sys_contact=LegitContact&foreign_source=AttackerReq&foreign_id=999&Type=D", 204);
+
+        final String xml = sendRequest(GET, "/nodes/1", 200); // still present -> Type=D was ignored
+        assertFalse("foreignSource must not be reassignable via update", xml.contains("AttackerReq"));
+        assertFalse("foreignId must not be reassignable via update", xml.contains("999"));
+        assertTrue("legitimate fields still update", xml.contains("LegitContact"));
     }
 
 }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -259,8 +259,8 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     /**
-     * The v2 node update must ignore provisioning-ownership fields, including key variants that
-     * a literal name check would miss.
+     * The v2 node update must ignore provisioning-ownership fields, however the request spells
+     * them and whether or not they are reached through a nested path.
      */
     @Test
     @JUnitTemporaryDatabase
@@ -323,7 +323,7 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         snmpInterface.put("ifType", 6);
         sendData(POST, MediaType.APPLICATION_JSON, "/nodes/1/snmpinterfaces", snmpInterface.toString(), 201);
 
-        final String attack = "node.foreign_source=AttackerReq&node.foreignId=666";
+        final String attack = "node.foreign_source=AttackerReq&node.foreign_id=666";
         sendPut("/nodes/1/ipinterfaces/10.10.10.10", attack, 204);
         sendPut("/nodes/1/snmpinterfaces/6", attack, 204);
         // this one reports 304 Not Modified because the service status did not change

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -267,12 +267,13 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         node.put("sysName", "TestMachine1");
         sendData(POST, MediaType.APPLICATION_JSON, "/nodes", node.toString(), 201);
 
-        // Keys are normalized before binding, so the separator form is what reaches a camelCase
-        // property (foreign_source -> foreignSource).
-        sendPut("/nodes/1", "sys_contact=LegitContact&foreign_source=AttackerReq&foreign_id=999&Type=D", 204);
+        // Separator keys are what reach a camelCase property (foreign_source -> foreignSource).
+        sendPut("/nodes/1", "sys_contact=LegitContact&foreign_source=AttackerReq&foreign_id=999&Type=D"
+                + "&asset_record.node.foreign_source=NestedReq", 204);
 
         final String xml = sendRequest(GET, "/nodes/1", 200); // still present -> Type=D was ignored
         assertFalse("foreignSource must not be reassignable via update", xml.contains("AttackerReq"));
+        assertFalse("foreignSource must not be reachable through a nested path", xml.contains("NestedReq"));
         assertFalse("foreignId must not be reassignable via update", xml.contains("999"));
         assertTrue("legitimate fields still update", xml.contains("LegitContact"));
     }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -28,6 +28,7 @@
 
 package org.opennms.web.rest.v2;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,12 +43,16 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.MockLogAppender;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsNode.NodeType;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -74,6 +79,9 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @JUnitTemporaryDatabase
 public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestServiceIT.class);
+
+    @Autowired
+    private NodeDao m_nodeDao;
 
     public NodeRestServiceIT() {
         super(CXF_REST_V2_CONTEXT_PATH);
@@ -271,11 +279,59 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         sendPut("/nodes/1", "sys_contact=LegitContact&foreign_source=AttackerReq&foreign_id=999&Type=D"
                 + "&asset_record.node.foreign_source=NestedReq", 204);
 
-        final String xml = sendRequest(GET, "/nodes/1", 200); // still present -> Type=D was ignored
-        assertFalse("foreignSource must not be reassignable via update", xml.contains("AttackerReq"));
-        assertFalse("foreignSource must not be reachable through a nested path", xml.contains("NestedReq"));
-        assertFalse("foreignId must not be reassignable via update", xml.contains("999"));
-        assertTrue("legitimate fields still update", xml.contains("LegitContact"));
+        final OnmsNode updated = m_nodeDao.get(1);
+        assertEquals("foreignSource must not be reassignable", "JUnit", updated.getForeignSource());
+        assertEquals("foreignId must not be reassignable", "TestMachine1", updated.getForeignId());
+        assertEquals("type must not be reassignable", NodeType.ACTIVE, updated.getType());
+        assertEquals("legitimate fields still update", "LegitContact", updated.getSysContact());
+    }
+
+    /**
+     * The child endpoints bind to entities that hold a back-reference to their node, so none of
+     * them may be used as a route to the node's protected properties.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    public void subResourceUpdatesCannotReachNodeForeignSource() throws Exception {
+        final JSONObject node = new JSONObject();
+        node.put("type", "A");
+        node.put("label", "TestMachine1");
+        node.put("foreignSource", "JUnit");
+        node.put("foreignId", "TestMachine1");
+        node.put("location", "Default");
+        node.put("labelSource", "H");
+        node.put("sysName", "TestMachine1");
+        sendData(POST, MediaType.APPLICATION_JSON, "/nodes", node.toString(), 201);
+
+        final JSONObject ipInterface = new JSONObject();
+        ipInterface.put("snmpPrimary", "P");
+        ipInterface.put("ipAddress", "10.10.10.10");
+        ipInterface.put("hostName", "TestMachine");
+        sendData(POST, MediaType.APPLICATION_JSON, "/nodes/1/ipinterfaces", ipInterface.toString(), 201);
+
+        final JSONObject service = new JSONObject();
+        service.put("status", "A");
+        final JSONObject serviceType = new JSONObject();
+        serviceType.put("name", "ICMP");
+        service.put("serviceType", serviceType);
+        sendData(POST, MediaType.APPLICATION_JSON, "/nodes/1/ipinterfaces/10.10.10.10/services", service.toString(), 201);
+
+        final JSONObject snmpInterface = new JSONObject();
+        snmpInterface.put("ifIndex", 6);
+        snmpInterface.put("ifDescr", "en1");
+        snmpInterface.put("ifName", "en1");
+        snmpInterface.put("ifType", 6);
+        sendData(POST, MediaType.APPLICATION_JSON, "/nodes/1/snmpinterfaces", snmpInterface.toString(), 201);
+
+        final String attack = "node.foreign_source=AttackerReq&node.foreignId=666";
+        sendPut("/nodes/1/ipinterfaces/10.10.10.10", attack, 204);
+        sendPut("/nodes/1/snmpinterfaces/6", attack, 204);
+        // this one reports 304 Not Modified because the service status did not change
+        sendPut("/nodes/1/ipinterfaces/10.10.10.10/services/ICMP", attack, 304);
+
+        final OnmsNode updated = m_nodeDao.get(1);
+        assertEquals("foreignSource must not be reachable from a child endpoint", "JUnit", updated.getForeignSource());
+        assertEquals("foreignId must not be reachable from a child endpoint", "TestMachine1", updated.getForeignId());
     }
 
 }


### PR DESCRIPTION
 Protected fields (primary keys, category authorizedGroups, node foreignSource/foreignId/type) could be set via a blind BeanWrapper copy. Adds an allow-list guard so those are ignored on update (still settable on create)

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20055

