### PR TITLE
docs: Fix malformed system requirements xref on the core install page

### DIFF
--- a/docs/modules/deployment/pages/core/getting-started.adoc
+++ b/docs/modules/deployment/pages/core/getting-started.adoc
@@ -51,7 +51,7 @@ ifeval::["{page-component-title}" == "Meridian"]
 * Credentials to access the Meridian repositories.
 endif::[]
 * A Linux physical server, or a virtual machine running a <<./system-requirements.adoc#operating-systems-core, supported Linux operating system>>.
-* Internet access to download the installation packages. xref:system-requirements.adoc
+* Internet access to download the installation packages (see xref:core/system-requirements.adoc[]).
 * A working DNS server, and a localhost and server name that resolve properly.
 * A system user with administrative permissions (`sudo`) to perform installation.
 * A SELinux policy that permits binding to the ICMP service, if necessary.


### PR DESCRIPTION
The requirements bullet ended with a bare `xref:system-requirements.adoc` with no target brackets. Without them it is not a macro at all, so AsciiDoc rendered the raw text instead of a link.

Assisted by Anthropic Claude Opus 5.