### PR TITLE
Increment the dropwizardMetricsVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1788,7 +1788,7 @@
     <serviceMixDnsjavaVersion>3.5.3_1</serviceMixDnsjavaVersion>
     <dnsjavaVersion>3.6.1</dnsjavaVersion>
     <dom4jVersion>2.1.4</dom4jVersion>
-    <dropwizardMetricsVersion>4.2.10</dropwizardMetricsVersion>
+    <dropwizardMetricsVersion>4.2.25</dropwizardMetricsVersion>
     <ecjVersion>4.4.2</ecjVersion>
     <eclipselinkVersion>2.5.1</eclipselinkVersion>
     <eddsaVersion>0.3.0</eddsaVersion>


### PR DESCRIPTION
Bumping dropwizard Metrics Version to 4.2.25 to resolve the Sentinel smoke test failures.


```
Headers: {Cache-Control=[must-revalidate,no-cache,no-store], WWW-Authenticate=[BASIC realm="karaf"], Content-Length=[112], Content-Type=[text/plain;charset=iso-8859-1]}
HTTP ERROR 401 Unauthorized
URI: /sentinel/rest/health/probe
STATUS: 401
MESSAGE: Unauthorized
SERVLET: default
".
        at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
        at org.awaitility.core.AbstractHamcrestCondition.await(AbstractHamcrestCondition.java:86)
        at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:985)
        at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:691)
        at org.*******.smoketest.containers.SentinelContainer$WaitForSentinel.waitUntilReady(SentinelContainer.java:293)
        at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:52)
        at org.testcontainers.containers.GenericContainer.waitUntilContainerStarted(GenericContainer.java:909)
        at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:492)
        ... 37 more
```

In logs we see..
```
org.apache.karaf.features.internal.util.MultiException: Error:
	Error downloading mvn:io.dropwizard.metrics/metrics-core/4.2.25
	at org.apache.karaf.features.internal.download.impl.MavenDownloadManager$MavenDownloader.<init>(MavenDownloadManager.java:91)
	at org.apache.karaf.features.internal.download.impl.MavenDownloadManager.createDownloader(MavenDownloadManager.java:72)
	at org.apache.karaf.features.internal.region.Subsystem.downloadBundles(Subsystem.java:474)
	at org.apache.karaf.features.internal.region.Subsystem.downloadBundles(Subsystem.java:469)
	at org.apache.karaf.features.internal.region.SubsystemResolver.resolve(SubsystemResolver.java:223)
	at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:399)
	at org.apache.karaf.features.internal.service.Deployer.handlePrerequisites(Deployer.java:1121)
	at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:394)
	at org.apache.karaf.features.internal.service.FeaturesServiceImpl.doProvision(FeaturesServiceImpl.java:1069)
	at org.apache.karaf.features.internal.service.FeaturesServiceImpl.lambda$doProvisionInThread$13(FeaturesServiceImpl.java:1004)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	Suppressed: java.io.IOException: Error downloading mvn:io.dropwizard.metrics/metrics-core/4.2.25
		at org.apache.karaf.features.internal.download.impl.AbstractRetryableDownloadTask.run(AbstractRetryableDownloadTask.java:77)
		at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
		at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
		... 3 more
	Caused by: java.io.IOException: Error resolving artifact io.dropwizard.metrics:metrics-core:jar:4.2.25: [Could not find artifact io.dropwizard.metrics:metrics-core:jar:4.2.25 in system (file:/opt/sentinel/system/)]
		at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.configureIOException(AetherBasedResolver.java:803)
		at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:774)
		at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:657)
		at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:598)
		at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:565)
		at org.apache.karaf.features.internal.download.impl.MavenDownloadTask.download(MavenDownloadTask.java:52)
		at org.apache.karaf.features.internal.download.impl.AbstractRetryableDownloadTask.run(AbstractRetryableDownloadTask.java:60)
		... 6 more
		Suppressed: shaded.org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact io.dropwizard.metrics:metrics-core:jar:4.2.25 in system (file:/opt/sentinel/system/)
			at shaded.org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed(ArtifactTransportListener.java:48)
			at shaded.org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:401)
			at shaded.org.eclipse.aether.util.concurrency.RunnableErrorForwarder.lambda$wrap$0(RunnableErrorForwarder.java:73)
			at shaded.org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute(BasicRepositoryConnector.java:669)
			at shaded.org.eclipse.aether.connector.basic.BasicRepositoryConnector.get(BasicRepositoryConnector.java:290)
			at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads(DefaultArtifactResolver.java:520)
			at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:408)
			at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:235)
			at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact(DefaultArtifactResolver.java:212)
			at shaded.org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveArtifact(DefaultRepositorySystem.java:272)
			at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:767)
			... 11 more
	Caused by: shaded.org.eclipse.aether.resolution.ArtifactResolutionException: Error resolving artifact io.dropwizard.metrics:metrics-core:jar:4.2.25
		at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:431)
		at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:235)
		at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact(DefaultArtifactResolver.java:212)
		at shaded.org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveArtifact(DefaultRepositorySystem.java:272)
		at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:767)
		... 11 more
```



### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?
