### PR TITLE
NMS-19975: Fix flicker when navigating to JSP pages

### DIFF
--- a/opennms-webapp/src/main/webapp/includes/bootstrap.jsp
+++ b/opennms-webapp/src/main/webapp/includes/bootstrap.jsp
@@ -200,7 +200,32 @@
   </c:if>
 
   <%-- Vue side menu --%>
+  <%--
+    Apply the persisted UI theme class to <html> before first paint so
+    theme-dependent styles (PrimeVue's .open-dark darkModeSelector, the menu
+    token overrides in the Vue menu's stylesheet) are correct from the very
+    first frame instead of flipping when the menu bundle mounts (NMS-19975).
+    Storage key and class names mirror ui/src/services/themeService.ts; the
+    menu app re-asserts the class (and adds it to <body>) via initTheme().
+  --%>
+  <script type="text/javascript">
+    (function () {
+      var theme = 'open-light';
+      try {
+        var stored = window.localStorage.getItem('theme');
+        if (stored === 'open-light' || stored === 'open-dark') {
+          theme = stored;
+        }
+      } catch (e) {
+        // localStorage unavailable; fall through to the default theme
+      }
+      document.documentElement.classList.add(theme);
+    })();
+  </script>
   <link rel="stylesheet" href="<%= __baseHref %>ui-components/assets/index.css" media="screen" />
+  <%-- Start fetching/compiling the menu bundle now rather than when the parser
+       reaches its <script type="module"> tag near the end of the body. --%>
+  <link rel="modulepreload" href="<%= __baseHref %>ui-components/assets/index.js" />
 </head>
 
 <%-- The <body> tag is unmatched in this file (its matching tag is in the

--- a/ui/src/menu/main.ts
+++ b/ui/src/menu/main.ts
@@ -28,6 +28,7 @@ import '../styles/onms-base.scss'
 import '../styles/onms-theme.scss'
 import '../styles/opennms-styles.scss'
 import { setupPrimeVue } from '../theme/primevue-setup'
+import { useAppStore } from '../stores/appStore'
 import App from './App.vue'
 
 // id of div to mount this Vue app onto, expected to exist in the embedding web application
@@ -39,6 +40,12 @@ const app = createApp({
 
 setupPrimeVue(app)
 
-app
-  .use(createPinia())
-  .mount(`#${appMountId}`)
+app.use(createPinia())
+
+// Apply the persisted .open-light/.open-dark class to <html>/<body>, as the SPA
+// does in main/main.ts. The embedding JSP (includes/bootstrap.jsp) applies the
+// class to <html> before first paint; this re-asserts it (and covers <body>) so
+// theme-dependent rules and PrimeVue's darkModeSelector track the stored theme.
+useAppStore().initTheme()
+
+app.mount(`#${appMountId}`)

--- a/ui/src/styles/opennms-styles.scss
+++ b/ui/src/styles/opennms-styles.scss
@@ -77,6 +77,42 @@ footer#footer,
   --p-text-color: rgb(255, 255, 255);
 }
 
+// Pre-mount skeleton for the Vue menu on legacy JSP pages (NMS-19975). JSP
+// navigations are full document loads and #opennms-sidemenu-container is
+// server-rendered empty, so nothing dark exists where the fixed menubar and
+// side rail belong until the menu bundle executes and Vue mounts — the light
+// page background flashes through on every JSP navigation. This stylesheet is
+// render-blocking in <head> (bootstrap.jsp), so paint the menubar and the
+// collapsed side rail as pseudo-elements of the still-empty container; :empty
+// stops matching the instant Vue mounts children, so the skeleton removes
+// itself with no JS coordination. Geometry, colors and z-indexes mirror
+// .onms-menubar (Menubar.vue) and .onms-side-menu (SideMenu.vue); the literal
+// fallbacks match --onms-surface-dark in onms-theme.scss for the first frames
+// before any theme class is present.
+#opennms-sidemenu-container:empty::before,
+#opennms-sidemenu-container:empty::after {
+  content: '';
+  position: fixed;
+  left: 0;
+  background-color: var(--onms-surface-dark, #131736);
+}
+
+// Menubar
+#opennms-sidemenu-container:empty::before {
+  top: 0;
+  right: 0;
+  height: var(--onms-header-height, 3.75rem);
+  z-index: var(--onms-zindex-fixed, 1030);
+}
+
+// Collapsed side menu rail
+#opennms-sidemenu-container:empty::after {
+  top: var(--onms-header-height, 3.75rem);
+  bottom: 0;
+  width: var(--onms-side-menu-collapsed, 3.75rem);
+  z-index: 2000; // matches .onms-side-menu in SideMenu.vue
+}
+
 // Visited links keep the normal color (no distinct visited color), matching the
 // app convention in onms-base.scss.
 a:visited {


### PR DESCRIPTION
# NMS-19975: Fix screen flicker when navigating to JSP pages

## Problem

Navigating **to** any JSP page (from a Vue SPA page or from another JSP page) caused a visible flicker: a light/white background painted first — including where the dark top menu bar and side rail belong — and the dark menu chrome only appeared a moment later.

## Root cause

JSP navigations are full document loads (unlike Vue SPA routing, which is client-side). The server-rendered HTML contains only an empty `<div id="opennms-sidemenu-container">` plus a `<script type="module">` tag for the menu bundle. On first paint nothing dark exists where the fixed menubar and side rail belong, so the light page background flashes through on every JSP navigation. The dark chrome appears only after the menu bundle is fetched, parsed, and executed and Vue mounts.

A related latent bug: the standalone menu bundle never called `initTheme()` (only the SPA did), so the persisted `open-light`/`open-dark` theme class was never applied to `<html>`/`<body>` on JSP page loads — only the in-page theme toggle ever applied it. As a result, the `.open-dark #opennms-sidemenu-container` token overrides silently didn't apply on freshly loaded JSP pages in dark mode.

## Changes

**`ui/src/styles/opennms-styles.scss`** — Among other things, ensures dark background/chrome before re-render.

**`opennms-webapp/src/main/webapp/includes/bootstrap.jsp`** —
- Inline `<head>` script that applies the persisted `open-light`/`open-dark` class to `<html>` before first paint (storage key and class names mirror `ui/src/services/themeService.ts`; falls back to light if `localStorage` is unavailable).
- `<link rel="modulepreload">` for the menu bundle, so fetch/compile starts during head parsing instead of when the parser reaches the script tag near the end of the body.

**`ui/src/menu/main.ts`** — the standalone menu app now calls `useAppStore().initTheme()` before mount, mirroring the SPA (`ui/src/main/main.ts`). This fixes the latent theme-class bug above and re-asserts the class on `<body>` after the JSP inline script has set it on `<html>`.

## Out of scope (deliberately deferred)

These were deferred as they are bigger changes with minimal improvements. Main issue to fix in future would be some minor redraw differences between Vue SPA top menu and the embedded Vue menu on JSP pages, e.g. search box placement is slightly different.

- Cache-header changes for `/ui-components/assets/*` (currently `Cache-Control: no-cache`).
- Server-side inlining of the menu JSON to avoid the post-mount `/rest/menu` pop-in.
- Cross-document View Transitions polish.
- Residual minor redraw differences as the real menu replaces the skeleton.


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19975
