### PR TITLE
NMS-20084: Remove OTRS orphan directories and packaging tombstones

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -99,8 +99,6 @@ install: build
 	mv debian/temp/etc/wsman-asset-adapter-configuration.xml                 debian/opennms-plugin-provisioning-wsman-asset/opt/opennms/etc/
 	find debian/opennms-plugin*/opt/opennms/etc -type f -execdir chmod 644 {} \;
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-dns,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-dns.postinst
-	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-link,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-link.postinst
-	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-map,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-map.postinst
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-reverse-dns,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-reverse-dns.postinst
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-snmp-asset,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-snmp-asset.postinst
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-snmp-hardware-inventory,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-snmp-hardware-inventory.postinst

--- a/features/ticketing/otrs-integration-31/src/license/THIRD-PARTY.properties
+++ b/features/ticketing/otrs-integration-31/src/license/THIRD-PARTY.properties
@@ -1,1 +1,0 @@
-xalan--serializer--2.7.3=apache_v2

--- a/features/ticketing/otrs-integration-common/src/license/THIRD-PARTY.properties
+++ b/features/ticketing/otrs-integration-common/src/license/THIRD-PARTY.properties
@@ -1,1 +1,0 @@
-xalan--serializer--2.7.3=apache_v2

--- a/pom.xml
+++ b/pom.xml
@@ -1950,7 +1950,6 @@
     <pyroscopeVersion>0.13.1</pyroscopeVersion>
     <lz4JavaVersion>1.10.2</lz4JavaVersion>
     <quartzVersion>2.3.2</quartzVersion>
-    <rancidApiVersion>2.0.0</rancidApiVersion>
     <rateLimitedLoggerVersion>2.0.2</rateLimitedLoggerVersion>
     <resilience4jVersion>0.17.0</resilience4jVersion>
     <rocksdbjniVersion>8.5.4</rocksdbjniVersion>

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -240,24 +240,6 @@ external JMS listener.
 %{extrainfo2}
 
 
-%package plugin-provisioning-map
-Summary:	Obsolete: Map Provisioning Adapter
-Group:		Applications/System
-Requires(pre):	%{name}-core = %{version}-%{release}
-Requires:	%{name}-core = %{version}-%{release}
-
-%description plugin-provisioning-map
-The map provisioning adapter is no longer part of OpenNMS.
-
-
-%package plugin-provisioning-link
-Summary:	Obsolete: Link Provisioning Adapter
-Group:		Applications/System
-Requires(pre):	%{name}-core = %{version}-%{release}
-Requires:	%{name}-core = %{version}-%{release}
-
-%description plugin-provisioning-link
-The map provisioning adapter is no longer part of OpenNMS.
 
 
 %package plugin-provisioning-dns


### PR DESCRIPTION
The two otrs-integration directories each held a single stale THIRD-PARTY.properties and were not in the ticketing module list. The plugin-provisioning-map/-link spec stanzas had no %files sections (rpmbuild never emitted them) and no Obsoletes lines, and debian/rules generated postinst scripts for those same packages that debian/control never declares. rancidApiVersion was referenced by nothing. 

Removal assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20084
