### PR TITLE
NMS-20085: Remove unused dependencyManagement entries from the root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1760,11 +1760,9 @@
     <commonsCompressVersion>1.26.1</commonsCompressVersion>
     <commonsConfigurationVersion>1.10</commonsConfigurationVersion>
     <commonsCsvVersion>1.5</commonsCsvVersion>
-    <commonsDaemonVersion>1.3.4</commonsDaemonVersion>
     <commonsDbcpVersion>1.4</commonsDbcpVersion>
     <commonsDigesterVersion>2.1</commonsDigesterVersion>
     <commonsExecVersion>1.4.0</commonsExecVersion>
-    <commonsFileuploadVersion>1.6.0</commonsFileuploadVersion>
     <commonsJexlVersion>2.1.1</commonsJexlVersion>
     <commonsJexl3Version>3.3</commonsJexl3Version>
     <commonsJxpathVersion>1.3</commonsJxpathVersion>
@@ -1848,7 +1846,6 @@
     <javaxMailVersion>1.4.7</javaxMailVersion>
     <jbossLoggingVersion>3.5.3.Final</jbossLoggingVersion>
     <jcifsVersion>2.1.6</jcifsVersion>
-    <jcommonVersion>1.0.24</jcommonVersion>
     <jdom2Version>2.0.6.1</jdom2Version>
     <jettisonVersion>1.5.4</jettisonVersion>
     <jettyVersion>9.4.60.onms1</jettyVersion>
@@ -1987,7 +1984,6 @@
     <xmlgraphicsCommonsVersion>2.9</xmlgraphicsCommonsVersion>
     <xmlsecVersion>2.3.4</xmlsecVersion>
     <xstreamVersion>1.4.21</xstreamVersion>
-    <wsdl4jVersion>1.6.3</wsdl4jVersion>
     <wsmanVersion>1.3.3</wsmanVersion>
     <zookeeperVersion>3.7.2</zookeeperVersion>
     <zstdJniVersion>1.5.2-1</zstdJniVersion>
@@ -3104,12 +3100,6 @@
       </dependency>
       <dependency>
         <groupId>org.opennms.dependencies</groupId>
-        <artifactId>aws-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.opennms.dependencies</groupId>
         <artifactId>camel-dependencies</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
@@ -3130,18 +3120,6 @@
       <dependency>
         <groupId>org.opennms.dependencies</groupId>
         <artifactId>felix-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.opennms.dependencies</groupId>
-        <artifactId>geronimo-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.opennms.dependencies</groupId>
-        <artifactId>gwt-maps-dependencies</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
       </dependency>
@@ -3607,11 +3585,6 @@
       </dependency>
       <dependency>
         <groupId>org.opennms</groupId>
-        <artifactId>opennms-rrd-jrobin</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.opennms</groupId>
         <artifactId>opennms-rrd-rrdtool</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -3789,12 +3762,6 @@
       </dependency>
       <dependency>
         <groupId>org.opennms.dependencies</groupId>
-        <artifactId>tracker-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.opennms.dependencies</groupId>
         <artifactId>jmx-dependencies</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
@@ -3940,28 +3907,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
-        <artifactId>curator-client</artifactId>
-        <version>${curatorVersion}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>log4j</artifactId>
-            <groupId>log4j</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-framework</artifactId>
-        <version>${curatorVersion}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>log4j</artifactId>
-            <groupId>log4j</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.curator</groupId>
         <artifactId>curator-recipes</artifactId>
         <version>${curatorVersion}</version>
         <exclusions>
@@ -4085,11 +4030,6 @@
         <version>${caffeineVersion}</version>
       </dependency>
       <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>${xstreamVersion}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.xstream</artifactId>
         <version>${xstreamVersion}_1</version>
@@ -4157,11 +4097,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>commons-daemon</groupId>
-        <artifactId>commons-daemon</artifactId>
-        <version>${commonsDaemonVersion}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-dbcp</groupId>
         <artifactId>commons-dbcp</artifactId>
         <version>${commonsDbcpVersion}</version>
@@ -4181,11 +4116,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-exec</artifactId>
         <version>${commonsExecVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-fileupload</groupId>
-        <artifactId>commons-fileupload</artifactId>
-        <version>${commonsFileuploadVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -4334,23 +4264,6 @@
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-validator</groupId>
-        <artifactId>commons-validator-core</artifactId>
-        <version>${commonsValidatorVersion}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.dbunit</groupId>
-        <artifactId>dbunit</artifactId>
-        <version>2.4.8</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.dom4j</groupId>
@@ -4546,17 +4459,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>net.sf.ehcache</groupId>
-        <artifactId>ehcache</artifactId>
-        <version>1.8.0</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.jfree</groupId>
-        <artifactId>jcommon</artifactId>
-        <version>${jcommonVersion}</version>
-      </dependency>
-      <dependency>
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>${jfreechartVersion}</version>
@@ -4569,16 +4471,6 @@
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-osgi-bundle</artifactId>
-        <version>${kotlinVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
-        <version>${kotlinVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-common</artifactId>
         <version>${kotlinVersion}</version>
       </dependency>
       <dependency>
@@ -4758,11 +4650,6 @@
         <version>1.0</version>
       </dependency>
       <!-- this should match what's in Karaf's lib/jdk9plus directory -->
-      <dependency>
-        <groupId>com.sun.activation</groupId>
-        <artifactId>javax.activation</artifactId>
-        <version>1.2.0</version>
-      </dependency>
       <dependency>
         <groupId>javax.activation</groupId>
         <artifactId>activation</artifactId>
@@ -5047,12 +4934,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>net.sourceforge.jwebunit</groupId>
-        <artifactId>jwebunit-htmlunit-plugin</artifactId>
-        <version>2.5</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.apache.karaf.shell</groupId>
         <artifactId>org.apache.karaf.shell.core</artifactId>
         <version>${karafVersion}</version>
@@ -5083,11 +4964,6 @@
         <groupId>mx4j</groupId>
         <artifactId>mx4j-tools</artifactId>
         <version>3.0.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.nokogiri</groupId>
-        <artifactId>nekohtml</artifactId>
-        <version>1.9.22.noko2</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml</groupId>
@@ -5445,11 +5321,6 @@
         <version>${velocityVersion}</version>
       </dependency>
       <dependency>
-        <groupId>wsdl4j</groupId>
-        <artifactId>wsdl4j</artifactId>
-        <version>${wsdl4jVersion}</version>
-      </dependency>
-      <dependency>
         <groupId>xalan</groupId>
         <artifactId>xalan</artifactId>
         <version>${xalanVersion}</version>
@@ -5584,18 +5455,6 @@
         <groupId>net.jqwik</groupId>
         <artifactId>jqwik</artifactId>
         <version>${jqwikVersion}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit5Version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-engine</artifactId>
-        <version>${junit5PlatformVersion}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
22 managed artifacts that no module declares and no code imports, including four org.opennms.dependencies aggregates that do not exist as modules, EOL libraries (ehcache 1.8.0, dbunit 2.4.8, jcommon, wsdl4j), standing CVE surface (xstream, commons-fileupload), the stale opennms-rrd-jrobin entry left from the Horizon 36 JoeSNMP/RRD cleanup, and JUnit 5 API entries with zero org.junit.jupiter imports in the tree. Four version properties whose only consumer was a removed entry go with them. junit-vintage-engine, curator-recipes, and the xstreamVersion property (used by the servicemix bundle lists in container poms) are untouched.

List:

- Four org.opennms.dependencies aggregates (tracker, aws, geronimo, gwt-maps) don't exist as modules at all.
- EOL/abandoned: ehcache 1.8.0, dbunit 2.4.8, jcommon (JFreeChart 1.5 absorbed it), wsdl4j, jwebunit, nekohtml, commons-daemon.
- Unused CVE surface: xstream, commons-fileupload.
- junit-jupiter-api/junit-platform-engine — zero org.junit.jupiter imports exist; junit-vintage-engine (actually used) stays.
- curator-client/curator-framework — only curator-recipes is consumed.
- Stale opennms-rrd-jrobin entry left from the Horizon 36 RRD cleanup.
- Four version properties whose only consumer was a removed entry are removed with them; xstreamVersion stays (the servicemix xstream bundle ships via the container bundle lists).

Cleanup assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-2008
