### PR TITLE
NMS-20092: Remove EOL BouncyCastle jdk15on and SAML deps

### DIFF
--- a/dependencies/spring-security/pom.xml
+++ b/dependencies/spring-security/pom.xml
@@ -39,27 +39,9 @@
     </dependency>
     <!-- spring-security-openid + openid4java dropped: the OpenID 1.0 module was removed in Spring
          Security 5.x and was unwired in OpenNMS. spring-security-saml2-core (EOL 1.0.x extension,
-         incompatible with 5.x) likewise dropped; reintroduce via spring-security-saml2-service-provider
-         if SAML SSO is needed. -->
-    <dependency>
-      <groupId>org.owasp.esapi</groupId>
-      <artifactId>esapi</artifactId>
-      <version>${esapiVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.santuario</groupId>
-      <artifactId>xmlsec</artifactId>
-    </dependency>
+         incompatible with 5.x) was dropped for the same reason, and esapi, xmlsec, and the
+         BouncyCastle jdk15on artifacts existed only to support it, so they are gone too.
+         Reintroduce via spring-security-saml2-service-provider if SAML SSO is ever needed. -->
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId>
@@ -159,21 +141,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-ext-jdk15on</artifactId>
-      <version>1.70</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.70</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.70</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1794,7 +1794,6 @@
     <elasticsearchTargetVersion>7.17.9</elasticsearchTargetVersion>
     <elasticsearchClientVersion>8.18.1</elasticsearchClientVersion>
     <errorProneAnnotationsVersion>2.25.0</errorProneAnnotationsVersion>
-    <esapiVersion>2.5.2.0</esapiVersion>
     <felixBridgeVersion>4.1.6</felixBridgeVersion>
     <felixProxyVersion>3.0.6</felixProxyVersion>
     <fopVersion>2.10</fopVersion>
@@ -1980,7 +1979,6 @@
     <xmlApisExtVersion>1.3.04</xmlApisExtVersion>
     <xmlSchemaVersion>2.3.1</xmlSchemaVersion>
     <xmlgraphicsCommonsVersion>2.9</xmlgraphicsCommonsVersion>
-    <xmlsecVersion>2.3.4</xmlsecVersion>
     <xstreamVersion>1.4.21</xstreamVersion>
     <wsmanVersion>1.3.3</wsmanVersion>
     <zookeeperVersion>3.7.2</zookeeperVersion>
@@ -3989,11 +3987,6 @@
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.santuario</groupId>
-        <artifactId>xmlsec</artifactId>
-        <version>${xmlsecVersion}</version>
       </dependency>
       <dependency>
         <groupId>bsf</groupId>


### PR DESCRIPTION
Removes the EOL BouncyCastle jdk15on provider and orphaned SAML-era dependencies from the spring-security aggregator.

- bcprov-ext/bcprov/bcpkix-jdk15on 1.70 shipped a second, EOL crypto provider alongside the jdk18on 1.84 the rest of the build uses.
- esapi and xmlsec lost their last consumer when spring-security-saml2-core was dropped; their orphaned root-pom property/dependencyManagement entries are removed too.
- Dropping esapi also removes its transitive baggage (antisamy, bcutil-jdk15on, neko-htmlunit, xom, httpclient5/httpcore5).
- Login and authenticated REST verified on a local build; the LDAP/Kerberos artifacts are untouched.

We probably do want to actually add proper SAML auth at some point but I suspect removing these won't impact that.  Claude put a comment/hint here for that future case.

Removal assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20092

