### PR TITLE
NMS-20093: Restore xstream and kotlin-stdlib dependencyManagement pins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4028,6 +4028,13 @@
         <artifactId>caffeine</artifactId>
         <version>${caffeineVersion}</version>
       </dependency>
+      <!-- no direct users, but pins the xstream shipped in lib/ (transitive of
+           drools-xml-support, which declares an older release) -->
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>${xstreamVersion}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.xstream</artifactId>
@@ -4470,6 +4477,18 @@
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-osgi-bundle</artifactId>
+        <version>${kotlinVersion}</version>
+      </dependency>
+      <!-- no direct users, but pins the kotlin-stdlib shipped in lib/ (transitive of
+           okhttp, which declares an older release) -->
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlinVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
         <version>${kotlinVersion}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5475,6 +5475,21 @@
         <version>${jqwikVersion}</version>
         <scope>test</scope>
       </dependency>
+      <!-- no direct users, but these align the JUnit Platform on test classpaths:
+           transitives declare jupiter-api 5.6.x, which skews platform-commons
+           against the pinned vintage-engine and breaks the surefire provider -->
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit5Version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${junit5PlatformVersion}</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>


### PR DESCRIPTION
NMS-20085 removed these as unused, but they were pinning the versions of transitive dependencies that we ship.

- xstream 1.4.21 -> 1.4.20 (via drools-xml-support 1.4.21 was a CVE-motivated bump)
- kotlin-stdlib/-common 1.9.10 -> 1.4.10 (via okhttp). 

The restored entries carry comments naming the transitive consumer they govern.

This regression fix brought to you by the letter R and assisted by Anthropic Claude Opus 5. 

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20093