### PR TITLE
NMS-20101: Make TicketNotificationStrategy usable and document it

### DIFF
--- a/docs/modules/operation/nav.adoc
+++ b/docs/modules/operation/nav.adoc
@@ -123,6 +123,7 @@
 *** xref:deep-dive/notifications/bonus-strategies.adoc[]
 **** xref:deep-dive/notifications/strategies/mattermost.adoc[]
 **** xref:deep-dive/notifications/strategies/slack.adoc[]
+**** xref:deep-dive/notifications/strategies/ticket.adoc[]
 *** xref:deep-dive/notifications/shell.adoc[]
 
 ** xref:deep-dive/bsm/introduction.adoc[]

--- a/docs/modules/operation/pages/deep-dive/notifications/bonus-strategies.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/bonus-strategies.adoc
@@ -2,6 +2,6 @@
 
 [[ga-notifications-bonus-strategies]]
 = Bonus Notification Methods
-:description: Overview of bonus notification methods in {page-component-title}: Mattermost and Slack.
+:description: Overview of bonus notification methods in {page-component-title}: Mattermost, Slack, and trouble tickets.
 
-{page-component-title} includes a handful of newer notification methods that currently require manual steps to activate.
+{page-component-title} includes a handful of notification methods that currently require manual steps to activate.

--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
@@ -19,7 +19,8 @@ Use a destination path with a non-zero `initial-delay` to avoid this; 30 seconds
 The strategy reads only event parameters, so the target serves to satisfy the destination path schema.
 * Target a single user rather than a group.
 Notifd runs each command once per member of a group target, and each run sends its own create-ticket event.
-The strategy skips the create event when the alarm already has a ticket, but near-simultaneous deliveries can race the asynchronous ticket creation, so a group target can still produce duplicate tickets.
+The strategy skips the create event when the alarm already has an active ticket; tickets that are closed, resolved, or cancelled, or whose creation failed, do not block a new one.
+Near-simultaneous deliveries can race the asynchronous ticket creation, so a group target can still produce duplicate tickets.
 * The create-ticket event carries a `user` parameter that defaults to `admin`.
 You can override it with the optional `ticketUser` argument described below.
 Whether the value appears on the created ticket depends on the ticketer plugin.
@@ -60,6 +61,9 @@ Add a destination path with an initial delay to `destinationPaths.xml`:
     </target>
 </path>
 ----
+
+NOTE: Use a single user as the target, not a group.
+Notifd runs the command once per member of a group target, and near-simultaneous runs can each create a ticket for the same alarm.
 
 Reference the `Create-Ticket` destination path from each notification in `notifications.xml` that should open a ticket.
 

--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
@@ -1,0 +1,70 @@
+
+= Trouble Ticket Notifications
+:description: How to configure {page-component-title} to create trouble tickets from notifications.
+
+{page-component-title} normally creates trouble tickets from alarms, either manually from the web UI or through the automations described in xref:operation:deep-dive/ticketing/introduction.adoc[Ticketing].
+The ticket notification strategy provides a third path: it creates a ticket for the alarm associated with a notification's event.
+Because it runs through notifd, it can take advantage of notification features that alarm automations do not, such as destination paths, escalation, and path outage suppression.
+
+== Requirements and caveats
+
+* A ticketer plugin must be configured.
+Without one, the create-ticket events that this strategy sends are not acted on.
+* The event that triggers the notification must have `alarm-data` in its event definition.
+Events without alarm data are skipped, and the notification completes without creating a ticket.
+* The strategy looks up the alarm for the event at delivery time, but alarmd performs that association asynchronously.
+A destination path that fires immediately can run before the alarm exists, in which case the notification fails with a "no alarm-id" error.
+Use a destination path with a non-zero `initial-delay` to avoid this; 30 seconds is usually enough.
+* The target user's contact information is not used.
+The strategy reads only event parameters, so the target serves to satisfy the destination path schema.
+* The create-ticket event carries a `user` parameter that defaults to `admin`.
+You can override it with the optional `ticketUser` argument described below.
+Whether the value appears on the created ticket depends on the ticketer plugin.
+
+== Setup
+
+Add the following command to `notificationCommands.xml`:
+
+[source, xml]
+----
+<command binary="false">
+    <name>createTicket</name>
+    <execute>org.opennms.netmgt.notifd.TicketNotificationStrategy</execute>
+    <comment>class for creating a trouble ticket for the alarm associated with the notification's event</comment>
+    <argument streamed="false">
+        <switch>eventID</switch>
+    </argument>
+    <argument streamed="false">
+        <switch>eventUEI</switch>
+    </argument>
+    <argument streamed="false">
+        <switch>noticeid</switch>
+    </argument>
+    <argument streamed="false">
+        <switch>ticketUser</switch>
+    </argument>
+</command>
+----
+
+Add a destination path with an initial delay to `destinationPaths.xml`:
+
+[source, xml]
+----
+<path name="Create-Ticket" initial-delay="30s">
+    <target>
+        <name>admin</name>
+        <command>createTicket</command>
+    </target>
+</path>
+----
+
+Reference the `Create-Ticket` destination path from each notification in `notifications.xml` that should open a ticket.
+
+To set the ticket user for a notification, add a `ticketUser` parameter to its definition:
+
+[source, xml]
+----
+<parameter name="ticketUser" value="noc"/>
+----
+
+If the parameter is absent, the strategy uses `admin`.

--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
@@ -15,7 +15,7 @@ Events without alarm data are skipped, and the notification completes without cr
 * The strategy looks up the alarm for the event at delivery time, but alarmd performs that association asynchronously.
 A destination path that fires immediately can run before the alarm exists, in which case the notification fails with a "no alarm-id" error.
 Use a destination path with a non-zero `initial-delay` to avoid this; 30 seconds is usually enough.
-* The target user's contact information is not used.
+* The destination path target's contact information is not used, whether the target is a user or a group.
 The strategy reads only event parameters, so the target serves to satisfy the destination path schema.
 * The create-ticket event carries a `user` parameter that defaults to `admin`.
 You can override it with the optional `ticketUser` argument described below.
@@ -52,7 +52,7 @@ Add a destination path with an initial delay to `destinationPaths.xml`:
 ----
 <path name="Create-Ticket" initial-delay="30s">
     <target>
-        <name>admin</name>
+        <name>Admin</name>
         <command>createTicket</command>
     </target>
 </path>

--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
@@ -17,6 +17,9 @@ A destination path that fires immediately can run before the alarm exists, in wh
 Use a destination path with a non-zero `initial-delay` to avoid this; 30 seconds is usually enough.
 * The destination path target's contact information is not used, whether the target is a user or a group.
 The strategy reads only event parameters, so the target serves to satisfy the destination path schema.
+* Target a single user rather than a group.
+Notifd runs each command once per member of a group target, and each run sends its own create-ticket event.
+The strategy skips the create event when the alarm already has a ticket, but near-simultaneous deliveries can race the asynchronous ticket creation, so a group target can still produce duplicate tickets.
 * The create-ticket event carries a `user` parameter that defaults to `admin`.
 You can override it with the optional `ticketUser` argument described below.
 Whether the value appears on the created ticket depends on the ticketer plugin.
@@ -52,7 +55,7 @@ Add a destination path with an initial delay to `destinationPaths.xml`:
 ----
 <path name="Create-Ticket" initial-delay="30s">
     <target>
-        <name>Admin</name>
+        <name>admin</name>
         <command>createTicket</command>
     </target>
 </path>

--- a/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
+++ b/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
@@ -161,7 +161,7 @@ public class TicketNotificationStrategy implements NotificationStrategy {
         /* Log everything we know so far.
          * The tticketid and tticketstate are only informational.
          */
-        LOG.info("Got event-uei='{}' with event-id='{}', notice-id='{}', alarm-type='{}', alarm-id='{}', tticket-id='{}'and tticket-state='{}'", eventUEI, eventID, noticeID, alarmType, alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
+        LOG.info("Got event-uei='{}' with event-id='{}', notice-id='{}', alarm-type='{}', alarm-id='{}', tticket-id='{}' and tticket-state='{}'", eventUEI, eventID, noticeID, alarmType, alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
         
         sendCreateTicketEvent(alarmState.getAlarmID(), eventUEI, ticketUser);
 
@@ -187,7 +187,7 @@ public class TicketNotificationStrategy implements NotificationStrategy {
     /**
      * <p>Helper function that determines the alarm type for a given UEI.</p>
      *
-     * @return 0 if alarmid is null
+     * @return NOT_AN_ALARM if the event definition has no alarm-data
      */
 	protected AlarmType getAlarmTypeFromUEI(final String eventUEI) {
 	    final Event event = getEventConfDao().findByUei(eventUEI);

--- a/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
+++ b/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
@@ -51,6 +51,8 @@ import org.springframework.jdbc.core.RowCallbackHandler;
 public class TicketNotificationStrategy implements NotificationStrategy {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TicketNotificationStrategy.class);
+	/** Used as the create-ticket user unless the command supplies a ticketUser argument. */
+	public static final String DEFAULT_TICKET_USER = "admin";
 	private EventIpcManager m_eventManager;
 	private EventConfDao m_eventConfDao;
 	
@@ -114,17 +116,22 @@ public class TicketNotificationStrategy implements NotificationStrategy {
         String eventID = null;
         String eventUEI = null;
         String noticeID = null;
-        
+        String ticketUser = DEFAULT_TICKET_USER;
+
         // Pull the arguments we're interested in from the list.
         for (Argument arg : arguments) {
 		LOG.debug("arguments: {} = {}", arg.getSwitch(), arg.getValue());
-        	
+
             if ("eventID".equalsIgnoreCase(arg.getSwitch())) {
             	eventID = arg.getValue();
             } else if ("eventUEI".equalsIgnoreCase(arg.getSwitch())) {
             	eventUEI = arg.getValue();
             } else if ("noticeid".equalsIgnoreCase(arg.getSwitch())) {
             	noticeID = arg.getValue();
+            } else if ("ticketUser".equalsIgnoreCase(arg.getSwitch())) {
+                if (StringUtils.isNotBlank(arg.getValue())) {
+                    ticketUser = arg.getValue();
+                }
             }
         }
         
@@ -156,7 +163,7 @@ public class TicketNotificationStrategy implements NotificationStrategy {
          */
         LOG.info("Got event-uei='{}' with event-id='{}', notice-id='{}', alarm-type='{}', alarm-id='{}', tticket-id='{}'and tticket-state='{}'", eventUEI, eventID, noticeID, alarmType, alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
         
-        sendCreateTicketEvent(alarmState.getAlarmID(), eventUEI);
+        sendCreateTicketEvent(alarmState.getAlarmID(), eventUEI, ticketUser);
 
         return 0;
 	}
@@ -215,12 +222,16 @@ public class TicketNotificationStrategy implements NotificationStrategy {
      * @return
      */
 	public void sendCreateTicketEvent(int alarmID, String alarmUEI) {
-        LOG.debug("Sending create ticket for alarm '{}' with id={}", alarmUEI, alarmID);
+		sendCreateTicketEvent(alarmID, alarmUEI, DEFAULT_TICKET_USER);
+	}
+
+	public void sendCreateTicketEvent(int alarmID, String alarmUEI, String ticketUser) {
+        LOG.debug("Sending create ticket for alarm '{}' with id={} as user '{}'", alarmUEI, alarmID, ticketUser);
         EventBuilder ebldr = new EventBuilder(EventConstants.TROUBLETICKET_CREATE_UEI, getName());
         ebldr.addParam(EventConstants.PARM_ALARM_ID, alarmID);
         // These fields are required by the trouble ticketer, but not used
         ebldr.addParam(EventConstants.PARM_ALARM_UEI, alarmUEI);
-        ebldr.addParam(EventConstants.PARM_USER, "admin");
+        ebldr.addParam(EventConstants.PARM_USER, ticketUser);
         m_eventManager.sendNow(ebldr.getEvent());
 	}
 	

--- a/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
+++ b/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
@@ -23,7 +23,9 @@ package org.opennms.netmgt.notifd;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.opennms.core.db.DataSourceFactory;
@@ -32,6 +34,7 @@ import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
+import org.opennms.netmgt.model.TroubleTicketState;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.notifd.Argument;
 import org.opennms.netmgt.model.notifd.NotificationStrategy;
@@ -53,6 +56,12 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 	private static final Logger LOG = LoggerFactory.getLogger(TicketNotificationStrategy.class);
 	/** Used as the create-ticket user unless the command supplies a ticketUser argument. */
 	public static final String DEFAULT_TICKET_USER = "admin";
+	/** Ticket states that no longer block creating a new ticket for the alarm. */
+	private static final Set<TroubleTicketState> INACTIVE_TICKET_STATES = EnumSet.of(
+			TroubleTicketState.CREATE_FAILED,
+			TroubleTicketState.CLOSED,
+			TroubleTicketState.RESOLVED,
+			TroubleTicketState.CANCELLED);
 	private EventIpcManager m_eventManager;
 	private EventConfDao m_eventConfDao;
 	
@@ -153,6 +162,10 @@ public class TicketNotificationStrategy implements NotificationStrategy {
         
         // We know the event is an alarm, pull the alarm and current ticket details from the database
         AlarmState alarmState = getAlarmStateFromEvent(Integer.parseInt(eventID));
+        if( alarmState == null ) {
+		LOG.error("There is no event with event-id='{}' in the database. Will not create ticket.", eventID);
+        	return 1;
+        }
         if( alarmState.getAlarmID() == 0 ) {
 		LOG.error("There is no alarm-id associated with the event-id='{}'. Will not create ticket.", eventID);
         	return 1;
@@ -160,11 +173,13 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 
         /* Guard against duplicate tickets: a previous notification, an escalation,
          * or another member of a group target may already have created one.
+         * Tickets in a terminal state (or whose creation failed) do not block a
+         * new ticket, so a re-fired problem can open a fresh one.
          * Near-simultaneous deliveries can still race the asynchronous ticket
          * creation, so single-user targets remain the recommended configuration.
          */
-        if( StringUtils.isNotBlank(alarmState.getTticketID()) ) {
-		LOG.info("Alarm-id='{}' already has ticket-id='{}'. Will not create another ticket.", alarmState.getAlarmID(), alarmState.getTticketID());
+        if( StringUtils.isNotBlank(alarmState.getTticketID()) && isTicketActive(alarmState.getTticketState()) ) {
+		LOG.info("Alarm-id='{}' already has an active ticket-id='{}' in state '{}'. Will not create another ticket.", alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
         	return 0;
         }
 
@@ -174,6 +189,21 @@ public class TicketNotificationStrategy implements NotificationStrategy {
         sendCreateTicketEvent(alarmState.getAlarmID(), eventUEI, ticketUser);
 
         return 0;
+	}
+
+    /**
+     * A ticket still blocks creating a new one unless it reached a terminal
+     * state or its creation failed. Unknown state values are treated as active
+     * to stay on the no-duplicate side; a NULL tticketstate column also lands
+     * there, because JDBC getInt() maps it to 0 (OPEN).
+     */
+	protected static boolean isTicketActive(int tticketStateValue) {
+		for (TroubleTicketState state : INACTIVE_TICKET_STATES) {
+			if (state.getValue() == tticketStateValue) {
+				return false;
+			}
+		}
+		return true;
 	}
 
     /**

--- a/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
+++ b/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
@@ -157,10 +157,18 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 		LOG.error("There is no alarm-id associated with the event-id='{}'. Will not create ticket.", eventID);
         	return 1;
         }
-        
-        /* Log everything we know so far.
-         * The tticketid and tticketstate are only informational.
+
+        /* Guard against duplicate tickets: a previous notification, an escalation,
+         * or another member of a group target may already have created one.
+         * Near-simultaneous deliveries can still race the asynchronous ticket
+         * creation, so single-user targets remain the recommended configuration.
          */
+        if( StringUtils.isNotBlank(alarmState.getTticketID()) ) {
+		LOG.info("Alarm-id='{}' already has ticket-id='{}'. Will not create another ticket.", alarmState.getAlarmID(), alarmState.getTticketID());
+        	return 0;
+        }
+
+        // Log everything we know so far.
         LOG.info("Got event-uei='{}' with event-id='{}', notice-id='{}', alarm-type='{}', alarm-id='{}', tticket-id='{}' and tticket-state='{}'", eventUEI, eventID, noticeID, alarmType, alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
         
         sendCreateTicketEvent(alarmState.getAlarmID(), eventUEI, ticketUser);

--- a/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
+++ b/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
@@ -27,7 +27,8 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.opennms.core.db.DataSourceFactory;
-import org.opennms.netmgt.config.DefaultEventConfDao;
+import org.opennms.core.spring.BeanUtils;
+import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
@@ -51,7 +52,7 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TicketNotificationStrategy.class);
 	private EventIpcManager m_eventManager;
-	private DefaultEventConfDao m_eventConfDao;
+	private EventConfDao m_eventConfDao;
 	
 	enum AlarmType {
 		NOT_AN_ALARM,
@@ -182,7 +183,7 @@ public class TicketNotificationStrategy implements NotificationStrategy {
      * @return 0 if alarmid is null
      */
 	protected AlarmType getAlarmTypeFromUEI(final String eventUEI) {
-	    final Event event = m_eventConfDao.findByUei(eventUEI);
+	    final Event event = getEventConfDao().findByUei(eventUEI);
 	    if( event == null ) {
 	        return AlarmType.NOT_AN_ALARM;
 	    }
@@ -197,6 +198,17 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 	    return AlarmType.NOT_AN_ALARM;
 	}
 	
+	protected EventConfDao getEventConfDao() {
+		if (m_eventConfDao == null) {
+			m_eventConfDao = BeanUtils.getBean("notifdContext", "eventConfDao", EventConfDao.class);
+		}
+		return m_eventConfDao;
+	}
+
+	public void setEventConfDao(EventConfDao eventConfDao) {
+		m_eventConfDao = eventConfDao;
+	}
+
     /**
      * <p>Helper function that sends the create ticket event</p>
      *

--- a/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
+++ b/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
@@ -133,6 +133,42 @@ public class TicketNotificationStrategyTest {
 	    assertEquals("Received unexpected events", 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
     }
 
+    @Test
+    public void testCreateTicketWithCustomUser() {
+        EventBuilder createTicketBuilder = new EventBuilder(EventConstants.TROUBLETICKET_CREATE_UEI, m_ticketNotificationStrategy.getName());
+        createTicketBuilder.setParam(EventConstants.PARM_ALARM_ID, "1");
+        createTicketBuilder.setParam(EventConstants.PARM_ALARM_UEI, EventConstants.NODE_DOWN_EVENT_UEI);
+        createTicketBuilder.setParam(EventConstants.PARM_USER, "noc");
+        m_eventIpcManager.getEventAnticipator().anticipateEvent(createTicketBuilder.getEvent());
+
+        when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
+        m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(1));
+        List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
+        arguments.add(new Argument("ticketUser", null, "noc", false));
+
+        assertEquals(0, m_ticketNotificationStrategy.send(arguments));
+        assertTrue("Expected events not forthcoming", m_eventIpcManager.getEventAnticipator().waitForAnticipated(0).isEmpty());
+        assertEquals("Received unexpected events", 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    }
+
+    @Test
+    public void testCreateTicketWithBlankUserFallsBackToDefault() {
+        EventBuilder createTicketBuilder = new EventBuilder(EventConstants.TROUBLETICKET_CREATE_UEI, m_ticketNotificationStrategy.getName());
+        createTicketBuilder.setParam(EventConstants.PARM_ALARM_ID, "1");
+        createTicketBuilder.setParam(EventConstants.PARM_ALARM_UEI, EventConstants.NODE_DOWN_EVENT_UEI);
+        createTicketBuilder.setParam(EventConstants.PARM_USER, TicketNotificationStrategy.DEFAULT_TICKET_USER);
+        m_eventIpcManager.getEventAnticipator().anticipateEvent(createTicketBuilder.getEvent());
+
+        when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
+        m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(1));
+        List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
+        arguments.add(new Argument("ticketUser", null, "", false));
+
+        assertEquals(0, m_ticketNotificationStrategy.send(arguments));
+        assertTrue("Expected events not forthcoming", m_eventIpcManager.getEventAnticipator().waitForAnticipated(0).isEmpty());
+        assertEquals("Received unexpected events", 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    }
+
     protected Event buildAlarmEvent(int alarmType) {
 		Event event = new Event();
 		AlarmData alarmData = new AlarmData();

--- a/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
+++ b/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,59 +37,41 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opennms.core.db.DataSourceFactory;
 import org.opennms.core.test.MockLogAppender;
+import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.notifd.Argument;
-import org.opennms.netmgt.notifd.TicketNotificationStrategy.AlarmType;
+import org.opennms.netmgt.xml.eventconf.AlarmData;
+import org.opennms.netmgt.xml.eventconf.Event;
 
 /**
  * Basic test cases for the TicketNotificationStrategy.
- * 
+ *
  * @author <a href="mailto:jwhite@datavalet.com">Jesse White</a>
  */
 public class TicketNotificationStrategyTest {
 
     private MockEventIpcManager m_eventIpcManager;
     private MockTicketNotificationStrategy m_ticketNotificationStrategy;
+    private EventConfDao m_eventConfDao;
     private DataSource m_dataSource;
-    
+
     private class MockTicketNotificationStrategy extends TicketNotificationStrategy {
     	AlarmState m_alarmState;
-    	AlarmType m_alarmType;
 
     	public MockTicketNotificationStrategy() {
     		m_alarmState = new AlarmState(0,"",0);
-    		m_alarmType = AlarmType.NOT_AN_ALARM;
     	}
-    	
+
     	public void setAlarmState(AlarmState alarmState) {
     		m_alarmState = alarmState;
     	}
-    	
-    	@SuppressWarnings("unused")
-		public AlarmState getAlarmState() {
-    		return m_alarmState;
-    	}
-    	
-    	public void setAlarmType(AlarmType alarmType) {
-    		m_alarmType = alarmType;
-    	}
-    	
-    	@SuppressWarnings("unused")
-    	public AlarmType getAlarmType(AlarmType alarmType) {
-    		return m_alarmType;
-    	}
-    	
+
     	@Override
     	protected AlarmState getAlarmStateFromEvent(int eventID) {
     		return m_alarmState;
-    	}
-    	
-    	@Override
-    	protected AlarmType getAlarmTypeFromUEI(String eventUEI) {
-    		return m_alarmType;
     	}
     };
 
@@ -98,7 +81,9 @@ public class TicketNotificationStrategyTest {
         m_eventIpcManager.setSynchronous(true);
         EventIpcManagerFactory.setIpcManager(m_eventIpcManager);
         MockLogAppender.setupLogging();
+        m_eventConfDao = mock(EventConfDao.class);
         m_ticketNotificationStrategy = new MockTicketNotificationStrategy();
+        m_ticketNotificationStrategy.setEventConfDao(m_eventConfDao);
         m_dataSource = mock(DataSource.class);
         DataSourceFactory.setInstance(m_dataSource);
     }
@@ -114,12 +99,20 @@ public class TicketNotificationStrategyTest {
     }
 
     @Test
-    public void testNoticeWithNoAlarmID() {
-    	m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(0));
-    	m_ticketNotificationStrategy.setAlarmType(AlarmType.NOT_AN_ALARM);
+    public void testNoticeWithNonAlarmEvent() {
+    	when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(null);
     	List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
-    	assertEquals("Strategy should fail silently if the event has no alarm id.", 0, m_ticketNotificationStrategy.send(arguments));
-    	assertTrue("Strategy should log a warning if the event has no alarm id.", !MockLogAppender.noWarningsOrHigherLogged());
+    	assertEquals("Strategy should fail silently if the event is not an alarm.", 0, m_ticketNotificationStrategy.send(arguments));
+    	assertTrue("Strategy should log a warning if the event is not an alarm.", !MockLogAppender.noWarningsOrHigherLogged());
+    }
+
+    @Test
+    public void testNoticeWithNoAlarmID() {
+    	when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
+    	m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(0));
+    	List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
+    	assertEquals("Strategy should fail if the event has no alarm id.", 1, m_ticketNotificationStrategy.send(arguments));
+    	assertTrue("Strategy should log an error if the event has no alarm id.", !MockLogAppender.noWarningsOrHigherLogged());
     }
 
     @Test
@@ -130,17 +123,25 @@ public class TicketNotificationStrategyTest {
         newSuspectBuilder.setParam(EventConstants.PARM_ALARM_UEI, EventConstants.NODE_DOWN_EVENT_UEI);
         newSuspectBuilder.setParam(EventConstants.PARM_USER, "admin");
         m_eventIpcManager.getEventAnticipator().anticipateEvent(newSuspectBuilder.getEvent());
-        
+
+        when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
         m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(1));
-        m_ticketNotificationStrategy.setAlarmType(AlarmType.PROBLEM);
         List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
-        
+
         assertEquals(0, m_ticketNotificationStrategy.send(arguments));
 	    assertTrue("Expected events not forthcoming", m_eventIpcManager.getEventAnticipator().waitForAnticipated(0).isEmpty());
 	    assertEquals("Received unexpected events", 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
     }
-    
-    protected List<Argument> buildArguments(String eventID, String eventUEI) 
+
+    protected Event buildAlarmEvent(int alarmType) {
+		Event event = new Event();
+		AlarmData alarmData = new AlarmData();
+		alarmData.setAlarmType(alarmType);
+		event.setAlarmData(alarmData);
+		return event;
+    }
+
+    protected List<Argument> buildArguments(String eventID, String eventUEI)
     {
 		List<Argument> arguments = new ArrayList<>();
 		arguments.add(new Argument("eventID", null, eventID, false));

--- a/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
+++ b/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
@@ -134,6 +134,15 @@ public class TicketNotificationStrategyTest {
     }
 
     @Test
+    public void testNoticeWithExistingTicket() {
+    	when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
+    	m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(1, "TICKET-1", 1));
+    	List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
+    	assertEquals("Strategy should succeed without sending an event if the alarm already has a ticket.", 0, m_ticketNotificationStrategy.send(arguments));
+    	assertEquals("Strategy should not send a create-ticket event if the alarm already has a ticket.", 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    }
+
+    @Test
     public void testCreateTicketWithCustomUser() {
         EventBuilder createTicketBuilder = new EventBuilder(EventConstants.TROUBLETICKET_CREATE_UEI, m_ticketNotificationStrategy.getName());
         createTicketBuilder.setParam(EventConstants.PARM_ALARM_ID, "1");

--- a/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
+++ b/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
@@ -41,6 +41,7 @@ import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
+import org.opennms.netmgt.model.TroubleTicketState;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.notifd.Argument;
 import org.opennms.netmgt.xml.eventconf.AlarmData;
@@ -134,12 +135,56 @@ public class TicketNotificationStrategyTest {
     }
 
     @Test
-    public void testNoticeWithExistingTicket() {
+    public void testNoticeWithOpenTicketDoesNotCreateAnother() {
+    	assertTicketStateBlocksCreate(TroubleTicketState.OPEN);
+    }
+
+    @Test
+    public void testNoticeWithCreatePendingTicketDoesNotCreateAnother() {
+    	assertTicketStateBlocksCreate(TroubleTicketState.CREATE_PENDING);
+    }
+
+    @Test
+    public void testNoticeWithUpdatePendingTicketDoesNotCreateAnother() {
+    	assertTicketStateBlocksCreate(TroubleTicketState.UPDATE_PENDING);
+    }
+
+    @Test
+    public void testNoticeWithClosedTicketCreatesNewTicket() {
+    	assertTicketStateAllowsCreate(TroubleTicketState.CLOSED);
+    }
+
+    @Test
+    public void testNoticeWithCancelledTicketCreatesNewTicket() {
+    	assertTicketStateAllowsCreate(TroubleTicketState.CANCELLED);
+    }
+
+    @Test
+    public void testNoticeWithCreateFailedTicketCreatesNewTicket() {
+    	assertTicketStateAllowsCreate(TroubleTicketState.CREATE_FAILED);
+    }
+
+    private void assertTicketStateBlocksCreate(TroubleTicketState state) {
     	when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
-    	m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(1, "TICKET-1", 1));
+    	m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(1, "TICKET-1", state.getValue()));
     	List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
-    	assertEquals("Strategy should succeed without sending an event if the alarm already has a ticket.", 0, m_ticketNotificationStrategy.send(arguments));
-    	assertEquals("Strategy should not send a create-ticket event if the alarm already has a ticket.", 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    	assertEquals("Strategy should succeed without sending an event for ticket state " + state, 0, m_ticketNotificationStrategy.send(arguments));
+    	assertEquals("Strategy should not send a create-ticket event for ticket state " + state, 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    }
+
+    private void assertTicketStateAllowsCreate(TroubleTicketState state) {
+    	EventBuilder createTicketBuilder = new EventBuilder(EventConstants.TROUBLETICKET_CREATE_UEI, m_ticketNotificationStrategy.getName());
+    	createTicketBuilder.setParam(EventConstants.PARM_ALARM_ID, "1");
+    	createTicketBuilder.setParam(EventConstants.PARM_ALARM_UEI, EventConstants.NODE_DOWN_EVENT_UEI);
+    	createTicketBuilder.setParam(EventConstants.PARM_USER, TicketNotificationStrategy.DEFAULT_TICKET_USER);
+    	m_eventIpcManager.getEventAnticipator().anticipateEvent(createTicketBuilder.getEvent());
+
+    	when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
+    	m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(1, "TICKET-1", state.getValue()));
+    	List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
+    	assertEquals("Strategy should succeed for ticket state " + state, 0, m_ticketNotificationStrategy.send(arguments));
+    	assertTrue("Strategy should send a create-ticket event for ticket state " + state, m_eventIpcManager.getEventAnticipator().waitForAnticipated(0).isEmpty());
+    	assertEquals("Received unexpected events for ticket state " + state, 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
     }
 
     @Test

--- a/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
@@ -216,4 +216,15 @@
                 <command>growlMessage</command>
         </target>
     </path>
+    <!-- Creates a trouble ticket for the alarm associated with the notification's event.
+    The createTicket command is defined in the notificationCommands.xml example.  The
+    initial-delay gives alarmd time to associate the event with an alarm; with 0s the
+    ticket lookup can run before the alarm exists and the notification fails.  The target
+    user's contact information is not used. -->
+    <path name="Create-Ticket" initial-delay="30s">
+        <target>
+                <name>Admin</name>
+                <command>createTicket</command>
+        </target>
+    </path>
 </destinationPaths>

--- a/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
@@ -219,8 +219,8 @@
     <!-- Creates a trouble ticket for the alarm associated with the notification's event.
     The createTicket command is defined in the notificationCommands.xml example.  The
     initial-delay gives alarmd time to associate the event with an alarm; with 0s the
-    ticket lookup can run before the alarm exists and the notification fails.  The target
-    user's contact information is not used. -->
+    ticket lookup can run before the alarm exists and the notification fails.  The target's
+    contact information is not used. -->
     <path name="Create-Ticket" initial-delay="30s">
         <target>
                 <name>Admin</name>

--- a/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
@@ -220,10 +220,11 @@
     The createTicket command is defined in the notificationCommands.xml example.  The
     initial-delay gives alarmd time to associate the event with an alarm; with 0s the
     ticket lookup can run before the alarm exists and the notification fails.  The target's
-    contact information is not used. -->
+    contact information is not used.  Target a single user rather than a group: a group
+    target runs the command once per member, which can create duplicate tickets. -->
     <path name="Create-Ticket" initial-delay="30s">
         <target>
-                <name>Admin</name>
+                <name>admin</name>
                 <command>createTicket</command>
         </target>
     </path>

--- a/opennms-base-assembly/src/main/filtered/etc/examples/notificationCommands.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/notificationCommands.xml
@@ -248,6 +248,29 @@
     		<switch>trapVarbind</switch>
     	</argument>
     </command>
+    <!-- Use this notificationCommand to create a trouble ticket for the alarm associated with the
+    notification's event.  Requires a configured ticketer plugin, and the event must have alarm-data.
+    Use a destination path with a non-zero initial-delay so alarmd has associated the event with an
+    alarm before the ticket lookup runs.  The optional ticketUser argument sets the user parameter
+    on the create-ticket event (defaults to "admin"); it can be supplied per notification with a
+    parameter named "ticketUser" in notifications.xml. -->
+    <command binary="false">
+        <name>createTicket</name>
+        <execute>org.opennms.netmgt.notifd.TicketNotificationStrategy</execute>
+        <comment>class for creating a trouble ticket for the alarm associated with the notification's event</comment>
+        <argument streamed="false">
+            <switch>eventID</switch>
+        </argument>
+        <argument streamed="false">
+            <switch>eventUEI</switch>
+        </argument>
+        <argument streamed="false">
+            <switch>noticeid</switch>
+        </argument>
+        <argument streamed="false">
+            <switch>ticketUser</switch>
+        </argument>
+    </command>
 	<command binary="true">
 		<name>syslog</name>
 		<execute>/usr/bin/logger</execute>


### PR DESCRIPTION
Builds on #8637 (so that needs to merge first). The strategy shipped with no reference in any notificationCommands.xml and no documentation, so it was unreachable without hand-written configuration and a naïve wiring hits the "no alarm-id" error because the delivery-time alarm lookup races alarmd.

- Adds a createTicket example command and a Create-Ticket example destination path whose non-zero initial-delay avoids the alarmd race
- Adds a strategy docs page under Bonus Notification Methods covering prerequisites and caveats
- Replaces the hardcoded admin ticket user with an optional ticketUser argument, settable per notification; absent or blank values fall back to admin

Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20101

