### PR TITLE
Fix sidebar rail overlapping content on all legacy JSP pages

### DIFF
--- a/ui/src/styles/opennms-styles.scss
+++ b/ui/src/styles/opennms-styles.scss
@@ -77,6 +77,17 @@ footer#footer,
   --p-text-color: rgb(255, 255, 255);
 }
 
+// Base (collapsed-rail) left offset for legacy JSP hosts. SideMenu.vue only
+// pushes the content when the rail is pinned open (inline padding-left, which
+// overrides this rule); the collapsed/base offset is the host stylesheet's
+// contract — the SPA owns its own in .app-layout (main/App.vue). Scope via
+// :has(> #opennms-sidemenu-container) so quiet pages (no menu) and
+// superQuiet/Vaadin embeds (menu outside #content) keep their full width.
+// Geometry mirrors .app-layout: collapsed rail width + the rail gap.
+#content:has(> #opennms-sidemenu-container) {
+  padding-left: calc(var(--onms-side-menu-collapsed, 3.75rem) + 0.25rem);
+}
+
 // Pre-mount skeleton for the Vue menu on legacy JSP pages (NMS-19975). JSP
 // navigations are full document loads and #opennms-sidemenu-container is
 // server-rendered empty, so nothing dark exists where the fixed menubar and


### PR DESCRIPTION
## What

Every legacy JSP page currently renders its content underneath the fixed collapsed side-menu rail — the leftmost ~3.75rem of `#content` (card titles, breadcrumbs, form labels) is clipped. Compare any JSP page (`admin/index.jsp`, `admin/notification/noticeWizard/buildPathOutage.jsp`, …) against an SPA page.

## Why

The side-menu rework made the collapsed-rail base offset the *host stylesheet's* responsibility: `SideMenu.vue` only pushes content (inline `padding-left`) when the rail is pinned open, and clears the inline style otherwise, per its own comment: *"The COLLAPSED/base left offset is owned by each host's stylesheet (JSP #content, SPA .app-layout)."* The SPA host has its rule (`.app-layout` in `main/App.vue`), but the JSP host rule was never added, so legacy pages get no base offset at all.

## How

Adds the missing rule to `opennms-styles.scss` (which the menubar bundle injects on JSP pages):

```scss
#content:has(> #opennms-sidemenu-container) {
  padding-left: calc(var(--onms-side-menu-collapsed, 3.75rem) + 0.25rem);
}
```

- Scoped with `:has(> #opennms-sidemenu-container)` so `quiet` pages (no menu) and `superQuiet`/Vaadin embeds (menu outside `#content`) keep their full width, and the `oldmenu=true` escape hatch is unaffected.
- Geometry mirrors `.app-layout` (collapsed rail width + rail gap).
- The pinned-open push still wins since SideMenu applies it as an inline style.

Verified on a local 37.0.0-SNAPSHOT build: JSP pages (home, admin, notification wizards) render with content clear of the rail in both collapsed and pinned states; quiet pages unaffected.