### PR TITLE
NMS-20104: Add ability to run full integration tests on CircleCI

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -32,6 +32,7 @@ The user has ability to modify the build path by
       | !oci          | Runs Docker Container jobs |
       | !doc          | Runs doc job  |
       | !ui           | Runs ui job |
+      | !integration  | Runs the full integration test suite (instead of changes-only) |
       * For the latest list take a look at `.circleci/main/workflows/workflows_v2.json`.
 
     * `process_generate.py` script attempts to detect and enable corresponding jobs automatically if incoming changes contains changes to:

--- a/.circleci/epoch
+++ b/.circleci/epoch
@@ -1,2 +1,2 @@
 # increment this to force a full build
-4
+5

--- a/.circleci/main/jobs/tests/integration/integration-test.yml
+++ b/.circleci/main/jobs/tests/integration/integration-test.yml
@@ -2,10 +2,15 @@ jobs:
   integration-test:
     executor: integration-test-executor
     parallelism: 8
-    resource_class: xlarge
+    resource_class: large
+    parameters:
+      changes-only:
+        type: boolean
+        default: true
     steps:
       - cached-checkout
       - attach_workspace:
           at: ~/
       - run-integration-tests:
           rerun-failtest-count: 1
+          changes-only: << parameters.changes-only >>

--- a/.circleci/main/parameters.yml
+++ b/.circleci/main/parameters.yml
@@ -47,6 +47,10 @@ parameters:
     description: whether to trigger a code coverage build
     type: boolean
     default: false
+  trigger-integration-changes-only:
+    description: whether integration tests should be limited to changed modules (false runs the full suite)
+    type: boolean
+    default: true
 
   ### config.yml parameters for when triggers are used (not used in main.yml, but needed defined here for trigger executions) ###
   trigger-prebuild:

--- a/.circleci/main/workflows/workflows_v2.json
+++ b/.circleci/main/workflows/workflows_v2.json
@@ -171,7 +171,10 @@
             ],
             "requires": [
                 "build"
-            ]
+            ],
+            "parameters": {
+                "changes-only": "<< pipeline.parameters.trigger-integration-changes-only >>"
+            }
         },
         "minion-rpm-build": {
             "context": [

--- a/.circleci/pyscripts/library/cci_components/workflow.py
+++ b/.circleci/pyscripts/library/cci_components/workflow.py
@@ -210,6 +210,15 @@ class workflow:
                                 "doesn't exist in our workflow_jobs",
                             )
 
+                elif "parameters" in element:
+                    for param_name, param_value in tmp_output_elements[element].items():
+                        tmp_output.append(
+                            self._common_library.create_space(leading_space + 4)
+                            + param_name
+                            + ": "
+                            + str(param_value)
+                        )
+
                 else:
                     print("Problem!!! Not sure how to handle element: ", element)
             if not re.match("^.*merge.*$", job):

--- a/.circleci/pyscripts/process_generate.py
+++ b/.circleci/pyscripts/process_generate.py
@@ -181,6 +181,13 @@ else:
 print("Build Trigger Override Found:", str(build_trigger_override_found))
 print()
 
+# Whether "integration" was forced on (as opposed to naturally detected from
+# src/test/ changes) determines whether integration tests should run against
+# the full suite instead of just the changed modules.
+integration_forced_by_override = build_trigger_override_found and build_mappings.get(
+    "integration", False
+)
+
 # Epoch file will force a build to run
 if ".circleci/epoch" in changed_files:
     print("`epoch` file detected")
@@ -303,8 +310,22 @@ if "rpms" in git_keywords:
 if "debs" in git_keywords:
     build_mappings["debs"] = True
 
-if "integration" in git_keywords or "Integration_tests" in What_to_build:
+integration_forced_by_keyword = "integration" in git_keywords
+
+if integration_forced_by_keyword or "Integration_tests" in What_to_build:
     build_mappings["integration"] = True
+
+# If integration was enabled naturally (src/test/ changes detected), only run
+# tests for the changed modules. If it was forced on via the override file or
+# the `!integration` commit keyword, run the full integration suite instead.
+integration_full_run = build_mappings["integration"] and (
+    integration_forced_by_override or integration_forced_by_keyword
+)
+mappings["trigger-integration-changes-only"] = not integration_full_run
+
+if integration_full_run:
+    print("Integration tests forced on, running full suite (changes-only=false)")
+    print()
 
 if "build" in What_to_build and not build_mappings["experimental"]:
     build_mappings["build-deploy"] = True


### PR DESCRIPTION
Allow the user to run the all our integration test cases.

The user can enable this by either:
 * Adding `!integration` tag as part of their commit message
 * Use `build-triggers.override.json` approach
 * Adding `trigger-integration-changes-only ` with value of `false` to *Parameters* section when requesting a build in CircleCI

*Note:*  This approach disables all filtering, as such we run all integration test cases, similar to what our coverage build does.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20104

