### PR TITLE
NMS-20106: versioned user management API and PrimeVue Manage Users page

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UsersRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UsersRestService.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+
+import org.opennms.netmgt.config.UserManager;
+import org.opennms.netmgt.config.api.UserConfig.ContactType;
+import org.opennms.netmgt.config.users.Contact;
+import org.opennms.netmgt.config.users.User;
+import org.opennms.web.api.Authentication;
+import org.opennms.web.rest.v2.api.UsersRestApi;
+import org.opennms.web.rest.v2.model.UserDto;
+import org.opennms.web.rest.v2.model.UserPasswordRequest;
+import org.opennms.web.rest.v2.model.UserRenameRequest;
+import org.opennms.web.rest.v2.model.UserWriteRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Versioned user management on top of {@link UserManager}: users.xml remains
+ * the system of record and hand-editing keeps working. Unlike the legacy JSPs
+ * (which only hid the buttons), the admin/rtc delete and rename protections
+ * are enforced here, server-side. The password hash is never serialized.
+ */
+@Component("usersRestServiceV2")
+public class UsersRestService implements UsersRestApi {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UsersRestService.class);
+
+    /** System accounts that must not be deleted or renamed. */
+    private static final Set<String> PROTECTED_USERS = Set.of("admin", "rtc");
+
+    /** Mirrors the legacy servlets' markup check on user ids. */
+    private static final Pattern INVALID_USER_ID = Pattern.compile(".*[&<>\"`']+.*");
+
+    @Autowired
+    private UserManager m_userManager;
+
+    @Override
+    public Response listUsers(final SecurityContext securityContext) {
+        assertAdmin(securityContext);
+        try {
+            final List<UserDto> users = new ArrayList<>();
+            for (final User user : m_userManager.getUsers().values()) {
+                users.add(toDto(user));
+            }
+            users.sort(Comparator.comparing(UserDto::getUserId, String.CASE_INSENSITIVE_ORDER));
+            return Response.ok(users).build();
+        } catch (final Exception e) {
+            return serverError("Can't read users: %s", e);
+        }
+    }
+
+    @Override
+    public Response getUser(final SecurityContext securityContext, final String userId) {
+        assertAdmin(securityContext);
+        try {
+            final User user = m_userManager.getUser(userId);
+            if (user == null) {
+                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            }
+            return Response.ok(toDto(user)).build();
+        } catch (final Exception e) {
+            return serverError("Can't read user: %s", e);
+        }
+    }
+
+    @Override
+    public Response listAvailableRoles(final SecurityContext securityContext) {
+        assertAdmin(securityContext);
+        final List<String> roles = new ArrayList<>(Authentication.getAvailableRoles());
+        roles.sort(String.CASE_INSENSITIVE_ORDER);
+        return Response.ok(roles).build();
+    }
+
+    @Override
+    public Response createUser(final SecurityContext securityContext, final UserWriteRequest request) {
+        assertAdmin(securityContext);
+        if (request == null || isBlank(request.getUserId())) {
+            return Response.status(Status.BAD_REQUEST).entity("A user-id is required.").build();
+        }
+        final String userId = request.getUserId().trim();
+        if (INVALID_USER_ID.matcher(userId).matches()) {
+            return Response.status(Status.BAD_REQUEST).entity("The user-id must not contain any HTML markup.").build();
+        }
+        if (isBlank(request.getPassword())) {
+            return Response.status(Status.BAD_REQUEST).entity("A password is required.").build();
+        }
+        try {
+            if (m_userManager.hasUser(userId)) {
+                return Response.status(Status.BAD_REQUEST).entity("User " + userId + " already exists.").build();
+            }
+            final User user = new User();
+            user.setUserId(userId);
+            user.setPassword(m_userManager.encryptedPassword(request.getPassword(), true), Boolean.TRUE);
+            applyDto(user, request);
+            m_userManager.saveUser(userId, user);
+            LOG.info("User {} created by {}", userId, securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName());
+            return Response.status(Status.CREATED).build();
+        } catch (final Exception e) {
+            return serverError("Can't create user: %s", e);
+        }
+    }
+
+    @Override
+    public Response updateUser(final SecurityContext securityContext, final String userId, final UserDto dto) {
+        assertAdmin(securityContext);
+        if (dto == null) {
+            return Response.status(Status.BAD_REQUEST).entity("A user body is required.").build();
+        }
+        try {
+            final User user = m_userManager.getUser(userId);
+            if (user == null) {
+                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            }
+            applyDto(user, dto);
+            m_userManager.saveUser(userId, user);
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            return serverError("Can't update user: %s", e);
+        }
+    }
+
+    @Override
+    public Response setPassword(final SecurityContext securityContext, final String userId, final UserPasswordRequest request) {
+        assertAdmin(securityContext);
+        if (request == null || isBlank(request.getPassword())) {
+            return Response.status(Status.BAD_REQUEST).entity("A password is required.").build();
+        }
+        try {
+            final User user = m_userManager.getUser(userId);
+            if (user == null) {
+                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            }
+            user.setPassword(m_userManager.encryptedPassword(request.getPassword(), true), Boolean.TRUE);
+            m_userManager.saveUser(userId, user);
+            LOG.info("Password changed for user {} by {}", userId, securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName());
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            return serverError("Can't change password: %s", e);
+        }
+    }
+
+    @Override
+    public Response renameUser(final SecurityContext securityContext, final String userId, final UserRenameRequest request) {
+        assertAdmin(securityContext);
+        if (request == null || isBlank(request.getNewUserId())) {
+            return Response.status(Status.BAD_REQUEST).entity("A new-user-id is required.").build();
+        }
+        if (PROTECTED_USERS.contains(userId)) {
+            return Response.status(Status.BAD_REQUEST).entity("The system user " + userId + " cannot be renamed.").build();
+        }
+        final String newUserId = request.getNewUserId().trim();
+        if (INVALID_USER_ID.matcher(newUserId).matches()) {
+            return Response.status(Status.BAD_REQUEST).entity("The user-id must not contain any HTML markup.").build();
+        }
+        try {
+            if (!m_userManager.hasUser(userId)) {
+                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            }
+            if (m_userManager.hasUser(newUserId)) {
+                return Response.status(Status.BAD_REQUEST).entity("User " + newUserId + " already exists.").build();
+            }
+            m_userManager.renameUser(userId, newUserId);
+            LOG.info("User {} renamed to {} by {}", userId, newUserId, securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName());
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            return serverError("Can't rename user: %s", e);
+        }
+    }
+
+    @Override
+    public Response deleteUser(final SecurityContext securityContext, final String userId) {
+        assertAdmin(securityContext);
+        if (PROTECTED_USERS.contains(userId)) {
+            return Response.status(Status.BAD_REQUEST).entity("The system user " + userId + " cannot be deleted.").build();
+        }
+        try {
+            if (!m_userManager.hasUser(userId)) {
+                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            }
+            m_userManager.deleteUser(userId);
+            LOG.info("User {} deleted by {}", userId, securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName());
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            return serverError("Can't delete user: %s", e);
+        }
+    }
+
+    private UserDto toDto(final User user) {
+        final UserDto dto = new UserDto();
+        dto.setUserId(user.getUserId());
+        dto.setFullName(user.getFullName().orElse(null));
+        dto.setUserComments(user.getUserComments().orElse(null));
+        dto.setEmail(contactInfo(user, ContactType.email));
+        dto.setPagerEmail(contactInfo(user, ContactType.pagerEmail));
+        dto.setTuiPin(user.getTuiPin().orElse(null));
+        dto.setTimeZoneId(user.getTimeZoneId().map(Objects::toString).orElse(null));
+        dto.setDutySchedules(new ArrayList<>(user.getDutySchedules()));
+        dto.setRoles(new ArrayList<>(user.getRoles()));
+        dto.setReadOnly(user.getRoles().contains(Authentication.ROLE_READONLY));
+        return dto;
+    }
+
+    /**
+     * Applies the DTO onto the JAXB user. Only the exposed contact types
+     * (email, pagerEmail) are touched; every other contact — XMPP, microblog,
+     * phones, paging services — and the password survive untouched, so a v2
+     * update can never corrupt hand-maintained users.xml entries.
+     */
+    private void applyDto(final User user, final UserDto dto) {
+        user.setFullName(trimToNull(dto.getFullName()));
+        user.setUserComments(trimToNull(dto.getUserComments()));
+        user.setTuiPin(trimToNull(dto.getTuiPin()));
+        final String timeZoneId = trimToNull(dto.getTimeZoneId());
+        if (timeZoneId == null) {
+            user.setTimeZoneId((java.time.ZoneId) null);
+        } else {
+            try {
+                user.setTimeZoneId(timeZoneId);
+            } catch (final RuntimeException e) {
+                throw new IllegalArgumentException("Invalid time-zone-id: " + timeZoneId);
+            }
+        }
+        setContact(user, ContactType.email, dto.getEmail());
+        setContact(user, ContactType.pagerEmail, dto.getPagerEmail());
+        if (dto.getDutySchedules() != null) {
+            user.setDutySchedules(new ArrayList<>(dto.getDutySchedules()));
+        }
+        if (dto.getRoles() != null) {
+            for (final String role : dto.getRoles()) {
+                if (!Authentication.isValidRole(role)) {
+                    throw new IllegalArgumentException("Unknown security role: " + role);
+                }
+            }
+            user.setRoles(new ArrayList<>(dto.getRoles()));
+        }
+    }
+
+    private static String contactInfo(final User user, final ContactType type) {
+        return user.getContacts().stream()
+                .filter(c -> type.name().equals(c.getType()))
+                .findFirst()
+                .flatMap(Contact::getInfo)
+                .filter(info -> !info.isEmpty())
+                .orElse(null);
+    }
+
+    private static void setContact(final User user, final ContactType type, final String value) {
+        final Optional<Contact> existing = user.getContacts().stream()
+                .filter(c -> type.name().equals(c.getType()))
+                .findFirst();
+        final String trimmed = trimToNull(value);
+        if (existing.isPresent()) {
+            existing.get().setInfo(trimmed == null ? "" : trimmed);
+        } else if (trimmed != null) {
+            final Contact contact = new Contact(type.name());
+            contact.setInfo(trimmed);
+            user.getContacts().add(contact);
+        }
+    }
+
+    private static void assertAdmin(final SecurityContext securityContext) {
+        if (securityContext == null || !securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
+            throw new javax.ws.rs.WebApplicationException(
+                    Response.status(Status.FORBIDDEN).entity("User management requires the admin role.").build());
+        }
+    }
+
+
+
+    private Response serverError(final String format, final Exception e) {
+        if (e instanceof IllegalArgumentException) {
+            return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
+        }
+        LOG.error(String.format(format, e.getMessage()), e);
+        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(String.format(format, e.getMessage())).build();
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static String trimToNull(final String value) {
+        if (value == null) {
+            return null;
+        }
+        final String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UsersRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UsersRestService.java
@@ -78,7 +78,10 @@ public class UsersRestService implements UsersRestApi {
      * references), and '/', '\', '%', '?', '#' (the id is a URL path segment
      * in every per-user endpoint).
      */
-    private static final Pattern INVALID_USER_ID = Pattern.compile(".*[&<>\"`':/\\\\%?#\\s]+.*");
+    private static final Pattern INVALID_USER_ID = Pattern.compile("[&<>\"`':/\\\\%?#\\s]");
+
+    /** Same markup characters the groups API rejects in comments. */
+    private static final Pattern INVALID_COMMENTS = Pattern.compile("[&<>\"`']");
 
     /**
      * Day tokens + military begin-end times, e.g. MoWeFr800-1700. Overnight
@@ -89,6 +92,10 @@ public class UsersRestService implements UsersRestApi {
 
     @Autowired
     private UserManager m_userManager;
+
+    /** For the on-call-role supervisor referential check on delete. */
+    @Autowired
+    private org.opennms.netmgt.config.GroupManager m_groupManager;
 
     @Override
     public Response listUsers(final SecurityContext securityContext) {
@@ -183,6 +190,12 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST)
                     .entity("The user-id in the body does not match the request path; use the rename endpoint to change ids.").build();
         }
+        // stripping ROLE_ADMIN from the admin account would lock every
+        // administrator out of the web UI until users.xml is hand-edited
+        if ("admin".equals(userId) && dto.getRoles() != null && !dto.getRoles().contains(Authentication.ROLE_ADMIN)) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity("The admin user must keep the " + Authentication.ROLE_ADMIN + " role.").build();
+        }
         try {
             synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 final User existing = m_userManager.getUser(userId);
@@ -269,6 +282,20 @@ public class UsersRestService implements UsersRestApi {
                 if (!m_userManager.hasUser(userId)) {
                     return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
                 }
+                // GroupManager.deleteUser strips memberships and schedules but
+                // leaves role supervisors dangling, silently killing the
+                // supervisor fallback for those rotas
+                final List<String> supervisedRoles = new ArrayList<>();
+                for (final org.opennms.netmgt.config.groups.Role role : m_groupManager.getRoles()) {
+                    if (userId.equals(role.getSupervisor())) {
+                        supervisedRoles.add(role.getName());
+                    }
+                }
+                if (!supervisedRoles.isEmpty()) {
+                    return Response.status(Status.BAD_REQUEST).entity("User " + userId
+                            + " is the supervisor of on-call role(s) " + String.join(", ", supervisedRoles)
+                            + "; assign a different supervisor first.").build();
+                }
                 m_userManager.deleteUser(userId);
             }
             LOG.info("User {} deleted by {}", userId, principal(securityContext));
@@ -321,6 +348,10 @@ public class UsersRestService implements UsersRestApi {
      * rejected request cannot leave partial state anywhere.
      */
     private static void validateDtoFields(final UserDto dto, final User existing) {
+        if (dto.getUserComments() != null && INVALID_COMMENTS.matcher(dto.getUserComments()).find()
+                && (existing == null || !dto.getUserComments().equals(existing.getUserComments().orElse(null)))) {
+            throw new IllegalArgumentException("The comments must not contain any HTML markup.");
+        }
         final String timeZoneId = trimToNull(dto.getTimeZoneId());
         if (timeZoneId != null) {
             try {
@@ -358,17 +389,31 @@ public class UsersRestService implements UsersRestApi {
      * out of the request body arrive as null and are preserved.
      */
     private static void applyDto(final User user, final UserDto dto) {
-        user.setFullName(trimToNull(dto.getFullName()));
-        user.setUserComments(trimToNull(dto.getUserComments()));
-        user.setTuiPin(trimToNull(dto.getTuiPin()));
-        final String timeZoneId = trimToNull(dto.getTimeZoneId());
-        if (timeZoneId == null) {
-            user.setTimeZoneId((java.time.ZoneId) null);
-        } else {
-            user.setTimeZoneId(timeZoneId);
+        // omitted (null) fields are preserved, matching the groups and
+        // on-call services; an empty string clears a field
+        if (dto.getFullName() != null) {
+            user.setFullName(trimToNull(dto.getFullName()));
         }
-        setContact(user, ContactType.email, dto.getEmail());
-        setContact(user, ContactType.pagerEmail, dto.getPagerEmail());
+        if (dto.getUserComments() != null) {
+            user.setUserComments(trimToNull(dto.getUserComments()));
+        }
+        if (dto.getTuiPin() != null) {
+            user.setTuiPin(trimToNull(dto.getTuiPin()));
+        }
+        if (dto.getTimeZoneId() != null) {
+            final String timeZoneId = trimToNull(dto.getTimeZoneId());
+            if (timeZoneId == null) {
+                user.setTimeZoneId((java.time.ZoneId) null);
+            } else {
+                user.setTimeZoneId(timeZoneId);
+            }
+        }
+        if (dto.getEmail() != null) {
+            setContact(user, ContactType.email, dto.getEmail());
+        }
+        if (dto.getPagerEmail() != null) {
+            setContact(user, ContactType.pagerEmail, dto.getPagerEmail());
+        }
         if (dto.getDutySchedules() != null) {
             user.setDutySchedules(new ArrayList<>(dto.getDutySchedules()));
         }
@@ -394,7 +439,7 @@ public class UsersRestService implements UsersRestApi {
 
     /** Returns a problem description, or null when the user id is acceptable. */
     private static String validateUserId(final String userId) {
-        if (INVALID_USER_ID.matcher(userId).matches()) {
+        if (INVALID_USER_ID.matcher(userId).find()) {
             return "The user-id must not contain markup, whitespace, or the characters : / \\ % ? #";
         }
         if (".".equals(userId) || "..".equals(userId)) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UsersRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UsersRestService.java
@@ -63,6 +63,10 @@ import org.springframework.stereotype.Component;
 @Component("usersRestServiceV2")
 public class UsersRestService implements UsersRestApi {
 
+    // Check-then-act sequences synchronize on GroupFactory.class: user
+    // mutations cascade into GroupManager (deleteUser/renameUser walk every
+    // group), so the v2 users and groups services must share one monitor.
+
     private static final Logger LOG = LoggerFactory.getLogger(UsersRestService.class);
 
     /** System accounts that must not be deleted or renamed. */
@@ -83,13 +87,6 @@ public class UsersRestService implements UsersRestApi {
      */
     private static final Pattern DUTY_SCHEDULE = Pattern.compile("^((?:Mo|Tu|We|Th|Fr|Sa|Su){1,7})(\\d{1,4})-(\\d{1,4})$");
 
-    /**
-     * Serializes this service's check-then-act sequences. UserManager's own
-     * lock is internal to each call, so without this two concurrent creates
-     * could both pass the hasUser() check.
-     */
-    private final Object m_lock = new Object();
-
     @Autowired
     private UserManager m_userManager;
 
@@ -97,7 +94,7 @@ public class UsersRestService implements UsersRestApi {
     public Response listUsers(final SecurityContext securityContext) {
         assertAdmin(securityContext);
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 final List<UserDto> users = new ArrayList<>();
                 for (final User user : m_userManager.getUsers().values()) {
                     users.add(toDto(user));
@@ -114,7 +111,7 @@ public class UsersRestService implements UsersRestApi {
     public Response getUser(final SecurityContext securityContext, final String userId) {
         assertAdmin(securityContext);
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 final User user = m_userManager.getUser(userId);
                 if (user == null) {
                     return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
@@ -149,12 +146,12 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST).entity("A password is required.").build();
         }
         try {
-            validateDtoFields(request);
+            validateDtoFields(request, null);
         } catch (final IllegalArgumentException e) {
             return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
         }
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 if (m_userManager.hasUser(userId)) {
                     return Response.status(Status.BAD_REQUEST).entity("User " + userId + " already exists.").build();
                 }
@@ -187,15 +184,15 @@ public class UsersRestService implements UsersRestApi {
                     .entity("The user-id in the body does not match the request path; use the rename endpoint to change ids.").build();
         }
         try {
-            validateDtoFields(dto);
-        } catch (final IllegalArgumentException e) {
-            return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
-        }
-        try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 final User existing = m_userManager.getUser(userId);
                 if (existing == null) {
                     return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+                }
+                try {
+                    validateDtoFields(dto, existing);
+                } catch (final IllegalArgumentException e) {
+                    return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
                 }
                 final User updated = copyOf(existing);
                 applyDto(updated, dto);
@@ -214,7 +211,7 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST).entity("A password is required.").build();
         }
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 final User existing = m_userManager.getUser(userId);
                 if (existing == null) {
                     return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
@@ -245,7 +242,7 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST).entity(userIdProblem).build();
         }
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 if (!m_userManager.hasUser(userId)) {
                     return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
                 }
@@ -268,7 +265,7 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST).entity("The system user " + userId + " cannot be deleted.").build();
         }
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 if (!m_userManager.hasUser(userId)) {
                     return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
                 }
@@ -323,7 +320,7 @@ public class UsersRestService implements UsersRestApi {
      * Validates every field of the request BEFORE anything is applied, so a
      * rejected request cannot leave partial state anywhere.
      */
-    private static void validateDtoFields(final UserDto dto) {
+    private static void validateDtoFields(final UserDto dto, final User existing) {
         final String timeZoneId = trimToNull(dto.getTimeZoneId());
         if (timeZoneId != null) {
             try {
@@ -340,8 +337,15 @@ public class UsersRestService implements UsersRestApi {
             }
         }
         if (dto.getDutySchedules() != null) {
+            // strings already stored on the record are preserved as-is so
+            // hand-edited files never make a user uneditable; only entries
+            // new to this request must pass validation
+            final Set<String> preExisting = existing == null
+                    ? Set.of() : new java.util.LinkedHashSet<>(existing.getDutySchedules());
             for (final String schedule : dto.getDutySchedules()) {
-                validateDutySchedule(schedule);
+                if (!preExisting.contains(schedule)) {
+                    validateDutySchedule(schedule);
+                }
             }
         }
     }
@@ -393,14 +397,16 @@ public class UsersRestService implements UsersRestApi {
         if (INVALID_USER_ID.matcher(userId).matches()) {
             return "The user-id must not contain markup, whitespace, or the characters : / \\ % ? #";
         }
+        if (".".equals(userId) || "..".equals(userId)) {
+            return "The user-id must not be a dot segment.";
+        }
         return null;
     }
 
     /**
      * Duty schedules are stored as strings like MoWeFr800-1700 and parsed with
      * unchecked exceptions all over notifd/group scheduling — an invalid string
-     * saved here would break duty evaluation at runtime. Overnight ranges
-     * (begin after end) are legal.
+     * saved here would break duty evaluation at runtime.
      */
     private static void validateDutySchedule(final String schedule) {
         final Matcher matcher = schedule == null ? null : DUTY_SCHEDULE.matcher(schedule);
@@ -411,6 +417,12 @@ public class UsersRestService implements UsersRestApi {
         final int end = Integer.parseInt(matcher.group(3));
         if (begin > 2359 || end > 2359 || begin % 100 > 59 || end % 100 > 59) {
             throw new IllegalArgumentException("Invalid duty schedule '" + schedule + "': times must be military clock values between 0 and 2359");
+        }
+        // DutySchedule.isInSchedule compares within one calendar day, so an
+        // overnight range can never match and would silently disable the
+        // schedule; require two rows (e.g. MoTu2000-2359 + TuWe0-800) instead
+        if (begin > end) {
+            throw new IllegalArgumentException("Invalid duty schedule '" + schedule + "': the begin time must not be after the end time; split overnight coverage into two schedules");
         }
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UsersRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UsersRestService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.ws.rs.core.Response;
@@ -36,6 +37,7 @@ import javax.ws.rs.core.SecurityContext;
 import org.opennms.netmgt.config.UserManager;
 import org.opennms.netmgt.config.api.UserConfig.ContactType;
 import org.opennms.netmgt.config.users.Contact;
+import org.opennms.netmgt.config.users.Password;
 import org.opennms.netmgt.config.users.User;
 import org.opennms.web.api.Authentication;
 import org.opennms.web.rest.v2.api.UsersRestApi;
@@ -53,6 +55,10 @@ import org.springframework.stereotype.Component;
  * the system of record and hand-editing keeps working. Unlike the legacy JSPs
  * (which only hid the buttons), the admin/rtc delete and rename protections
  * are enforced here, server-side. The password hash is never serialized.
+ *
+ * Mutations validate the full request up front and then apply it to a
+ * detached copy of the stored user, so a rejected request can never leave
+ * partial changes in the manager's shared in-memory state.
  */
 @Component("usersRestServiceV2")
 public class UsersRestService implements UsersRestApi {
@@ -62,8 +68,27 @@ public class UsersRestService implements UsersRestApi {
     /** System accounts that must not be deleted or renamed. */
     private static final Set<String> PROTECTED_USERS = Set.of("admin", "rtc");
 
-    /** Mirrors the legacy servlets' markup check on user ids. */
-    private static final Pattern INVALID_USER_ID = Pattern.compile(".*[&<>\"`']+.*");
+    /**
+     * Rejects markup (legacy servlet rule) plus characters that break how the
+     * id is used downstream: ':' (HTTP basic auth), whitespace (group
+     * references), and '/', '\', '%', '?', '#' (the id is a URL path segment
+     * in every per-user endpoint).
+     */
+    private static final Pattern INVALID_USER_ID = Pattern.compile(".*[&<>\"`':/\\\\%?#\\s]+.*");
+
+    /**
+     * Day tokens + military begin-end times, e.g. MoWeFr800-1700. Overnight
+     * schedules (begin after end, e.g. MoTu2000-800) are legal — the legacy
+     * UI wrote them and hand-edited files contain them.
+     */
+    private static final Pattern DUTY_SCHEDULE = Pattern.compile("^((?:Mo|Tu|We|Th|Fr|Sa|Su){1,7})(\\d{1,4})-(\\d{1,4})$");
+
+    /**
+     * Serializes this service's check-then-act sequences. UserManager's own
+     * lock is internal to each call, so without this two concurrent creates
+     * could both pass the hasUser() check.
+     */
+    private final Object m_lock = new Object();
 
     @Autowired
     private UserManager m_userManager;
@@ -72,12 +97,14 @@ public class UsersRestService implements UsersRestApi {
     public Response listUsers(final SecurityContext securityContext) {
         assertAdmin(securityContext);
         try {
-            final List<UserDto> users = new ArrayList<>();
-            for (final User user : m_userManager.getUsers().values()) {
-                users.add(toDto(user));
+            synchronized (m_lock) {
+                final List<UserDto> users = new ArrayList<>();
+                for (final User user : m_userManager.getUsers().values()) {
+                    users.add(toDto(user));
+                }
+                users.sort(Comparator.comparing(UserDto::getUserId, String.CASE_INSENSITIVE_ORDER));
+                return Response.ok(users).build();
             }
-            users.sort(Comparator.comparing(UserDto::getUserId, String.CASE_INSENSITIVE_ORDER));
-            return Response.ok(users).build();
         } catch (final Exception e) {
             return serverError("Can't read users: %s", e);
         }
@@ -87,11 +114,13 @@ public class UsersRestService implements UsersRestApi {
     public Response getUser(final SecurityContext securityContext, final String userId) {
         assertAdmin(securityContext);
         try {
-            final User user = m_userManager.getUser(userId);
-            if (user == null) {
-                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            synchronized (m_lock) {
+                final User user = m_userManager.getUser(userId);
+                if (user == null) {
+                    return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+                }
+                return Response.ok(toDto(user)).build();
             }
-            return Response.ok(toDto(user)).build();
         } catch (final Exception e) {
             return serverError("Can't read user: %s", e);
         }
@@ -112,22 +141,35 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST).entity("A user-id is required.").build();
         }
         final String userId = request.getUserId().trim();
-        if (INVALID_USER_ID.matcher(userId).matches()) {
-            return Response.status(Status.BAD_REQUEST).entity("The user-id must not contain any HTML markup.").build();
+        final String userIdProblem = validateUserId(userId);
+        if (userIdProblem != null) {
+            return Response.status(Status.BAD_REQUEST).entity(userIdProblem).build();
         }
         if (isBlank(request.getPassword())) {
             return Response.status(Status.BAD_REQUEST).entity("A password is required.").build();
         }
         try {
-            if (m_userManager.hasUser(userId)) {
-                return Response.status(Status.BAD_REQUEST).entity("User " + userId + " already exists.").build();
+            validateDtoFields(request);
+        } catch (final IllegalArgumentException e) {
+            return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
+        }
+        try {
+            synchronized (m_lock) {
+                if (m_userManager.hasUser(userId)) {
+                    return Response.status(Status.BAD_REQUEST).entity("User " + userId + " already exists.").build();
+                }
+                final User user = new User();
+                user.setUserId(userId);
+                user.setPassword(m_userManager.encryptedPassword(request.getPassword(), true), Boolean.TRUE);
+                applyDto(user, request);
+                try {
+                    m_userManager.saveUser(userId, user);
+                } catch (final Exception e) {
+                    rollbackPhantomUser(userId);
+                    throw e;
+                }
             }
-            final User user = new User();
-            user.setUserId(userId);
-            user.setPassword(m_userManager.encryptedPassword(request.getPassword(), true), Boolean.TRUE);
-            applyDto(user, request);
-            m_userManager.saveUser(userId, user);
-            LOG.info("User {} created by {}", userId, securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName());
+            LOG.info("User {} created by {}", userId, principal(securityContext));
             return Response.status(Status.CREATED).build();
         } catch (final Exception e) {
             return serverError("Can't create user: %s", e);
@@ -140,13 +182,25 @@ public class UsersRestService implements UsersRestApi {
         if (dto == null) {
             return Response.status(Status.BAD_REQUEST).entity("A user body is required.").build();
         }
+        if (dto.getUserId() != null && !userId.equals(dto.getUserId())) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity("The user-id in the body does not match the request path; use the rename endpoint to change ids.").build();
+        }
         try {
-            final User user = m_userManager.getUser(userId);
-            if (user == null) {
-                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            validateDtoFields(dto);
+        } catch (final IllegalArgumentException e) {
+            return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
+        }
+        try {
+            synchronized (m_lock) {
+                final User existing = m_userManager.getUser(userId);
+                if (existing == null) {
+                    return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+                }
+                final User updated = copyOf(existing);
+                applyDto(updated, dto);
+                m_userManager.saveUser(userId, updated);
             }
-            applyDto(user, dto);
-            m_userManager.saveUser(userId, user);
             return Response.noContent().build();
         } catch (final Exception e) {
             return serverError("Can't update user: %s", e);
@@ -160,13 +214,16 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST).entity("A password is required.").build();
         }
         try {
-            final User user = m_userManager.getUser(userId);
-            if (user == null) {
-                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            synchronized (m_lock) {
+                final User existing = m_userManager.getUser(userId);
+                if (existing == null) {
+                    return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+                }
+                final User updated = copyOf(existing);
+                updated.setPassword(m_userManager.encryptedPassword(request.getPassword(), true), Boolean.TRUE);
+                m_userManager.saveUser(userId, updated);
             }
-            user.setPassword(m_userManager.encryptedPassword(request.getPassword(), true), Boolean.TRUE);
-            m_userManager.saveUser(userId, user);
-            LOG.info("Password changed for user {} by {}", userId, securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName());
+            LOG.info("Password changed for user {} by {}", userId, principal(securityContext));
             return Response.noContent().build();
         } catch (final Exception e) {
             return serverError("Can't change password: %s", e);
@@ -183,18 +240,21 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST).entity("The system user " + userId + " cannot be renamed.").build();
         }
         final String newUserId = request.getNewUserId().trim();
-        if (INVALID_USER_ID.matcher(newUserId).matches()) {
-            return Response.status(Status.BAD_REQUEST).entity("The user-id must not contain any HTML markup.").build();
+        final String userIdProblem = validateUserId(newUserId);
+        if (userIdProblem != null) {
+            return Response.status(Status.BAD_REQUEST).entity(userIdProblem).build();
         }
         try {
-            if (!m_userManager.hasUser(userId)) {
-                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            synchronized (m_lock) {
+                if (!m_userManager.hasUser(userId)) {
+                    return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+                }
+                if (m_userManager.hasUser(newUserId)) {
+                    return Response.status(Status.BAD_REQUEST).entity("User " + newUserId + " already exists.").build();
+                }
+                m_userManager.renameUser(userId, newUserId);
             }
-            if (m_userManager.hasUser(newUserId)) {
-                return Response.status(Status.BAD_REQUEST).entity("User " + newUserId + " already exists.").build();
-            }
-            m_userManager.renameUser(userId, newUserId);
-            LOG.info("User {} renamed to {} by {}", userId, newUserId, securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName());
+            LOG.info("User {} renamed to {} by {}", userId, newUserId, principal(securityContext));
             return Response.noContent().build();
         } catch (final Exception e) {
             return serverError("Can't rename user: %s", e);
@@ -208,11 +268,13 @@ public class UsersRestService implements UsersRestApi {
             return Response.status(Status.BAD_REQUEST).entity("The system user " + userId + " cannot be deleted.").build();
         }
         try {
-            if (!m_userManager.hasUser(userId)) {
-                return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+            synchronized (m_lock) {
+                if (!m_userManager.hasUser(userId)) {
+                    return Response.status(Status.NOT_FOUND).entity("User " + userId + " was not found.").build();
+                }
+                m_userManager.deleteUser(userId);
             }
-            m_userManager.deleteUser(userId);
-            LOG.info("User {} deleted by {}", userId, securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName());
+            LOG.info("User {} deleted by {}", userId, principal(securityContext));
             return Response.noContent().build();
         } catch (final Exception e) {
             return serverError("Can't delete user: %s", e);
@@ -234,30 +296,41 @@ public class UsersRestService implements UsersRestApi {
         return dto;
     }
 
+    /** Detached copy so mutations never touch the manager's live object. */
+    private static User copyOf(final User user) {
+        final User copy = new User();
+        copy.setUserId(user.getUserId());
+        copy.setFullName(user.getFullName().orElse(null));
+        copy.setUserComments(user.getUserComments().orElse(null));
+        final Password password = user.getPassword();
+        if (password != null) {
+            copy.setPassword(password.getEncryptedPassword(), password.getSalt());
+        }
+        for (final Contact contact : user.getContacts()) {
+            final Contact contactCopy = new Contact(contact.getType());
+            contactCopy.setInfo(contact.getInfo().orElse(null));
+            contactCopy.setServiceProvider(contact.getServiceProvider().orElse(null));
+            copy.getContacts().add(contactCopy);
+        }
+        copy.setDutySchedules(new ArrayList<>(user.getDutySchedules()));
+        copy.setRoles(new ArrayList<>(user.getRoles()));
+        copy.setTuiPin(user.getTuiPin().orElse(null));
+        copy.setTimeZoneId(user.getTimeZoneId().orElse(null));
+        return copy;
+    }
+
     /**
-     * Applies the DTO onto the JAXB user. Only the exposed contact types
-     * (email, pagerEmail) are touched; every other contact — XMPP, microblog,
-     * phones, paging services — and the password survive untouched, so a v2
-     * update can never corrupt hand-maintained users.xml entries.
+     * Validates every field of the request BEFORE anything is applied, so a
+     * rejected request cannot leave partial state anywhere.
      */
-    private void applyDto(final User user, final UserDto dto) {
-        user.setFullName(trimToNull(dto.getFullName()));
-        user.setUserComments(trimToNull(dto.getUserComments()));
-        user.setTuiPin(trimToNull(dto.getTuiPin()));
+    private static void validateDtoFields(final UserDto dto) {
         final String timeZoneId = trimToNull(dto.getTimeZoneId());
-        if (timeZoneId == null) {
-            user.setTimeZoneId((java.time.ZoneId) null);
-        } else {
+        if (timeZoneId != null) {
             try {
-                user.setTimeZoneId(timeZoneId);
+                java.time.ZoneId.of(timeZoneId);
             } catch (final RuntimeException e) {
                 throw new IllegalArgumentException("Invalid time-zone-id: " + timeZoneId);
             }
-        }
-        setContact(user, ContactType.email, dto.getEmail());
-        setContact(user, ContactType.pagerEmail, dto.getPagerEmail());
-        if (dto.getDutySchedules() != null) {
-            user.setDutySchedules(new ArrayList<>(dto.getDutySchedules()));
         }
         if (dto.getRoles() != null) {
             for (final String role : dto.getRoles()) {
@@ -265,7 +338,79 @@ public class UsersRestService implements UsersRestApi {
                     throw new IllegalArgumentException("Unknown security role: " + role);
                 }
             }
+        }
+        if (dto.getDutySchedules() != null) {
+            for (final String schedule : dto.getDutySchedules()) {
+                validateDutySchedule(schedule);
+            }
+        }
+    }
+
+    /**
+     * Applies the pre-validated DTO. Only the exposed contact types (email,
+     * pagerEmail) are touched; every other contact — XMPP, microblog, phones,
+     * paging services — and the password survive untouched, so a v2 update
+     * can never corrupt hand-maintained users.xml entries. List fields left
+     * out of the request body arrive as null and are preserved.
+     */
+    private static void applyDto(final User user, final UserDto dto) {
+        user.setFullName(trimToNull(dto.getFullName()));
+        user.setUserComments(trimToNull(dto.getUserComments()));
+        user.setTuiPin(trimToNull(dto.getTuiPin()));
+        final String timeZoneId = trimToNull(dto.getTimeZoneId());
+        if (timeZoneId == null) {
+            user.setTimeZoneId((java.time.ZoneId) null);
+        } else {
+            user.setTimeZoneId(timeZoneId);
+        }
+        setContact(user, ContactType.email, dto.getEmail());
+        setContact(user, ContactType.pagerEmail, dto.getPagerEmail());
+        if (dto.getDutySchedules() != null) {
+            user.setDutySchedules(new ArrayList<>(dto.getDutySchedules()));
+        }
+        if (dto.getRoles() != null) {
             user.setRoles(new ArrayList<>(dto.getRoles()));
+        }
+    }
+
+    /**
+     * A failed save leaves the new user in UserManager's in-memory map
+     * (_writeUser puts before _saveCurrent), which would 400 every retry as
+     * "already exists". Best effort: remove the phantom again.
+     */
+    private void rollbackPhantomUser(final String userId) {
+        try {
+            if (m_userManager.hasUser(userId)) {
+                m_userManager.deleteUser(userId);
+            }
+        } catch (final Exception rollbackFailure) {
+            LOG.warn("Could not roll back partially created user {}", userId, rollbackFailure);
+        }
+    }
+
+    /** Returns a problem description, or null when the user id is acceptable. */
+    private static String validateUserId(final String userId) {
+        if (INVALID_USER_ID.matcher(userId).matches()) {
+            return "The user-id must not contain markup, whitespace, or the characters : / \\ % ? #";
+        }
+        return null;
+    }
+
+    /**
+     * Duty schedules are stored as strings like MoWeFr800-1700 and parsed with
+     * unchecked exceptions all over notifd/group scheduling — an invalid string
+     * saved here would break duty evaluation at runtime. Overnight ranges
+     * (begin after end) are legal.
+     */
+    private static void validateDutySchedule(final String schedule) {
+        final Matcher matcher = schedule == null ? null : DUTY_SCHEDULE.matcher(schedule);
+        if (matcher == null || !matcher.matches()) {
+            throw new IllegalArgumentException("Invalid duty schedule '" + schedule + "': expected day tokens followed by begin-end military times, e.g. MoWeFr800-1700");
+        }
+        final int begin = Integer.parseInt(matcher.group(2));
+        final int end = Integer.parseInt(matcher.group(3));
+        if (begin > 2359 || end > 2359 || begin % 100 > 59 || end % 100 > 59) {
+            throw new IllegalArgumentException("Invalid duty schedule '" + schedule + "': times must be military clock values between 0 and 2359");
         }
     }
 
@@ -299,7 +444,9 @@ public class UsersRestService implements UsersRestApi {
         }
     }
 
-
+    private static String principal(final SecurityContext securityContext) {
+        return securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName();
+    }
 
     private Response serverError(final String format, final Exception e) {
         if (e instanceof IllegalArgumentException) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/UsersRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/UsersRestApi.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.api;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+import org.opennms.web.rest.v2.model.UserDto;
+import org.opennms.web.rest.v2.model.UserPasswordRequest;
+import org.opennms.web.rest.v2.model.UserRenameRequest;
+import org.opennms.web.rest.v2.model.UserWriteRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * Versioned user management API backed by users.xml. Password hashes are
+ * never returned; admin-only (enforced by Spring Security and in-code).
+ */
+@Path("users")
+@Tag(name = "Users", description = "User Management API")
+public interface UsersRestApi {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "List all users", operationId = "listUsers")
+    Response listUsers(@Context SecurityContext securityContext);
+
+    @GET
+    @Path("{userId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Get one user", operationId = "getUser")
+    Response getUser(@Context SecurityContext securityContext, @PathParam("userId") String userId);
+
+    @GET
+    @Path("available-roles")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "List the assignable security roles", operationId = "listAvailableRoles")
+    Response listAvailableRoles(@Context SecurityContext securityContext);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Create a user", operationId = "createUser")
+    Response createUser(@Context SecurityContext securityContext, UserWriteRequest request);
+
+    @PUT
+    @Path("{userId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Update a user's details (contact types and password not covered here are preserved)", operationId = "updateUser")
+    Response updateUser(@Context SecurityContext securityContext, @PathParam("userId") String userId, UserDto user);
+
+    @PUT
+    @Path("{userId}/password")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Set a user's password (stored salted)", operationId = "setUserPassword")
+    Response setPassword(@Context SecurityContext securityContext, @PathParam("userId") String userId, UserPasswordRequest request);
+
+    @POST
+    @Path("{userId}/rename")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Rename a user (also updates group memberships)", operationId = "renameUser")
+    Response renameUser(@Context SecurityContext securityContext, @PathParam("userId") String userId, UserRenameRequest request);
+
+    @DELETE
+    @Path("{userId}")
+    @Operation(summary = "Delete a user (also removes group memberships; admin and rtc are protected)", operationId = "deleteUser")
+    Response deleteUser(@Context SecurityContext securityContext, @PathParam("userId") String userId);
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserDto.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * A user as exposed by the v2 user management API. Field names mirror
+ * users.xml where they overlap; the password hash is deliberately never part
+ * of this representation, and contact types the API does not expose (XMPP,
+ * microblog, phones, pager PINs) are preserved server-side on update.
+ */
+@XmlRootElement(name = "user")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UserDto {
+
+    @XmlElement(name = "user-id")
+    private String userId;
+
+    @XmlElement(name = "full-name")
+    private String fullName;
+
+    @XmlElement(name = "user-comments")
+    private String userComments;
+
+    @XmlElement(name = "email")
+    private String email;
+
+    @XmlElement(name = "pager-email")
+    private String pagerEmail;
+
+    @XmlElement(name = "tui-pin")
+    private String tuiPin;
+
+    @XmlElement(name = "time-zone-id")
+    private String timeZoneId;
+
+    @XmlElement(name = "duty-schedule")
+    private List<String> dutySchedules = new ArrayList<>();
+
+    @XmlElement(name = "role")
+    private List<String> roles = new ArrayList<>();
+
+    @XmlElement(name = "read-only")
+    private Boolean readOnly;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(final String userId) {
+        this.userId = userId;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(final String fullName) {
+        this.fullName = fullName;
+    }
+
+    public String getUserComments() {
+        return userComments;
+    }
+
+    public void setUserComments(final String userComments) {
+        this.userComments = userComments;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(final String email) {
+        this.email = email;
+    }
+
+    public String getPagerEmail() {
+        return pagerEmail;
+    }
+
+    public void setPagerEmail(final String pagerEmail) {
+        this.pagerEmail = pagerEmail;
+    }
+
+    public String getTuiPin() {
+        return tuiPin;
+    }
+
+    public void setTuiPin(final String tuiPin) {
+        this.tuiPin = tuiPin;
+    }
+
+    public String getTimeZoneId() {
+        return timeZoneId;
+    }
+
+    public void setTimeZoneId(final String timeZoneId) {
+        this.timeZoneId = timeZoneId;
+    }
+
+    public List<String> getDutySchedules() {
+        return dutySchedules;
+    }
+
+    public void setDutySchedules(final List<String> dutySchedules) {
+        this.dutySchedules = dutySchedules;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(final List<String> roles) {
+        this.roles = roles;
+    }
+
+    public Boolean getReadOnly() {
+        return readOnly;
+    }
+
+    public void setReadOnly(final Boolean readOnly) {
+        this.readOnly = readOnly;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserDto.java
@@ -21,7 +21,6 @@
  */
 package org.opennms.web.rest.v2.model;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -60,11 +59,13 @@ public class UserDto {
     @XmlElement(name = "time-zone-id")
     private String timeZoneId;
 
+    // null (not empty) defaults: a request body that omits these keys
+    // deserializes to null, which update semantics treat as "preserve"
     @XmlElement(name = "duty-schedule")
-    private List<String> dutySchedules = new ArrayList<>();
+    private List<String> dutySchedules;
 
     @XmlElement(name = "role")
-    private List<String> roles = new ArrayList<>();
+    private List<String> roles;
 
     @XmlElement(name = "read-only")
     private Boolean readOnly;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserPasswordRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserPasswordRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "user-password-request")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UserPasswordRequest {
+
+    @XmlElement(name = "password")
+    private String password;
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserRenameRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserRenameRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "user-rename-request")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UserRenameRequest {
+
+    @XmlElement(name = "new-user-id")
+    private String newUserId;
+
+    public String getNewUserId() {
+        return newUserId;
+    }
+
+    public void setNewUserId(final String newUserId) {
+        this.newUserId = newUserId;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserWriteRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/UserWriteRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Create request for the v2 user management API: the UserDto fields plus the
+ * initial password, which is hashed (salted) before it reaches users.xml.
+ * Password changes on existing users go through the dedicated password
+ * endpoint instead.
+ */
+@XmlRootElement(name = "user-create-request")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UserWriteRequest extends UserDto {
+
+    @XmlElement(name = "password")
+    private String password;
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+}

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -404,7 +404,7 @@
         {
           "id": "manageUsers",
           "name": "Manage Users",
-          "url": "admin/userGroupView/users/list.jsp",
+          "url": "ui/index.html#/admin/users",
           "locationMatch": "",
           "roles": null
         },

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/UsersRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/UsersRestServiceIT.java
@@ -70,6 +70,9 @@ public class UsersRestServiceIT extends AbstractSpringJerseyRestTestCase {
     @Autowired
     private UserManager m_userManager;
 
+    @Autowired
+    private org.opennms.netmgt.config.GroupManager m_groupManager;
+
     public UsersRestServiceIT() {
         super(CXF_REST_V2_CONTEXT_PATH);
     }
@@ -316,6 +319,76 @@ public class UsersRestServiceIT extends AbstractSpringJerseyRestTestCase {
         assertFalse(after.has("full-name") && !after.isNull("full-name"));
         assertFalse(after.has("email") && !after.isNull("email"));
         sendRequest(DELETE, "/users/clearme", 204);
+    }
+
+    @Test
+    public void testAdminRoleCannotBeStripped() throws Exception {
+        // removing ROLE_ADMIN from admin would lock every administrator out
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/admin",
+                "{\"user-id\":\"admin\",\"role\":[\"ROLE_USER\"]}", 400);
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/admin",
+                "{\"user-id\":\"admin\",\"role\":[\"ROLE_USER\",\"ROLE_ADMIN\"]}", 204);
+    }
+
+    @Test
+    public void testPartialUpdatePreservesScalarFields() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"partial\",\"password\":\"pw\",\"full-name\":\"Full Name\",\"user-comments\":\"kept\",\"email\":\"p@example.org\"}", 201);
+        // a roles-only body must not wipe the other fields
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/partial",
+                "{\"user-id\":\"partial\",\"role\":[\"ROLE_USER\"]}", 204);
+        final JSONObject after = new JSONObject(getJson("/users/partial", 200));
+        assertEquals("Full Name", after.getString("full-name"));
+        assertEquals("kept", after.getString("user-comments"));
+        assertEquals("p@example.org", after.getString("email"));
+        sendRequest(DELETE, "/users/partial", 204);
+    }
+
+    @Test
+    public void testCommentsMarkupRejectedEvenWithNewlines() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"markup\",\"password\":\"pw\"}", 201);
+        // newlines must not smuggle markup past the check
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/markup",
+                "{\"user-id\":\"markup\",\"user-comments\":\"hello\\n<script>alert(1)</script>\"}", 400);
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/markup",
+                "{\"user-id\":\"markup\",\"user-comments\":\"plain text\"}", 204);
+        sendRequest(DELETE, "/users/markup", 204);
+    }
+
+    @Test
+    public void testHandEditedMarkupCommentStaysEditable() throws Exception {
+        // a hand-edited users.xml comment with markup characters must not
+        // make the user uneditable when it round-trips unchanged
+        final User user = new User();
+        user.setUserId("legacycomment");
+        user.setPassword(m_userManager.encryptedPassword("pw", true), Boolean.TRUE);
+        user.setUserComments("Bob's R&D user");
+        m_userManager.saveUser("legacycomment", user);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/legacycomment",
+                "{\"user-id\":\"legacycomment\",\"user-comments\":\"Bob's R&D user\",\"full-name\":\"Touched\"}", 204);
+        final JSONObject after = new JSONObject(getJson("/users/legacycomment", 200));
+        assertEquals("Bob's R&D user", after.getString("user-comments"));
+        assertEquals("Touched", after.getString("full-name"));
+        sendRequest(DELETE, "/users/legacycomment", 204);
+    }
+
+    @Test
+    public void testDeleteBlockedWhileSupervisingOnCallRole() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"rolesuper\",\"password\":\"pw\"}", 201);
+        final org.opennms.netmgt.config.groups.Role role = new org.opennms.netmgt.config.groups.Role();
+        role.setName("super-role");
+        role.setMembershipGroup("Admin");
+        role.setSupervisor("rolesuper");
+        m_groupManager.saveRole(role);
+
+        // deleting the supervisor would leave the rota's fallback dangling
+        sendData(DELETE, MediaType.APPLICATION_JSON, "/users/rolesuper", "", 400);
+
+        m_groupManager.deleteRole("super-role");
+        sendRequest(DELETE, "/users/rolesuper", 204);
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/UsersRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/UsersRestServiceIT.java
@@ -269,19 +269,53 @@ public class UsersRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
-    public void testOvernightDutyScheduleRoundTrips() throws Exception {
-        // legacy UI and hand-edited users.xml contain overnight schedules;
-        // they must be accepted and must not make the user uneditable
+    public void testOvernightDutyScheduleRejectedForNewEntries() throws Exception {
+        // DutySchedule.isInSchedule compares within one calendar day, so an
+        // overnight range never matches and would silently disable the schedule
         sendData(POST, MediaType.APPLICATION_JSON, "/users",
-                "{\"user-id\":\"nightshift\",\"password\":\"pw\",\"duty-schedule\":[\"MoTu2000-800\"]}", 201);
+                "{\"user-id\":\"nightshift\",\"password\":\"pw\",\"duty-schedule\":[\"MoTu2000-800\"]}", 400);
+        sendRequest(GET, "/users/nightshift", 404);
+    }
 
-        sendData(PUT, MediaType.APPLICATION_JSON, "/users/nightshift",
-                "{\"user-id\":\"nightshift\",\"full-name\":\"Night Shift\",\"duty-schedule\":[\"MoTu2000-800\"]}", 204);
+    @Test
+    public void testPreExistingOddDutyScheduleStaysEditable() throws Exception {
+        // a hand-edited users.xml may already carry an overnight string; the
+        // record must remain editable when the UI round-trips it unchanged
+        final User user = new User();
+        user.setUserId("legacynight");
+        user.setPassword(m_userManager.encryptedPassword("pw", true), Boolean.TRUE);
+        user.getDutySchedules().add("MoTu2000-800");
+        m_userManager.saveUser("legacynight", user);
 
-        final JSONObject after = new JSONObject(getJson("/users/nightshift", 200));
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/legacynight",
+                "{\"user-id\":\"legacynight\",\"full-name\":\"Night Shift\",\"duty-schedule\":[\"MoTu2000-800\"]}", 204);
+        final JSONObject after = new JSONObject(getJson("/users/legacynight", 200));
         assertEquals("MoTu2000-800", after.getJSONArray("duty-schedule").getString(0));
 
-        sendRequest(DELETE, "/users/nightshift", 204);
+        // but ADDING another overnight entry is still rejected
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/legacynight",
+                "{\"user-id\":\"legacynight\",\"duty-schedule\":[\"MoTu2000-800\",\"WeTh2100-700\"]}", 400);
+
+        sendRequest(DELETE, "/users/legacynight", 204);
+    }
+
+    @Test
+    public void testDotSegmentIdsRejected() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\".\",\"password\":\"x\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"..\",\"password\":\"x\"}", 400);
+    }
+
+    @Test
+    public void testFieldsCanBeCleared() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"clearme\",\"password\":\"pw\",\"full-name\":\"Full\",\"email\":\"c@example.com\"}", 201);
+        // explicit empty strings clear; omitted keys preserve
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/clearme",
+                "{\"user-id\":\"clearme\",\"full-name\":\"\",\"email\":\"\"}", 204);
+        final JSONObject after = new JSONObject(getJson("/users/clearme", 200));
+        assertFalse(after.has("full-name") && !after.isNull("full-name"));
+        assertFalse(after.has("email") && !after.isNull("email"));
+        sendRequest(DELETE, "/users/clearme", 204);
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/UsersRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/UsersRestServiceIT.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.ws.rs.core.MediaType;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.netmgt.config.UserManager;
+import org.opennms.netmgt.config.users.Contact;
+import org.opennms.netmgt.config.users.User;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        // in-memory user/group managers so users.xml is never touched
+        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml",
+        "classpath:/applicationContext-rest-test.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties = "org.opennms.timeseries.strategy=integration")
+@JUnitTemporaryDatabase
+public class UsersRestServiceIT extends AbstractSpringJerseyRestTestCase {
+
+    @Autowired
+    private UserManager m_userManager;
+
+    public UsersRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
+
+    @Override
+    protected void beforeServletStart() {
+        MockLogAppender.setupLogging();
+    }
+
+    @Test
+    public void testListNeverContainsPasswordHashes() throws Exception {
+        final String json = getJson("/users", 200);
+        final JSONArray users = new JSONArray(json);
+        assertTrue(users.length() >= 1);
+        assertEquals("admin", users.getJSONObject(0).getString("user-id"));
+        // the v1 API leaks hashes to admins; the v2 contract is that no
+        // response ever carries the password in any form
+        assertFalse(json.contains("password"));
+        assertFalse(json.contains("21232F29"));
+    }
+
+    @Test
+    public void testGetUser() throws Exception {
+        final JSONObject admin = new JSONObject(getJson("/users/admin", 200));
+        assertEquals("admin", admin.getString("user-id"));
+        sendRequest(GET, "/users/idontexist", 404);
+    }
+
+    @Test
+    public void testAvailableRoles() throws Exception {
+        final JSONArray roles = new JSONArray(getJson("/users/available-roles", 200));
+        boolean foundAdmin = false;
+        for (int i = 0; i < roles.length(); i++) {
+            foundAdmin |= "ROLE_ADMIN".equals(roles.getString(i));
+        }
+        assertTrue(foundAdmin);
+    }
+
+    @Test
+    public void testCreateLifecycle() throws Exception {
+        final String body = "{\"user-id\":\"junituser\",\"password\":\"S3cret!pw\",\"full-name\":\"JUnit User\","
+                + "\"email\":\"junit@example.com\",\"pager-email\":\"junit-pager@example.com\","
+                + "\"duty-schedule\":[\"MoWeFr800-1700\"],\"role\":[\"ROLE_USER\"]}";
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", body, 201);
+
+        final JSONObject created = new JSONObject(getJson("/users/junituser", 200));
+        assertEquals("JUnit User", created.getString("full-name"));
+        assertEquals("junit@example.com", created.getString("email"));
+        assertEquals("junit-pager@example.com", created.getString("pager-email"));
+        assertEquals("MoWeFr800-1700", created.getJSONArray("duty-schedule").getString(0));
+        assertEquals("ROLE_USER", created.getJSONArray("role").getString(0));
+        assertTrue(m_userManager.comparePasswords("junituser", "S3cret!pw"));
+
+        // creating the same user again must be rejected
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", body, 400);
+
+        sendRequest(DELETE, "/users/junituser", 204);
+        sendRequest(GET, "/users/junituser", 404);
+    }
+
+    @Test
+    public void testCreateValidation() throws Exception {
+        // missing password
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"nopass\"}", 400);
+        // markup in the user id
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"bad<script>\",\"password\":\"x\"}", 400);
+        // colon breaks basic auth, whitespace breaks group references
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"with:colon\",\"password\":\"x\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"with space\",\"password\":\"x\"}", 400);
+        // unknown security role
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"badrole\",\"password\":\"x\",\"role\":[\"ROLE_NOT_A_THING\"]}", 400);
+        // invalid time zone
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"badzone\",\"password\":\"x\",\"time-zone-id\":\"Mars/Olympus\"}", 400);
+        // duty schedules that would break notifd's parsing at runtime
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"badduty\",\"password\":\"x\",\"duty-schedule\":[\"garbage\"]}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"badduty\",\"password\":\"x\",\"duty-schedule\":[\"Mo899-999\"]}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"badduty\",\"password\":\"x\",\"duty-schedule\":[\"Mo800-2400\"]}", 400);
+        // ids that cannot be addressed as a URL path segment
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"team/lead\",\"password\":\"x\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"pct%20\",\"password\":\"x\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"frag#1\",\"password\":\"x\"}", 400);
+        // none of the rejects may have been created
+        sendRequest(GET, "/users/badrole", 404);
+        sendRequest(GET, "/users/badzone", 404);
+        sendRequest(GET, "/users/badduty", 404);
+    }
+
+    @Test
+    public void testUpdatePreservesUnexposedContacts() throws Exception {
+        // seed a user carrying an XMPP contact, as a hand-edited users.xml would
+        final User user = new User();
+        user.setUserId("xmppuser");
+        user.setPassword(m_userManager.encryptedPassword("pw", true), Boolean.TRUE);
+        final Contact xmpp = new Contact("xmppAddress");
+        xmpp.setInfo("xmpp@jabber.example.com");
+        user.getContacts().add(xmpp);
+        m_userManager.saveUser("xmppuser", user);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/xmppuser",
+                "{\"user-id\":\"xmppuser\",\"full-name\":\"XMPP User\",\"email\":\"new@example.com\"}", 204);
+
+        final User updated = m_userManager.getUser("xmppuser");
+        assertNotNull(updated);
+        assertEquals("XMPP User", updated.getFullName().orElse(null));
+        assertTrue("the xmppAddress contact must survive an update that does not expose it",
+                updated.getContacts().stream().anyMatch(c ->
+                        "xmppAddress".equals(c.getType()) && "xmpp@jabber.example.com".equals(c.getInfo().orElse(null))));
+        // the password also survives a details update
+        assertTrue(m_userManager.comparePasswords("xmppuser", "pw"));
+
+        sendRequest(DELETE, "/users/xmppuser", 204);
+    }
+
+    @Test
+    public void testPasswordChange() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"pwuser\",\"password\":\"first\"}", 201);
+        assertTrue(m_userManager.comparePasswords("pwuser", "first"));
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/pwuser/password", "{\"password\":\"second\"}", 204);
+        assertFalse(m_userManager.comparePasswords("pwuser", "first"));
+        assertTrue(m_userManager.comparePasswords("pwuser", "second"));
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/pwuser/password", "{}", 400);
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/missing/password", "{\"password\":\"x\"}", 404);
+
+        sendRequest(DELETE, "/users/pwuser", 204);
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"renameme\",\"password\":\"pw\"}", 201);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"occupied\",\"password\":\"pw\"}", 201);
+
+        // renaming onto an existing user must be rejected
+        sendData(POST, MediaType.APPLICATION_JSON, "/users/renameme/rename", "{\"new-user-id\":\"occupied\"}", 400);
+        // markup in the new id
+        sendData(POST, MediaType.APPLICATION_JSON, "/users/renameme/rename", "{\"new-user-id\":\"bad<b>\"}", 400);
+
+        sendData(POST, MediaType.APPLICATION_JSON, "/users/renameme/rename", "{\"new-user-id\":\"renamed\"}", 204);
+        sendRequest(GET, "/users/renameme", 404);
+        sendRequest(GET, "/users/renamed", 200);
+
+        sendRequest(DELETE, "/users/renamed", 204);
+        sendRequest(DELETE, "/users/occupied", 204);
+    }
+
+    @Test
+    public void testSystemAccountProtections() throws Exception {
+        sendRequest(DELETE, "/users/admin", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users/admin/rename", "{\"new-user-id\":\"root\"}", 400);
+        sendRequest(GET, "/users/admin", 200);
+
+        // the protection is by name, wherever the account came from
+        sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"rtc\",\"password\":\"pw\"}", 201);
+        sendRequest(DELETE, "/users/rtc", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/users/rtc/rename", "{\"new-user-id\":\"rtc2\"}", 400);
+    }
+
+    @Test
+    public void testPartialUpdatePreservesRolesAndSchedules() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"partial\",\"password\":\"pw\",\"role\":[\"ROLE_USER\"],\"duty-schedule\":[\"MoWeFr800-1700\"]}", 201);
+
+        // a body that omits the role and duty-schedule keys must preserve both
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/partial",
+                "{\"user-id\":\"partial\",\"full-name\":\"Partial Update\"}", 204);
+
+        final JSONObject after = new JSONObject(getJson("/users/partial", 200));
+        assertEquals("Partial Update", after.getString("full-name"));
+        assertEquals("ROLE_USER", after.getJSONArray("role").getString(0));
+        assertEquals("MoWeFr800-1700", after.getJSONArray("duty-schedule").getString(0));
+
+        sendRequest(DELETE, "/users/partial", 204);
+    }
+
+    @Test
+    public void testRejectedUpdateLeavesNoPartialState() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"atomic\",\"password\":\"pw\",\"full-name\":\"Original Name\",\"email\":\"orig@example.com\"}", 201);
+
+        // invalid role arrives with new name/email; nothing may be applied
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/atomic",
+                "{\"user-id\":\"atomic\",\"full-name\":\"Changed Name\",\"email\":\"changed@example.com\",\"role\":[\"ROLE_TYPO\"]}", 400);
+
+        final JSONObject after = new JSONObject(getJson("/users/atomic", 200));
+        assertEquals("Original Name", after.getString("full-name"));
+        assertEquals("orig@example.com", after.getString("email"));
+        final User inManager = m_userManager.getUser("atomic");
+        assertEquals("Original Name", inManager.getFullName().orElse(null));
+
+        sendRequest(DELETE, "/users/atomic", 204);
+    }
+
+    @Test
+    public void testOvernightDutyScheduleRoundTrips() throws Exception {
+        // legacy UI and hand-edited users.xml contain overnight schedules;
+        // they must be accepted and must not make the user uneditable
+        sendData(POST, MediaType.APPLICATION_JSON, "/users",
+                "{\"user-id\":\"nightshift\",\"password\":\"pw\",\"duty-schedule\":[\"MoTu2000-800\"]}", 201);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/nightshift",
+                "{\"user-id\":\"nightshift\",\"full-name\":\"Night Shift\",\"duty-schedule\":[\"MoTu2000-800\"]}", 204);
+
+        final JSONObject after = new JSONObject(getJson("/users/nightshift", 200));
+        assertEquals("MoTu2000-800", after.getJSONArray("duty-schedule").getString(0));
+
+        sendRequest(DELETE, "/users/nightshift", 204);
+    }
+
+    @Test
+    public void testBodyPathUserIdMismatchRejected() throws Exception {
+        sendData(PUT, MediaType.APPLICATION_JSON, "/users/admin",
+                "{\"user-id\":\"somebody-else\",\"full-name\":\"X\"}", 400);
+    }
+
+    @Test
+    public void testForbiddenForNonAdmin() throws Exception {
+        setUser("nobody", new String[]{ "ROLE_USER" });
+        try {
+            sendRequest(GET, "/users", 403);
+            sendData(POST, MediaType.APPLICATION_JSON, "/users", "{\"user-id\":\"x\",\"password\":\"x\"}", 403);
+            sendRequest(DELETE, "/users/admin", 403);
+        } finally {
+            setUser("admin", new String[]{ "ROLE_ADMIN" });
+        }
+    }
+
+    private String getJson(final String url, final int expectedStatus) throws Exception {
+        final MockHttpServletRequest request = createRequest(GET, url);
+        request.addHeader("Accept", MediaType.APPLICATION_JSON);
+        return sendRequest(request, expectedStatus);
+    }
+}

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -193,6 +193,12 @@
     <intercept-url pattern="/api/v2/discovery" method="POST" access="ROLE_PROVISION,ROLE_ADMIN"/>
     <intercept-url pattern="/api/v2/discovery/**" method="POST" access="ROLE_PROVISION,ROLE_ADMIN"/>
 
+    <!-- User management exposes contact details and account controls; admin-only in every method -->
+    <intercept-url pattern="/api/v2/users/**" method="GET" access="ROLE_ADMIN" />
+    <intercept-url pattern="/api/v2/users/**" method="DELETE" access="ROLE_ADMIN" />
+    <intercept-url pattern="/api/v2/users/**" method="POST" access="ROLE_ADMIN" />
+    <intercept-url pattern="/api/v2/users/**" method="PUT" access="ROLE_ADMIN" />
+
     <!-- OPTIONS pre-flight requests should always be accepted -->
     <intercept-url pattern="/api/v2/**" method="OPTIONS" access="ROLE_ANONYMOUS,ROLE_REST,ROLE_ADMIN,ROLE_USER,ROLE_MOBILE"/>
 

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -195,6 +195,7 @@
 
     <!-- User management exposes contact details and account controls; admin-only in every method -->
     <intercept-url pattern="/api/v2/users/**" method="GET" access="ROLE_ADMIN" />
+    <intercept-url pattern="/api/v2/users/**" method="HEAD" access="ROLE_ADMIN" />
     <intercept-url pattern="/api/v2/users/**" method="DELETE" access="ROLE_ADMIN" />
     <intercept-url pattern="/api/v2/users/**" method="POST" access="ROLE_ADMIN" />
     <intercept-url pattern="/api/v2/users/**" method="PUT" access="ROLE_ADMIN" />

--- a/ui/src/components/ManageUsers/UserEditorDialog.vue
+++ b/ui/src/components/ManageUsers/UserEditorDialog.vue
@@ -1,0 +1,221 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :header="isEditing ? `Edit User: ${originalUserId}` : 'Add New User'"
+    class="user-editor-dialog"
+    :style="{ width: '640px', maxWidth: '95vw' }"
+    data-test="user-editor-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="form-grid">
+      <FormField v-if="!isEditing">
+        <IftaLabel>
+          <InputText
+            id="user-editor-id"
+            v-model="form.userId"
+            data-test="user-id-input"
+          />
+          <label for="user-editor-id">User ID *</label>
+        </IftaLabel>
+      </FormField>
+      <FormField v-if="!isEditing">
+        <IftaLabel>
+          <Password
+            v-model="form.password"
+            inputId="user-editor-password"
+            :feedback="false"
+            toggleMask
+            fluid
+            data-test="password-input"
+          />
+          <label for="user-editor-password">Password *</label>
+        </IftaLabel>
+      </FormField>
+      <FormField>
+        <IftaLabel>
+          <InputText
+            id="user-editor-fullname"
+            v-model="form.fullName"
+            data-test="full-name-input"
+          />
+          <label for="user-editor-fullname">Full Name</label>
+        </IftaLabel>
+      </FormField>
+      <FormField>
+        <IftaLabel>
+          <InputText
+            id="user-editor-comments"
+            v-model="form.comments"
+            data-test="comments-input"
+          />
+          <label for="user-editor-comments">Comments</label>
+        </IftaLabel>
+      </FormField>
+      <FormField>
+        <IftaLabel>
+          <InputText
+            id="user-editor-email"
+            v-model="form.email"
+            data-test="email-input"
+          />
+          <label for="user-editor-email">Email</label>
+        </IftaLabel>
+      </FormField>
+      <FormField>
+        <IftaLabel>
+          <InputText
+            id="user-editor-pager-email"
+            v-model="form.pagerEmail"
+            data-test="pager-email-input"
+          />
+          <label for="user-editor-pager-email">Pager Email</label>
+        </IftaLabel>
+      </FormField>
+      <FormField class="full-width">
+        <IftaLabel>
+          <MultiSelect
+            v-model="form.roles"
+            labelId="user-editor-roles"
+            :options="store.availableRoles"
+            display="chip"
+            :showToggleAll="false"
+            filter
+            fluid
+            data-test="roles-select"
+          />
+          <label for="user-editor-roles">Security Roles</label>
+        </IftaLabel>
+      </FormField>
+    </div>
+
+    <template #footer>
+      <Button
+        text
+        label="Cancel"
+        data-test="cancel-button"
+        @click="emit('update:visible', false)"
+      />
+      <Button
+        :label="isEditing ? 'Save User' : 'Add User'"
+        :disabled="!isValid || saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+import MultiSelect from 'primevue/multiselect'
+import Password from 'primevue/password'
+
+import FormField from '@/components/Common/FormField.vue'
+import { useUserAdminStore } from '@/stores/userAdminStore'
+import { ManagedUser } from '@/types/userAdmin'
+
+const props = defineProps<{
+  visible: boolean
+  user: ManagedUser | null
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useUserAdminStore()
+
+const form = reactive({
+  userId: '',
+  password: '',
+  fullName: '',
+  comments: '',
+  email: '',
+  pagerEmail: '',
+  roles: [] as string[]
+})
+
+const saving = ref(false)
+
+const isEditing = computed(() => props.user !== null)
+const originalUserId = computed(() => props.user?.['user-id'] ?? '')
+
+const isValid = computed(() => {
+  if (isEditing.value) {
+    return true
+  }
+  return !!form.userId.trim() && !!form.password
+})
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (!isVisible) {
+      return
+    }
+    if (props.user) {
+      Object.assign(form, {
+        userId: props.user['user-id'],
+        password: '',
+        fullName: props.user['full-name'] ?? '',
+        comments: props.user['user-comments'] ?? '',
+        email: props.user.email ?? '',
+        pagerEmail: props.user['pager-email'] ?? '',
+        roles: [...(props.user.role ?? [])]
+      })
+    } else {
+      Object.assign(form, { userId: '', password: '', fullName: '', comments: '', email: '', pagerEmail: '', roles: [] })
+    }
+  }
+)
+
+const save = async () => {
+  saving.value = true
+  try {
+    // spread the original so fields this form doesn't expose (duty schedules,
+    // tui-pin, time-zone-id) round-trip untouched; other contact types (XMPP
+    // among them) are preserved server-side.
+    const base = props.user ?? {}
+    const payload: ManagedUser = {
+      ...base,
+      'user-id': isEditing.value ? originalUserId.value : form.userId.trim(),
+      'full-name': form.fullName.trim() || undefined,
+      'user-comments': form.comments.trim() || undefined,
+      email: form.email.trim() || undefined,
+      'pager-email': form.pagerEmail.trim() || undefined,
+      role: [...form.roles]
+    }
+    const ok = isEditing.value
+      ? await store.updateUser(payload)
+      : await store.createUser({ ...payload, password: form.password })
+    if (ok) {
+      emit('update:visible', false)
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding-top: 0.5rem;
+
+  .full-width {
+    grid-column: 1 / -1;
+  }
+
+  :deep(input),
+  :deep(.p-password),
+  :deep(.p-multiselect) {
+    width: 100%;
+  }
+}
+</style>

--- a/ui/src/components/ManageUsers/UserEditorDialog.vue
+++ b/ui/src/components/ManageUsers/UserEditorDialog.vue
@@ -60,10 +60,16 @@
           <InputText
             id="user-editor-comments"
             v-model="form.comments"
+            :invalid="!!commentsProblem"
             data-test="comments-input"
           />
           <label for="user-editor-comments">Comments</label>
         </IftaLabel>
+        <small
+          v-if="commentsProblem"
+          class="field-error"
+          data-test="comments-error"
+        >{{ commentsProblem }}</small>
       </FormField>
       <FormField>
         <IftaLabel>
@@ -143,7 +149,7 @@ import MultiSelect from 'primevue/multiselect'
 import Password from 'primevue/password'
 
 import FormField from '@/components/Common/FormField.vue'
-import { validateAdminName, validateEmailShape } from '@/lib/adminValidation'
+import { validateAdminComments, validateAdminName, validateEmailShape } from '@/lib/adminValidation'
 import { useUserAdminStore } from '@/stores/userAdminStore'
 import { ManagedUser } from '@/types/userAdmin'
 
@@ -173,11 +179,21 @@ const isEditing = computed(() => props.user !== null)
 const originalUserId = computed(() => props.user?.['user-id'] ?? '')
 
 const userIdProblem = computed(() => (isEditing.value ? null : validateAdminName(form.userId, 'user-id')))
-const emailProblem = computed(() => validateEmailShape(form.email, 'email'))
-const pagerEmailProblem = computed(() => validateEmailShape(form.pagerEmail, 'pager email'))
+
+// pre-existing values are never flagged (hand-edited users.xml may hold
+// forms these checks don't model); only changed input is validated
+const changedOnly = (value: string, original: string | undefined, problem: string | null) =>
+  value.trim() === (original ?? '').trim() ? null : problem
+
+const emailProblem = computed(() =>
+  changedOnly(form.email, props.user?.email ?? '', validateEmailShape(form.email, 'email')))
+const pagerEmailProblem = computed(() =>
+  changedOnly(form.pagerEmail, props.user?.['pager-email'] ?? '', validateEmailShape(form.pagerEmail, 'pager email')))
+const commentsProblem = computed(() =>
+  changedOnly(form.comments, props.user?.['user-comments'] ?? '', validateAdminComments(form.comments)))
 
 const isValid = computed(() => {
-  if (userIdProblem.value || emailProblem.value || pagerEmailProblem.value) {
+  if (userIdProblem.value || emailProblem.value || pagerEmailProblem.value || commentsProblem.value) {
     return false
   }
   if (isEditing.value) {

--- a/ui/src/components/ManageUsers/UserEditorDialog.vue
+++ b/ui/src/components/ManageUsers/UserEditorDialog.vue
@@ -9,15 +9,28 @@
     @update:visible="(value: boolean) => emit('update:visible', value)"
   >
     <div class="form-grid">
+      <Message
+        v-if="errorText"
+        severity="error"
+        :closable="false"
+        class="full-width"
+        data-test="dialog-error"
+      >{{ errorText }}</Message>
       <FormField v-if="!isEditing">
         <IftaLabel>
           <InputText
             id="user-editor-id"
             v-model="form.userId"
+            :invalid="!!userIdProblem"
             data-test="user-id-input"
           />
           <label for="user-editor-id">User ID *</label>
         </IftaLabel>
+        <small
+          v-if="userIdProblem"
+          class="field-error"
+          data-test="user-id-error"
+        >{{ userIdProblem }}</small>
       </FormField>
       <FormField v-if="!isEditing">
         <IftaLabel>
@@ -57,20 +70,32 @@
           <InputText
             id="user-editor-email"
             v-model="form.email"
+            :invalid="!!emailProblem"
             data-test="email-input"
           />
           <label for="user-editor-email">Email</label>
         </IftaLabel>
+        <small
+          v-if="emailProblem"
+          class="field-error"
+          data-test="email-error"
+        >{{ emailProblem }}</small>
       </FormField>
       <FormField>
         <IftaLabel>
           <InputText
             id="user-editor-pager-email"
             v-model="form.pagerEmail"
+            :invalid="!!pagerEmailProblem"
             data-test="pager-email-input"
           />
           <label for="user-editor-pager-email">Pager Email</label>
         </IftaLabel>
+        <small
+          v-if="pagerEmailProblem"
+          class="field-error"
+          data-test="pager-email-error"
+        >{{ pagerEmailProblem }}</small>
       </FormField>
       <FormField class="full-width">
         <IftaLabel>
@@ -113,10 +138,12 @@ import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import IftaLabel from 'primevue/iftalabel'
 import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
 import MultiSelect from 'primevue/multiselect'
 import Password from 'primevue/password'
 
 import FormField from '@/components/Common/FormField.vue'
+import { validateAdminName, validateEmailShape } from '@/lib/adminValidation'
 import { useUserAdminStore } from '@/stores/userAdminStore'
 import { ManagedUser } from '@/types/userAdmin'
 
@@ -140,11 +167,19 @@ const form = reactive({
 })
 
 const saving = ref(false)
+const errorText = ref('')
 
 const isEditing = computed(() => props.user !== null)
 const originalUserId = computed(() => props.user?.['user-id'] ?? '')
 
+const userIdProblem = computed(() => (isEditing.value ? null : validateAdminName(form.userId, 'user-id')))
+const emailProblem = computed(() => validateEmailShape(form.email, 'email'))
+const pagerEmailProblem = computed(() => validateEmailShape(form.pagerEmail, 'pager email'))
+
 const isValid = computed(() => {
+  if (userIdProblem.value || emailProblem.value || pagerEmailProblem.value) {
+    return false
+  }
   if (isEditing.value) {
     return true
   }
@@ -157,6 +192,7 @@ watch(
     if (!isVisible) {
       return
     }
+    errorText.value = ''
     if (props.user) {
       Object.assign(form, {
         userId: props.user['user-id'],
@@ -189,11 +225,13 @@ const save = async () => {
       'pager-email': form.pagerEmail.trim(),
       role: [...form.roles]
     }
-    const ok = isEditing.value
+    const error = isEditing.value
       ? await store.updateUser(payload)
       : await store.createUser({ ...payload, password: form.password })
-    if (ok) {
+    if (error === null) {
       emit('update:visible', false)
+    } else {
+      errorText.value = error
     }
   } finally {
     saving.value = false
@@ -217,5 +255,11 @@ const save = async () => {
   :deep(.p-multiselect) {
     width: 100%;
   }
+}
+
+.field-error {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-red-500, #e24c4c);
 }
 </style>

--- a/ui/src/components/ManageUsers/UserEditorDialog.vue
+++ b/ui/src/components/ManageUsers/UserEditorDialog.vue
@@ -183,10 +183,10 @@ const save = async () => {
     const payload: ManagedUser = {
       ...base,
       'user-id': isEditing.value ? originalUserId.value : form.userId.trim(),
-      'full-name': form.fullName.trim() || undefined,
-      'user-comments': form.comments.trim() || undefined,
-      email: form.email.trim() || undefined,
-      'pager-email': form.pagerEmail.trim() || undefined,
+      'full-name': form.fullName.trim(),
+      'user-comments': form.comments.trim(),
+      email: form.email.trim(),
+      'pager-email': form.pagerEmail.trim(),
       role: [...form.roles]
     }
     const ok = isEditing.value

--- a/ui/src/components/ManageUsers/UserPasswordDialog.vue
+++ b/ui/src/components/ManageUsers/UserPasswordDialog.vue
@@ -1,0 +1,124 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :header="`Change Password: ${userId}`"
+    class="user-password-dialog"
+    :style="{ width: '420px', maxWidth: '95vw' }"
+    data-test="user-password-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="form-column">
+      <FormField>
+        <IftaLabel>
+          <Password
+            v-model="password"
+            inputId="user-password-new"
+            :feedback="false"
+            toggleMask
+            fluid
+            data-test="new-password-input"
+          />
+          <label for="user-password-new">New Password *</label>
+        </IftaLabel>
+      </FormField>
+      <FormField>
+        <IftaLabel>
+          <Password
+            v-model="confirmation"
+            inputId="user-password-confirm"
+            :feedback="false"
+            toggleMask
+            fluid
+            data-test="confirm-password-input"
+          />
+          <label for="user-password-confirm">Confirm Password *</label>
+        </IftaLabel>
+        <small
+          v-if="confirmation && password !== confirmation"
+          class="mismatch"
+          data-test="password-mismatch"
+        >Passwords do not match</small>
+      </FormField>
+    </div>
+
+    <template #footer>
+      <Button
+        text
+        label="Cancel"
+        data-test="cancel-button"
+        @click="emit('update:visible', false)"
+      />
+      <Button
+        label="Change Password"
+        :disabled="!password || password !== confirmation || saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import IftaLabel from 'primevue/iftalabel'
+import Password from 'primevue/password'
+
+import FormField from '@/components/Common/FormField.vue'
+import { useUserAdminStore } from '@/stores/userAdminStore'
+
+const props = defineProps<{
+  visible: boolean
+  userId: string
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useUserAdminStore()
+
+const password = ref('')
+const confirmation = ref('')
+const saving = ref(false)
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (isVisible) {
+      password.value = ''
+      confirmation.value = ''
+    }
+  }
+)
+
+const save = async () => {
+  saving.value = true
+  try {
+    const ok = await store.setPassword(props.userId, password.value)
+    if (ok) {
+      emit('update:visible', false)
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.form-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 0.5rem;
+
+  :deep(.p-password) {
+    width: 100%;
+  }
+}
+
+.mismatch {
+  color: var(--p-red-500, #e24c4c);
+}
+</style>

--- a/ui/src/components/ManageUsers/UserPasswordDialog.vue
+++ b/ui/src/components/ManageUsers/UserPasswordDialog.vue
@@ -9,6 +9,12 @@
     @update:visible="(value: boolean) => emit('update:visible', value)"
   >
     <div class="form-column">
+      <Message
+        v-if="errorText"
+        severity="error"
+        :closable="false"
+        data-test="dialog-error"
+      >{{ errorText }}</Message>
       <FormField>
         <IftaLabel>
           <Password
@@ -65,6 +71,7 @@ import { ref, watch } from 'vue'
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import IftaLabel from 'primevue/iftalabel'
+import Message from 'primevue/message'
 import Password from 'primevue/password'
 
 import FormField from '@/components/Common/FormField.vue'
@@ -82,6 +89,7 @@ const store = useUserAdminStore()
 const password = ref('')
 const confirmation = ref('')
 const saving = ref(false)
+const errorText = ref('')
 
 watch(
   () => props.visible,
@@ -89,6 +97,7 @@ watch(
     if (isVisible) {
       password.value = ''
       confirmation.value = ''
+      errorText.value = ''
     }
   }
 )
@@ -96,9 +105,11 @@ watch(
 const save = async () => {
   saving.value = true
   try {
-    const ok = await store.setPassword(props.userId, password.value)
-    if (ok) {
+    const error = await store.setPassword(props.userId, password.value)
+    if (error === null) {
       emit('update:visible', false)
+    } else {
+      errorText.value = error
     }
   } finally {
     saving.value = false

--- a/ui/src/components/ManageUsers/UserRenameDialog.vue
+++ b/ui/src/components/ManageUsers/UserRenameDialog.vue
@@ -1,0 +1,104 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :header="`Rename User: ${userId}`"
+    class="user-rename-dialog"
+    :style="{ width: '420px', maxWidth: '95vw' }"
+    data-test="user-rename-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="form-column">
+      <FormField>
+        <IftaLabel>
+          <InputText
+            id="user-rename-new-id"
+            v-model="newUserId"
+            data-test="new-user-id-input"
+          />
+          <label for="user-rename-new-id">New User ID *</label>
+        </IftaLabel>
+        <small class="hint">Group memberships follow the rename.</small>
+      </FormField>
+    </div>
+
+    <template #footer>
+      <Button
+        text
+        label="Cancel"
+        data-test="cancel-button"
+        @click="emit('update:visible', false)"
+      />
+      <Button
+        label="Rename"
+        :disabled="!newUserId.trim() || newUserId.trim() === userId || saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+
+import FormField from '@/components/Common/FormField.vue'
+import { useUserAdminStore } from '@/stores/userAdminStore'
+
+const props = defineProps<{
+  visible: boolean
+  userId: string
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useUserAdminStore()
+
+const newUserId = ref('')
+const saving = ref(false)
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (isVisible) {
+      newUserId.value = ''
+    }
+  }
+)
+
+const save = async () => {
+  saving.value = true
+  try {
+    const ok = await store.renameUser(props.userId, newUserId.value.trim())
+    if (ok) {
+      emit('update:visible', false)
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.form-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 0.5rem;
+
+  :deep(input) {
+    width: 100%;
+  }
+}
+
+.hint {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-text-muted-color);
+}
+</style>

--- a/ui/src/components/ManageUsers/UserRenameDialog.vue
+++ b/ui/src/components/ManageUsers/UserRenameDialog.vue
@@ -9,15 +9,27 @@
     @update:visible="(value: boolean) => emit('update:visible', value)"
   >
     <div class="form-column">
+      <Message
+        v-if="errorText"
+        severity="error"
+        :closable="false"
+        data-test="dialog-error"
+      >{{ errorText }}</Message>
       <FormField>
         <IftaLabel>
           <InputText
             id="user-rename-new-id"
             v-model="newUserId"
+            :invalid="!!nameProblem"
             data-test="new-user-id-input"
           />
           <label for="user-rename-new-id">New User ID *</label>
         </IftaLabel>
+        <small
+          v-if="nameProblem"
+          class="field-error"
+          data-test="name-error"
+        >{{ nameProblem }}</small>
         <small class="hint">Group memberships follow the rename.</small>
       </FormField>
     </div>
@@ -31,7 +43,7 @@
       />
       <Button
         label="Rename"
-        :disabled="!newUserId.trim() || newUserId.trim() === userId || saving"
+        :disabled="!newUserId.trim() || !!nameProblem || newUserId.trim() === userId || saving"
         data-test="save-button"
         @click="save"
       />
@@ -40,14 +52,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import IftaLabel from 'primevue/iftalabel'
 import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
 
 import FormField from '@/components/Common/FormField.vue'
+import { validateAdminName } from '@/lib/adminValidation'
 import { useUserAdminStore } from '@/stores/userAdminStore'
 
 const props = defineProps<{
@@ -61,12 +75,16 @@ const store = useUserAdminStore()
 
 const newUserId = ref('')
 const saving = ref(false)
+const errorText = ref('')
+
+const nameProblem = computed(() => validateAdminName(newUserId.value, 'user-id'))
 
 watch(
   () => props.visible,
   (isVisible) => {
     if (isVisible) {
       newUserId.value = ''
+      errorText.value = ''
     }
   }
 )
@@ -74,9 +92,11 @@ watch(
 const save = async () => {
   saving.value = true
   try {
-    const ok = await store.renameUser(props.userId, newUserId.value.trim())
-    if (ok) {
+    const error = await store.renameUser(props.userId, newUserId.value.trim())
+    if (error === null) {
       emit('update:visible', false)
+    } else {
+      errorText.value = error
     }
   } finally {
     saving.value = false
@@ -94,6 +114,12 @@ const save = async () => {
   :deep(input) {
     width: 100%;
   }
+}
+
+.field-error {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-red-500, #e24c4c);
 }
 
 .hint {

--- a/ui/src/components/ManageUsers/UsersHelpPanel.vue
+++ b/ui/src/components/ManageUsers/UsersHelpPanel.vue
@@ -1,0 +1,94 @@
+<template>
+  <TogglePanel
+    :collapsed="collapsed"
+    class="users-help-panel"
+    data-test="users-help-panel"
+    @update:collapsed="(value: boolean) => (collapsed = value)"
+  >
+    <template #header>
+      <span class="panel-header">
+        <i class="pi pi-question-circle" aria-hidden="true" />
+        About Users
+      </span>
+    </template>
+    <div class="help-columns">
+      <div class="help-section">
+        <div class="section-title">What users are for</div>
+        <p>
+          A user is both a web console login and a notification recipient. The email and pager
+          email addresses entered here are where notifd delivers notices when the user is targeted
+          directly or through a group or on-call role. Security roles control what the account may
+          do: <em>ROLE_USER</em> grants normal console access, <em>ROLE_ADMIN</em> full
+          administration, <em>ROLE_READONLY</em> makes the account read-only.
+        </p>
+        <p>
+          Users are stored in <code>users.xml</code>. Editing that file by hand keeps working, and
+          contact types this page does not show (XMPP, phone numbers, paging services) as well as
+          duty schedules are preserved untouched. Passwords are always stored salted; they are
+          never shown or returned by the API.
+        </p>
+      </div>
+      <div class="help-section">
+        <div class="section-title">How to use this page</div>
+        <p>
+          <strong>Add New User</strong> creates the account with its initial password;
+          <strong>Edit</strong> changes contact details and security roles;
+          <strong>Password</strong> resets the password. New accounts can log in within a few
+          seconds of creation.
+        </p>
+        <p>
+          <strong>Rename</strong> keeps group memberships intact — the user stays in all their
+          groups under the new id. <strong>Delete</strong> also removes the user from every group.
+          The <em>admin</em> and <em>rtc</em> accounts are system accounts and cannot be deleted
+          or renamed. All of this is also available to your own tooling through the versioned
+          <code>/api/v2/users</code> REST API.
+        </p>
+      </div>
+    </div>
+  </TogglePanel>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+
+// Starts collapsed — the "?" invites first-time users to expand.
+const collapsed = ref(true)
+</script>
+
+<style lang="scss" scoped>
+.panel-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+
+  .pi-question-circle {
+    color: var(--p-primary-color);
+  }
+}
+
+.help-columns {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+
+  .help-section {
+    flex: 1;
+    min-width: 320px;
+  }
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+</style>

--- a/ui/src/components/ManageUsers/UsersTable.vue
+++ b/ui/src/components/ManageUsers/UsersTable.vue
@@ -1,0 +1,237 @@
+<template>
+  <TableCard class="users-table">
+    <div class="header">
+      <div class="card-title">Users</div>
+      <Button
+        outlined
+        label="Add New User"
+        icon="pi pi-plus"
+        data-test="add-user-button"
+        @click="openEditor(null)"
+      />
+    </div>
+
+    <DataTable
+      v-if="store.users.length"
+      :value="store.users"
+      paginator
+      dataKey="user-id"
+      :rows="10"
+      :rowsPerPageOptions="[10, 20, 50, 100]"
+      class="data-table"
+      data-test="users-table"
+    >
+      <Column
+        field="user-id"
+        header="User ID"
+        sortable
+      >
+        <template #body="{ data }">
+          <span class="user-id">{{ data['user-id'] }}</span>
+          <Tag
+            v-if="isProtected(data['user-id'])"
+            value="system"
+            severity="secondary"
+            class="system-tag"
+            v-tooltip.top="'System account: cannot be deleted or renamed'"
+          />
+        </template>
+      </Column>
+      <Column
+        field="full-name"
+        header="Full Name"
+        sortable
+      />
+      <Column
+        field="email"
+        header="Email"
+        sortable
+      />
+      <Column
+        field="pager-email"
+        header="Pager Email"
+      />
+      <Column header="Roles">
+        <template #body="{ data }">
+          <span class="roles">{{ (data.role ?? []).join(', ') || '-' }}</span>
+        </template>
+      </Column>
+      <Column header="Actions">
+        <template #body="{ data }">
+          <div class="action-container">
+            <Button
+              text
+              label="Edit"
+              :aria-label="`Edit ${data['user-id']}`"
+              data-test="edit-user-button"
+              @click="openEditor(data)"
+            />
+            <Button
+              text
+              label="Password"
+              :aria-label="`Change password for ${data['user-id']}`"
+              data-test="password-user-button"
+              @click="openPassword(data)"
+            />
+            <Button
+              text
+              label="Rename"
+              :disabled="isProtected(data['user-id'])"
+              :aria-label="`Rename ${data['user-id']}`"
+              data-test="rename-user-button"
+              @click="openRename(data)"
+            />
+            <Button
+              text
+              label="Delete"
+              severity="danger"
+              :disabled="isProtected(data['user-id'])"
+              :aria-label="`Delete ${data['user-id']}`"
+              data-test="delete-user-button"
+              @click="askDelete(data)"
+            />
+          </div>
+        </template>
+      </Column>
+    </DataTable>
+
+    <div v-if="!store.users.length">
+      <EmptyList
+        :content="emptyListContent"
+        data-test="empty-list"
+      />
+    </div>
+  </TableCard>
+
+  <UserEditorDialog
+    v-model:visible="showEditor"
+    :user="userToEdit"
+  />
+  <UserPasswordDialog
+    v-model:visible="showPassword"
+    :userId="actionUserId"
+  />
+  <UserRenameDialog
+    v-model:visible="showRename"
+    :userId="actionUserId"
+  />
+  <OnmsConfirmationDialog
+    :visible="showDeleteConfirmation"
+    title="Delete User"
+    actionButtonText="Delete"
+    @ok="confirmDelete"
+    @cancel="cancelDelete"
+  >
+    <template #content>
+      <p>
+        Are you sure you want to delete the user <strong>{{ userToDelete?.['user-id'] }}</strong>?
+        The user is also removed from all groups. This action cannot be undone.
+      </p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { OnmsConfirmationDialog } from '@opennms/onms-ui'
+
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import Tag from 'primevue/tag'
+
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import UserEditorDialog from '@/components/ManageUsers/UserEditorDialog.vue'
+import UserPasswordDialog from '@/components/ManageUsers/UserPasswordDialog.vue'
+import UserRenameDialog from '@/components/ManageUsers/UserRenameDialog.vue'
+import { useUserAdminStore } from '@/stores/userAdminStore'
+import { ManagedUser, PROTECTED_USER_IDS } from '@/types/userAdmin'
+
+const store = useUserAdminStore()
+
+const showEditor = ref(false)
+const userToEdit = ref<ManagedUser | null>(null)
+const showPassword = ref(false)
+const showRename = ref(false)
+const actionUserId = ref('')
+const showDeleteConfirmation = ref(false)
+const userToDelete = ref<ManagedUser | null>(null)
+
+const emptyListContent = {
+  msg: 'No users found.'
+}
+
+const isProtected = (userId: string) => PROTECTED_USER_IDS.includes(userId)
+
+const openEditor = (user: ManagedUser | null) => {
+  userToEdit.value = user
+  showEditor.value = true
+}
+
+const openPassword = (user: ManagedUser) => {
+  actionUserId.value = user['user-id']
+  showPassword.value = true
+}
+
+const openRename = (user: ManagedUser) => {
+  actionUserId.value = user['user-id']
+  showRename.value = true
+}
+
+const askDelete = (user: ManagedUser) => {
+  userToDelete.value = user
+  showDeleteConfirmation.value = true
+}
+
+const confirmDelete = async () => {
+  if (userToDelete.value) {
+    await store.deleteUser(userToDelete.value['user-id'])
+  }
+  showDeleteConfirmation.value = false
+  userToDelete.value = null
+}
+
+const cancelDelete = () => {
+  showDeleteConfirmation.value = false
+  userToDelete.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.users-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.user-id {
+  font-weight: 600;
+}
+
+.system-tag {
+  margin-left: 0.5rem;
+}
+
+.roles {
+  font-size: 0.875rem;
+  color: var(--p-text-muted-color);
+}
+
+.action-container {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+</style>

--- a/ui/src/components/ManageUsers/UsersTable.vue
+++ b/ui/src/components/ManageUsers/UsersTable.vue
@@ -58,7 +58,13 @@
       </Column>
       <Column header="Actions">
         <template #body="{ data }">
-          <div class="action-container">
+          <span
+            v-if="!isPathAddressable(data['user-id'])"
+            class="unaddressable"
+            v-tooltip.top="'This user-id contains / \\ or %, which the API cannot address; manage it by editing users.xml.'"
+            data-test="unaddressable-note"
+          >file-managed</span>
+          <div v-else class="action-container">
             <Button
               text
               label="Edit"
@@ -146,6 +152,7 @@ import TableCard from '@/components/Common/TableCard.vue'
 import UserEditorDialog from '@/components/ManageUsers/UserEditorDialog.vue'
 import UserPasswordDialog from '@/components/ManageUsers/UserPasswordDialog.vue'
 import UserRenameDialog from '@/components/ManageUsers/UserRenameDialog.vue'
+import { isPathAddressable } from '@/lib/adminValidation'
 import { useUserAdminStore } from '@/stores/userAdminStore'
 import { ManagedUser, PROTECTED_USER_IDS } from '@/types/userAdmin'
 
@@ -227,6 +234,11 @@ const cancelDelete = () => {
 .roles {
   font-size: 0.875rem;
   color: var(--p-text-muted-color);
+}
+
+.unaddressable {
+  color: var(--p-text-muted-color);
+  font-style: italic;
 }
 
 .action-container {

--- a/ui/src/containers/ManageUsers.vue
+++ b/ui/src/containers/ManageUsers.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+  <div class="manage-users-container">
+    <h1 class="page-title">Manage Users</h1>
+    <UsersTable />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+
+import UsersTable from '@/components/ManageUsers/UsersTable.vue'
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import { useMenuStore } from '@/stores/menuStore'
+import { useUserAdminStore } from '@/stores/userAdminStore'
+import { BreadCrumb } from '@/types'
+
+const menuStore = useMenuStore()
+const store = useUserAdminStore()
+
+const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
+
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Manage Users', to: '#', position: 'last' }
+  ]
+})
+
+onMounted(async () => {
+  await store.populate()
+})
+</script>
+
+<style lang="scss" scoped>
+.manage-users-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 2px 2rem 2px;
+}
+
+.page-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+</style>

--- a/ui/src/containers/ManageUsers.vue
+++ b/ui/src/containers/ManageUsers.vue
@@ -6,6 +6,7 @@
   </div>
   <div class="manage-users-container">
     <h1 class="page-title">Manage Users</h1>
+    <UsersHelpPanel />
     <UsersTable />
   </div>
 </template>
@@ -13,6 +14,7 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
 
+import UsersHelpPanel from '@/components/ManageUsers/UsersHelpPanel.vue'
 import UsersTable from '@/components/ManageUsers/UsersTable.vue'
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
 import { useMenuStore } from '@/stores/menuStore'

--- a/ui/src/lib/adminValidation.ts
+++ b/ui/src/lib/adminValidation.ts
@@ -26,7 +26,7 @@
 
 const INVALID_NAME = /[&<>"`':/\\%?#\s]/
 const INVALID_COMMENTS = /[&<>"`']/
-const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+$/
+const EMAIL_SHAPE = /[^\s@]+@[^\s@]+/
 
 /**
  * Validates a user-id, group name or on-call role name.
@@ -62,10 +62,18 @@ export const validateAdminComments = (value: string): string | null => {
  */
 export const isPathAddressable = (name: string): boolean => !/[/\\%]/.test(name)
 
-/** Loose shape check: notification delivery needs at least local@domain. */
+/**
+ * Loose shape check: every comma-separated recipient must contain a
+ * local@domain somewhere, which also accepts RFC-5322 display-name forms
+ * like `Bill Smith <bill@example.com>`.
+ */
 export const validateEmailShape = (value: string, label: string): string | null => {
   const trimmed = value.trim()
-  if (trimmed && !EMAIL_SHAPE.test(trimmed)) {
+  if (!trimmed) {
+    return null
+  }
+  const parts = trimmed.split(',').map((part) => part.trim())
+  if (parts.some((part) => !part || !EMAIL_SHAPE.test(part))) {
     return `The ${label} must look like an email address (name@domain).`
   }
   return null

--- a/ui/src/lib/adminValidation.ts
+++ b/ui/src/lib/adminValidation.ts
@@ -1,0 +1,72 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Client-side mirrors of the /api/v2 admin validation rules so forms can flag
+// problems before submitting. These must stay in sync with UsersRestService,
+// GroupsRestService and OnCallRolesRestService (INVALID_NAME/INVALID_COMMENTS).
+
+const INVALID_NAME = /[&<>"`':/\\%?#\s]/
+const INVALID_COMMENTS = /[&<>"`']/
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+$/
+
+/**
+ * Validates a user-id, group name or on-call role name.
+ * Returns a problem description, or null when the value is acceptable.
+ * Emptiness is not checked here; required-ness is a per-form concern.
+ */
+export const validateAdminName = (value: string, label: string): string | null => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+  if (INVALID_NAME.test(trimmed)) {
+    return `The ${label} must not contain markup, whitespace, or the characters : / \\ % ? #`
+  }
+  if (trimmed === '.' || trimmed === '..') {
+    return `The ${label} must not be a dot segment.`
+  }
+  return null
+}
+
+/** Group comments may not contain HTML markup characters. */
+export const validateAdminComments = (value: string): string | null => {
+  if (value && INVALID_COMMENTS.test(value)) {
+    return 'The comments must not contain the characters & < > " ` \''
+  }
+  return null
+}
+
+/**
+ * Names containing / \ or % cannot be addressed as a URL path segment (the
+ * security filter rejects their encoded forms), so per-item API operations
+ * are unavailable for such hand-edited legacy entries.
+ */
+export const isPathAddressable = (name: string): boolean => !/[/\\%]/.test(name)
+
+/** Loose shape check: notification delivery needs at least local@domain. */
+export const validateEmailShape = (value: string, label: string): string | null => {
+  const trimmed = value.trim()
+  if (trimmed && !EMAIL_SHAPE.test(trimmed)) {
+    return `The ${label} must look like an email address (name@domain).`
+  }
+  return null
+}

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -159,6 +159,25 @@ const router = createRouter({
       }
     },
     {
+      path: '/admin/users',
+      name: 'Manage Users',
+      component: () => import('@/containers/ManageUsers.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'Must be admin to manage users.' })
+            router.push(from.path)
+          }
+        }
+
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
+      }
+    },
+    {
       path: '/map',
       name: 'Map',
       component: () => import('@/containers/Map.vue'),

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -74,6 +74,15 @@ import {
   setUsageStatisticsStatus
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
+import {
+  createManagedUser,
+  deleteManagedUser,
+  getAvailableUserRoles,
+  getManagedUsers,
+  renameManagedUser,
+  setManagedUserPassword,
+  updateManagedUser
+} from './userAdminService'
 
 export default {
   search,
@@ -135,5 +144,12 @@ export default {
   setUsageStatisticsStatus,
   addZenithRegistration,
   getZenithRegistrations,
-  performLogout
+  performLogout,
+  createManagedUser,
+  deleteManagedUser,
+  getAvailableUserRoles,
+  getManagedUsers,
+  renameManagedUser,
+  setManagedUserPassword,
+  updateManagedUser
 }

--- a/ui/src/services/userAdminService.ts
+++ b/ui/src/services/userAdminService.ts
@@ -34,14 +34,15 @@ const errorMessage = (err: any, fallback: string): string => {
   return typeof detail === 'string' && detail ? detail : fallback
 }
 
-const getManagedUsers = async (): Promise<ManagedUser[]> => {
+// null on failure (not []) so callers can keep showing the previous list
+const getManagedUsers = async (): Promise<ManagedUser[] | null> => {
   try {
     startSpinner()
     const resp = await v2.get(endpoint)
     return Array.isArray(resp.data) ? resp.data : []
   } catch (_err) {
     showSnackBar({ msg: 'Failed to load users.' })
-    return []
+    return null
   } finally {
     stopSpinner()
   }

--- a/ui/src/services/userAdminService.ts
+++ b/ui/src/services/userAdminService.ts
@@ -1,0 +1,138 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+import useSpinner from '@/composables/useSpinner'
+import { ManagedUser, ManagedUserCreate } from '@/types/userAdmin'
+import { v2 } from './axiosInstances'
+
+const { showSnackBar } = useSnackbar()
+const { startSpinner, stopSpinner } = useSpinner()
+const endpoint = '/users'
+
+const errorMessage = (err: any, fallback: string): string => {
+  const detail = err?.response?.data
+  return typeof detail === 'string' && detail ? detail : fallback
+}
+
+const getManagedUsers = async (): Promise<ManagedUser[]> => {
+  try {
+    startSpinner()
+    const resp = await v2.get(endpoint)
+    return Array.isArray(resp.data) ? resp.data : []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load users.' })
+    return []
+  } finally {
+    stopSpinner()
+  }
+}
+
+const getAvailableUserRoles = async (): Promise<string[]> => {
+  try {
+    const resp = await v2.get(`${endpoint}/available-roles`)
+    return Array.isArray(resp.data) ? resp.data : []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load available roles.' })
+    return []
+  }
+}
+
+const createManagedUser = async (user: ManagedUserCreate): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.post(endpoint, user)
+    showSnackBar({ msg: `User '${user['user-id']}' created.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to create user '${user['user-id']}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const updateManagedUser = async (user: ManagedUser): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.put(`${endpoint}/${encodeURIComponent(user['user-id'])}`, user)
+    showSnackBar({ msg: `User '${user['user-id']}' updated.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to update user '${user['user-id']}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const setManagedUserPassword = async (userId: string, password: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.put(`${endpoint}/${encodeURIComponent(userId)}/password`, { password })
+    showSnackBar({ msg: `Password changed for '${userId}'.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to change the password for '${userId}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const renameManagedUser = async (userId: string, newUserId: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.post(`${endpoint}/${encodeURIComponent(userId)}/rename`, { 'new-user-id': newUserId })
+    showSnackBar({ msg: `User '${userId}' renamed to '${newUserId}'.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to rename user '${userId}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const deleteManagedUser = async (userId: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.delete(`${endpoint}/${encodeURIComponent(userId)}`)
+    showSnackBar({ msg: `User '${userId}' deleted.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to delete user '${userId}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+export {
+  createManagedUser,
+  deleteManagedUser,
+  getAvailableUserRoles,
+  getManagedUsers,
+  renameManagedUser,
+  setManagedUserPassword,
+  updateManagedUser
+}

--- a/ui/src/services/userAdminService.ts
+++ b/ui/src/services/userAdminService.ts
@@ -58,71 +58,76 @@ const getAvailableUserRoles = async (): Promise<string[]> => {
   }
 }
 
-const createManagedUser = async (user: ManagedUserCreate): Promise<boolean> => {
+const createManagedUser = async (user: ManagedUserCreate): Promise<string | null> => {
   try {
     startSpinner()
     await v2.post(endpoint, user)
     showSnackBar({ msg: `User '${user['user-id']}' created.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to create user '${user['user-id']}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to create user '${user['user-id']}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }
 }
 
-const updateManagedUser = async (user: ManagedUser): Promise<boolean> => {
+const updateManagedUser = async (user: ManagedUser): Promise<string | null> => {
   try {
     startSpinner()
     await v2.put(`${endpoint}/${encodeURIComponent(user['user-id'])}`, user)
     showSnackBar({ msg: `User '${user['user-id']}' updated.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to update user '${user['user-id']}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to update user '${user['user-id']}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }
 }
 
-const setManagedUserPassword = async (userId: string, password: string): Promise<boolean> => {
+const setManagedUserPassword = async (userId: string, password: string): Promise<string | null> => {
   try {
     startSpinner()
     await v2.put(`${endpoint}/${encodeURIComponent(userId)}/password`, { password })
     showSnackBar({ msg: `Password changed for '${userId}'.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to change the password for '${userId}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to change the password for '${userId}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }
 }
 
-const renameManagedUser = async (userId: string, newUserId: string): Promise<boolean> => {
+const renameManagedUser = async (userId: string, newUserId: string): Promise<string | null> => {
   try {
     startSpinner()
     await v2.post(`${endpoint}/${encodeURIComponent(userId)}/rename`, { 'new-user-id': newUserId })
     showSnackBar({ msg: `User '${userId}' renamed to '${newUserId}'.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to rename user '${userId}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to rename user '${userId}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }
 }
 
-const deleteManagedUser = async (userId: string): Promise<boolean> => {
+const deleteManagedUser = async (userId: string): Promise<string | null> => {
   try {
     startSpinner()
     await v2.delete(`${endpoint}/${encodeURIComponent(userId)}`)
     showSnackBar({ msg: `User '${userId}' deleted.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to delete user '${userId}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to delete user '${userId}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }

--- a/ui/src/stores/userAdminStore.ts
+++ b/ui/src/stores/userAdminStore.ts
@@ -41,19 +41,19 @@ export const useUserAdminStore = defineStore('userAdminStore', () => {
   }
 
   const createUser = async (user: ManagedUserCreate) => {
-    const ok = await API.createManagedUser(user)
-    if (ok) {
+    const error = await API.createManagedUser(user)
+    if (error === null) {
       await getUsers()
     }
-    return ok
+    return error
   }
 
   const updateUser = async (user: ManagedUser) => {
-    const ok = await API.updateManagedUser(user)
-    if (ok) {
+    const error = await API.updateManagedUser(user)
+    if (error === null) {
       await getUsers()
     }
-    return ok
+    return error
   }
 
   const setPassword = async (userId: string, password: string) => {
@@ -61,19 +61,19 @@ export const useUserAdminStore = defineStore('userAdminStore', () => {
   }
 
   const renameUser = async (userId: string, newUserId: string) => {
-    const ok = await API.renameManagedUser(userId, newUserId)
-    if (ok) {
+    const error = await API.renameManagedUser(userId, newUserId)
+    if (error === null) {
       await getUsers()
     }
-    return ok
+    return error
   }
 
   const deleteUser = async (userId: string) => {
-    const ok = await API.deleteManagedUser(userId)
-    if (ok) {
+    const error = await API.deleteManagedUser(userId)
+    if (error === null) {
       await getUsers()
     }
-    return ok
+    return error
   }
 
   const populate = async () => {

--- a/ui/src/stores/userAdminStore.ts
+++ b/ui/src/stores/userAdminStore.ts
@@ -1,0 +1,92 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import API from '@/services'
+import { ManagedUser, ManagedUserCreate } from '@/types/userAdmin'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useUserAdminStore = defineStore('userAdminStore', () => {
+  const users = ref([] as ManagedUser[])
+  const availableRoles = ref([] as string[])
+
+  const getUsers = async () => {
+    users.value = await API.getManagedUsers()
+  }
+
+  const getAvailableRoles = async () => {
+    availableRoles.value = await API.getAvailableUserRoles()
+  }
+
+  const createUser = async (user: ManagedUserCreate) => {
+    const ok = await API.createManagedUser(user)
+    if (ok) {
+      await getUsers()
+    }
+    return ok
+  }
+
+  const updateUser = async (user: ManagedUser) => {
+    const ok = await API.updateManagedUser(user)
+    if (ok) {
+      await getUsers()
+    }
+    return ok
+  }
+
+  const setPassword = async (userId: string, password: string) => {
+    return await API.setManagedUserPassword(userId, password)
+  }
+
+  const renameUser = async (userId: string, newUserId: string) => {
+    const ok = await API.renameManagedUser(userId, newUserId)
+    if (ok) {
+      await getUsers()
+    }
+    return ok
+  }
+
+  const deleteUser = async (userId: string) => {
+    const ok = await API.deleteManagedUser(userId)
+    if (ok) {
+      await getUsers()
+    }
+    return ok
+  }
+
+  const populate = async () => {
+    await Promise.all([getUsers(), getAvailableRoles()])
+  }
+
+  return {
+    users,
+    availableRoles,
+    getUsers,
+    getAvailableRoles,
+    createUser,
+    updateUser,
+    setPassword,
+    renameUser,
+    deleteUser,
+    populate
+  }
+})

--- a/ui/src/stores/userAdminStore.ts
+++ b/ui/src/stores/userAdminStore.ts
@@ -30,7 +30,10 @@ export const useUserAdminStore = defineStore('userAdminStore', () => {
   const availableRoles = ref([] as string[])
 
   const getUsers = async () => {
-    users.value = await API.getManagedUsers()
+    const result = await API.getManagedUsers()
+    if (result !== null) {
+      users.value = result
+    }
   }
 
   const getAvailableRoles = async () => {

--- a/ui/src/types/userAdmin.ts
+++ b/ui/src/types/userAdmin.ts
@@ -1,0 +1,47 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Wire shapes of the v2 user management API (/api/v2/users). Field names
+// follow users.xml; the password hash is never part of any response, and
+// contact types the API does not expose (XMPP among them) are preserved
+// server-side on update.
+
+export interface ManagedUser {
+  'user-id': string
+  'full-name'?: string | null
+  'user-comments'?: string | null
+  email?: string | null
+  'pager-email'?: string | null
+  'tui-pin'?: string | null
+  'time-zone-id'?: string | null
+  'duty-schedule'?: string[]
+  role?: string[]
+  'read-only'?: boolean
+}
+
+export interface ManagedUserCreate extends ManagedUser {
+  password: string
+}
+
+// System accounts the server refuses to delete or rename; mirrored here so
+// the UI can disable the controls with an explanation instead of a 400.
+export const PROTECTED_USER_IDS = ['admin', 'rtc']

--- a/ui/tests/components/AdminDialogs/UserEditorDialog.test.ts
+++ b/ui/tests/components/AdminDialogs/UserEditorDialog.test.ts
@@ -1,0 +1,94 @@
+import UserEditorDialog from '@/components/ManageUsers/UserEditorDialog.vue'
+import { useUserAdminStore } from '@/stores/userAdminStore'
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/stores/userAdminStore')
+
+const DialogStub = {
+  name: 'Dialog',
+  props: ['visible', 'header', 'modal'],
+  template: '<div v-if="visible"><slot /><slot name="footer" /></div>'
+}
+
+describe('UserEditorDialog.vue', () => {
+  let wrapper: VueWrapper<any>
+  let store: any
+
+  const mountDialog = async (user: any = null) => {
+    wrapper = mount(UserEditorDialog, {
+      props: { visible: false, user },
+      global: {
+        plugins: [PrimeVue],
+        stubs: { Dialog: DialogStub }
+      }
+    })
+    await wrapper.setProps({ visible: true })
+    await flushPromises()
+  }
+
+  const setPassword = async (value: string) => {
+    await wrapper.find('[data-test="password-input"] input').setValue(value)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store = {
+      availableRoles: ['ROLE_USER', 'ROLE_ADMIN'],
+      createUser: vi.fn().mockResolvedValue(null),
+      updateUser: vi.fn().mockResolvedValue(null)
+    }
+    vi.mocked(useUserAdminStore).mockReturnValue(store)
+  })
+
+  it('flags a user id with whitespace or reserved characters and disables saving', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="user-id-input"]').setValue('jose anes')
+    await setPassword('secret')
+
+    expect(wrapper.find('[data-test="user-id-error"]').text()).toContain('must not contain')
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('flags an email without a domain part', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="user-id-input"]').setValue('jose')
+    await setPassword('secret')
+    await wrapper.find('[data-test="email-input"]').setValue('not-an-email')
+
+    expect(wrapper.find('[data-test="email-error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('requires a password before a new user can be saved', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="user-id-input"]').setValue('jose')
+
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('creates a valid user and closes', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="user-id-input"]').setValue('jose')
+    await setPassword('secret')
+    await wrapper.find('[data-test="email-input"]').setValue('jose@example.org')
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+
+    expect(store.createUser).toHaveBeenCalledWith(expect.objectContaining({ 'user-id': 'jose', password: 'secret' }))
+    expect(wrapper.emitted('update:visible')?.at(-1)).toEqual([false])
+  })
+
+  it('shows a server rejection inside the dialog and stays open', async () => {
+    store.createUser.mockResolvedValue('User jose already exists.')
+    await mountDialog()
+    await wrapper.find('[data-test="user-id-input"]').setValue('jose')
+    await setPassword('secret')
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="dialog-error"]').text()).toContain('already exists')
+    expect(wrapper.emitted('update:visible') ?? []).toEqual([])
+  })
+})

--- a/ui/tests/lib/adminValidation.test.ts
+++ b/ui/tests/lib/adminValidation.test.ts
@@ -43,15 +43,17 @@ describe('validateAdminComments', () => {
 })
 
 describe('validateEmailShape', () => {
-  it('accepts empty and name@domain shapes', () => {
+  it('accepts empty values and common deliverable forms', () => {
     expect(validateEmailShape('', 'email')).toBeNull()
     expect(validateEmailShape('noc@example.org', 'email')).toBeNull()
+    expect(validateEmailShape('Bill Smith <bill@example.com>', 'email')).toBeNull()
+    expect(validateEmailShape('a@example.com, b@example.com', 'email')).toBeNull()
   })
 
-  it('rejects values without an @ or with whitespace', () => {
+  it('rejects values without a local@domain part', () => {
     expect(validateEmailShape('not-an-email', 'email')).toContain('email')
-    expect(validateEmailShape('a b@example.org', 'pager email')).toContain('pager email')
     expect(validateEmailShape('a@', 'email')).not.toBeNull()
+    expect(validateEmailShape('a@example.com,,b@example.com', 'pager email')).toContain('pager email')
   })
 })
 

--- a/ui/tests/lib/adminValidation.test.ts
+++ b/ui/tests/lib/adminValidation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isPathAddressable,
+  validateAdminComments,
+  validateAdminName,
+  validateEmailShape
+} from '@/lib/adminValidation'
+
+describe('validateAdminName', () => {
+  it('accepts ordinary names and empty values', () => {
+    expect(validateAdminName('NOC-Duty_1', 'group name')).toBeNull()
+    expect(validateAdminName('', 'group name')).toBeNull()
+    expect(validateAdminName('   ', 'group name')).toBeNull()
+  })
+
+  it('rejects whitespace, markup and URL-hostile characters', () => {
+    for (const bad of ['Test Group', 'a<b', 'a&b', 'a"b', "a'b", 'a`b', 'a:b', 'a/b', 'a\\b', 'a%b', 'a?b', 'a#b']) {
+      expect(validateAdminName(bad, 'group name'), bad).toContain('must not contain')
+    }
+  })
+
+  it('rejects dot segments', () => {
+    expect(validateAdminName('.', 'user-id')).toContain('dot segment')
+    expect(validateAdminName('..', 'user-id')).toContain('dot segment')
+  })
+
+  it('names the field in the message', () => {
+    expect(validateAdminName('a b', 'role name')).toContain('role name')
+  })
+})
+
+describe('validateAdminComments', () => {
+  it('accepts plain text and empty values', () => {
+    expect(validateAdminComments('The administrators, on shift 24/7.')).toBeNull()
+    expect(validateAdminComments('')).toBeNull()
+  })
+
+  it('rejects markup characters', () => {
+    for (const bad of ['<b>x</b>', 'a & b', 'quote "x"', "it's", 'tick `x`']) {
+      expect(validateAdminComments(bad), bad).not.toBeNull()
+    }
+  })
+})
+
+describe('validateEmailShape', () => {
+  it('accepts empty and name@domain shapes', () => {
+    expect(validateEmailShape('', 'email')).toBeNull()
+    expect(validateEmailShape('noc@example.org', 'email')).toBeNull()
+  })
+
+  it('rejects values without an @ or with whitespace', () => {
+    expect(validateEmailShape('not-an-email', 'email')).toContain('email')
+    expect(validateEmailShape('a b@example.org', 'pager email')).toContain('pager email')
+    expect(validateEmailShape('a@', 'email')).not.toBeNull()
+  })
+})
+
+describe('isPathAddressable', () => {
+  it('allows ordinary names', () => {
+    expect(isPathAddressable('NOC-Duty')).toBe(true)
+    expect(isPathAddressable('Some Group')).toBe(true)
+  })
+
+  it('flags names the security filter cannot address as path segments', () => {
+    expect(isPathAddressable('NOC/Primary')).toBe(false)
+    expect(isPathAddressable('a\\b')).toBe(false)
+    expect(isPathAddressable('a%b')).toBe(false)
+  })
+})

--- a/ui/tests/stores/userAdminStore.test.ts
+++ b/ui/tests/stores/userAdminStore.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useUserAdminStore } from '@/stores/userAdminStore'
+import API from '@/services'
+import { ManagedUser } from '@/types/userAdmin'
+
+vi.mock('@/services', () => ({
+  default: {
+    getManagedUsers: vi.fn(),
+    getAvailableUserRoles: vi.fn(),
+    createManagedUser: vi.fn(),
+    updateManagedUser: vi.fn(),
+    setManagedUserPassword: vi.fn(),
+    renameManagedUser: vi.fn(),
+    deleteManagedUser: vi.fn()
+  }
+}))
+
+describe('useUserAdminStore', () => {
+  let store: ReturnType<typeof useUserAdminStore>
+
+  const mockUsers: ManagedUser[] = [
+    { 'user-id': 'admin', 'full-name': 'Administrator', role: ['ROLE_ADMIN'] },
+    { 'user-id': 'noc', 'full-name': 'NOC Operator', email: 'noc@example.com', role: ['ROLE_USER'] }
+  ]
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useUserAdminStore()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should start empty', () => {
+    expect(store.users).toEqual([])
+    expect(store.availableRoles).toEqual([])
+  })
+
+  it('populate should load users and roles', async () => {
+    vi.mocked(API.getManagedUsers).mockResolvedValue(mockUsers)
+    vi.mocked(API.getAvailableUserRoles).mockResolvedValue(['ROLE_ADMIN', 'ROLE_USER'])
+
+    await store.populate()
+
+    expect(store.users).toEqual(mockUsers)
+    expect(store.availableRoles).toEqual(['ROLE_ADMIN', 'ROLE_USER'])
+  })
+
+  it('createUser should refresh on success', async () => {
+    vi.mocked(API.createManagedUser).mockResolvedValue(true)
+    vi.mocked(API.getManagedUsers).mockResolvedValue(mockUsers)
+
+    const ok = await store.createUser({ 'user-id': 'noc', password: 'secret' })
+
+    expect(ok).toBe(true)
+    expect(API.getManagedUsers).toHaveBeenCalledTimes(1)
+  })
+
+  it('createUser should not refresh on failure', async () => {
+    vi.mocked(API.createManagedUser).mockResolvedValue(false)
+
+    const ok = await store.createUser({ 'user-id': 'noc', password: 'secret' })
+
+    expect(ok).toBe(false)
+    expect(API.getManagedUsers).not.toHaveBeenCalled()
+  })
+
+  it('updateUser should refresh on success', async () => {
+    vi.mocked(API.updateManagedUser).mockResolvedValue(true)
+    vi.mocked(API.getManagedUsers).mockResolvedValue(mockUsers)
+
+    await store.updateUser(mockUsers[1])
+
+    expect(API.updateManagedUser).toHaveBeenCalledWith(mockUsers[1])
+    expect(API.getManagedUsers).toHaveBeenCalledTimes(1)
+  })
+
+  it('renameUser should pass old and new ids and refresh', async () => {
+    vi.mocked(API.renameManagedUser).mockResolvedValue(true)
+    vi.mocked(API.getManagedUsers).mockResolvedValue(mockUsers)
+
+    await store.renameUser('noc', 'noc2')
+
+    expect(API.renameManagedUser).toHaveBeenCalledWith('noc', 'noc2')
+    expect(API.getManagedUsers).toHaveBeenCalledTimes(1)
+  })
+
+  it('deleteUser should refresh on success', async () => {
+    vi.mocked(API.deleteManagedUser).mockResolvedValue(true)
+    vi.mocked(API.getManagedUsers).mockResolvedValue([mockUsers[0]])
+
+    await store.deleteUser('noc')
+
+    expect(store.users).toEqual([mockUsers[0]])
+  })
+
+  it('setPassword should not trigger a reload', async () => {
+    vi.mocked(API.setManagedUserPassword).mockResolvedValue(true)
+
+    const ok = await store.setPassword('noc', 'newpw')
+
+    expect(ok).toBe(true)
+    expect(API.setManagedUserPassword).toHaveBeenCalledWith('noc', 'newpw')
+    expect(API.getManagedUsers).not.toHaveBeenCalled()
+  })
+})

--- a/ui/tests/stores/userAdminStore.test.ts
+++ b/ui/tests/stores/userAdminStore.test.ts
@@ -97,6 +97,16 @@ describe('useUserAdminStore', () => {
     expect(store.users).toEqual([mockUsers[0]])
   })
 
+  it('a failed refresh should keep the previous user list', async () => {
+    vi.mocked(API.getManagedUsers).mockResolvedValue(mockUsers)
+    await store.getUsers()
+    expect(store.users).toEqual(mockUsers)
+
+    vi.mocked(API.getManagedUsers).mockResolvedValue(null)
+    await store.getUsers()
+    expect(store.users).toEqual(mockUsers)
+  })
+
   it('setPassword should not trigger a reload', async () => {
     vi.mocked(API.setManagedUserPassword).mockResolvedValue(true)
 

--- a/ui/tests/stores/userAdminStore.test.ts
+++ b/ui/tests/stores/userAdminStore.test.ts
@@ -50,26 +50,26 @@ describe('useUserAdminStore', () => {
   })
 
   it('createUser should refresh on success', async () => {
-    vi.mocked(API.createManagedUser).mockResolvedValue(true)
+    vi.mocked(API.createManagedUser).mockResolvedValue(null)
     vi.mocked(API.getManagedUsers).mockResolvedValue(mockUsers)
 
     const ok = await store.createUser({ 'user-id': 'noc', password: 'secret' })
 
-    expect(ok).toBe(true)
+    expect(ok).toBe(null)
     expect(API.getManagedUsers).toHaveBeenCalledTimes(1)
   })
 
   it('createUser should not refresh on failure', async () => {
-    vi.mocked(API.createManagedUser).mockResolvedValue(false)
+    vi.mocked(API.createManagedUser).mockResolvedValue('it failed')
 
     const ok = await store.createUser({ 'user-id': 'noc', password: 'secret' })
 
-    expect(ok).toBe(false)
+    expect(ok).toBe('it failed')
     expect(API.getManagedUsers).not.toHaveBeenCalled()
   })
 
   it('updateUser should refresh on success', async () => {
-    vi.mocked(API.updateManagedUser).mockResolvedValue(true)
+    vi.mocked(API.updateManagedUser).mockResolvedValue(null)
     vi.mocked(API.getManagedUsers).mockResolvedValue(mockUsers)
 
     await store.updateUser(mockUsers[1])
@@ -79,7 +79,7 @@ describe('useUserAdminStore', () => {
   })
 
   it('renameUser should pass old and new ids and refresh', async () => {
-    vi.mocked(API.renameManagedUser).mockResolvedValue(true)
+    vi.mocked(API.renameManagedUser).mockResolvedValue(null)
     vi.mocked(API.getManagedUsers).mockResolvedValue(mockUsers)
 
     await store.renameUser('noc', 'noc2')
@@ -89,7 +89,7 @@ describe('useUserAdminStore', () => {
   })
 
   it('deleteUser should refresh on success', async () => {
-    vi.mocked(API.deleteManagedUser).mockResolvedValue(true)
+    vi.mocked(API.deleteManagedUser).mockResolvedValue(null)
     vi.mocked(API.getManagedUsers).mockResolvedValue([mockUsers[0]])
 
     await store.deleteUser('noc')
@@ -108,11 +108,11 @@ describe('useUserAdminStore', () => {
   })
 
   it('setPassword should not trigger a reload', async () => {
-    vi.mocked(API.setManagedUserPassword).mockResolvedValue(true)
+    vi.mocked(API.setManagedUserPassword).mockResolvedValue(null)
 
     const ok = await store.setPassword('noc', 'newpw')
 
-    expect(ok).toBe(true)
+    expect(ok).toBe(null)
     expect(API.setManagedUserPassword).toHaveBeenCalledWith('noc', 'newpw')
     expect(API.getManagedUsers).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
[NMS-20106](https://opennms.atlassian.net/browse/NMS-20106): a versioned user management API (`/api/v2/users`) so users can be provisioned by external tooling, and a PrimeVue Manage Users page that is a straight visualization of it. `users.xml` stays the system of record via the existing `UserManager`; fields the API does not expose (XMPP among them, deliberately hidden in the UI) and the password survive updates untouched.

- Endpoints: list/get/create/update/set-password/rename/delete plus available-roles, admin-only via new Spring Security rules and in-code checks.
- Responses never contain the password hash in any form (the v1 API returns it to admins).
- The admin/rtc delete and rename protections and the admin ROLE_ADMIN-retention guard are enforced server-side; the legacy page only hid the buttons.
- Requests are validated up front (ids, roles, time zones, duty schedule grammar, comments markup) and applied to a detached copy, so a rejected request leaves no partial state, while hand-edited values are grandfathered so files never become uneditable.
- The page validates fields inline against the same rules and shows API rejections inside the dialogs.
- 22 integration tests (mock managers, `users.xml` never touched) plus Vitest store/dialog tests; verified end to end against a local instance including byte-level `users.xml` restoration.


[NMS-20106]: https://opennms.atlassian.net/browse/NMS-20106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ