### PR TITLE
NMS-20107: versioned group management API and PrimeVue Manage Groups page

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/GroupsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/GroupsRestService.java
@@ -74,9 +74,9 @@ public class GroupsRestService implements GroupsRestApi {
     private static final Set<String> PROTECTED_GROUPS = Set.of("Admin");
 
     /** Markup per the legacy controller, plus URL-path-segment safety. */
-    private static final Pattern INVALID_NAME = Pattern.compile(".*[&<>\"`':/\\\\%?#\\s]+.*");
+    private static final Pattern INVALID_NAME = Pattern.compile("[&<>\"`':/\\\\%?#\\s]");
 
-    private static final Pattern INVALID_COMMENTS = Pattern.compile(".*[&<>\"`']+.*");
+    private static final Pattern INVALID_COMMENTS = Pattern.compile("[&<>\"`']");
 
     /** Same grammar as the users API. */
     private static final Pattern DUTY_SCHEDULE = Pattern.compile("^((?:Mo|Tu|We|Th|Fr|Sa|Su){1,7})(\\d{1,4})-(\\d{1,4})$");
@@ -217,6 +217,15 @@ public class GroupsRestService implements GroupsRestApi {
                 try {
                     m_groupService.renameGroup(name, newName);
                 } catch (final Exception e) {
+                    // only roll the roles back if the rename did NOT persist
+                    // (GroupService renames the file first, then migrates the
+                    // DB category authorizations); re-pointing after a
+                    // persisted rename would diverge memory from groups.xml
+                    if (m_groupManager.hasGroup(newName) && !m_groupManager.hasGroup(name)) {
+                        throw new IllegalStateException("The group was renamed, but migrating its category"
+                                + " authorizations failed; review the group's authorized categories. ("
+                                + e.getMessage() + ")", e);
+                    }
                     for (final Role role : repointedRoles) {
                         role.setMembershipGroup(name);
                     }
@@ -288,7 +297,8 @@ public class GroupsRestService implements GroupsRestApi {
      * rejected request cannot leave partial state anywhere.
      */
     private void validateDtoFields(final GroupDto dto, final Group existing) throws Exception {
-        if (dto.getComments() != null && INVALID_COMMENTS.matcher(dto.getComments()).matches()) {
+        if (dto.getComments() != null && INVALID_COMMENTS.matcher(dto.getComments()).find()
+                && (existing == null || !dto.getComments().equals(existing.getComments().orElse(null)))) {
             throw new IllegalArgumentException("The comments must not contain any HTML markup.");
         }
         if (dto.getUsers() != null) {
@@ -344,7 +354,7 @@ public class GroupsRestService implements GroupsRestApi {
 
     /** Returns a problem description, or null when the group name is acceptable. */
     private static String validateName(final String name) {
-        if (INVALID_NAME.matcher(name).matches()) {
+        if (INVALID_NAME.matcher(name).find()) {
             return "The group name must not contain markup, whitespace, or the characters : / \\ % ? #";
         }
         if (".".equals(name) || "..".equals(name)) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/GroupsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/GroupsRestService.java
@@ -292,6 +292,11 @@ public class GroupsRestService implements GroupsRestApi {
             throw new IllegalArgumentException("The comments must not contain any HTML markup.");
         }
         if (dto.getUsers() != null) {
+            // members already stored on the group are grandfathered (a
+            // hand-edited file may reference a user that no longer exists);
+            // only members new to this request must resolve to a real user
+            final Set<String> preExistingMembers = existing == null
+                    ? Set.of() : new LinkedHashSet<>(existing.getUsers());
             final Set<String> seen = new LinkedHashSet<>();
             for (final String user : dto.getUsers()) {
                 if (isBlank(user)) {
@@ -300,7 +305,7 @@ public class GroupsRestService implements GroupsRestApi {
                 if (!seen.add(user)) {
                     throw new IllegalArgumentException("Duplicate group member: " + user);
                 }
-                if (!m_userManager.hasUser(user)) {
+                if (!preExistingMembers.contains(user) && !m_userManager.hasUser(user)) {
                     throw new IllegalArgumentException("Unknown user: " + user);
                 }
             }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/GroupsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/GroupsRestService.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+
+import org.opennms.netmgt.config.GroupManager;
+import org.opennms.netmgt.config.UserManager;
+import org.opennms.netmgt.config.groups.Group;
+import org.opennms.netmgt.config.groups.Role;
+import org.opennms.web.api.Authentication;
+import org.opennms.web.rest.v2.api.GroupsRestApi;
+import org.opennms.web.rest.v2.model.GroupDto;
+import org.opennms.web.rest.v2.model.GroupRenameRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Versioned group management on top of {@link GroupManager}: groups.xml
+ * remains the system of record and hand-editing keeps working. Unlike the
+ * legacy JSPs (which only hid the buttons), the Admin-group protections are
+ * enforced here, server-side, and referential integrity with on-call roles is
+ * handled deliberately: renames follow the roles' membership-group, deletes
+ * are rejected while roles still reference the group.
+ *
+ * Mutations validate the full request up front and then apply it to a
+ * detached copy of the stored group, so a rejected request can never leave
+ * partial changes in the manager's shared in-memory state.
+ */
+@Component("groupsRestServiceV2")
+public class GroupsRestService implements GroupsRestApi {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GroupsRestService.class);
+
+    /** The default group; the on-call role machinery references it. */
+    private static final Set<String> PROTECTED_GROUPS = Set.of("Admin");
+
+    /** Markup per the legacy controller, plus URL-path-segment safety. */
+    private static final Pattern INVALID_NAME = Pattern.compile(".*[&<>\"`':/\\\\%?#\\s]+.*");
+
+    private static final Pattern INVALID_COMMENTS = Pattern.compile(".*[&<>\"`']+.*");
+
+    /** Same grammar as the users API; overnight ranges are legal. */
+    private static final Pattern DUTY_SCHEDULE = Pattern.compile("^((?:Mo|Tu|We|Th|Fr|Sa|Su){1,7})(\\d{1,4})-(\\d{1,4})$");
+
+    /** Serializes this service's check-then-act sequences. */
+    private final Object m_lock = new Object();
+
+    @Autowired
+    private GroupManager m_groupManager;
+
+    @Autowired
+    private UserManager m_userManager;
+
+    @Override
+    public Response listGroups(final SecurityContext securityContext) {
+        assertAdmin(securityContext);
+        try {
+            synchronized (m_lock) {
+                final List<GroupDto> groups = new ArrayList<>();
+                for (final Group group : m_groupManager.getGroups().values()) {
+                    groups.add(toDto(group));
+                }
+                groups.sort(Comparator.comparing(GroupDto::getName, String.CASE_INSENSITIVE_ORDER));
+                return Response.ok(groups).build();
+            }
+        } catch (final Exception e) {
+            return serverError("Can't read groups: %s", e);
+        }
+    }
+
+    @Override
+    public Response getGroup(final SecurityContext securityContext, final String name) {
+        assertAdmin(securityContext);
+        try {
+            synchronized (m_lock) {
+                final Group group = m_groupManager.getGroup(name);
+                if (group == null) {
+                    return Response.status(Status.NOT_FOUND).entity("Group " + name + " was not found.").build();
+                }
+                return Response.ok(toDto(group)).build();
+            }
+        } catch (final Exception e) {
+            return serverError("Can't read group: %s", e);
+        }
+    }
+
+    @Override
+    public Response createGroup(final SecurityContext securityContext, final GroupDto dto) {
+        assertAdmin(securityContext);
+        if (dto == null || isBlank(dto.getName())) {
+            return Response.status(Status.BAD_REQUEST).entity("A group name is required.").build();
+        }
+        final String name = dto.getName().trim();
+        final String nameProblem = validateName(name);
+        if (nameProblem != null) {
+            return Response.status(Status.BAD_REQUEST).entity(nameProblem).build();
+        }
+        try {
+            validateDtoFields(dto);
+            synchronized (m_lock) {
+                if (m_groupManager.hasGroup(name)) {
+                    return Response.status(Status.BAD_REQUEST).entity("Group " + name + " already exists.").build();
+                }
+                final Group group = new Group();
+                group.setName(name);
+                applyDto(group, dto);
+                m_groupManager.saveGroup(name, group);
+            }
+            LOG.info("Group {} created by {}", name, principal(securityContext));
+            return Response.status(Status.CREATED).build();
+        } catch (final Exception e) {
+            return serverError("Can't create group: %s", e);
+        }
+    }
+
+    @Override
+    public Response updateGroup(final SecurityContext securityContext, final String name, final GroupDto dto) {
+        assertAdmin(securityContext);
+        if (dto == null) {
+            return Response.status(Status.BAD_REQUEST).entity("A group body is required.").build();
+        }
+        if (dto.getName() != null && !name.equals(dto.getName())) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity("The name in the body does not match the request path; use the rename endpoint to change names.").build();
+        }
+        try {
+            validateDtoFields(dto);
+            synchronized (m_lock) {
+                final Group existing = m_groupManager.getGroup(name);
+                if (existing == null) {
+                    return Response.status(Status.NOT_FOUND).entity("Group " + name + " was not found.").build();
+                }
+                final Group updated = copyOf(existing);
+                applyDto(updated, dto);
+                m_groupManager.saveGroup(name, updated);
+            }
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            return serverError("Can't update group: %s", e);
+        }
+    }
+
+    @Override
+    public Response renameGroup(final SecurityContext securityContext, final String name, final GroupRenameRequest request) {
+        assertAdmin(securityContext);
+        if (request == null || isBlank(request.getNewName())) {
+            return Response.status(Status.BAD_REQUEST).entity("A new-name is required.").build();
+        }
+        if (PROTECTED_GROUPS.contains(name)) {
+            return Response.status(Status.BAD_REQUEST).entity("The system group " + name + " cannot be renamed.").build();
+        }
+        final String newName = request.getNewName().trim();
+        final String nameProblem = validateName(newName);
+        if (nameProblem != null) {
+            return Response.status(Status.BAD_REQUEST).entity(nameProblem).build();
+        }
+        try {
+            synchronized (m_lock) {
+                if (!m_groupManager.hasGroup(name)) {
+                    return Response.status(Status.NOT_FOUND).entity("Group " + name + " was not found.").build();
+                }
+                if (m_groupManager.hasGroup(newName)) {
+                    return Response.status(Status.BAD_REQUEST).entity("Group " + newName + " already exists.").build();
+                }
+                m_groupManager.renameGroup(name, newName);
+                // GroupManager.renameGroup does not touch roles; keep the
+                // on-call roles' membership-group references working
+                for (final Role role : new ArrayList<>(m_groupManager.getRoles())) {
+                    if (name.equals(role.getMembershipGroup())) {
+                        role.setMembershipGroup(newName);
+                        m_groupManager.saveRole(role);
+                    }
+                }
+            }
+            LOG.info("Group {} renamed to {} by {}", name, newName, principal(securityContext));
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            return serverError("Can't rename group: %s", e);
+        }
+    }
+
+    @Override
+    public Response deleteGroup(final SecurityContext securityContext, final String name) {
+        assertAdmin(securityContext);
+        if (PROTECTED_GROUPS.contains(name)) {
+            return Response.status(Status.BAD_REQUEST).entity("The system group " + name + " cannot be deleted.").build();
+        }
+        try {
+            synchronized (m_lock) {
+                if (!m_groupManager.hasGroup(name)) {
+                    return Response.status(Status.NOT_FOUND).entity("Group " + name + " was not found.").build();
+                }
+                final List<String> referencingRoles = m_groupManager.getRoles().stream()
+                        .filter(role -> name.equals(role.getMembershipGroup()))
+                        .map(Role::getName)
+                        .sorted()
+                        .collect(Collectors.toList());
+                if (!referencingRoles.isEmpty()) {
+                    return Response.status(Status.BAD_REQUEST)
+                            .entity("Group " + name + " is the membership group of on-call role(s) " + String.join(", ", referencingRoles)
+                                    + "; delete or reassign those roles first.").build();
+                }
+                m_groupManager.deleteGroup(name);
+            }
+            LOG.info("Group {} deleted by {}", name, principal(securityContext));
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            return serverError("Can't delete group: %s", e);
+        }
+    }
+
+    private static GroupDto toDto(final Group group) {
+        final GroupDto dto = new GroupDto();
+        dto.setName(group.getName());
+        dto.setComments(group.getComments().orElse(null));
+        dto.setUsers(new ArrayList<>(group.getUsers()));
+        dto.setDutySchedules(new ArrayList<>(group.getDutySchedules()));
+        return dto;
+    }
+
+    /** Detached copy so mutations never touch the manager's live object. */
+    private static Group copyOf(final Group group) {
+        final Group copy = new Group();
+        copy.setName(group.getName());
+        group.getDefaultMap().ifPresent(copy::setDefaultMap);
+        group.getComments().ifPresent(copy::setComments);
+        copy.setUsers(new ArrayList<>(group.getUsers()));
+        copy.setDutySchedules(new ArrayList<>(group.getDutySchedules()));
+        return copy;
+    }
+
+    /**
+     * Validates every field of the request BEFORE anything is applied, so a
+     * rejected request cannot leave partial state anywhere.
+     */
+    private void validateDtoFields(final GroupDto dto) throws Exception {
+        if (dto.getComments() != null && INVALID_COMMENTS.matcher(dto.getComments()).matches()) {
+            throw new IllegalArgumentException("The comments must not contain any HTML markup.");
+        }
+        if (dto.getUsers() != null) {
+            final Set<String> seen = new LinkedHashSet<>();
+            for (final String user : dto.getUsers()) {
+                if (isBlank(user)) {
+                    throw new IllegalArgumentException("Group members must not be blank.");
+                }
+                if (!seen.add(user)) {
+                    throw new IllegalArgumentException("Duplicate group member: " + user);
+                }
+                if (!m_userManager.hasUser(user)) {
+                    throw new IllegalArgumentException("Unknown user: " + user);
+                }
+            }
+        }
+        if (dto.getDutySchedules() != null) {
+            for (final String schedule : dto.getDutySchedules()) {
+                validateDutySchedule(schedule);
+            }
+        }
+    }
+
+    /**
+     * Applies the pre-validated DTO. default-map is not exposed by the API and
+     * survives untouched; list fields left out of the request body arrive as
+     * null and are preserved. The user list order is kept exactly as sent —
+     * it drives the notification escalation order.
+     */
+    private static void applyDto(final Group group, final GroupDto dto) {
+        if (dto.getComments() != null) {
+            group.setComments(trimToNull(dto.getComments()));
+        }
+        if (dto.getUsers() != null) {
+            group.setUsers(new ArrayList<>(dto.getUsers()));
+        }
+        if (dto.getDutySchedules() != null) {
+            group.setDutySchedules(new ArrayList<>(dto.getDutySchedules()));
+        }
+    }
+
+    /** Returns a problem description, or null when the group name is acceptable. */
+    private static String validateName(final String name) {
+        if (INVALID_NAME.matcher(name).matches()) {
+            return "The group name must not contain markup, whitespace, or the characters : / \\ % ? #";
+        }
+        return null;
+    }
+
+    private static void validateDutySchedule(final String schedule) {
+        final Matcher matcher = schedule == null ? null : DUTY_SCHEDULE.matcher(schedule);
+        if (matcher == null || !matcher.matches()) {
+            throw new IllegalArgumentException("Invalid duty schedule '" + schedule + "': expected day tokens followed by begin-end military times, e.g. MoWeFr800-1700");
+        }
+        final int begin = Integer.parseInt(matcher.group(2));
+        final int end = Integer.parseInt(matcher.group(3));
+        if (begin > 2359 || end > 2359 || begin % 100 > 59 || end % 100 > 59) {
+            throw new IllegalArgumentException("Invalid duty schedule '" + schedule + "': times must be military clock values between 0 and 2359");
+        }
+    }
+
+    private static void assertAdmin(final SecurityContext securityContext) {
+        if (securityContext == null || !securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
+            throw new javax.ws.rs.WebApplicationException(
+                    Response.status(Status.FORBIDDEN).entity("Group management requires the admin role.").build());
+        }
+    }
+
+    private static String principal(final SecurityContext securityContext) {
+        return securityContext.getUserPrincipal() == null ? "?" : securityContext.getUserPrincipal().getName();
+    }
+
+    private Response serverError(final String format, final Exception e) {
+        if (e instanceof IllegalArgumentException) {
+            return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
+        }
+        LOG.error(String.format(format, e.getMessage()), e);
+        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(String.format(format, e.getMessage())).build();
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static String trimToNull(final String value) {
+        if (value == null) {
+            return null;
+        }
+        final String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/GroupsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/GroupsRestService.java
@@ -39,6 +39,7 @@ import org.opennms.netmgt.config.UserManager;
 import org.opennms.netmgt.config.groups.Group;
 import org.opennms.netmgt.config.groups.Role;
 import org.opennms.web.api.Authentication;
+import org.opennms.web.svclayer.api.GroupService;
 import org.opennms.web.rest.v2.api.GroupsRestApi;
 import org.opennms.web.rest.v2.model.GroupDto;
 import org.opennms.web.rest.v2.model.GroupRenameRequest;
@@ -62,6 +63,11 @@ import org.springframework.stereotype.Component;
 @Component("groupsRestServiceV2")
 public class GroupsRestService implements GroupsRestApi {
 
+    // Check-then-act sequences synchronize on GroupFactory.class: user
+    // mutations cascade into GroupManager (deleteUser/renameUser walk every
+    // group), so a service-private lock cannot serialize the two v2 services
+    // against each other.
+
     private static final Logger LOG = LoggerFactory.getLogger(GroupsRestService.class);
 
     /** The default group; the on-call role machinery references it. */
@@ -72,11 +78,8 @@ public class GroupsRestService implements GroupsRestApi {
 
     private static final Pattern INVALID_COMMENTS = Pattern.compile(".*[&<>\"`']+.*");
 
-    /** Same grammar as the users API; overnight ranges are legal. */
+    /** Same grammar as the users API. */
     private static final Pattern DUTY_SCHEDULE = Pattern.compile("^((?:Mo|Tu|We|Th|Fr|Sa|Su){1,7})(\\d{1,4})-(\\d{1,4})$");
-
-    /** Serializes this service's check-then-act sequences. */
-    private final Object m_lock = new Object();
 
     @Autowired
     private GroupManager m_groupManager;
@@ -84,11 +87,15 @@ public class GroupsRestService implements GroupsRestApi {
     @Autowired
     private UserManager m_userManager;
 
+    /** Handles the DB-side category authorizations on delete/rename. */
+    @Autowired
+    private GroupService m_groupService;
+
     @Override
     public Response listGroups(final SecurityContext securityContext) {
         assertAdmin(securityContext);
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 final List<GroupDto> groups = new ArrayList<>();
                 for (final Group group : m_groupManager.getGroups().values()) {
                     groups.add(toDto(group));
@@ -105,7 +112,7 @@ public class GroupsRestService implements GroupsRestApi {
     public Response getGroup(final SecurityContext securityContext, final String name) {
         assertAdmin(securityContext);
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 final Group group = m_groupManager.getGroup(name);
                 if (group == null) {
                     return Response.status(Status.NOT_FOUND).entity("Group " + name + " was not found.").build();
@@ -129,8 +136,8 @@ public class GroupsRestService implements GroupsRestApi {
             return Response.status(Status.BAD_REQUEST).entity(nameProblem).build();
         }
         try {
-            validateDtoFields(dto);
-            synchronized (m_lock) {
+            validateDtoFields(dto, null);
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 if (m_groupManager.hasGroup(name)) {
                     return Response.status(Status.BAD_REQUEST).entity("Group " + name + " already exists.").build();
                 }
@@ -157,12 +164,12 @@ public class GroupsRestService implements GroupsRestApi {
                     .entity("The name in the body does not match the request path; use the rename endpoint to change names.").build();
         }
         try {
-            validateDtoFields(dto);
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 final Group existing = m_groupManager.getGroup(name);
                 if (existing == null) {
                     return Response.status(Status.NOT_FOUND).entity("Group " + name + " was not found.").build();
                 }
+                validateDtoFields(dto, existing);
                 final Group updated = copyOf(existing);
                 applyDto(updated, dto);
                 m_groupManager.saveGroup(name, updated);
@@ -188,21 +195,32 @@ public class GroupsRestService implements GroupsRestApi {
             return Response.status(Status.BAD_REQUEST).entity(nameProblem).build();
         }
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 if (!m_groupManager.hasGroup(name)) {
                     return Response.status(Status.NOT_FOUND).entity("Group " + name + " was not found.").build();
                 }
                 if (m_groupManager.hasGroup(newName)) {
                     return Response.status(Status.BAD_REQUEST).entity("Group " + newName + " already exists.").build();
                 }
-                m_groupManager.renameGroup(name, newName);
-                // GroupManager.renameGroup does not touch roles; keep the
-                // on-call roles' membership-group references working
-                for (final Role role : new ArrayList<>(m_groupManager.getRoles())) {
+                // Pre-point the on-call roles at the new name in memory, then
+                // let the rename's single save persist groups AND roles
+                // together (GroupManager.renameGroup ends in saveGroups, which
+                // serializes both). GroupService.renameGroup also migrates the
+                // DB category authorizations, as the legacy page did.
+                final List<Role> repointedRoles = new ArrayList<>();
+                for (final Role role : m_groupManager.getRoles()) {
                     if (name.equals(role.getMembershipGroup())) {
                         role.setMembershipGroup(newName);
-                        m_groupManager.saveRole(role);
+                        repointedRoles.add(role);
                     }
+                }
+                try {
+                    m_groupService.renameGroup(name, newName);
+                } catch (final Exception e) {
+                    for (final Role role : repointedRoles) {
+                        role.setMembershipGroup(name);
+                    }
+                    throw e;
                 }
             }
             LOG.info("Group {} renamed to {} by {}", name, newName, principal(securityContext));
@@ -219,7 +237,7 @@ public class GroupsRestService implements GroupsRestApi {
             return Response.status(Status.BAD_REQUEST).entity("The system group " + name + " cannot be deleted.").build();
         }
         try {
-            synchronized (m_lock) {
+            synchronized (org.opennms.netmgt.config.GroupFactory.class) {
                 if (!m_groupManager.hasGroup(name)) {
                     return Response.status(Status.NOT_FOUND).entity("Group " + name + " was not found.").build();
                 }
@@ -233,7 +251,10 @@ public class GroupsRestService implements GroupsRestApi {
                             .entity("Group " + name + " is the membership group of on-call role(s) " + String.join(", ", referencingRoles)
                                     + "; delete or reassign those roles first.").build();
                 }
-                m_groupManager.deleteGroup(name);
+                // GroupService.deleteGroup also clears the DB category
+                // authorizations; without that, a future group reusing the
+                // name would silently inherit the old authorizations
+                m_groupService.deleteGroup(name);
             }
             LOG.info("Group {} deleted by {}", name, principal(securityContext));
             return Response.noContent().build();
@@ -266,7 +287,7 @@ public class GroupsRestService implements GroupsRestApi {
      * Validates every field of the request BEFORE anything is applied, so a
      * rejected request cannot leave partial state anywhere.
      */
-    private void validateDtoFields(final GroupDto dto) throws Exception {
+    private void validateDtoFields(final GroupDto dto, final Group existing) throws Exception {
         if (dto.getComments() != null && INVALID_COMMENTS.matcher(dto.getComments()).matches()) {
             throw new IllegalArgumentException("The comments must not contain any HTML markup.");
         }
@@ -285,8 +306,15 @@ public class GroupsRestService implements GroupsRestApi {
             }
         }
         if (dto.getDutySchedules() != null) {
+            // strings already stored on the record are preserved as-is so
+            // hand-edited files never make a group uneditable; only entries
+            // new to this request must pass validation
+            final Set<String> preExisting = existing == null
+                    ? Set.of() : new LinkedHashSet<>(existing.getDutySchedules());
             for (final String schedule : dto.getDutySchedules()) {
-                validateDutySchedule(schedule);
+                if (!preExisting.contains(schedule)) {
+                    validateDutySchedule(schedule);
+                }
             }
         }
     }
@@ -314,6 +342,9 @@ public class GroupsRestService implements GroupsRestApi {
         if (INVALID_NAME.matcher(name).matches()) {
             return "The group name must not contain markup, whitespace, or the characters : / \\ % ? #";
         }
+        if (".".equals(name) || "..".equals(name)) {
+            return "The group name must not be a dot segment.";
+        }
         return null;
     }
 
@@ -326,6 +357,12 @@ public class GroupsRestService implements GroupsRestApi {
         final int end = Integer.parseInt(matcher.group(3));
         if (begin > 2359 || end > 2359 || begin % 100 > 59 || end % 100 > 59) {
             throw new IllegalArgumentException("Invalid duty schedule '" + schedule + "': times must be military clock values between 0 and 2359");
+        }
+        // DutySchedule.isInSchedule compares within one calendar day, so an
+        // overnight range can never match and would silently disable the
+        // schedule; require two rows (e.g. MoTu2000-2359 + TuWe0-800) instead
+        if (begin > end) {
+            throw new IllegalArgumentException("Invalid duty schedule '" + schedule + "': the begin time must not be after the end time; split overnight coverage into two schedules");
         }
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/GroupsRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/GroupsRestApi.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.api;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+import org.opennms.web.rest.v2.model.GroupDto;
+import org.opennms.web.rest.v2.model.GroupRenameRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * Versioned group management API backed by groups.xml. Admin-only
+ * (enforced by Spring Security and in-code).
+ */
+@Path("groups")
+@Tag(name = "Groups", description = "Group Management API")
+public interface GroupsRestApi {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "List all groups", operationId = "listGroups")
+    Response listGroups(@Context SecurityContext securityContext);
+
+    @GET
+    @Path("{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Get one group", operationId = "getGroup")
+    Response getGroup(@Context SecurityContext securityContext, @PathParam("name") String name);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Create a group", operationId = "createGroup")
+    Response createGroup(@Context SecurityContext securityContext, GroupDto group);
+
+    @PUT
+    @Path("{name}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Update a group (fields not carried by the API are preserved; the user list order drives notification escalation)", operationId = "updateGroup")
+    Response updateGroup(@Context SecurityContext securityContext, @PathParam("name") String name, GroupDto group);
+
+    @POST
+    @Path("{name}/rename")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Rename a group (on-call roles referencing it follow the rename)", operationId = "renameGroup")
+    Response renameGroup(@Context SecurityContext securityContext, @PathParam("name") String name, GroupRenameRequest request);
+
+    @DELETE
+    @Path("{name}")
+    @Operation(summary = "Delete a group (rejected while on-call roles reference it; the Admin group is protected)", operationId = "deleteGroup")
+    Response deleteGroup(@Context SecurityContext securityContext, @PathParam("name") String name);
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/GroupDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/GroupDto.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * A group as exposed by the v2 user management API. Field names mirror
+ * groups.xml where they overlap. The user list is ordered — the order drives
+ * notification escalation. Fields the API does not expose (default-map) are
+ * preserved server-side on update; list fields default to null (not empty) so
+ * a request body that omits them means "preserve".
+ */
+@XmlRootElement(name = "group")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class GroupDto {
+
+    @XmlElement(name = "name")
+    private String name;
+
+    @XmlElement(name = "comments")
+    private String comments;
+
+    @XmlElement(name = "user")
+    private List<String> users;
+
+    @XmlElement(name = "duty-schedule")
+    private List<String> dutySchedules;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(final String comments) {
+        this.comments = comments;
+    }
+
+    public List<String> getUsers() {
+        return users;
+    }
+
+    public void setUsers(final List<String> users) {
+        this.users = users;
+    }
+
+    public List<String> getDutySchedules() {
+        return dutySchedules;
+    }
+
+    public void setDutySchedules(final List<String> dutySchedules) {
+        this.dutySchedules = dutySchedules;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/GroupRenameRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/GroupRenameRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "group-rename-request")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class GroupRenameRequest {
+
+    @XmlElement(name = "new-name")
+    private String newName;
+
+    public String getNewName() {
+        return newName;
+    }
+
+    public void setNewName(final String newName) {
+        this.newName = newName;
+    }
+}

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -411,7 +411,7 @@
         {
           "id": "manageGroups",
           "name": "Manage Groups",
-          "url": "admin/userGroupView/groups/list.htm",
+          "url": "ui/index.html#/admin/groups",
           "locationMatch": "",
           "roles": null
         },

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/GroupsRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/GroupsRestServiceIT.java
@@ -180,6 +180,36 @@ public class GroupsRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
+    public void testCommentsMarkupRejectedEvenWithNewlines() throws Exception {
+        // newlines must not smuggle markup past the full-string match
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups",
+                "{\"name\":\"nlgroup\",\"comments\":\"hello\\n<script>alert(1)</script>\"}", 400);
+        sendRequest(GET, "/groups/nlgroup", 404);
+    }
+
+    @Test
+    public void testHandEditedMarkupCommentStaysEditable() throws Exception {
+        // "Bob's R&D team" is legal free text in a hand-edited groups.xml;
+        // the group must stay editable while the comment is unchanged
+        final Group group = new Group();
+        group.setName("legacycomment");
+        group.setComments("Bob's R&D team");
+        m_groupManager.saveGroup("legacycomment", group);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/legacycomment",
+                "{\"name\":\"legacycomment\",\"comments\":\"Bob's R&D team\",\"user\":[\"admin\"]}", 204);
+        final JSONObject after = new JSONObject(getJson("/groups/legacycomment", 200));
+        assertEquals("Bob's R&D team", after.getString("comments"));
+        assertEquals("admin", after.getJSONArray("user").getString(0));
+
+        // but CHANGING the comment to new markup is still rejected
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/legacycomment",
+                "{\"name\":\"legacycomment\",\"comments\":\"<b>new markup</b>\"}", 400);
+
+        sendRequest(DELETE, "/groups/legacycomment", 204);
+    }
+
+    @Test
     public void testPreExistingUnknownMemberStaysEditable() throws Exception {
         // a hand-edited groups.xml may reference a user that no longer exists;
         // the group must remain editable while that member round-trips

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/GroupsRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/GroupsRestServiceIT.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import javax.ws.rs.core.MediaType;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.netmgt.config.GroupManager;
+import org.opennms.netmgt.config.UserManager;
+import org.opennms.netmgt.config.groups.Group;
+import org.opennms.netmgt.config.groups.Role;
+import org.opennms.netmgt.config.users.User;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        // in-memory user/group managers so groups.xml is never touched
+        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml",
+        "classpath:/applicationContext-rest-test.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties = "org.opennms.timeseries.strategy=integration")
+@JUnitTemporaryDatabase
+public class GroupsRestServiceIT extends AbstractSpringJerseyRestTestCase {
+
+    @Autowired
+    private GroupManager m_groupManager;
+
+    @Autowired
+    private UserManager m_userManager;
+
+    public GroupsRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
+
+    @Override
+    protected void beforeServletStart() {
+        MockLogAppender.setupLogging();
+    }
+
+    private void ensureUser(final String userId) throws Exception {
+        if (!m_userManager.hasUser(userId)) {
+            final User user = new User();
+            user.setUserId(userId);
+            user.setPassword(m_userManager.encryptedPassword("pw", true), Boolean.TRUE);
+            m_userManager.saveUser(userId, user);
+        }
+    }
+
+    @Test
+    public void testListAndGet() throws Exception {
+        final JSONArray groups = new JSONArray(getJson("/groups", 200));
+        assertTrue(groups.length() >= 1);
+        assertEquals("Admin", groups.getJSONObject(0).getString("name"));
+
+        final JSONObject admin = new JSONObject(getJson("/groups/Admin", 200));
+        assertEquals("admin", admin.getJSONArray("user").getString(0));
+
+        sendRequest(GET, "/groups/idontexist", 404);
+    }
+
+    @Test
+    public void testCreateLifecycle() throws Exception {
+        ensureUser("alpha");
+        ensureUser("beta");
+        final String body = "{\"name\":\"junitgroup\",\"comments\":\"a junit group\","
+                + "\"user\":[\"beta\",\"alpha\"],\"duty-schedule\":[\"MoWeFr800-1700\"]}";
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", body, 201);
+
+        final JSONObject created = new JSONObject(getJson("/groups/junitgroup", 200));
+        assertEquals("a junit group", created.getString("comments"));
+        // the member order drives notification escalation and must round-trip
+        assertEquals("beta", created.getJSONArray("user").getString(0));
+        assertEquals("alpha", created.getJSONArray("user").getString(1));
+        assertEquals("MoWeFr800-1700", created.getJSONArray("duty-schedule").getString(0));
+
+        // creating the same group again must be rejected
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", body, 400);
+
+        sendRequest(DELETE, "/groups/junitgroup", 204);
+        sendRequest(GET, "/groups/junitgroup", 404);
+    }
+
+    @Test
+    public void testCreateValidation() throws Exception {
+        // markup / path-segment characters in the name
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"bad<b>\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"team/lead\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"with space\"}", 400);
+        // markup in the comments
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"badc\",\"comments\":\"<script>\"}", 400);
+        // unknown member
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"badu\",\"user\":[\"nosuchuser\"]}", 400);
+        // duplicate member
+        ensureUser("dupuser");
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"badd\",\"user\":[\"dupuser\",\"dupuser\"]}", 400);
+        // broken duty schedules
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"bads\",\"duty-schedule\":[\"garbage\"]}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"bads\",\"duty-schedule\":[\"Mo899-999\"]}", 400);
+        // none of the rejects may have been created
+        sendRequest(GET, "/groups/badc", 404);
+        sendRequest(GET, "/groups/badu", 404);
+        sendRequest(GET, "/groups/badd", 404);
+        sendRequest(GET, "/groups/bads", 404);
+    }
+
+    @Test
+    public void testOvernightDutyScheduleRoundTrips() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups",
+                "{\"name\":\"nightgroup\",\"duty-schedule\":[\"MoTu2000-800\"]}", 201);
+        final JSONObject created = new JSONObject(getJson("/groups/nightgroup", 200));
+        assertEquals("MoTu2000-800", created.getJSONArray("duty-schedule").getString(0));
+        sendRequest(DELETE, "/groups/nightgroup", 204);
+    }
+
+    @Test
+    public void testUpdateReordersMembers() throws Exception {
+        ensureUser("first");
+        ensureUser("second");
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups",
+                "{\"name\":\"ordergroup\",\"user\":[\"first\",\"second\"]}", 201);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/ordergroup",
+                "{\"name\":\"ordergroup\",\"user\":[\"second\",\"first\"]}", 204);
+
+        final JSONObject after = new JSONObject(getJson("/groups/ordergroup", 200));
+        assertEquals("second", after.getJSONArray("user").getString(0));
+        assertEquals("first", after.getJSONArray("user").getString(1));
+
+        sendRequest(DELETE, "/groups/ordergroup", 204);
+    }
+
+    @Test
+    public void testPartialUpdatePreservesOmittedLists() throws Exception {
+        ensureUser("keepme");
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups",
+                "{\"name\":\"partialgroup\",\"user\":[\"keepme\"],\"duty-schedule\":[\"MoWeFr800-1700\"]}", 201);
+
+        // a body that omits the user and duty-schedule keys must preserve both
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/partialgroup",
+                "{\"name\":\"partialgroup\",\"comments\":\"updated\"}", 204);
+
+        final JSONObject after = new JSONObject(getJson("/groups/partialgroup", 200));
+        assertEquals("updated", after.getString("comments"));
+        assertEquals("keepme", after.getJSONArray("user").getString(0));
+        assertEquals("MoWeFr800-1700", after.getJSONArray("duty-schedule").getString(0));
+
+        sendRequest(DELETE, "/groups/partialgroup", 204);
+    }
+
+    @Test
+    public void testUpdatePreservesDefaultMap() throws Exception {
+        // default-map has no editor anywhere but exists in hand-edited files
+        final Group group = new Group();
+        group.setName("mapgroup");
+        group.setDefaultMap("some-map");
+        m_groupManager.saveGroup("mapgroup", group);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/mapgroup",
+                "{\"name\":\"mapgroup\",\"comments\":\"touched\"}", 204);
+
+        assertEquals("some-map", m_groupManager.getGroup("mapgroup").getDefaultMap().orElse(null));
+        sendRequest(DELETE, "/groups/mapgroup", 204);
+    }
+
+    @Test
+    public void testRejectedUpdateLeavesNoPartialState() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups",
+                "{\"name\":\"atomicgroup\",\"comments\":\"original\"}", 201);
+
+        // new comments arrive with an unknown member; nothing may be applied
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/atomicgroup",
+                "{\"name\":\"atomicgroup\",\"comments\":\"changed\",\"user\":[\"nosuchuser\"]}", 400);
+
+        final JSONObject after = new JSONObject(getJson("/groups/atomicgroup", 200));
+        assertEquals("original", after.getString("comments"));
+        assertEquals("original", m_groupManager.getGroup("atomicgroup").getComments().orElse(null));
+
+        sendRequest(DELETE, "/groups/atomicgroup", 204);
+    }
+
+    @Test
+    public void testBodyPathNameMismatchRejected() throws Exception {
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/Admin",
+                "{\"name\":\"somebody-else\",\"comments\":\"x\"}", 400);
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"renamegroup\"}", 201);
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"occupiedgroup\"}", 201);
+
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups/renamegroup/rename", "{\"new-name\":\"occupiedgroup\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups/renamegroup/rename", "{\"new-name\":\"bad<b>\"}", 400);
+
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups/renamegroup/rename", "{\"new-name\":\"renamedgroup\"}", 204);
+        sendRequest(GET, "/groups/renamegroup", 404);
+        sendRequest(GET, "/groups/renamedgroup", 200);
+
+        sendRequest(DELETE, "/groups/renamedgroup", 204);
+        sendRequest(DELETE, "/groups/occupiedgroup", 204);
+    }
+
+    @Test
+    public void testRenameFollowsRoleReferences() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"rolegroup\"}", 201);
+        final Role role = new Role();
+        role.setName("junit-oncall-role");
+        role.setMembershipGroup("rolegroup");
+        role.setSupervisor("admin");
+        m_groupManager.saveRole(role);
+
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups/rolegroup/rename", "{\"new-name\":\"rolegroup2\"}", 204);
+
+        assertEquals("rolegroup2", m_groupManager.getRole("junit-oncall-role").getMembershipGroup());
+
+        // and delete is rejected while the role still references the group
+        sendRequest(DELETE, "/groups/rolegroup2", 400);
+        m_groupManager.deleteRole("junit-oncall-role");
+        sendRequest(DELETE, "/groups/rolegroup2", 204);
+    }
+
+    @Test
+    public void testAdminGroupProtections() throws Exception {
+        sendRequest(DELETE, "/groups/Admin", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups/Admin/rename", "{\"new-name\":\"Admins2\"}", 400);
+        sendRequest(GET, "/groups/Admin", 200);
+    }
+
+    @Test
+    public void testForbiddenForNonAdmin() throws Exception {
+        setUser("nobody", new String[]{ "ROLE_USER" });
+        try {
+            sendRequest(GET, "/groups", 403);
+            sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"x\"}", 403);
+            sendRequest(DELETE, "/groups/Admin", 403);
+        } finally {
+            setUser("admin", new String[]{ "ROLE_ADMIN" });
+        }
+    }
+
+    private String getJson(final String url, final int expectedStatus) throws Exception {
+        final MockHttpServletRequest request = createRequest(GET, url);
+        request.addHeader("Accept", MediaType.APPLICATION_JSON);
+        return sendRequest(request, expectedStatus);
+    }
+}

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/GroupsRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/GroupsRestServiceIT.java
@@ -180,6 +180,28 @@ public class GroupsRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
+    public void testPreExistingUnknownMemberStaysEditable() throws Exception {
+        // a hand-edited groups.xml may reference a user that no longer exists;
+        // the group must remain editable while that member round-trips
+        final Group group = new Group();
+        group.setName("stalemember");
+        group.addUser("ghostuser");
+        m_groupManager.saveGroup("stalemember", group);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/stalemember",
+                "{\"name\":\"stalemember\",\"comments\":\"touched\",\"user\":[\"ghostuser\"]}", 204);
+        final JSONObject after = new JSONObject(getJson("/groups/stalemember", 200));
+        assertEquals("touched", after.getString("comments"));
+        assertEquals("ghostuser", after.getJSONArray("user").getString(0));
+
+        // but ADDING a different unknown user is still rejected
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/stalemember",
+                "{\"name\":\"stalemember\",\"user\":[\"ghostuser\",\"anotherghost\"]}", 400);
+
+        sendRequest(DELETE, "/groups/stalemember", 204);
+    }
+
+    @Test
     public void testDotSegmentNamesRejected() throws Exception {
         sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\".\"}", 400);
         sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"..\"}", 400);

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/GroupsRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/GroupsRestServiceIT.java
@@ -149,12 +149,52 @@ public class GroupsRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
-    public void testOvernightDutyScheduleRoundTrips() throws Exception {
+    public void testOvernightDutyScheduleRejectedForNewEntries() throws Exception {
+        // DutySchedule.isInSchedule compares within one calendar day, so an
+        // overnight range never matches — accepting it would silently put the
+        // group permanently off duty
         sendData(POST, MediaType.APPLICATION_JSON, "/groups",
-                "{\"name\":\"nightgroup\",\"duty-schedule\":[\"MoTu2000-800\"]}", 201);
-        final JSONObject created = new JSONObject(getJson("/groups/nightgroup", 200));
-        assertEquals("MoTu2000-800", created.getJSONArray("duty-schedule").getString(0));
-        sendRequest(DELETE, "/groups/nightgroup", 204);
+                "{\"name\":\"nightgroup\",\"duty-schedule\":[\"MoTu2000-800\"]}", 400);
+        sendRequest(GET, "/groups/nightgroup", 404);
+    }
+
+    @Test
+    public void testPreExistingOddDutyScheduleStaysEditable() throws Exception {
+        // a hand-edited groups.xml may already carry an overnight string; the
+        // record must remain editable when the UI round-trips it unchanged
+        final Group group = new Group();
+        group.setName("legacynight");
+        group.addDutySchedule("MoTu2000-800");
+        m_groupManager.saveGroup("legacynight", group);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/legacynight",
+                "{\"name\":\"legacynight\",\"comments\":\"touched\",\"duty-schedule\":[\"MoTu2000-800\"]}", 204);
+        final JSONObject after = new JSONObject(getJson("/groups/legacynight", 200));
+        assertEquals("MoTu2000-800", after.getJSONArray("duty-schedule").getString(0));
+
+        // but ADDING another overnight entry is still rejected
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/legacynight",
+                "{\"name\":\"legacynight\",\"duty-schedule\":[\"MoTu2000-800\",\"WeTh2100-700\"]}", 400);
+
+        sendRequest(DELETE, "/groups/legacynight", 204);
+    }
+
+    @Test
+    public void testDotSegmentNamesRejected() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\".\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups", "{\"name\":\"..\"}", 400);
+    }
+
+    @Test
+    public void testCommentsCanBeCleared() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/groups",
+                "{\"name\":\"commentgroup\",\"comments\":\"to be removed\"}", 201);
+        // an explicit empty string clears; an omitted key preserves
+        sendData(PUT, MediaType.APPLICATION_JSON, "/groups/commentgroup",
+                "{\"name\":\"commentgroup\",\"comments\":\"\"}", 204);
+        final String json = getJson("/groups/commentgroup", 200);
+        assertTrue(!new JSONObject(json).has("comments") || new JSONObject(json).isNull("comments"));
+        sendRequest(DELETE, "/groups/commentgroup", 204);
     }
 
     @Test

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -193,6 +193,12 @@
     <intercept-url pattern="/api/v2/discovery" method="POST" access="ROLE_PROVISION,ROLE_ADMIN"/>
     <intercept-url pattern="/api/v2/discovery/**" method="POST" access="ROLE_PROVISION,ROLE_ADMIN"/>
 
+    <!-- Group membership drives notification routing; admin-only in every method -->
+    <intercept-url pattern="/api/v2/groups/**" method="GET" access="ROLE_ADMIN" />
+    <intercept-url pattern="/api/v2/groups/**" method="HEAD" access="ROLE_ADMIN" />
+    <intercept-url pattern="/api/v2/groups/**" method="DELETE" access="ROLE_ADMIN" />
+    <intercept-url pattern="/api/v2/groups/**" method="POST" access="ROLE_ADMIN" />
+    <intercept-url pattern="/api/v2/groups/**" method="PUT" access="ROLE_ADMIN" />
     <!-- OPTIONS pre-flight requests should always be accepted -->
     <intercept-url pattern="/api/v2/**" method="OPTIONS" access="ROLE_ANONYMOUS,ROLE_REST,ROLE_ADMIN,ROLE_USER,ROLE_MOBILE"/>
 

--- a/ui/src/components/ManageGroups/GroupEditorDialog.vue
+++ b/ui/src/components/ManageGroups/GroupEditorDialog.vue
@@ -9,25 +9,43 @@
     @update:visible="(value: boolean) => emit('update:visible', value)"
   >
     <div class="form-column">
+      <Message
+        v-if="errorText"
+        severity="error"
+        :closable="false"
+        data-test="dialog-error"
+      >{{ errorText }}</Message>
       <FormField v-if="!isEditing">
         <IftaLabel>
           <InputText
             id="group-editor-name"
             v-model="name"
+            :invalid="!!nameProblem"
             data-test="group-name-input"
           />
           <label for="group-editor-name">Group Name *</label>
         </IftaLabel>
+        <small
+          v-if="nameProblem"
+          class="field-error"
+          data-test="name-error"
+        >{{ nameProblem }}</small>
       </FormField>
       <FormField>
         <IftaLabel>
           <InputText
             id="group-editor-comments"
             v-model="comments"
+            :invalid="!!commentsProblem"
             data-test="group-comments-input"
           />
           <label for="group-editor-comments">Comments</label>
         </IftaLabel>
+        <small
+          v-if="commentsProblem"
+          class="field-error"
+          data-test="comments-error"
+        >{{ commentsProblem }}</small>
       </FormField>
 
       <div class="members-section">
@@ -129,9 +147,11 @@ import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import IftaLabel from 'primevue/iftalabel'
 import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
 import Select from 'primevue/select'
 
 import FormField from '@/components/Common/FormField.vue'
+import { validateAdminComments, validateAdminName } from '@/lib/adminValidation'
 import { useGroupAdminStore } from '@/stores/groupAdminStore'
 import { ManagedGroup } from '@/types/groupAdmin'
 
@@ -149,13 +169,18 @@ const comments = ref('')
 const members = ref<string[]>([])
 const memberToAdd = ref<string | null>(null)
 const saving = ref(false)
+const errorText = ref('')
 
 const isEditing = computed(() => props.group !== null)
 const originalName = computed(() => props.group?.name ?? '')
 
 const addableUsers = computed(() => store.memberCandidates.filter((u) => !members.value.includes(u)))
 
-const isValid = computed(() => isEditing.value || !!name.value.trim())
+const nameProblem = computed(() => (isEditing.value ? null : validateAdminName(name.value, 'group name')))
+const commentsProblem = computed(() => validateAdminComments(comments.value))
+
+const isValid = computed(() =>
+  (isEditing.value || !!name.value.trim()) && !nameProblem.value && !commentsProblem.value)
 
 watch(
   () => props.visible,
@@ -163,6 +188,7 @@ watch(
     if (!isVisible) {
       return
     }
+    errorText.value = ''
     memberToAdd.value = null
     if (props.group) {
       name.value = props.group.name
@@ -206,9 +232,11 @@ const save = async () => {
       comments: comments.value.trim(),
       user: [...members.value]
     }
-    const ok = isEditing.value ? await store.updateGroup(payload) : await store.createGroup(payload)
-    if (ok) {
+    const error = isEditing.value ? await store.updateGroup(payload) : await store.createGroup(payload)
+    if (error === null) {
       emit('update:visible', false)
+    } else {
+      errorText.value = error
     }
   } finally {
     saving.value = false
@@ -227,6 +255,12 @@ const save = async () => {
   :deep(.p-select) {
     width: 100%;
   }
+}
+
+.field-error {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-red-500, #e24c4c);
 }
 
 .members-section {

--- a/ui/src/components/ManageGroups/GroupEditorDialog.vue
+++ b/ui/src/components/ManageGroups/GroupEditorDialog.vue
@@ -203,7 +203,7 @@ const save = async () => {
     const payload: ManagedGroup = {
       ...base,
       name: isEditing.value ? originalName.value : name.value.trim(),
-      comments: comments.value.trim() || undefined,
+      comments: comments.value.trim(),
       user: [...members.value]
     }
     const ok = isEditing.value ? await store.updateGroup(payload) : await store.createGroup(payload)

--- a/ui/src/components/ManageGroups/GroupEditorDialog.vue
+++ b/ui/src/components/ManageGroups/GroupEditorDialog.vue
@@ -177,7 +177,11 @@ const originalName = computed(() => props.group?.name ?? '')
 const addableUsers = computed(() => store.memberCandidates.filter((u) => !members.value.includes(u)))
 
 const nameProblem = computed(() => (isEditing.value ? null : validateAdminName(name.value, 'group name')))
-const commentsProblem = computed(() => validateAdminComments(comments.value))
+
+// a hand-edited comment that predates this page stays editable: only
+// changed input is validated (the server grandfathers unchanged values too)
+const commentsProblem = computed(() =>
+  comments.value.trim() === (props.group?.comments ?? '').trim() ? null : validateAdminComments(comments.value))
 
 const isValid = computed(() =>
   (isEditing.value || !!name.value.trim()) && !nameProblem.value && !commentsProblem.value)

--- a/ui/src/components/ManageGroups/GroupEditorDialog.vue
+++ b/ui/src/components/ManageGroups/GroupEditorDialog.vue
@@ -1,0 +1,298 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :header="isEditing ? `Edit Group: ${originalName}` : 'Add New Group'"
+    class="group-editor-dialog"
+    :style="{ width: '640px', maxWidth: '95vw' }"
+    data-test="group-editor-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="form-column">
+      <FormField v-if="!isEditing">
+        <IftaLabel>
+          <InputText
+            id="group-editor-name"
+            v-model="name"
+            data-test="group-name-input"
+          />
+          <label for="group-editor-name">Group Name *</label>
+        </IftaLabel>
+      </FormField>
+      <FormField>
+        <IftaLabel>
+          <InputText
+            id="group-editor-comments"
+            v-model="comments"
+            data-test="group-comments-input"
+          />
+          <label for="group-editor-comments">Comments</label>
+        </IftaLabel>
+      </FormField>
+
+      <div class="members-section">
+        <div class="members-header">
+          <span class="members-title">Members</span>
+          <span class="members-hint">Order matters: it is the notification escalation order.</span>
+        </div>
+        <div class="add-member-row">
+          <IftaLabel>
+            <Select
+              v-model="memberToAdd"
+              labelId="group-editor-add-member"
+              :options="addableUsers"
+              filter
+              data-test="add-member-select"
+            />
+            <label for="group-editor-add-member">Add user</label>
+          </IftaLabel>
+          <Button
+            outlined
+            icon="pi pi-plus"
+            aria-label="Add member"
+            data-test="add-member-button"
+            :disabled="!memberToAdd"
+            @click="addMember"
+          />
+        </div>
+        <ul
+          v-if="members.length"
+          class="member-list"
+          data-test="member-list"
+        >
+          <li
+            v-for="(member, index) in members"
+            :key="member"
+            class="member-row"
+          >
+            <span class="member-order">{{ index + 1 }}.</span>
+            <span class="member-name">{{ member }}</span>
+            <span class="member-actions">
+              <Button
+                text
+                rounded
+                icon="pi pi-chevron-up"
+                :aria-label="`Move ${member} up`"
+                data-test="move-up-button"
+                :disabled="index === 0"
+                @click="move(index, -1)"
+              />
+              <Button
+                text
+                rounded
+                icon="pi pi-chevron-down"
+                :aria-label="`Move ${member} down`"
+                data-test="move-down-button"
+                :disabled="index === members.length - 1"
+                @click="move(index, 1)"
+              />
+              <Button
+                text
+                rounded
+                icon="pi pi-times"
+                severity="danger"
+                :aria-label="`Remove ${member}`"
+                data-test="remove-member-button"
+                @click="members.splice(index, 1)"
+              />
+            </span>
+          </li>
+        </ul>
+        <p
+          v-else
+          class="no-members"
+        >No members yet.</p>
+      </div>
+    </div>
+
+    <template #footer>
+      <Button
+        text
+        label="Cancel"
+        data-test="cancel-button"
+        @click="emit('update:visible', false)"
+      />
+      <Button
+        :label="isEditing ? 'Save Group' : 'Add Group'"
+        :disabled="!isValid || saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
+
+import FormField from '@/components/Common/FormField.vue'
+import { useGroupAdminStore } from '@/stores/groupAdminStore'
+import { ManagedGroup } from '@/types/groupAdmin'
+
+const props = defineProps<{
+  visible: boolean
+  group: ManagedGroup | null
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useGroupAdminStore()
+
+const name = ref('')
+const comments = ref('')
+const members = ref<string[]>([])
+const memberToAdd = ref<string | null>(null)
+const saving = ref(false)
+
+const isEditing = computed(() => props.group !== null)
+const originalName = computed(() => props.group?.name ?? '')
+
+const addableUsers = computed(() => store.memberCandidates.filter((u) => !members.value.includes(u)))
+
+const isValid = computed(() => isEditing.value || !!name.value.trim())
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (!isVisible) {
+      return
+    }
+    memberToAdd.value = null
+    if (props.group) {
+      name.value = props.group.name
+      comments.value = props.group.comments ?? ''
+      members.value = [...(props.group.user ?? [])]
+    } else {
+      name.value = ''
+      comments.value = ''
+      members.value = []
+    }
+  }
+)
+
+const addMember = () => {
+  if (memberToAdd.value && !members.value.includes(memberToAdd.value)) {
+    members.value.push(memberToAdd.value)
+  }
+  memberToAdd.value = null
+}
+
+const move = (index: number, delta: number) => {
+  const target = index + delta
+  if (target < 0 || target >= members.value.length) {
+    return
+  }
+  const list = [...members.value]
+  const [item] = list.splice(index, 1)
+  list.splice(target, 0, item)
+  members.value = list
+}
+
+const save = async () => {
+  saving.value = true
+  try {
+    // spread the original so fields this form doesn't expose (duty
+    // schedules) round-trip untouched; default-map is preserved server-side
+    const base = props.group ?? {}
+    const payload: ManagedGroup = {
+      ...base,
+      name: isEditing.value ? originalName.value : name.value.trim(),
+      comments: comments.value.trim() || undefined,
+      user: [...members.value]
+    }
+    const ok = isEditing.value ? await store.updateGroup(payload) : await store.createGroup(payload)
+    if (ok) {
+      emit('update:visible', false)
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.form-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 0.5rem;
+
+  :deep(input),
+  :deep(.p-select) {
+    width: 100%;
+  }
+}
+
+.members-section {
+  .members-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+
+    .members-title {
+      font-weight: 600;
+    }
+
+    .members-hint {
+      font-size: 0.85rem;
+      color: var(--p-text-muted-color);
+    }
+  }
+
+  .add-member-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: stretch;
+    margin-bottom: 0.5rem;
+
+    :deep(.p-iftalabel) {
+      flex: 1;
+    }
+  }
+
+  .member-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border: 1px solid var(--p-content-border-color);
+    border-radius: 6px;
+
+    .member-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.25rem 0.75rem;
+
+      & + .member-row {
+        border-top: 1px solid var(--p-content-border-color);
+      }
+
+      .member-order {
+        color: var(--p-text-muted-color);
+        min-width: 1.5rem;
+      }
+
+      .member-name {
+        flex: 1;
+        font-weight: 500;
+      }
+
+      .member-actions {
+        display: flex;
+      }
+    }
+  }
+
+  .no-members {
+    margin: 0;
+    color: var(--p-text-muted-color);
+  }
+}
+</style>

--- a/ui/src/components/ManageGroups/GroupRenameDialog.vue
+++ b/ui/src/components/ManageGroups/GroupRenameDialog.vue
@@ -1,0 +1,104 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :header="`Rename Group: ${groupName}`"
+    class="group-rename-dialog"
+    :style="{ width: '420px', maxWidth: '95vw' }"
+    data-test="group-rename-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="form-column">
+      <FormField>
+        <IftaLabel>
+          <InputText
+            id="group-rename-new-name"
+            v-model="newName"
+            data-test="new-name-input"
+          />
+          <label for="group-rename-new-name">New Group Name *</label>
+        </IftaLabel>
+        <small class="hint">On-call roles referencing this group follow the rename.</small>
+      </FormField>
+    </div>
+
+    <template #footer>
+      <Button
+        text
+        label="Cancel"
+        data-test="cancel-button"
+        @click="emit('update:visible', false)"
+      />
+      <Button
+        label="Rename"
+        :disabled="!newName.trim() || newName.trim() === groupName || saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+
+import FormField from '@/components/Common/FormField.vue'
+import { useGroupAdminStore } from '@/stores/groupAdminStore'
+
+const props = defineProps<{
+  visible: boolean
+  groupName: string
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useGroupAdminStore()
+
+const newName = ref('')
+const saving = ref(false)
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (isVisible) {
+      newName.value = ''
+    }
+  }
+)
+
+const save = async () => {
+  saving.value = true
+  try {
+    const ok = await store.renameGroup(props.groupName, newName.value.trim())
+    if (ok) {
+      emit('update:visible', false)
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.form-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 0.5rem;
+
+  :deep(input) {
+    width: 100%;
+  }
+}
+
+.hint {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-text-muted-color);
+}
+</style>

--- a/ui/src/components/ManageGroups/GroupRenameDialog.vue
+++ b/ui/src/components/ManageGroups/GroupRenameDialog.vue
@@ -9,15 +9,27 @@
     @update:visible="(value: boolean) => emit('update:visible', value)"
   >
     <div class="form-column">
+      <Message
+        v-if="errorText"
+        severity="error"
+        :closable="false"
+        data-test="dialog-error"
+      >{{ errorText }}</Message>
       <FormField>
         <IftaLabel>
           <InputText
             id="group-rename-new-name"
             v-model="newName"
+            :invalid="!!nameProblem"
             data-test="new-name-input"
           />
           <label for="group-rename-new-name">New Group Name *</label>
         </IftaLabel>
+        <small
+          v-if="nameProblem"
+          class="field-error"
+          data-test="name-error"
+        >{{ nameProblem }}</small>
         <small class="hint">On-call roles referencing this group follow the rename.</small>
       </FormField>
     </div>
@@ -31,7 +43,7 @@
       />
       <Button
         label="Rename"
-        :disabled="!newName.trim() || newName.trim() === groupName || saving"
+        :disabled="!newName.trim() || !!nameProblem || newName.trim() === groupName || saving"
         data-test="save-button"
         @click="save"
       />
@@ -40,14 +52,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import IftaLabel from 'primevue/iftalabel'
 import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
 
 import FormField from '@/components/Common/FormField.vue'
+import { validateAdminName } from '@/lib/adminValidation'
 import { useGroupAdminStore } from '@/stores/groupAdminStore'
 
 const props = defineProps<{
@@ -61,12 +75,16 @@ const store = useGroupAdminStore()
 
 const newName = ref('')
 const saving = ref(false)
+const errorText = ref('')
+
+const nameProblem = computed(() => validateAdminName(newName.value, 'group name'))
 
 watch(
   () => props.visible,
   (isVisible) => {
     if (isVisible) {
       newName.value = ''
+      errorText.value = ''
     }
   }
 )
@@ -74,9 +92,11 @@ watch(
 const save = async () => {
   saving.value = true
   try {
-    const ok = await store.renameGroup(props.groupName, newName.value.trim())
-    if (ok) {
+    const error = await store.renameGroup(props.groupName, newName.value.trim())
+    if (error === null) {
       emit('update:visible', false)
+    } else {
+      errorText.value = error
     }
   } finally {
     saving.value = false
@@ -94,6 +114,12 @@ const save = async () => {
   :deep(input) {
     width: 100%;
   }
+}
+
+.field-error {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-red-500, #e24c4c);
 }
 
 .hint {

--- a/ui/src/components/ManageGroups/GroupsHelpPanel.vue
+++ b/ui/src/components/ManageGroups/GroupsHelpPanel.vue
@@ -1,0 +1,92 @@
+<template>
+  <TogglePanel
+    :collapsed="collapsed"
+    class="groups-help-panel"
+    data-test="groups-help-panel"
+    @update:collapsed="(value: boolean) => (collapsed = value)"
+  >
+    <template #header>
+      <span class="panel-header">
+        <i class="pi pi-question-circle" aria-hidden="true" />
+        About Groups
+      </span>
+    </template>
+    <div class="help-columns">
+      <div class="help-section">
+        <div class="section-title">What groups are for</div>
+        <p>
+          A group is an ordered collection of users, used mainly for notifications: when a
+          destination path targets a group, its members are notified one at a time, in the order
+          they appear here, with the configured interval between them. Groups are also the
+          membership pool for on-call roles, which schedule who is on duty.
+        </p>
+        <p>
+          Groups are stored in <code>groups.xml</code>. Editing that file by hand keeps working;
+          changes made here and changes made in the file stay in sync. Group duty schedules and
+          the default map, which have no editor on this page yet, are preserved untouched.
+        </p>
+      </div>
+      <div class="help-section">
+        <div class="section-title">How to use this page</div>
+        <p>
+          <strong>Add New Group</strong> creates a group; <strong>Edit</strong> manages the
+          members. Use the up and down arrows to set the member order — for notifications this is
+          the escalation order, so put the first responder at the top.
+        </p>
+        <p>
+          <strong>Rename</strong> keeps everything consistent: on-call roles that reference the
+          group follow the rename automatically. <strong>Delete</strong> is refused while an
+          on-call role still references the group — delete or reassign the role first. The
+          <em>Admin</em> group is a system group and cannot be deleted or renamed. Destination
+          paths that target a group by name do not follow renames or deletes; review them after
+          changing group names.
+        </p>
+      </div>
+    </div>
+  </TogglePanel>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+
+// Starts collapsed — the "?" invites first-time users to expand.
+const collapsed = ref(true)
+</script>
+
+<style lang="scss" scoped>
+.panel-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+
+  .pi-question-circle {
+    color: var(--p-primary-color);
+  }
+}
+
+.help-columns {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+
+  .help-section {
+    flex: 1;
+    min-width: 320px;
+  }
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+</style>

--- a/ui/src/components/ManageGroups/GroupsTable.vue
+++ b/ui/src/components/ManageGroups/GroupsTable.vue
@@ -1,0 +1,210 @@
+<template>
+  <TableCard class="groups-table">
+    <div class="header">
+      <div class="card-title">Groups</div>
+      <Button
+        outlined
+        label="Add New Group"
+        icon="pi pi-plus"
+        data-test="add-group-button"
+        @click="openEditor(null)"
+      />
+    </div>
+
+    <DataTable
+      v-if="store.groups.length"
+      :value="store.groups"
+      paginator
+      dataKey="name"
+      :rows="10"
+      :rowsPerPageOptions="[10, 20, 50, 100]"
+      class="data-table"
+      data-test="groups-table"
+    >
+      <Column
+        field="name"
+        header="Group Name"
+        sortable
+      >
+        <template #body="{ data }">
+          <span class="group-name">{{ data.name }}</span>
+          <Tag
+            v-if="isProtected(data.name)"
+            value="system"
+            severity="secondary"
+            class="system-tag"
+            v-tooltip.top="'System group: cannot be deleted or renamed'"
+          />
+        </template>
+      </Column>
+      <Column
+        field="comments"
+        header="Comments"
+        sortable
+      />
+      <Column header="Members">
+        <template #body="{ data }">
+          <span class="members">{{ (data.user ?? []).join(', ') || '-' }}</span>
+        </template>
+      </Column>
+      <Column header="Actions">
+        <template #body="{ data }">
+          <div class="action-container">
+            <Button
+              text
+              label="Edit"
+              :aria-label="`Edit ${data.name}`"
+              data-test="edit-group-button"
+              @click="openEditor(data)"
+            />
+            <Button
+              text
+              label="Rename"
+              :disabled="isProtected(data.name)"
+              :aria-label="`Rename ${data.name}`"
+              data-test="rename-group-button"
+              @click="openRename(data)"
+            />
+            <Button
+              text
+              label="Delete"
+              severity="danger"
+              :disabled="isProtected(data.name)"
+              :aria-label="`Delete ${data.name}`"
+              data-test="delete-group-button"
+              @click="askDelete(data)"
+            />
+          </div>
+        </template>
+      </Column>
+    </DataTable>
+
+    <div v-if="!store.groups.length">
+      <EmptyList
+        :content="emptyListContent"
+        data-test="empty-list"
+      />
+    </div>
+  </TableCard>
+
+  <GroupEditorDialog
+    v-model:visible="showEditor"
+    :group="groupToEdit"
+  />
+  <GroupRenameDialog
+    v-model:visible="showRename"
+    :groupName="actionGroupName"
+  />
+  <OnmsConfirmationDialog
+    :visible="showDeleteConfirmation"
+    title="Delete Group"
+    actionButtonText="Delete"
+    @ok="confirmDelete"
+    @cancel="cancelDelete"
+  >
+    <template #content>
+      <p>
+        Are you sure you want to delete the group <strong>{{ groupToDelete?.name }}</strong>?
+        Destination paths targeting it will stop resolving. This action cannot be undone.
+      </p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { OnmsConfirmationDialog } from '@opennms/onms-ui'
+
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import Tag from 'primevue/tag'
+
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import GroupEditorDialog from '@/components/ManageGroups/GroupEditorDialog.vue'
+import GroupRenameDialog from '@/components/ManageGroups/GroupRenameDialog.vue'
+import { useGroupAdminStore } from '@/stores/groupAdminStore'
+import { ManagedGroup, PROTECTED_GROUP_NAMES } from '@/types/groupAdmin'
+
+const store = useGroupAdminStore()
+
+const showEditor = ref(false)
+const groupToEdit = ref<ManagedGroup | null>(null)
+const showRename = ref(false)
+const actionGroupName = ref('')
+const showDeleteConfirmation = ref(false)
+const groupToDelete = ref<ManagedGroup | null>(null)
+
+const emptyListContent = {
+  msg: 'No groups found.'
+}
+
+const isProtected = (name: string) => PROTECTED_GROUP_NAMES.includes(name)
+
+const openEditor = (group: ManagedGroup | null) => {
+  groupToEdit.value = group
+  showEditor.value = true
+}
+
+const openRename = (group: ManagedGroup) => {
+  actionGroupName.value = group.name
+  showRename.value = true
+}
+
+const askDelete = (group: ManagedGroup) => {
+  groupToDelete.value = group
+  showDeleteConfirmation.value = true
+}
+
+const confirmDelete = async () => {
+  if (groupToDelete.value) {
+    await store.deleteGroup(groupToDelete.value.name)
+  }
+  showDeleteConfirmation.value = false
+  groupToDelete.value = null
+}
+
+const cancelDelete = () => {
+  showDeleteConfirmation.value = false
+  groupToDelete.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.groups-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.group-name {
+  font-weight: 600;
+}
+
+.system-tag {
+  margin-left: 0.5rem;
+}
+
+.members {
+  font-size: 0.875rem;
+  color: var(--p-text-muted-color);
+}
+
+.action-container {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+</style>

--- a/ui/src/components/ManageGroups/GroupsTable.vue
+++ b/ui/src/components/ManageGroups/GroupsTable.vue
@@ -49,7 +49,13 @@
       </Column>
       <Column header="Actions">
         <template #body="{ data }">
-          <div class="action-container">
+          <span
+            v-if="!isPathAddressable(data.name)"
+            class="unaddressable"
+            v-tooltip.top="'This group name contains / \\ or %, which the API cannot address; manage it by editing groups.xml.'"
+            data-test="unaddressable-note"
+          >file-managed</span>
+          <div v-else class="action-container">
             <Button
               text
               label="Edit"
@@ -125,6 +131,7 @@ import EmptyList from '@/components/Common/EmptyList.vue'
 import TableCard from '@/components/Common/TableCard.vue'
 import GroupEditorDialog from '@/components/ManageGroups/GroupEditorDialog.vue'
 import GroupRenameDialog from '@/components/ManageGroups/GroupRenameDialog.vue'
+import { isPathAddressable } from '@/lib/adminValidation'
 import { useGroupAdminStore } from '@/stores/groupAdminStore'
 import { ManagedGroup, PROTECTED_GROUP_NAMES } from '@/types/groupAdmin'
 
@@ -200,6 +207,11 @@ const cancelDelete = () => {
 .members {
   font-size: 0.875rem;
   color: var(--p-text-muted-color);
+}
+
+.unaddressable {
+  color: var(--p-text-muted-color);
+  font-style: italic;
 }
 
 .action-container {

--- a/ui/src/containers/ManageGroups.vue
+++ b/ui/src/containers/ManageGroups.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+  <div class="manage-groups-container">
+    <h1 class="page-title">Manage Groups</h1>
+    <GroupsTable />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import GroupsTable from '@/components/ManageGroups/GroupsTable.vue'
+import { useGroupAdminStore } from '@/stores/groupAdminStore'
+import { useMenuStore } from '@/stores/menuStore'
+import { BreadCrumb } from '@/types'
+
+const menuStore = useMenuStore()
+const store = useGroupAdminStore()
+
+const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
+
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Manage Groups', to: '#', position: 'last' }
+  ]
+})
+
+onMounted(async () => {
+  await store.populate()
+})
+</script>
+
+<style lang="scss" scoped>
+.manage-groups-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 2px 2rem 2px;
+}
+
+.page-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+</style>

--- a/ui/src/containers/ManageGroups.vue
+++ b/ui/src/containers/ManageGroups.vue
@@ -6,6 +6,7 @@
   </div>
   <div class="manage-groups-container">
     <h1 class="page-title">Manage Groups</h1>
+    <GroupsHelpPanel />
     <GroupsTable />
   </div>
 </template>
@@ -14,6 +15,7 @@
 import { computed, onMounted } from 'vue'
 
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import GroupsHelpPanel from '@/components/ManageGroups/GroupsHelpPanel.vue'
 import GroupsTable from '@/components/ManageGroups/GroupsTable.vue'
 import { useGroupAdminStore } from '@/stores/groupAdminStore'
 import { useMenuStore } from '@/stores/menuStore'

--- a/ui/src/lib/adminValidation.ts
+++ b/ui/src/lib/adminValidation.ts
@@ -26,7 +26,7 @@
 
 const INVALID_NAME = /[&<>"`':/\\%?#\s]/
 const INVALID_COMMENTS = /[&<>"`']/
-const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+$/
+const EMAIL_SHAPE = /[^\s@]+@[^\s@]+/
 
 /**
  * Validates a user-id, group name or on-call role name.
@@ -62,10 +62,18 @@ export const validateAdminComments = (value: string): string | null => {
  */
 export const isPathAddressable = (name: string): boolean => !/[/\\%]/.test(name)
 
-/** Loose shape check: notification delivery needs at least local@domain. */
+/**
+ * Loose shape check: every comma-separated recipient must contain a
+ * local@domain somewhere, which also accepts RFC-5322 display-name forms
+ * like `Bill Smith <bill@example.com>`.
+ */
 export const validateEmailShape = (value: string, label: string): string | null => {
   const trimmed = value.trim()
-  if (trimmed && !EMAIL_SHAPE.test(trimmed)) {
+  if (!trimmed) {
+    return null
+  }
+  const parts = trimmed.split(',').map((part) => part.trim())
+  if (parts.some((part) => !part || !EMAIL_SHAPE.test(part))) {
     return `The ${label} must look like an email address (name@domain).`
   }
   return null

--- a/ui/src/lib/adminValidation.ts
+++ b/ui/src/lib/adminValidation.ts
@@ -1,0 +1,72 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Client-side mirrors of the /api/v2 admin validation rules so forms can flag
+// problems before submitting. These must stay in sync with UsersRestService,
+// GroupsRestService and OnCallRolesRestService (INVALID_NAME/INVALID_COMMENTS).
+
+const INVALID_NAME = /[&<>"`':/\\%?#\s]/
+const INVALID_COMMENTS = /[&<>"`']/
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+$/
+
+/**
+ * Validates a user-id, group name or on-call role name.
+ * Returns a problem description, or null when the value is acceptable.
+ * Emptiness is not checked here; required-ness is a per-form concern.
+ */
+export const validateAdminName = (value: string, label: string): string | null => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+  if (INVALID_NAME.test(trimmed)) {
+    return `The ${label} must not contain markup, whitespace, or the characters : / \\ % ? #`
+  }
+  if (trimmed === '.' || trimmed === '..') {
+    return `The ${label} must not be a dot segment.`
+  }
+  return null
+}
+
+/** Group comments may not contain HTML markup characters. */
+export const validateAdminComments = (value: string): string | null => {
+  if (value && INVALID_COMMENTS.test(value)) {
+    return 'The comments must not contain the characters & < > " ` \''
+  }
+  return null
+}
+
+/**
+ * Names containing / \ or % cannot be addressed as a URL path segment (the
+ * security filter rejects their encoded forms), so per-item API operations
+ * are unavailable for such hand-edited legacy entries.
+ */
+export const isPathAddressable = (name: string): boolean => !/[/\\%]/.test(name)
+
+/** Loose shape check: notification delivery needs at least local@domain. */
+export const validateEmailShape = (value: string, label: string): string | null => {
+  const trimmed = value.trim()
+  if (trimmed && !EMAIL_SHAPE.test(trimmed)) {
+    return `The ${label} must look like an email address (name@domain).`
+  }
+  return null
+}

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -159,6 +159,25 @@ const router = createRouter({
       }
     },
     {
+      path: '/admin/groups',
+      name: 'Manage Groups',
+      component: () => import('@/containers/ManageGroups.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'Must be admin to manage groups.' })
+            router.push(from.path)
+          }
+        }
+
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
+      }
+    },
+    {
       path: '/map',
       name: 'Map',
       component: () => import('@/containers/Map.vue'),

--- a/ui/src/services/groupAdminService.ts
+++ b/ui/src/services/groupAdminService.ts
@@ -1,0 +1,126 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+import useSpinner from '@/composables/useSpinner'
+import { ManagedGroup } from '@/types/groupAdmin'
+import { rest, v2 } from './axiosInstances'
+
+const { showSnackBar } = useSnackbar()
+const { startSpinner, stopSpinner } = useSpinner()
+const endpoint = '/groups'
+
+const errorMessage = (err: any, fallback: string): string => {
+  const detail = err?.response?.data
+  return typeof detail === 'string' && detail ? detail : fallback
+}
+
+// null on failure (not []) so callers can keep showing the previous list
+const getManagedGroups = async (): Promise<ManagedGroup[] | null> => {
+  try {
+    startSpinner()
+    const resp = await v2.get(endpoint)
+    return Array.isArray(resp.data) ? resp.data : []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load groups.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+// member picker options; the v1 users endpoint exists on every install
+const getGroupMemberCandidates = async (): Promise<string[]> => {
+  try {
+    const resp = await rest.get('/users?limit=0')
+    const users = resp.data?.user ?? []
+    return (Array.isArray(users) ? users : [users]).map((u: any) => u['user-id']).filter(Boolean)
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load users.' })
+    return []
+  }
+}
+
+const createManagedGroup = async (group: ManagedGroup): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.post(endpoint, group)
+    showSnackBar({ msg: `Group '${group.name}' created.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to create group '${group.name}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const updateManagedGroup = async (group: ManagedGroup): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.put(`${endpoint}/${encodeURIComponent(group.name)}`, group)
+    showSnackBar({ msg: `Group '${group.name}' updated.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to update group '${group.name}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const renameManagedGroup = async (name: string, newName: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.post(`${endpoint}/${encodeURIComponent(name)}/rename`, { 'new-name': newName })
+    showSnackBar({ msg: `Group '${name}' renamed to '${newName}'.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to rename group '${name}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const deleteManagedGroup = async (name: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await v2.delete(`${endpoint}/${encodeURIComponent(name)}`)
+    showSnackBar({ msg: `Group '${name}' deleted.` })
+    return true
+  } catch (err: any) {
+    showSnackBar({ msg: errorMessage(err, `Failed to delete group '${name}'.`) })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+export {
+  createManagedGroup,
+  deleteManagedGroup,
+  getGroupMemberCandidates,
+  getManagedGroups,
+  renameManagedGroup,
+  updateManagedGroup
+}

--- a/ui/src/services/groupAdminService.ts
+++ b/ui/src/services/groupAdminService.ts
@@ -60,57 +60,61 @@ const getGroupMemberCandidates = async (): Promise<string[]> => {
   }
 }
 
-const createManagedGroup = async (group: ManagedGroup): Promise<boolean> => {
+const createManagedGroup = async (group: ManagedGroup): Promise<string | null> => {
   try {
     startSpinner()
     await v2.post(endpoint, group)
     showSnackBar({ msg: `Group '${group.name}' created.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to create group '${group.name}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to create group '${group.name}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }
 }
 
-const updateManagedGroup = async (group: ManagedGroup): Promise<boolean> => {
+const updateManagedGroup = async (group: ManagedGroup): Promise<string | null> => {
   try {
     startSpinner()
     await v2.put(`${endpoint}/${encodeURIComponent(group.name)}`, group)
     showSnackBar({ msg: `Group '${group.name}' updated.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to update group '${group.name}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to update group '${group.name}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }
 }
 
-const renameManagedGroup = async (name: string, newName: string): Promise<boolean> => {
+const renameManagedGroup = async (name: string, newName: string): Promise<string | null> => {
   try {
     startSpinner()
     await v2.post(`${endpoint}/${encodeURIComponent(name)}/rename`, { 'new-name': newName })
     showSnackBar({ msg: `Group '${name}' renamed to '${newName}'.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to rename group '${name}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to rename group '${name}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }
 }
 
-const deleteManagedGroup = async (name: string): Promise<boolean> => {
+const deleteManagedGroup = async (name: string): Promise<string | null> => {
   try {
     startSpinner()
     await v2.delete(`${endpoint}/${encodeURIComponent(name)}`)
     showSnackBar({ msg: `Group '${name}' deleted.` })
-    return true
+    return null
   } catch (err: any) {
-    showSnackBar({ msg: errorMessage(err, `Failed to delete group '${name}'.`) })
-    return false
+    const msg = errorMessage(err, `Failed to delete group '${name}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
   } finally {
     stopSpinner()
   }

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -74,6 +74,14 @@ import {
   setUsageStatisticsStatus
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
+import {
+  createManagedGroup,
+  deleteManagedGroup,
+  getGroupMemberCandidates,
+  getManagedGroups,
+  renameManagedGroup,
+  updateManagedGroup
+} from './groupAdminService'
 
 export default {
   search,
@@ -135,5 +143,11 @@ export default {
   setUsageStatisticsStatus,
   addZenithRegistration,
   getZenithRegistrations,
-  performLogout
+  performLogout,
+  createManagedGroup,
+  deleteManagedGroup,
+  getGroupMemberCandidates,
+  getManagedGroups,
+  renameManagedGroup,
+  updateManagedGroup
 }

--- a/ui/src/stores/groupAdminStore.ts
+++ b/ui/src/stores/groupAdminStore.ts
@@ -41,35 +41,35 @@ export const useGroupAdminStore = defineStore('groupAdminStore', () => {
   }
 
   const createGroup = async (group: ManagedGroup) => {
-    const ok = await API.createManagedGroup(group)
-    if (ok) {
+    const error = await API.createManagedGroup(group)
+    if (error === null) {
       await getGroups()
     }
-    return ok
+    return error
   }
 
   const updateGroup = async (group: ManagedGroup) => {
-    const ok = await API.updateManagedGroup(group)
-    if (ok) {
+    const error = await API.updateManagedGroup(group)
+    if (error === null) {
       await getGroups()
     }
-    return ok
+    return error
   }
 
   const renameGroup = async (name: string, newName: string) => {
-    const ok = await API.renameManagedGroup(name, newName)
-    if (ok) {
+    const error = await API.renameManagedGroup(name, newName)
+    if (error === null) {
       await getGroups()
     }
-    return ok
+    return error
   }
 
   const deleteGroup = async (name: string) => {
-    const ok = await API.deleteManagedGroup(name)
-    if (ok) {
+    const error = await API.deleteManagedGroup(name)
+    if (error === null) {
       await getGroups()
     }
-    return ok
+    return error
   }
 
   const populate = async () => {

--- a/ui/src/stores/groupAdminStore.ts
+++ b/ui/src/stores/groupAdminStore.ts
@@ -1,0 +1,90 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import API from '@/services'
+import { ManagedGroup } from '@/types/groupAdmin'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useGroupAdminStore = defineStore('groupAdminStore', () => {
+  const groups = ref([] as ManagedGroup[])
+  const memberCandidates = ref([] as string[])
+
+  const getGroups = async () => {
+    const result = await API.getManagedGroups()
+    if (result !== null) {
+      groups.value = result
+    }
+  }
+
+  const getMemberCandidates = async () => {
+    memberCandidates.value = await API.getGroupMemberCandidates()
+  }
+
+  const createGroup = async (group: ManagedGroup) => {
+    const ok = await API.createManagedGroup(group)
+    if (ok) {
+      await getGroups()
+    }
+    return ok
+  }
+
+  const updateGroup = async (group: ManagedGroup) => {
+    const ok = await API.updateManagedGroup(group)
+    if (ok) {
+      await getGroups()
+    }
+    return ok
+  }
+
+  const renameGroup = async (name: string, newName: string) => {
+    const ok = await API.renameManagedGroup(name, newName)
+    if (ok) {
+      await getGroups()
+    }
+    return ok
+  }
+
+  const deleteGroup = async (name: string) => {
+    const ok = await API.deleteManagedGroup(name)
+    if (ok) {
+      await getGroups()
+    }
+    return ok
+  }
+
+  const populate = async () => {
+    await Promise.all([getGroups(), getMemberCandidates()])
+  }
+
+  return {
+    groups,
+    memberCandidates,
+    getGroups,
+    getMemberCandidates,
+    createGroup,
+    updateGroup,
+    renameGroup,
+    deleteGroup,
+    populate
+  }
+})

--- a/ui/src/types/groupAdmin.ts
+++ b/ui/src/types/groupAdmin.ts
@@ -1,0 +1,37 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Wire shapes of the v2 group management API (/api/v2/groups). Field names
+// follow groups.xml; the user list is ordered — the order drives notification
+// escalation. Fields the API does not expose (default-map) are preserved
+// server-side on update.
+
+export interface ManagedGroup {
+  name: string
+  comments?: string | null
+  user?: string[]
+  'duty-schedule'?: string[]
+}
+
+// The server refuses to delete or rename this group; mirrored here so the UI
+// can disable the controls with an explanation instead of a 400.
+export const PROTECTED_GROUP_NAMES = ['Admin']

--- a/ui/tests/components/AdminDialogs/GroupEditorDialog.test.ts
+++ b/ui/tests/components/AdminDialogs/GroupEditorDialog.test.ts
@@ -58,6 +58,16 @@ describe('GroupEditorDialog.vue', () => {
     expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
   })
 
+  it('keeps a group with a pre-existing markup comment editable', async () => {
+    await mountDialog({ name: 'Legacy', comments: "Bob's R&D team", user: [] })
+
+    expect(wrapper.find('[data-test="comments-error"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeUndefined()
+
+    await wrapper.find('[data-test="group-comments-input"]').setValue('<b>changed</b>')
+    expect(wrapper.find('[data-test="comments-error"]').exists()).toBe(true)
+  })
+
   it('submits a valid group and closes', async () => {
     await mountDialog()
     await wrapper.find('[data-test="group-name-input"]').setValue('TestGroup')

--- a/ui/tests/components/AdminDialogs/GroupEditorDialog.test.ts
+++ b/ui/tests/components/AdminDialogs/GroupEditorDialog.test.ts
@@ -1,0 +1,95 @@
+import GroupEditorDialog from '@/components/ManageGroups/GroupEditorDialog.vue'
+import { useGroupAdminStore } from '@/stores/groupAdminStore'
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/stores/groupAdminStore')
+
+// PrimeVue's Dialog teleports its content; a passthrough stub keeps the form
+// and footer in the wrapper so the dialog's own behavior can be asserted.
+const DialogStub = {
+  name: 'Dialog',
+  props: ['visible', 'header', 'modal'],
+  template: '<div v-if="visible"><slot /><slot name="footer" /></div>'
+}
+
+describe('GroupEditorDialog.vue', () => {
+  let wrapper: VueWrapper<any>
+  let store: any
+
+  const mountDialog = async (group: any = null) => {
+    wrapper = mount(GroupEditorDialog, {
+      props: { visible: false, group },
+      global: {
+        plugins: [PrimeVue],
+        stubs: { Dialog: DialogStub }
+      }
+    })
+    await wrapper.setProps({ visible: true })
+    await flushPromises()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store = {
+      memberCandidates: ['admin', 'jose'],
+      createGroup: vi.fn().mockResolvedValue(null),
+      updateGroup: vi.fn().mockResolvedValue(null)
+    }
+    vi.mocked(useGroupAdminStore).mockReturnValue(store)
+  })
+
+  it('flags a group name with whitespace and disables saving', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="group-name-input"]').setValue('Test Group')
+
+    expect(wrapper.find('[data-test="name-error"]').text()).toContain('must not contain')
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+    expect(store.createGroup).not.toHaveBeenCalled()
+  })
+
+  it('flags markup in the comments and disables saving', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="group-name-input"]').setValue('TestGroup')
+    await wrapper.find('[data-test="group-comments-input"]').setValue('<b>styled</b>')
+
+    expect(wrapper.find('[data-test="comments-error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('submits a valid group and closes', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="group-name-input"]').setValue('TestGroup')
+    await wrapper.find('[data-test="group-comments-input"]').setValue('Test Group')
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+
+    expect(store.createGroup).toHaveBeenCalledWith(expect.objectContaining({ name: 'TestGroup', comments: 'Test Group' }))
+    expect(wrapper.emitted('update:visible')?.at(-1)).toEqual([false])
+  })
+
+  it('shows a server rejection inside the dialog and stays open', async () => {
+    store.createGroup.mockResolvedValue('Group TestGroup already exists.')
+    await mountDialog()
+    await wrapper.find('[data-test="group-name-input"]').setValue('TestGroup')
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="dialog-error"]').text()).toContain('already exists')
+    expect(wrapper.emitted('update:visible') ?? []).toEqual([])
+  })
+
+  it('clears a previous error when reopened', async () => {
+    store.createGroup.mockResolvedValue('rejected')
+    await mountDialog()
+    await wrapper.find('[data-test="group-name-input"]').setValue('TestGroup')
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-test="dialog-error"]').exists()).toBe(true)
+
+    await wrapper.setProps({ visible: false })
+    await wrapper.setProps({ visible: true })
+    expect(wrapper.find('[data-test="dialog-error"]').exists()).toBe(false)
+  })
+})

--- a/ui/tests/lib/adminValidation.test.ts
+++ b/ui/tests/lib/adminValidation.test.ts
@@ -43,15 +43,17 @@ describe('validateAdminComments', () => {
 })
 
 describe('validateEmailShape', () => {
-  it('accepts empty and name@domain shapes', () => {
+  it('accepts empty values and common deliverable forms', () => {
     expect(validateEmailShape('', 'email')).toBeNull()
     expect(validateEmailShape('noc@example.org', 'email')).toBeNull()
+    expect(validateEmailShape('Bill Smith <bill@example.com>', 'email')).toBeNull()
+    expect(validateEmailShape('a@example.com, b@example.com', 'email')).toBeNull()
   })
 
-  it('rejects values without an @ or with whitespace', () => {
+  it('rejects values without a local@domain part', () => {
     expect(validateEmailShape('not-an-email', 'email')).toContain('email')
-    expect(validateEmailShape('a b@example.org', 'pager email')).toContain('pager email')
     expect(validateEmailShape('a@', 'email')).not.toBeNull()
+    expect(validateEmailShape('a@example.com,,b@example.com', 'pager email')).toContain('pager email')
   })
 })
 

--- a/ui/tests/lib/adminValidation.test.ts
+++ b/ui/tests/lib/adminValidation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isPathAddressable,
+  validateAdminComments,
+  validateAdminName,
+  validateEmailShape
+} from '@/lib/adminValidation'
+
+describe('validateAdminName', () => {
+  it('accepts ordinary names and empty values', () => {
+    expect(validateAdminName('NOC-Duty_1', 'group name')).toBeNull()
+    expect(validateAdminName('', 'group name')).toBeNull()
+    expect(validateAdminName('   ', 'group name')).toBeNull()
+  })
+
+  it('rejects whitespace, markup and URL-hostile characters', () => {
+    for (const bad of ['Test Group', 'a<b', 'a&b', 'a"b', "a'b", 'a`b', 'a:b', 'a/b', 'a\\b', 'a%b', 'a?b', 'a#b']) {
+      expect(validateAdminName(bad, 'group name'), bad).toContain('must not contain')
+    }
+  })
+
+  it('rejects dot segments', () => {
+    expect(validateAdminName('.', 'user-id')).toContain('dot segment')
+    expect(validateAdminName('..', 'user-id')).toContain('dot segment')
+  })
+
+  it('names the field in the message', () => {
+    expect(validateAdminName('a b', 'role name')).toContain('role name')
+  })
+})
+
+describe('validateAdminComments', () => {
+  it('accepts plain text and empty values', () => {
+    expect(validateAdminComments('The administrators, on shift 24/7.')).toBeNull()
+    expect(validateAdminComments('')).toBeNull()
+  })
+
+  it('rejects markup characters', () => {
+    for (const bad of ['<b>x</b>', 'a & b', 'quote "x"', "it's", 'tick `x`']) {
+      expect(validateAdminComments(bad), bad).not.toBeNull()
+    }
+  })
+})
+
+describe('validateEmailShape', () => {
+  it('accepts empty and name@domain shapes', () => {
+    expect(validateEmailShape('', 'email')).toBeNull()
+    expect(validateEmailShape('noc@example.org', 'email')).toBeNull()
+  })
+
+  it('rejects values without an @ or with whitespace', () => {
+    expect(validateEmailShape('not-an-email', 'email')).toContain('email')
+    expect(validateEmailShape('a b@example.org', 'pager email')).toContain('pager email')
+    expect(validateEmailShape('a@', 'email')).not.toBeNull()
+  })
+})
+
+describe('isPathAddressable', () => {
+  it('allows ordinary names', () => {
+    expect(isPathAddressable('NOC-Duty')).toBe(true)
+    expect(isPathAddressable('Some Group')).toBe(true)
+  })
+
+  it('flags names the security filter cannot address as path segments', () => {
+    expect(isPathAddressable('NOC/Primary')).toBe(false)
+    expect(isPathAddressable('a\\b')).toBe(false)
+    expect(isPathAddressable('a%b')).toBe(false)
+  })
+})

--- a/ui/tests/stores/groupAdminStore.test.ts
+++ b/ui/tests/stores/groupAdminStore.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useGroupAdminStore } from '@/stores/groupAdminStore'
+import API from '@/services'
+import { ManagedGroup } from '@/types/groupAdmin'
+
+vi.mock('@/services', () => ({
+  default: {
+    getManagedGroups: vi.fn(),
+    getGroupMemberCandidates: vi.fn(),
+    createManagedGroup: vi.fn(),
+    updateManagedGroup: vi.fn(),
+    renameManagedGroup: vi.fn(),
+    deleteManagedGroup: vi.fn()
+  }
+}))
+
+describe('useGroupAdminStore', () => {
+  let store: ReturnType<typeof useGroupAdminStore>
+
+  const mockGroups: ManagedGroup[] = [
+    { name: 'Admin', comments: 'The administrators', user: ['admin'] },
+    { name: 'NOC', user: ['second', 'first'] }
+  ]
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useGroupAdminStore()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should start empty', () => {
+    expect(store.groups).toEqual([])
+    expect(store.memberCandidates).toEqual([])
+  })
+
+  it('populate should load groups and member candidates', async () => {
+    vi.mocked(API.getManagedGroups).mockResolvedValue(mockGroups)
+    vi.mocked(API.getGroupMemberCandidates).mockResolvedValue(['admin', 'first', 'second'])
+
+    await store.populate()
+
+    expect(store.groups).toEqual(mockGroups)
+    expect(store.memberCandidates).toEqual(['admin', 'first', 'second'])
+  })
+
+  it('a failed refresh should keep the previous group list', async () => {
+    vi.mocked(API.getManagedGroups).mockResolvedValue(mockGroups)
+    await store.getGroups()
+    expect(store.groups).toEqual(mockGroups)
+
+    vi.mocked(API.getManagedGroups).mockResolvedValue(null)
+    await store.getGroups()
+    expect(store.groups).toEqual(mockGroups)
+  })
+
+  it('createGroup should refresh on success and preserve member order in the payload', async () => {
+    vi.mocked(API.createManagedGroup).mockResolvedValue(true)
+    vi.mocked(API.getManagedGroups).mockResolvedValue(mockGroups)
+
+    const group: ManagedGroup = { name: 'NOC', user: ['second', 'first'] }
+    const ok = await store.createGroup(group)
+
+    expect(ok).toBe(true)
+    expect(API.createManagedGroup).toHaveBeenCalledWith(group)
+    expect(vi.mocked(API.createManagedGroup).mock.calls[0][0].user).toEqual(['second', 'first'])
+    expect(API.getManagedGroups).toHaveBeenCalledTimes(1)
+  })
+
+  it('createGroup should not refresh on failure', async () => {
+    vi.mocked(API.createManagedGroup).mockResolvedValue(false)
+
+    const ok = await store.createGroup({ name: 'NOC' })
+
+    expect(ok).toBe(false)
+    expect(API.getManagedGroups).not.toHaveBeenCalled()
+  })
+
+  it('updateGroup should refresh on success', async () => {
+    vi.mocked(API.updateManagedGroup).mockResolvedValue(true)
+    vi.mocked(API.getManagedGroups).mockResolvedValue(mockGroups)
+
+    await store.updateGroup(mockGroups[1])
+
+    expect(API.updateManagedGroup).toHaveBeenCalledWith(mockGroups[1])
+    expect(API.getManagedGroups).toHaveBeenCalledTimes(1)
+  })
+
+  it('renameGroup should pass old and new names and refresh', async () => {
+    vi.mocked(API.renameManagedGroup).mockResolvedValue(true)
+    vi.mocked(API.getManagedGroups).mockResolvedValue(mockGroups)
+
+    await store.renameGroup('NOC', 'NOC2')
+
+    expect(API.renameManagedGroup).toHaveBeenCalledWith('NOC', 'NOC2')
+    expect(API.getManagedGroups).toHaveBeenCalledTimes(1)
+  })
+
+  it('deleteGroup should refresh on success', async () => {
+    vi.mocked(API.deleteManagedGroup).mockResolvedValue(true)
+    vi.mocked(API.getManagedGroups).mockResolvedValue([mockGroups[0]])
+
+    await store.deleteGroup('NOC')
+
+    expect(store.groups).toEqual([mockGroups[0]])
+  })
+})

--- a/ui/tests/stores/groupAdminStore.test.ts
+++ b/ui/tests/stores/groupAdminStore.test.ts
@@ -59,29 +59,29 @@ describe('useGroupAdminStore', () => {
   })
 
   it('createGroup should refresh on success and preserve member order in the payload', async () => {
-    vi.mocked(API.createManagedGroup).mockResolvedValue(true)
+    vi.mocked(API.createManagedGroup).mockResolvedValue(null)
     vi.mocked(API.getManagedGroups).mockResolvedValue(mockGroups)
 
     const group: ManagedGroup = { name: 'NOC', user: ['second', 'first'] }
     const ok = await store.createGroup(group)
 
-    expect(ok).toBe(true)
+    expect(ok).toBe(null)
     expect(API.createManagedGroup).toHaveBeenCalledWith(group)
     expect(vi.mocked(API.createManagedGroup).mock.calls[0][0].user).toEqual(['second', 'first'])
     expect(API.getManagedGroups).toHaveBeenCalledTimes(1)
   })
 
   it('createGroup should not refresh on failure', async () => {
-    vi.mocked(API.createManagedGroup).mockResolvedValue(false)
+    vi.mocked(API.createManagedGroup).mockResolvedValue('it failed')
 
     const ok = await store.createGroup({ name: 'NOC' })
 
-    expect(ok).toBe(false)
+    expect(ok).toBe('it failed')
     expect(API.getManagedGroups).not.toHaveBeenCalled()
   })
 
   it('updateGroup should refresh on success', async () => {
-    vi.mocked(API.updateManagedGroup).mockResolvedValue(true)
+    vi.mocked(API.updateManagedGroup).mockResolvedValue(null)
     vi.mocked(API.getManagedGroups).mockResolvedValue(mockGroups)
 
     await store.updateGroup(mockGroups[1])
@@ -91,7 +91,7 @@ describe('useGroupAdminStore', () => {
   })
 
   it('renameGroup should pass old and new names and refresh', async () => {
-    vi.mocked(API.renameManagedGroup).mockResolvedValue(true)
+    vi.mocked(API.renameManagedGroup).mockResolvedValue(null)
     vi.mocked(API.getManagedGroups).mockResolvedValue(mockGroups)
 
     await store.renameGroup('NOC', 'NOC2')
@@ -101,7 +101,7 @@ describe('useGroupAdminStore', () => {
   })
 
   it('deleteGroup should refresh on success', async () => {
-    vi.mocked(API.deleteManagedGroup).mockResolvedValue(true)
+    vi.mocked(API.deleteManagedGroup).mockResolvedValue(null)
     vi.mocked(API.getManagedGroups).mockResolvedValue([mockGroups[0]])
 
     await store.deleteGroup('NOC')


### PR DESCRIPTION
[NMS-20107](https://opennms.atlassian.net/browse/NMS-20107): a versioned group management API (`/api/v2/groups`) and a PrimeVue Manage Groups page that is a straight visualization of it; independent companion to #8698. `groups.xml` stays the system of record via the existing `GroupManager`, with member order (the notification escalation order) and `default-map` preserved end to end.

- Endpoints: list/get/create/update/rename/delete, admin-only via new Spring Security rules and in-code checks.
- The Admin group cannot be deleted or renamed, enforced server-side (the legacy page only hid the buttons).
- Renames follow the on-call roles' membership-group references in the same file write, deletes are rejected while a role still references the group, and both go through `GroupService` so the DB category authorizations are migrated or cleared as the legacy page did.
- Overnight duty schedules are rejected for new entries because the runtime never matches them; stored strings, hand-edited comments and stale members are grandfathered so files never become uneditable.
- The page validates fields inline, shows API rejections inside the dialogs, and includes a collapsed in-context help panel.
- 19 integration tests (mock managers, `groups.xml` never touched) plus Vitest store/dialog tests; verified end to end including hand-editing `groups.xml` between API calls.


[NMS-20107]: https://opennms.atlassian.net/browse/NMS-20107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ