### PR TITLE
NMS-20100: Destination Paths tab

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/GroupManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/GroupManager.java
@@ -144,11 +144,11 @@ public abstract class GroupManager implements GroupConfig {
         }
         buildDutySchedules(m_groups);
         
-        if (groupinfo.getRoles().size() > 0) {
-            m_roles = new LinkedHashMap<String, Role>();
-            for (final Role role : groupinfo.getRoles()) {
-                m_roles.put(role.getName(), role);
-            }
+        // always rebuild, so removing the last role from groups.xml doesn't
+        // leave the previous roles cached until restart
+        m_roles = new LinkedHashMap<String, Role>();
+        for (final Role role : groupinfo.getRoles()) {
+            m_roles.put(role.getName(), role);
         }
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.netmgt.config.DestinationPathFactory;
+import org.opennms.netmgt.config.NotifdConfigFactory;
+import org.opennms.netmgt.config.destinationPaths.DestinationPaths;
+import org.opennms.netmgt.events.api.EventProxy;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.web.api.Authentication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST access to the notification configuration that has historically only been
+ * reachable through the admin JSP wizards. All operations delegate to the same
+ * file-backed config factories the legacy servlets use, so the XML files
+ * (notifications.xml, destinationPaths.xml, notificationCommands.xml,
+ * notifd-configuration.xml) remain the system of record and stay fully
+ * editable by hand.
+ *
+ * <ul>
+ * <li><b>GET /notification-config/status</b> global notifd on/off status</li>
+ * <li><b>PUT /notification-config/status</b> turn notifd on or off</li>
+ * <li><b>GET /notification-config/destination-paths</b> all destination paths</li>
+ * </ul>
+ */
+@Component("notificationConfigRestService")
+@Path("notification-config")
+@Tag(name = "Notification-config", description = "Notification Configuration API")
+public class NotificationConfigRestService extends OnmsRestService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationConfigRestService.class);
+
+    @Autowired
+    @Qualifier("eventProxy")
+    protected EventProxy m_eventProxy;
+
+    @XmlRootElement(name = "notification-status")
+    public static class NotificationStatus {
+        private String m_status;
+
+        public NotificationStatus() {
+        }
+
+        public NotificationStatus(final String status) {
+            m_status = status;
+        }
+
+        @XmlAttribute(name = "status")
+        public String getStatus() {
+            return m_status;
+        }
+
+        public void setStatus(final String status) {
+            m_status = status;
+        }
+    }
+
+    @GET
+    @Path("status")
+    @Produces(MediaType.APPLICATION_JSON)
+    public NotificationStatus getStatus(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read the notification status");
+        try {
+            return new NotificationStatus(getNotifdConfigFactory().getNotificationStatus());
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read notifd status: {}", e.getMessage());
+        }
+    }
+
+    @PUT
+    @Path("status")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response setStatus(@Context final SecurityContext securityContext, final NotificationStatus status) {
+        assertAdmin(securityContext, "change the notification status");
+        if (status == null || !("on".equals(status.getStatus()) || "off".equals(status.getStatus()))) {
+            throw getException(Status.BAD_REQUEST, "Status must be 'on' or 'off'");
+        }
+        writeLock();
+        try {
+            LOG.info("Setting notifd status to {} for user {}", status.getStatus(), securityContext.getUserPrincipal().getName());
+            if ("on".equals(status.getStatus())) {
+                getNotifdConfigFactory().turnNotifdOn();
+                sendStatusEvent("uei.opennms.org/internal/notificationsTurnedOn", securityContext);
+            } else {
+                getNotifdConfigFactory().turnNotifdOff();
+                sendStatusEvent("uei.opennms.org/internal/notificationsTurnedOff", securityContext);
+            }
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't update notifd status: {}", e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @GET
+    @Path("destination-paths")
+    @Produces(MediaType.APPLICATION_JSON)
+    public DestinationPaths getDestinationPaths(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read destination paths");
+        readLock();
+        try {
+            final DestinationPaths paths = new DestinationPaths();
+            final List<org.opennms.netmgt.config.destinationPaths.Path> list = new ArrayList<>(getDestinationPathFactory().getPaths().values());
+            list.sort(Comparator.comparing(org.opennms.netmgt.config.destinationPaths.Path::getName, String.CASE_INSENSITIVE_ORDER));
+            paths.setPaths(list);
+            return paths;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read destination paths: {}", e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @GET
+    @Path("destination-paths/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public org.opennms.netmgt.config.destinationPaths.Path getDestinationPath(@Context final SecurityContext securityContext, @PathParam("name") final String name) {
+        assertAdmin(securityContext, "read destination paths");
+        readLock();
+        try {
+            final org.opennms.netmgt.config.destinationPaths.Path path = getDestinationPathFactory().getPath(name);
+            if (path == null) {
+                throw getException(Status.NOT_FOUND, "Destination path {} was not found.", name);
+            }
+            return path;
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read destination path {}: {}", name, e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    private static void assertAdmin(final SecurityContext securityContext, final String operation) {
+        if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
+            throw getException(Status.FORBIDDEN, "User {} does not have access to {}.", securityContext.getUserPrincipal().getName(), operation);
+        }
+    }
+
+    private void sendStatusEvent(final String uei, final SecurityContext securityContext) {
+        final EventBuilder bldr = new EventBuilder(uei, "ReST");
+        bldr.addParam("remoteUser", securityContext.getUserPrincipal().getName());
+        try {
+            m_eventProxy.send(bldr.getEvent());
+        } catch (final Exception e) {
+            LOG.warn("Can't send event {}", uei, e);
+        }
+    }
+
+    private static NotifdConfigFactory getNotifdConfigFactory() throws Exception {
+        NotifdConfigFactory.init();
+        return NotifdConfigFactory.getInstance();
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static DestinationPathFactory getDestinationPathFactory() throws Exception {
+        DestinationPathFactory.init();
+        return DestinationPathFactory.getInstance();
+    }
+
+
+
+
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -42,8 +42,14 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.netmgt.config.DestinationPathFactory;
+import org.opennms.netmgt.config.GroupFactory;
+import org.opennms.netmgt.config.GroupManager;
 import org.opennms.netmgt.config.NotifdConfigFactory;
+import org.opennms.netmgt.config.NotificationCommandFactory;
+import org.opennms.netmgt.config.NotificationFactory;
 import org.opennms.netmgt.config.destinationPaths.DestinationPaths;
+import org.opennms.netmgt.config.notificationCommands.Command;
+import org.opennms.netmgt.config.notifications.Notification;
 import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.web.api.Authentication;
@@ -67,6 +73,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * <li><b>GET /notification-config/status</b> global notifd on/off status</li>
  * <li><b>PUT /notification-config/status</b> turn notifd on or off</li>
  * <li><b>GET /notification-config/destination-paths</b> all destination paths</li>
+ * <li><b>GET/POST/PUT/DELETE /notification-config/destination-paths/{name}</b> CRUD for one destination path</li>
+ * <li><b>GET /notification-config/commands</b> available notification commands (read-only)</li>
  * </ul>
  */
 @Component("notificationConfigRestService")
@@ -179,6 +187,124 @@ public class NotificationConfigRestService extends OnmsRestService {
         }
     }
 
+    @POST
+    @Path("destination-paths")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response addDestinationPath(@Context final SecurityContext securityContext, final org.opennms.netmgt.config.destinationPaths.Path path) {
+        assertAdmin(securityContext, "add destination paths");
+        validateDestinationPath(path);
+        writeLock();
+        try {
+            if (getDestinationPathFactory().getPath(path.getName()) != null) {
+                throw getException(Status.BAD_REQUEST, "Destination path {} already exists.", path.getName());
+            }
+            getDestinationPathFactory().addPath(path);
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't add destination path {}: {}", path.getName(), e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @PUT
+    @Path("destination-paths/{name}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateDestinationPath(@Context final SecurityContext securityContext, @PathParam("name") final String name, final org.opennms.netmgt.config.destinationPaths.Path path) {
+        assertAdmin(securityContext, "update destination paths");
+        validateDestinationPath(path);
+        writeLock();
+        try {
+            if (getDestinationPathFactory().getPath(name) == null) {
+                throw getException(Status.NOT_FOUND, "Destination path {} was not found.", name);
+            }
+            final boolean renamed = !name.equals(path.getName());
+            if (renamed && getDestinationPathFactory().getPath(path.getName()) != null) {
+                throw getException(Status.BAD_REQUEST, "Destination path {} already exists.", path.getName());
+            }
+            getDestinationPathFactory().replacePath(name, path);
+            if (renamed) {
+                // keep event notifications pointing at the renamed path
+                boolean changed = false;
+                for (final Notification n : getNotificationFactory().getNotifications().values()) {
+                    if (name.equals(n.getDestinationPath())) {
+                        n.setDestinationPath(path.getName());
+                        changed = true;
+                    }
+                }
+                if (changed) {
+                    getNotificationFactory().saveCurrent();
+                }
+            }
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't update destination path {}: {}", name, e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @DELETE
+    @Path("destination-paths/{name}")
+    public Response deleteDestinationPath(@Context final SecurityContext securityContext, @PathParam("name") final String name) {
+        assertAdmin(securityContext, "delete destination paths");
+        writeLock();
+        try {
+            if (getDestinationPathFactory().getPath(name) == null) {
+                throw getException(Status.NOT_FOUND, "Destination path {} was not found.", name);
+            }
+            getDestinationPathFactory().removePath(name);
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't delete destination path {}: {}", name, e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @GET
+    @Path("commands")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Command> getCommands(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read notification commands");
+        readLock();
+        try {
+            final List<Command> commands = new ArrayList<>(getNotificationCommandFactory().getCommands().values());
+            commands.sort(Comparator.comparing(Command::getName, String.CASE_INSENSITIVE_ORDER));
+            return commands;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read notification commands: {}", e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @GET
+    @Path("on-call-roles")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getOnCallRoles(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read on-call roles");
+        readLock();
+        try {
+            final GroupManager manager = getGroupManager();
+            // getRoleNames() reads cached state without checking the file
+            manager.update();
+            final List<String> roles = new ArrayList<>(java.util.Arrays.asList(manager.getRoleNames()));
+            roles.sort(String.CASE_INSENSITIVE_ORDER);
+            return roles;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read on-call roles: {}", e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
     private static void assertAdmin(final SecurityContext securityContext, final String operation) {
         if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
             throw getException(Status.FORBIDDEN, "User {} does not have access to {}.", securityContext.getUserPrincipal().getName(), operation);
@@ -200,6 +326,43 @@ public class NotificationConfigRestService extends OnmsRestService {
         return NotifdConfigFactory.getInstance();
     }
 
+    private static NotificationFactory getNotificationFactory() throws Exception {
+        // NotificationFactory's constructor requires an initialized NotifdConfigFactory
+        NotifdConfigFactory.init();
+        NotificationFactory.init();
+        return NotificationFactory.getInstance();
+    }
+
+    private static void validateDestinationPath(final org.opennms.netmgt.config.destinationPaths.Path path) {
+        if (path == null || isBlank(path.getName())) {
+            throw getException(Status.BAD_REQUEST, "The destination path and its name are required");
+        }
+        if (path.getTargets().isEmpty()) {
+            throw getException(Status.BAD_REQUEST, "The destination path requires at least one target");
+        }
+        validateTargets(path.getTargets());
+        for (final org.opennms.netmgt.config.destinationPaths.Escalate escalate : path.getEscalates()) {
+            if (isBlank(escalate.getDelay())) {
+                throw getException(Status.BAD_REQUEST, "Every escalation requires a delay");
+            }
+            if (escalate.getTargets().isEmpty()) {
+                throw getException(Status.BAD_REQUEST, "Every escalation requires at least one target");
+            }
+            validateTargets(escalate.getTargets());
+        }
+    }
+
+    private static void validateTargets(final List<org.opennms.netmgt.config.destinationPaths.Target> targets) {
+        for (final org.opennms.netmgt.config.destinationPaths.Target target : targets) {
+            if (isBlank(target.getName())) {
+                throw getException(Status.BAD_REQUEST, "Every target requires a name");
+            }
+            if (target.getCommands().isEmpty() || target.getCommands().stream().anyMatch(NotificationConfigRestService::isBlank)) {
+                throw getException(Status.BAD_REQUEST, "Every target requires at least one non-empty command");
+            }
+        }
+    }
+
     private static boolean isBlank(final String value) {
         return value == null || value.isBlank();
     }
@@ -207,6 +370,16 @@ public class NotificationConfigRestService extends OnmsRestService {
     private static DestinationPathFactory getDestinationPathFactory() throws Exception {
         DestinationPathFactory.init();
         return DestinationPathFactory.getInstance();
+    }
+
+    private static NotificationCommandFactory getNotificationCommandFactory() throws Exception {
+        NotificationCommandFactory.init();
+        return NotificationCommandFactory.getInstance();
+    }
+
+    private static GroupManager getGroupManager() throws Exception {
+        GroupFactory.init();
+        return GroupFactory.getInstance();
     }
 
 

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -262,7 +262,7 @@
         {
           "id": "notifications",
           "name": "Notifications",
-          "url": "notification/index.jsp",
+          "url": "ui/index.html#/admin/notifications",
           "locationMatch": "notification",
           "roles": null
         },

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -38,6 +38,7 @@ import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.netmgt.config.GroupFactory;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -130,6 +131,10 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
     public void afterServletStart() throws Exception {
         System.setProperty("opennms.home", m_onmsHome);
         ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+        // Webapp beans may have initialized GroupFactory while context startup
+        // had opennms.home pointed elsewhere; pin a factory built against the
+        // test home so the seeded roles are visible.
+        GroupFactory.setInstance(new GroupFactory());
     }
 
     @Test
@@ -143,6 +148,94 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
 
         // only on/off are valid
         sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"maybe\"}", 400);
+    }
+
+    @Test
+    public void testDestinationPathLifecycle() throws Exception {
+        JSONObject list = new JSONObject(getJson("/notification-config/destination-paths"));
+        Assert.assertEquals(1, list.getJSONArray("path").length());
+
+        final String newPath = "{\"name\":\"junit-path\",\"initial-delay\":\"30s\","
+                + "\"target\":[{\"name\":\"noc@example.com\",\"command\":[\"javaEmail\"]}],"
+                + "\"escalate\":[{\"delay\":\"15m\",\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}]}]}";
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/destination-paths", newPath, 204);
+
+        JSONObject added = new JSONObject(getJson("/notification-config/destination-paths/junit-path"));
+        Assert.assertEquals("30s", added.getString("initial-delay"));
+        Assert.assertEquals(1, added.getJSONArray("escalate").length());
+
+        final String updatedPath = "{\"name\":\"junit-path\",\"initial-delay\":\"1m\","
+                + "\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}],\"escalate\":[]}";
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/junit-path", updatedPath, 204);
+        added = new JSONObject(getJson("/notification-config/destination-paths/junit-path"));
+        Assert.assertEquals("1m", added.getString("initial-delay"));
+
+        sendRequest(DELETE, "/notification-config/destination-paths/junit-path", 204);
+        sendRequest(GET, "/notification-config/destination-paths/junit-path", 404);
+    }
+
+    @Test
+    public void testCommands() throws Exception {
+        JSONArray commands = new JSONArray(getJson("/notification-config/commands"));
+        Assert.assertEquals(1, commands.length());
+        Assert.assertEquals("javaEmail", commands.getJSONObject(0).getString("name"));
+    }
+
+    @Test
+    public void testDestinationPathInvalidUpdateKeepsExistingPath() throws Exception {
+        // a target with no commands would fail the schema-validated save AFTER
+        // the factory already removed the old entry — must be rejected up front
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/Email-Admin",
+                "{\"name\":\"Email-Admin\",\"target\":[{\"name\":\"Admin\",\"command\":[]}]}", 400);
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/Email-Admin",
+                "{\"name\":\"Email-Admin\",\"target\":[]}", 400);
+        JSONObject unchanged = new JSONObject(getJson("/notification-config/destination-paths/Email-Admin"));
+        Assert.assertEquals(1, unchanged.getJSONArray("target").length());
+    }
+
+    @Test
+    public void testDestinationPathRenameCollisionRejected() throws Exception {
+        final String other = "{\"name\":\"junit-p2\",\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}]}";
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/destination-paths", other, 204);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/Email-Admin",
+                "{\"name\":\"junit-p2\",\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}]}", 400);
+        // both paths still intact
+        sendRequest(GET, "/notification-config/destination-paths/Email-Admin", 200);
+        sendRequest(GET, "/notification-config/destination-paths/junit-p2", 200);
+    }
+
+    @Test
+    public void testDestinationPathRenameUpdatesReferences() throws Exception {
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/Email-Admin",
+                "{\"name\":\"Email-Ops\",\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}]}", 204);
+        sendRequest(GET, "/notification-config/destination-paths/Email-Admin", 404);
+        sendRequest(GET, "/notification-config/destination-paths/Email-Ops", 200);
+        // the notification that referenced the old name follows the rename
+        org.opennms.netmgt.config.NotificationFactory.init();
+        Assert.assertEquals("Email-Ops", org.opennms.netmgt.config.NotificationFactory.getInstance()
+                .getNotification("junitNotification").getDestinationPath());
+    }
+
+    @Test
+    public void testOnCallRoles() throws Exception {
+        JSONArray roles = new JSONArray(getJson("/notification-config/on-call-roles"));
+        Assert.assertEquals(1, roles.length());
+        Assert.assertEquals("junit-oncall", roles.getString(0));
+    }
+
+    @Test
+    public void testOnCallRolesFollowFileChanges() throws Exception {
+        Assert.assertEquals(1, new JSONArray(getJson("/notification-config/on-call-roles")).length());
+        // removing the last role from groups.xml must not leave it cached
+        final File groupsFile = new File("target/test-work-dir/etc/groups.xml");
+        FileUtils.writeStringToFile(groupsFile, "<?xml version=\"1.0\"?>"
+                + "<groupinfo xmlns=\"http://xmlns.opennms.org/xsd/groups\">"
+                + "<header><rev>1.3</rev><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<groups><group><name>Admin</name><user>admin</user></group></groups>"
+                + "</groupinfo>", Charset.defaultCharset());
+        groupsFile.setLastModified(System.currentTimeMillis() + 1000);
+        Assert.assertEquals(0, new JSONArray(getJson("/notification-config/on-call-roles")).length());
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1;
+
+
+import java.io.File;
+import java.nio.charset.Charset;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.io.FileUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.ConfigurationTestUtils;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties="org.opennms.timeseries.strategy=integration")
+@JUnitTemporaryDatabase
+public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTestCase {
+
+
+    private String m_onmsHome;
+
+
+    @Override
+    protected void beforeServletStart() throws Exception {
+        MockLogAppender.setupLogging();
+        File etc = new File("target/test-work-dir/etc");
+        etc.mkdirs();
+        m_onmsHome = etc.getParent();
+        System.setProperty("opennms.home", m_onmsHome);
+        ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+
+        FileUtils.writeStringToFile(new File(etc, "notifd-configuration.xml"), "<?xml version=\"1.0\"?>"
+                + "<notifd-configuration status=\"off\" match-all=\"true\">"
+                + "<queue><queue-id>default</queue-id><interval>20s</interval>"
+                + "<handler-class><name>org.opennms.netmgt.notifd.DefaultQueueHandler</name></handler-class>"
+                + "</queue>"
+                + "</notifd-configuration>", Charset.defaultCharset());
+        // deliberately NOT calling NotifdConfigFactory.init() here: the service
+        // must initialize it itself (cold-start ordering regression guard)
+
+        FileUtils.writeStringToFile(new File(etc, "notifications.xml"), "<?xml version=\"1.0\"?>"
+                + "<notifications xmlns=\"http://xmlns.opennms.org/xsd/notifications\">"
+                + "<header><rev>1.2</rev><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<notification name=\"junitNotification\" status=\"on\">"
+                + "<uei>uei.opennms.org/nodes/nodeDown</uei>"
+                + "<rule>IPADDR != '0.0.0.0'</rule>"
+                + "<destinationPath>Email-Admin</destinationPath>"
+                + "<text-message>node down</text-message>"
+                + "</notification>"
+                + "</notifications>", Charset.defaultCharset());
+
+        FileUtils.writeStringToFile(new File(etc, "destinationPaths.xml"), "<?xml version=\"1.0\"?>"
+                + "<destinationPaths>"
+                + "<header><rev>1.2</rev><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<path name=\"Email-Admin\">"
+                + "<target><name>Admin</name><command>javaEmail</command></target>"
+                + "</path>"
+                + "</destinationPaths>", Charset.defaultCharset());
+
+        FileUtils.writeStringToFile(new File(etc, "notificationCommands.xml"), "<?xml version=\"1.0\"?>"
+                + "<notification-commands xmlns=\"http://xmlns.opennms.org/xsd/notificationCommands\">"
+                + "<header><ver>.9</ver><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<command binary=\"false\">"
+                + "<name>javaEmail</name>"
+                + "<execute>org.opennms.netmgt.notifd.JavaMailNotificationStrategy</execute>"
+                + "<comment>send an email</comment>"
+                + "</command>"
+                + "</notification-commands>", Charset.defaultCharset());
+
+        FileUtils.writeStringToFile(new File(etc, "groups.xml"), "<?xml version=\"1.0\"?>"
+                + "<groupinfo xmlns=\"http://xmlns.opennms.org/xsd/groups\">"
+                + "<header><rev>1.3</rev><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<groups><group><name>Admin</name><user>admin</user></group></groups>"
+                + "<roles><role name=\"junit-oncall\" supervisor=\"admin\" membership-group=\"Admin\"/></roles>"
+                + "</groupinfo>", Charset.defaultCharset());
+
+    }
+
+    // Required so context initialization can't repoint opennms.home at
+    // opennms-base-assembly between servlet start and the first request.
+    @Override
+    public void afterServletStart() throws Exception {
+        System.setProperty("opennms.home", m_onmsHome);
+        ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+    }
+
+    @Test
+    public void testNotifdStatus() throws Exception {
+        JSONObject status = new JSONObject(getJson("/notification-config/status"));
+        Assert.assertEquals("off", status.getString("status"));
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"on\"}", 204);
+        status = new JSONObject(getJson("/notification-config/status"));
+        Assert.assertEquals("on", status.getString("status"));
+
+        // only on/off are valid
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"maybe\"}", 400);
+    }
+
+    @Test
+    public void testDestinationPathsReadable() throws Exception {
+        // the read side ships in the base PR: the event-notification editor
+        // needs the path list for its destination picker
+        // order-independent: sibling tests may add or rename paths
+        JSONObject list = new JSONObject(getJson("/notification-config/destination-paths"));
+        Assert.assertTrue(list.getJSONArray("path").length() >= 1);
+        final String firstName = list.getJSONArray("path").getJSONObject(0).getString("name");
+        JSONObject path = new JSONObject(getJson("/notification-config/destination-paths/"
+                + java.net.URLEncoder.encode(firstName, java.nio.charset.StandardCharsets.UTF_8)));
+        Assert.assertEquals(firstName, path.getString("name"));
+    }
+
+    @Test
+    public void testForbiddenForNonAdmin() throws Exception {
+        setUser("nobody", new String[]{ "ROLE_USER" });
+        try {
+            sendRequest(GET, "/notification-config/status", 403);
+            sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"on\"}", 403);
+        } finally {
+            setUser("admin", new String[]{ "ROLE_ADMIN" });
+        }
+    }
+
+    private String getJson(final String url) throws Exception {
+        // the instance createRequest carries the setUser() user AND roles
+        final MockHttpServletRequest request = createRequest(GET, url);
+        request.addHeader("Accept", MediaType.APPLICATION_JSON);
+        return sendRequest(request, 200);
+    }
+}

--- a/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
+++ b/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
@@ -1,0 +1,106 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    maximizable
+    header="Configure Notifications"
+    class="configure-notifications-dialog"
+    :style="{ width: '1100px', maxWidth: '95vw' }"
+    data-test="configure-notifications-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <Tabs v-model:value="activeTab">
+      <TabList>
+        <Tab value="general" data-test="tab-general">General</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel value="general">
+          <div class="general-tab">
+            <div class="status-toggle">
+              <PToggleSwitch
+                :modelValue="store.notifdStatus === 'on'"
+                :disabled="store.notifdStatus === null || statusPending"
+                aria-label="Turn notifications on or off"
+                data-test="notifd-status-toggle"
+                @update:modelValue="onStatusToggle"
+              />
+              <span class="status-label">Notifications are <strong>{{ store.notifdStatus ?? 'unknown' }}</strong></span>
+            </div>
+            <p class="status-hint">
+              System-wide switch. While off, OpenNMS will not create outgoing notices for any
+              event. The current status is also reflected by the bell icon in the top bar.
+            </p>
+          </div>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import Dialog from 'primevue/dialog'
+import Tab from 'primevue/tab'
+import TabList from 'primevue/tablist'
+import TabPanel from 'primevue/tabpanel'
+import TabPanels from 'primevue/tabpanels'
+import Tabs from 'primevue/tabs'
+import ToggleSwitch from 'primevue/toggleswitch'
+
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { NotifdStatus } from '@/types/notificationConfig'
+
+const PToggleSwitch = ToggleSwitch
+
+const props = defineProps<{
+  visible: boolean
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useNotificationConfigStore()
+
+const activeTab = ref('general')
+const statusPending = ref(false)
+const populated = ref(false)
+
+watch(
+  () => props.visible,
+  async (isVisible) => {
+    if (isVisible && !populated.value) {
+      await store.populate()
+      populated.value = true
+    }
+  }
+)
+
+const onStatusToggle = async (value: boolean) => {
+  statusPending.value = true
+  try {
+    await store.setStatus((value ? 'on' : 'off') as NotifdStatus)
+  } finally {
+    statusPending.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.general-tab {
+  padding: 1rem 0;
+
+  .status-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .status-hint {
+    margin-top: 1rem;
+    color: var(--p-text-muted-color);
+    font-size: 0.9rem;
+    max-width: 60ch;
+  }
+}
+
+</style>

--- a/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
+++ b/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
@@ -11,9 +11,13 @@
   >
     <Tabs v-model:value="activeTab">
       <TabList>
+        <Tab value="destination-paths" data-test="tab-destination-paths">Destination Paths</Tab>
         <Tab value="general" data-test="tab-general">General</Tab>
       </TabList>
       <TabPanels>
+        <TabPanel value="destination-paths">
+          <DestinationPathsTable />
+        </TabPanel>
         <TabPanel value="general">
           <div class="general-tab">
             <div class="status-toggle">
@@ -48,6 +52,7 @@ import TabPanels from 'primevue/tabpanels'
 import Tabs from 'primevue/tabs'
 import ToggleSwitch from 'primevue/toggleswitch'
 
+import DestinationPathsTable from '@/components/AdminNotifications/DestinationPathsTable.vue'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import { NotifdStatus } from '@/types/notificationConfig'
 

--- a/ui/src/components/AdminNotifications/DestinationPathEditorDialog.vue
+++ b/ui/src/components/AdminNotifications/DestinationPathEditorDialog.vue
@@ -1,0 +1,397 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    maximizable
+    :header="isEditing ? `Edit Destination Path: ${originalName}` : 'New Destination Path'"
+    class="destination-path-editor-dialog"
+    :style="{ width: '900px', maxWidth: '95vw' }"
+    data-test="destination-path-editor-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="editor-body">
+      <div class="form-row">
+        <FormField>
+          <IftaLabel>
+            <InputText
+              id="path-name"
+              v-model="name"
+              data-test="path-name-input"
+            />
+            <label for="path-name">Path Name *</label>
+          </IftaLabel>
+        </FormField>
+        <FormField>
+          <IftaLabel>
+            <Select
+              v-model="initialDelay"
+              labelId="path-initial-delay"
+              :options="delayOptions"
+              editable
+              data-test="initial-delay-select"
+            />
+            <label for="path-initial-delay">Initial Delay</label>
+          </IftaLabel>
+        </FormField>
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title">Initial Targets</div>
+          <Button
+            outlined
+            size="small"
+            label="Add Target"
+            icon="pi pi-plus"
+            data-test="add-target-button"
+            @click="addTarget(targets)"
+          />
+        </div>
+        <p class="section-hint">
+          Who gets notified first, and how. Each target is notified via the selected methods;
+          Email and Browser (on-screen, for logged-in users) methods are fully supported today —
+          the remaining methods are shown for completeness and will be enabled as their
+          configuration screens land.
+        </p>
+        <TargetRowEditor
+          v-for="(row, index) in targets"
+          :key="row.key"
+          :row="row"
+          :users="store.users"
+          :groups="store.groups"
+          :roles="store.roles"
+          :methodOptions="methodOptions"
+          :removable="targets.length > 1"
+          @remove="targets.splice(index, 1)"
+        />
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title">Escalations</div>
+          <Button
+            outlined
+            size="small"
+            label="Add Escalation"
+            icon="pi pi-plus"
+            data-test="add-escalation-button"
+            @click="addEscalation"
+          />
+        </div>
+        <p class="section-hint">
+          If the notice is still unacknowledged after the delay, the escalation's targets are
+          notified next.
+        </p>
+        <div
+          v-for="(escalation, eIndex) in escalations"
+          :key="escalation.key"
+          class="escalation-block"
+        >
+          <div class="escalation-header">
+            <IftaLabel>
+              <Select
+                v-model="escalation.delay"
+                :labelId="`escalation-delay-${eIndex}`"
+                :options="delayOptions"
+                editable
+                data-test="escalation-delay-select"
+              />
+              <label :for="`escalation-delay-${eIndex}`">Escalate After</label>
+            </IftaLabel>
+            <div class="escalation-actions">
+              <Button
+                outlined
+                size="small"
+                label="Add Target"
+                icon="pi pi-plus"
+                data-test="add-escalation-target-button"
+                @click="addTarget(escalation.targets)"
+              />
+              <Button
+                text
+                size="small"
+                label="Remove Escalation"
+                severity="danger"
+                data-test="remove-escalation-button"
+                @click="escalations.splice(eIndex, 1)"
+              />
+            </div>
+          </div>
+          <TargetRowEditor
+            v-for="(row, tIndex) in escalation.targets"
+            :key="row.key"
+            :row="row"
+            :users="store.users"
+            :groups="store.groups"
+            :roles="store.roles"
+            :methodOptions="methodOptions"
+            :removable="escalation.targets.length > 1"
+            @remove="escalation.targets.splice(tIndex, 1)"
+          />
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <Button
+        text
+        label="Cancel"
+        data-test="cancel-button"
+        @click="emit('update:visible', false)"
+      />
+      <Button
+        :label="isEditing ? 'Save Path' : 'Add Path'"
+        :disabled="!isValid || saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
+
+import TargetRowEditor, { MethodOption, TargetRow } from '@/components/AdminNotifications/TargetRowEditor.vue'
+import FormField from '@/components/Common/FormField.vue'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { DestinationPath, DestinationPathTarget } from '@/types/notificationConfig'
+
+const props = defineProps<{
+  visible: boolean
+  path: DestinationPath | null
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useNotificationConfigStore()
+
+// Methods with a working configuration today. The rest of the commands from
+// notificationCommands.xml are listed but disabled until their config lands.
+const ENABLED_METHODS = new Set(['javaEmail', 'javaPagerEmail', 'browser'])
+
+const METHOD_LABELS: Record<string, string> = {
+  javaEmail: 'Email',
+  javaPagerEmail: 'Pager Email',
+  textPage: 'Text Page',
+  numericPage: 'Numeric Page',
+  xmppMessage: 'XMPP Message',
+  xmppGroupMessage: 'XMPP Group Message',
+  microblogUpdate: 'Microblog Update',
+  microblogReply: 'Microblog Reply',
+  microblogDM: 'Microblog DM',
+  ircCat: 'IRC',
+  callWorkPhone: 'Call Work Phone',
+  callMobilePhone: 'Call Mobile Phone',
+  callHomePhone: 'Call Home Phone',
+  browser: 'Browser'
+}
+
+const delayOptions = ['0s', '30s', '1m', '2m', '5m', '10m', '15m', '30m', '1h', '2h', '6h', '12h', '1d']
+
+interface EscalationBlock {
+  key: number
+  delay: string
+  targets: TargetRow[]
+}
+
+let rowKey = 0
+
+const name = ref('')
+const initialDelay = ref('0s')
+const targets = ref<TargetRow[]>([])
+const escalations = ref<EscalationBlock[]>([])
+const saving = ref(false)
+
+const isEditing = computed(() => props.path !== null)
+const originalName = computed(() => props.path?.name ?? '')
+
+const methodOptions = computed<MethodOption[]>(() => {
+  const commands = store.commands.length ? store.commands.map((c) => c.name) : Array.from(ENABLED_METHODS)
+  return commands.map((command) => ({
+    value: command,
+    label: METHOD_LABELS[command] ? `${METHOD_LABELS[command]} (${command})` : command,
+    disabled: !ENABLED_METHODS.has(command)
+  }))
+})
+
+const newTargetRow = (): TargetRow => ({
+  key: rowKey++,
+  type: 'user',
+  name: '',
+  commands: ['javaEmail'],
+  interval: undefined,
+  autoNotify: undefined
+})
+
+const addTarget = (list: TargetRow[]) => {
+  list.push(newTargetRow())
+}
+
+const addEscalation = () => {
+  escalations.value.push({ key: rowKey++, delay: '15m', targets: [newTargetRow()] })
+}
+
+const inferType = (targetName: string): TargetRow['type'] => {
+  if (targetName.includes('@')) {
+    return 'email'
+  }
+  if (store.groups.includes(targetName)) {
+    return 'group'
+  }
+  if (store.roles.includes(targetName)) {
+    return 'role'
+  }
+  return 'user'
+}
+
+const toRow = (target: DestinationPathTarget): TargetRow => ({
+  key: rowKey++,
+  type: inferType(target.name),
+  name: target.name,
+  commands: [...(target.command ?? [])],
+  interval: target.interval ?? undefined,
+  autoNotify: target.autoNotify ?? undefined
+})
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (!isVisible) {
+      return
+    }
+    if (props.path) {
+      name.value = props.path.name
+      initialDelay.value = props.path['initial-delay'] ?? '0s'
+      targets.value = (props.path.target ?? []).map(toRow)
+      escalations.value = (props.path.escalate ?? []).map((esc) => ({
+        key: rowKey++,
+        delay: esc.delay ?? '15m',
+        targets: (esc.target ?? []).map(toRow)
+      }))
+      if (!targets.value.length) {
+        targets.value = [newTargetRow()]
+      }
+    } else {
+      name.value = ''
+      initialDelay.value = '0s'
+      targets.value = [newTargetRow()]
+      escalations.value = []
+    }
+  }
+)
+
+const rowIsValid = (row: TargetRow) => !!row.name.trim() && row.commands.length > 0
+
+const isValid = computed(() => {
+  if (!name.value.trim() || !targets.value.length) {
+    return false
+  }
+  if (!targets.value.every(rowIsValid)) {
+    return false
+  }
+  return escalations.value.every((esc) => esc.targets.length > 0 && esc.targets.every(rowIsValid))
+})
+
+const toTarget = (row: TargetRow): DestinationPathTarget => ({
+  name: row.name.trim(),
+  command: [...row.commands],
+  ...(row.interval ? { interval: row.interval } : {}),
+  ...(row.autoNotify ? { autoNotify: row.autoNotify } : {})
+})
+
+const save = async () => {
+  saving.value = true
+  try {
+    const path: DestinationPath = {
+      name: name.value.trim(),
+      'initial-delay': initialDelay.value,
+      target: targets.value.map(toTarget),
+      escalate: escalations.value.map((esc) => ({
+        delay: esc.delay,
+        target: esc.targets.map(toTarget)
+      }))
+    }
+    const ok = isEditing.value
+      ? await store.updateDestinationPath(originalName.value, path)
+      : await store.addDestinationPath(path)
+    if (ok) {
+      emit('update:visible', false)
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-top: 0.5rem;
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+
+  :deep(input),
+  :deep(.p-select) {
+    min-width: 220px;
+  }
+}
+
+.section {
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.25rem;
+
+    .section-title {
+      font-size: 1rem;
+      font-weight: 600;
+    }
+  }
+
+  .section-hint {
+    margin: 0 0 0.75rem 0;
+    font-size: 0.875rem;
+    color: var(--p-text-muted-color);
+    max-width: 80ch;
+  }
+}
+
+.escalation-block {
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+
+  .escalation-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+
+    :deep(.p-select) {
+      min-width: 160px;
+    }
+
+    .escalation-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+  }
+}
+</style>

--- a/ui/src/components/AdminNotifications/DestinationPathsTable.vue
+++ b/ui/src/components/AdminNotifications/DestinationPathsTable.vue
@@ -1,0 +1,200 @@
+<template>
+  <TableCard class="destination-paths-table">
+    <div class="header">
+      <div class="card-title">Destination Paths</div>
+      <Button
+        outlined
+        label="New Path"
+        icon="pi pi-plus"
+        data-test="add-destination-path-button"
+        @click="openEditor(null)"
+      />
+    </div>
+
+    <DataTable
+      v-if="store.destinationPaths.length"
+      :value="store.destinationPaths"
+      dataKey="name"
+      class="data-table"
+      data-test="destination-paths-table"
+    >
+      <Column
+        field="name"
+        header="Name"
+        sortable
+      />
+      <Column header="Initial Delay">
+        <template #body="{ data }">
+          {{ data['initial-delay'] ?? '0s' }}
+        </template>
+      </Column>
+      <Column header="Targets">
+        <template #body="{ data }">
+          {{ targetSummary(data) }}
+        </template>
+      </Column>
+      <Column header="Actions">
+        <template #body="{ data }">
+          <div class="action-container">
+            <Button
+              text
+              label="Edit"
+              :aria-label="`Edit ${data.name}`"
+              data-test="edit-destination-path-button"
+              @click="openEditor(data)"
+            />
+            <Button
+              text
+              label="Test"
+              :aria-label="`Send test notification via ${data.name}`"
+              data-test="test-destination-path-button"
+              @click="askTest(data)"
+            />
+            <Button
+              text
+              label="Delete"
+              severity="danger"
+              :aria-label="`Delete ${data.name}`"
+              data-test="delete-destination-path-button"
+              @click="askDelete(data)"
+            />
+          </div>
+        </template>
+      </Column>
+    </DataTable>
+
+    <div v-if="!store.destinationPaths.length">
+      <EmptyList
+        :content="emptyListContent"
+        data-test="empty-list"
+      />
+    </div>
+  </TableCard>
+  <DestinationPathEditorDialog
+    v-model:visible="showEditor"
+    :path="pathToEdit"
+  />
+  <OnmsConfirmationDialog
+    :visible="showDeleteConfirmation"
+    title="Delete Destination Path"
+    actionButtonText="Delete"
+    @ok="confirmDelete"
+    @cancel="cancelDelete"
+  >
+    <template #content>
+      <p>Are you sure you want to delete the destination path <strong>{{ pathToDelete?.name }}</strong>? Event notifications referencing it will stop resolving targets. This action cannot be undone.</p>
+    </template>
+  </OnmsConfirmationDialog>
+  <OnmsConfirmationDialog
+    :visible="showTestConfirmation"
+    title="Send Test Notification"
+    actionButtonText="Send Test"
+    @ok="confirmTest"
+    @cancel="cancelTest"
+  >
+    <template #content>
+      <p>Send a test notification to every target of <strong>{{ pathToTest?.name }}</strong>? Real notifications (email, pager, etc.) will be delivered to the configured users and groups.</p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { OnmsConfirmationDialog } from '@opennms/onms-ui'
+
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+
+import DestinationPathEditorDialog from '@/components/AdminNotifications/DestinationPathEditorDialog.vue'
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { DestinationPath } from '@/types/notificationConfig'
+
+const store = useNotificationConfigStore()
+
+const showEditor = ref(false)
+const pathToEdit = ref<DestinationPath | null>(null)
+
+const openEditor = (path: DestinationPath | null) => {
+  pathToEdit.value = path
+  showEditor.value = true
+}
+
+const showDeleteConfirmation = ref(false)
+const pathToDelete = ref<DestinationPath | null>(null)
+const showTestConfirmation = ref(false)
+const pathToTest = ref<DestinationPath | null>(null)
+
+const emptyListContent = {
+  msg: 'No destination paths configured.'
+}
+
+const targetSummary = (path: DestinationPath) => {
+  const targets = (path.target ?? []).map((t) => t.name)
+  const escalations = path.escalate?.length ?? 0
+  const summary = targets.join(', ') || 'none'
+  return escalations ? `${summary} (+${escalations} escalation${escalations > 1 ? 's' : ''})` : summary
+}
+
+const askDelete = (path: DestinationPath) => {
+  pathToDelete.value = path
+  showDeleteConfirmation.value = true
+}
+
+const confirmDelete = async () => {
+  if (pathToDelete.value) {
+    await store.deleteDestinationPath(pathToDelete.value.name)
+  }
+  showDeleteConfirmation.value = false
+  pathToDelete.value = null
+}
+
+const cancelDelete = () => {
+  showDeleteConfirmation.value = false
+  pathToDelete.value = null
+}
+
+const askTest = (path: DestinationPath) => {
+  pathToTest.value = path
+  showTestConfirmation.value = true
+}
+
+const confirmTest = async () => {
+  if (pathToTest.value) {
+    await store.testDestinationPath(pathToTest.value.name)
+  }
+  showTestConfirmation.value = false
+  pathToTest.value = null
+}
+
+const cancelTest = () => {
+  showTestConfirmation.value = false
+  pathToTest.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.destination-paths-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.action-container {
+  display: flex;
+  gap: 0.25rem;
+}
+</style>

--- a/ui/src/components/AdminNotifications/NoticesTable.vue
+++ b/ui/src/components/AdminNotifications/NoticesTable.vue
@@ -1,0 +1,308 @@
+<template>
+  <TableCard class="notices-table">
+    <div class="header">
+      <div class="card-title" data-test="notices-title">{{ store.title }}</div>
+      <div class="header-right">
+        <div class="count" data-test="notices-count">{{ store.totalCount }} notice{{ store.totalCount === 1 ? '' : 's' }}</div>
+        <OnmsIconButton
+          text
+          :icon="DownloadFileIcon"
+          iconSize="1.2rem"
+          title="Download as CSV"
+          aria-label="Download notices as CSV"
+          data-test="csv-download-button"
+          :disabled="!store.totalCount"
+          @click="downloadCsv"
+        />
+        <OnmsIconButton
+          text
+          :icon="PrintIcon"
+          iconSize="1.2rem"
+          title="Print / save as PDF"
+          aria-label="Print notices"
+          data-test="print-button"
+          :disabled="!store.totalCount"
+          @click="printNotices"
+        />
+      </div>
+    </div>
+
+    <DataTable
+      v-if="store.notices.length"
+      lazy
+      :value="store.notices"
+      :totalRecords="store.totalCount"
+      :loading="store.loading"
+      paginator
+      dataKey="id"
+      :first="store.first"
+      :rows="store.rows"
+      :rowsPerPageOptions="[10, 20, 50, 100]"
+      class="data-table"
+      data-test="notices-table"
+      @page="onPage"
+    >
+      <Column
+        field="id"
+        header="ID"
+      >
+        <template #body="{ data }">
+          <a
+            :href="`${baseHref}notification/detail.jsp?notice=${data.id}`"
+            :data-test="`notice-link-${data.id}`"
+          >{{ data.id }}</a>
+        </template>
+      </Column>
+      <Column header="Severity">
+        <template #body="{ data }">
+          <Tag
+            v-if="data.severity"
+            :value="data.severity"
+            :severity="severityMap[String(data.severity).toLowerCase()] ?? 'secondary'"
+          />
+          <span v-else>-</span>
+        </template>
+      </Column>
+      <Column header="Subject">
+        <template #body="{ data }">
+          <span :title="data.textMessage ?? ''">{{ truncate(data.subject || data.textMessage || '-') }}</span>
+        </template>
+      </Column>
+      <Column header="Sent Time">
+        <template #body="{ data }">
+          {{ formatTime(data.pageTime) }}
+        </template>
+      </Column>
+      <Column header="Node">
+        <template #body="{ data }">
+          <a
+            v-if="data.nodeId"
+            :href="`${baseHref}element/node.jsp?node=${data.nodeId}`"
+          >{{ data.nodeLabel ?? data.nodeId }}</a>
+          <span v-else>-</span>
+        </template>
+      </Column>
+      <Column header="Interface">
+        <template #body="{ data }">
+          {{ data.ipAddress ?? '-' }}
+        </template>
+      </Column>
+      <Column header="Service">
+        <template #body="{ data }">
+          {{ data.serviceType?.name ?? '-' }}
+        </template>
+      </Column>
+      <Column
+        v-if="showAckColumns"
+        header="Responder"
+      >
+        <template #body="{ data }">
+          {{ data.ackUser ?? '-' }}
+        </template>
+      </Column>
+      <Column
+        v-if="showAckColumns"
+        header="Respond Time"
+      >
+        <template #body="{ data }">
+          {{ formatTime(data.ackTime) }}
+        </template>
+      </Column>
+      <Column
+        v-if="!showAckColumns"
+        header="Actions"
+      >
+        <template #body="{ data }">
+          <Button
+            text
+            label="Acknowledge"
+            :aria-label="`Acknowledge notice ${data.id}`"
+            :data-test="`ack-button-${data.id}`"
+            :disabled="store.loading"
+            @click="store.acknowledge(data)"
+          />
+        </template>
+      </Column>
+    </DataTable>
+
+    <div v-if="!store.notices.length">
+      <EmptyList
+        :content="emptyListContent"
+        data-test="empty-list"
+      />
+    </div>
+  </TableCard>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { OnmsIconButton } from '@opennms/onms-ui'
+
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable, { DataTablePageEvent } from 'primevue/datatable'
+import Tag from 'primevue/tag'
+
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import DownloadFileIcon from '@/components/icons/action/DownloadFile.vue'
+import PrintIcon from '@/components/icons/action/Print.vue'
+import API from '@/services'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNoticesStore } from '@/stores/noticesStore'
+import { OnmsNotice } from '@/types/notices'
+
+const menuStore = useMenuStore()
+const store = useNoticesStore()
+
+// Cap for export/print fetches; the table itself stays server-paginated.
+const EXPORT_LIMIT = 1000
+
+const baseHref = computed<string>(() => menuStore.mainMenu.baseHref)
+const showAckColumns = computed<boolean>(() => store.preset === 'allAcknowledged')
+
+const emptyListContent = computed(() => ({
+  msg: store.preset === 'allAcknowledged' ? 'No acknowledged notices found.' : 'No outstanding notices found.'
+}))
+
+const severityMap: Record<string, string> = {
+  critical: 'danger',
+  major: 'danger',
+  minor: 'warn',
+  warning: 'warn',
+  normal: 'success',
+  cleared: 'success',
+  indeterminate: 'secondary'
+}
+
+const truncate = (text: string, max = 90) => {
+  return text.length > max ? `${text.slice(0, max)}…` : text
+}
+
+const formatTime = (value?: number | string | null) => {
+  if (value === null || value === undefined || value === '') {
+    return '-'
+  }
+  const date = new Date(value)
+  return isNaN(date.getTime()) ? '-' : date.toLocaleString()
+}
+
+const onPage = (event: DataTablePageEvent) => {
+  store.onPage(event.first, event.rows)
+}
+
+const fetchAllForExport = async (): Promise<OnmsNotice[]> => {
+  const result = await API.browseNotices({
+    acktype: store.preset === 'allAcknowledged' ? 'ack' : 'unack',
+    user: store.preset === 'yourOutstanding' ? store.currentUser : store.preset === 'userSearch' ? store.userFilter : null,
+    limit: EXPORT_LIMIT,
+    offset: 0
+  })
+  return result.notices
+}
+
+const exportColumns = (notice: OnmsNotice): Record<string, string> => ({
+  'ID': String(notice.id),
+  'Severity': notice.severity ?? '',
+  'Subject': notice.subject ?? '',
+  'Text Message': notice.textMessage ?? '',
+  'Sent Time': formatTime(notice.pageTime),
+  'Node': notice.nodeLabel ?? '',
+  'Interface': notice.ipAddress ?? '',
+  'Service': notice.serviceType?.name ?? '',
+  'Responder': notice.ackUser ?? '',
+  'Respond Time': formatTime(notice.ackTime)
+})
+
+const downloadCsv = async () => {
+  const notices = await fetchAllForExport()
+  if (!notices.length) {
+    return
+  }
+  const rows = notices.map(exportColumns)
+  const headers = Object.keys(rows[0])
+  const escapeCell = (value: string) => `"${value.replaceAll('"', '""')}"`
+  const csv = [
+    headers.map(escapeCell).join(','),
+    ...rows.map((row) => headers.map((h) => escapeCell(row[h] === '-' ? '' : row[h])).join(','))
+  ].join('\r\n')
+  const blob = new Blob([`﻿${csv}`], { type: 'text/csv;charset=utf-8' })
+  const link = document.createElement('a')
+  link.href = URL.createObjectURL(blob)
+  link.download = `notices-${store.preset}-${new Date().toISOString().slice(0, 19).replaceAll(':', '-')}.csv`
+  link.click()
+  URL.revokeObjectURL(link.href)
+}
+
+const printNotices = async () => {
+  const notices = await fetchAllForExport()
+  if (!notices.length) {
+    return
+  }
+  const rows = notices.map(exportColumns)
+  const headers = Object.keys(rows[0])
+  const escapeHtml = (value: string) =>
+    value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>${escapeHtml(store.title)}</title>
+<style>
+  body { font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; margin: 24px; color: #222; }
+  h1 { font-size: 18px; margin: 0 0 4px 0; }
+  .meta { color: #666; font-size: 12px; margin-bottom: 16px; }
+  table { border-collapse: collapse; width: 100%; font-size: 12px; }
+  th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; vertical-align: top; }
+  th { background: #f0f0f5; }
+  @media print { body { margin: 8px; } }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(store.title)}</h1>
+<div class="meta">OpenNMS Horizon — generated ${escapeHtml(new Date().toLocaleString())} — ${rows.length} notice${rows.length === 1 ? '' : 's'}</div>
+<table>
+<thead><tr>${headers.map((h) => `<th>${escapeHtml(h)}</th>`).join('')}</tr></thead>
+<tbody>${rows.map((row) => `<tr>${headers.map((h) => `<td>${escapeHtml(row[h])}</td>`).join('')}</tr>`).join('')}</tbody>
+</table>
+</body>
+</html>`
+  const printWindow = window.open('', '_blank')
+  if (!printWindow) {
+    return
+  }
+  printWindow.document.write(html)
+  printWindow.document.close()
+  printWindow.focus()
+  printWindow.print()
+}
+</script>
+
+<style lang="scss" scoped>
+.notices-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.count {
+  color: var(--p-text-muted-color);
+  font-size: 0.9rem;
+}
+</style>

--- a/ui/src/components/AdminNotifications/NotificationExplanationsCard.vue
+++ b/ui/src/components/AdminNotifications/NotificationExplanationsCard.vue
@@ -1,0 +1,115 @@
+<template>
+  <TogglePanel
+    :collapsed="collapsed"
+    class="notification-explanations-panel"
+    data-test="explanations-panel"
+    @update:collapsed="onCollapsedChange"
+  >
+    <template #header>
+      <span class="panel-header">
+        <i class="pi pi-question-circle" aria-hidden="true" />
+        About Notices and Escalation
+      </span>
+    </template>
+    <div class="explanation-columns">
+      <div class="explanation-section">
+        <div class="section-title">Outstanding and Acknowledged Notices</div>
+        <p>
+          When important events are detected by OpenNMS, users may receive a <em>notice</em>, a
+          descriptive message sent automatically to a pager, an email address, or both. In order to
+          receive notices, the user must have their notification information configured in their
+          user profile (see your Administrator for assistance), notices must be <em>on</em>, and an
+          important event must be received.
+        </p>
+        <p>
+          From this panel, you may: <strong>Check your outstanding notices</strong>, which displays
+          all unacknowledged notices sent to your user ID; <strong>View all outstanding
+          notices</strong>, which displays all unacknowledged notices for all users; or
+          <strong>View all acknowledged notices</strong>, which provides a summary of all notices
+          sent and acknowledged for all users.
+        </p>
+        <p>
+          You may also search for notices associated with a specific user ID by entering that user
+          ID in the <strong>Check notices for user</strong> text box. And finally, you can jump
+          immediately to a page with details specific to a given notice identifier by entering that
+          numeric identifier in the <strong>Get details for notice</strong> text box. Note that
+          this is particularly useful if you are using a numeric paging service and receive the
+          numeric notice identifier as part of the page.
+        </p>
+      </div>
+      <div class="explanation-section">
+        <div class="section-title">Notification Escalation</div>
+        <p>
+          Once a notice is sent, it is considered <em>outstanding</em> until someone
+          <em>acknowledge</em>s receipt of the notice via the OpenNMS Notification interface. If
+          the event that triggered the notice was related to managed network devices or systems,
+          the <strong>Network/Systems</strong> group will be notified, one by one, with a notice
+          sent to the next member on the list only after 15 minutes has elapsed since the last
+          message was sent. This progression through the list, or <em>escalation</em>, can be
+          stopped at any time by acknowledging the notice. Note that this is <strong>not</strong>
+          the same as acknowledging the event which triggered the notice. If all members of the
+          group have been notified and the notice has not been acknowledged, the notice will be
+          escalated to the <strong>Management</strong> group, where all members of that group will
+          be notified at once with no 15 minute escalation interval.
+        </p>
+      </div>
+    </div>
+  </TogglePanel>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+
+// Starts collapsed — the "?" in the header invites first-time users to expand;
+// the notices list keeps the screen real estate by default.
+const collapsed = ref(true)
+
+const onCollapsedChange = (value: boolean) => {
+  collapsed.value = value
+}
+</script>
+
+<style lang="scss" scoped>
+// Line the +/- toggle up with the page-header gear button above it: both sit
+// on the page's right edge, but the Panel header's default right padding puts
+// the toggle ~10px left of the gear's icon center.
+.notification-explanations-panel :deep(.p-panel-header) {
+  padding-right: 0.5rem;
+}
+
+.panel-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+
+  .pi-question-circle {
+    color: var(--p-primary-color);
+  }
+}
+
+.explanation-columns {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+
+  .explanation-section {
+    flex: 1;
+    min-width: 320px;
+  }
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+</style>

--- a/ui/src/components/AdminNotifications/NotificationQueriesCard.vue
+++ b/ui/src/components/AdminNotifications/NotificationQueriesCard.vue
@@ -1,0 +1,150 @@
+<template>
+  <TableCard class="notification-queries-bar">
+    <div class="bar-content">
+      <div class="query-links">
+        <a
+          :class="{ active: store.preset === 'yourOutstanding' }"
+          data-test="query-your-outstanding"
+          @click.prevent="store.applyPreset('yourOutstanding')"
+        >Your outstanding notices</a>
+        <span class="separator">|</span>
+        <a
+          :class="{ active: store.preset === 'allOutstanding' }"
+          data-test="query-all-outstanding"
+          @click.prevent="store.applyPreset('allOutstanding')"
+        >All outstanding notices</a>
+        <span class="separator">|</span>
+        <a
+          :class="{ active: store.preset === 'allAcknowledged' }"
+          data-test="query-all-acknowledged"
+          @click.prevent="store.applyPreset('allAcknowledged')"
+        >All acknowledged notices</a>
+      </div>
+      <div class="query-forms">
+        <div class="search-row">
+          <IftaLabel>
+            <InputText
+              id="notification-user-search"
+              v-model="userSearch"
+              data-test="user-search-input"
+              @keyup.enter="searchByUser"
+            />
+            <label for="notification-user-search">Check notices for user</label>
+          </IftaLabel>
+          <Button
+            outlined
+            icon="pi pi-search"
+            aria-label="Show notices for user"
+            data-test="user-search-button"
+            @click="searchByUser"
+          />
+        </div>
+        <div class="search-row">
+          <IftaLabel>
+            <InputText
+              id="notification-notice-search"
+              v-model="noticeSearch"
+              data-test="notice-search-input"
+              @keyup.enter="goToNotice"
+            />
+            <label for="notification-notice-search">Get details for notice</label>
+          </IftaLabel>
+          <Button
+            outlined
+            icon="pi pi-search"
+            aria-label="Get notice detail"
+            data-test="notice-search-button"
+            @click="goToNotice"
+          />
+        </div>
+      </div>
+    </div>
+  </TableCard>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import Button from 'primevue/button'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+
+import TableCard from '@/components/Common/TableCard.vue'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNoticesStore } from '@/stores/noticesStore'
+
+const menuStore = useMenuStore()
+const store = useNoticesStore()
+
+const baseHref = computed<string>(() => menuStore.mainMenu.baseHref)
+
+const userSearch = ref('')
+const noticeSearch = ref('')
+
+const searchByUser = () => {
+  const user = userSearch.value.trim()
+  if (user) {
+    store.applyPreset('userSearch', user)
+  }
+}
+
+const goToNotice = () => {
+  const notice = noticeSearch.value.trim()
+  if (notice) {
+    window.location.href = `${baseHref.value}notification/detail.jsp?notice=${encodeURIComponent(notice)}`
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.notification-queries-bar {
+  padding: 12px 25px;
+}
+
+.bar-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.query-links {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+
+  .separator {
+    color: var(--p-text-muted-color);
+  }
+
+  a {
+    color: var(--p-primary-color);
+    cursor: pointer;
+    white-space: nowrap;
+
+    &.active {
+      font-weight: 700;
+      text-decoration: underline;
+    }
+  }
+}
+
+.query-forms {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+
+  .search-row {
+    display: flex;
+    align-items: stretch;
+    gap: 0.4rem;
+
+    :deep(input) {
+      min-width: 190px;
+    }
+  }
+}
+</style>

--- a/ui/src/components/AdminNotifications/TargetRowEditor.vue
+++ b/ui/src/components/AdminNotifications/TargetRowEditor.vue
@@ -1,0 +1,199 @@
+<template>
+  <div class="target-row">
+    <IftaLabel>
+      <Select
+        v-model="row.type"
+        :labelId="`target-type-${row.key}`"
+        :options="typeOptions"
+        optionLabel="label"
+        optionValue="value"
+        optionDisabled="disabled"
+        data-test="target-type-select"
+        @update:modelValue="onTypeChange"
+      />
+      <label :for="`target-type-${row.key}`">Target Type</label>
+    </IftaLabel>
+
+    <IftaLabel class="target-name">
+      <Select
+        v-if="row.type === 'user'"
+        v-model="row.name"
+        :labelId="`target-name-${row.key}`"
+        :options="users"
+        filter
+        data-test="target-user-select"
+      />
+      <Select
+        v-else-if="row.type === 'group'"
+        v-model="row.name"
+        :labelId="`target-name-${row.key}`"
+        :options="groups"
+        filter
+        data-test="target-group-select"
+      />
+      <Select
+        v-else-if="row.type === 'role'"
+        v-model="row.name"
+        :labelId="`target-name-${row.key}`"
+        :options="roles"
+        filter
+        data-test="target-role-select"
+      />
+      <InputText
+        v-else
+        :id="`target-name-${row.key}`"
+        v-model="row.name"
+        :placeholder="row.type === 'email' ? 'someone@example.com' : ''"
+        data-test="target-name-input"
+      />
+      <label :for="`target-name-${row.key}`">{{ nameLabel }}</label>
+    </IftaLabel>
+
+    <IftaLabel class="target-methods">
+      <MultiSelect
+        v-model="row.commands"
+        :labelId="`target-methods-${row.key}`"
+        :options="rowMethodOptions"
+        optionLabel="label"
+        optionValue="value"
+        optionDisabled="disabled"
+        display="chip"
+        :showToggleAll="false"
+        data-test="target-methods-select"
+      />
+      <label :for="`target-methods-${row.key}`">Notification Methods</label>
+    </IftaLabel>
+
+    <IftaLabel class="target-interval">
+      <InputText
+        :id="`target-interval-${row.key}`"
+        v-model="row.interval"
+        placeholder="0s"
+        data-test="target-interval-input"
+      />
+      <label :for="`target-interval-${row.key}`">Interval</label>
+    </IftaLabel>
+
+    <Button
+      v-if="removable"
+      text
+      rounded
+      icon="pi pi-times"
+      severity="danger"
+      aria-label="Remove target"
+      data-test="remove-target-button"
+      @click="emit('remove')"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+// Shared row model between the editor dialog and this row component.
+export interface TargetRow {
+  key: number
+  type: 'user' | 'group' | 'email' | 'role'
+  name: string
+  commands: string[]
+  interval?: string
+  autoNotify?: string
+}
+
+export interface MethodOption {
+  value: string
+  label: string
+  disabled: boolean
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import Button from 'primevue/button'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+import MultiSelect from 'primevue/multiselect'
+import Select from 'primevue/select'
+
+const props = defineProps<{
+  row: TargetRow
+  users: string[]
+  groups: string[]
+  roles: string[]
+  methodOptions: MethodOption[]
+  removable: boolean
+}>()
+
+const emit = defineEmits(['remove'])
+
+const typeOptions = [
+  { label: 'User', value: 'user' },
+  { label: 'Group', value: 'group' },
+  { label: 'Email Address', value: 'email' },
+  { label: 'On-Call Role', value: 'role' }
+]
+
+// Browser notifications are delivered to logged-in web sessions by user id.
+// Group and role targets resolve to users at send time, so only raw email
+// address targets can never receive them.
+const rowMethodOptions = computed<MethodOption[]>(() => {
+  if (props.row.type !== 'email') {
+    return props.methodOptions
+  }
+  return props.methodOptions.map((option) =>
+    option.value === 'browser' ? { ...option, label: `${option.label} — not for email targets`, disabled: true } : option
+  )
+})
+
+const nameLabel = computed(() => {
+  switch (props.row.type) {
+    case 'user':
+      return 'User'
+    case 'group':
+      return 'Group'
+    case 'email':
+      return 'Email Address'
+    default:
+      return 'Role'
+  }
+})
+
+const onTypeChange = () => {
+  props.row.name = ''
+}
+</script>
+
+<style lang="scss" scoped>
+.target-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+
+  :deep(.p-select) {
+    min-width: 150px;
+  }
+
+  .target-name {
+    :deep(.p-select),
+    :deep(input) {
+      min-width: 200px;
+    }
+  }
+
+  .target-methods {
+    flex: 1;
+    min-width: 240px;
+
+    :deep(.p-multiselect) {
+      width: 100%;
+    }
+  }
+
+  .target-interval {
+    :deep(input) {
+      width: 90px;
+    }
+  }
+}
+</style>

--- a/ui/src/composables/useBrowserNotifications.ts
+++ b/ui/src/composables/useBrowserNotifications.ts
@@ -1,0 +1,93 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+
+// Consumes the notifd 'browser' notification method for the Vue app: the
+// BrowserNotificationStrategy publishes {id, head, body} messages per user on
+// the /notification/stream WebSocket. Legacy JSP pages have their own consumer
+// (core/web-assets notifications app); this one covers all /ui pages. Desktop
+// notifications are used when the user has granted permission, with an
+// in-page snackbar as the fallback so the message is never silently dropped.
+
+interface BrowserNotificationMessage {
+  id?: string | string[]
+  head?: string | string[]
+  body?: string | string[]
+}
+
+const { showSnackBar } = useSnackbar()
+
+let socket: WebSocket | null = null
+let started = false
+
+// the stream serializes each field as a single-element array
+const unwrap = (value?: string | string[]): string | undefined => {
+  if (Array.isArray(value)) {
+    return value.length ? String(value[0]) : undefined
+  }
+  return value ?? undefined
+}
+
+const display = (message: BrowserNotificationMessage) => {
+  const head = unwrap(message.head) ?? 'OpenNMS Notification'
+  const body = unwrap(message.body)
+  if ('Notification' in window && Notification.permission === 'granted') {
+    new Notification(head, {
+      body: body ?? '',
+      tag: `opennms:notification:${unwrap(message.id) ?? head}`
+    })
+  } else {
+    showSnackBar({ msg: body ? `${head} — ${body}` : head, timeout: 8000 })
+  }
+}
+
+const connect = (baseHref: string) => {
+  socket = new WebSocket(`${baseHref}notification/stream`.replace(/^http/, 'ws'))
+
+  socket.onmessage = (event: MessageEvent) => {
+    try {
+      display(JSON.parse(event.data))
+    } catch {
+      // not a notification payload; ignore
+    }
+  }
+
+  socket.onclose = () => {
+    socket = null
+    setTimeout(() => connect(baseHref), 5000)
+  }
+}
+
+const startBrowserNotifications = (baseHref: string) => {
+  if (started || !baseHref) {
+    return
+  }
+  started = true
+  if ('Notification' in window && Notification.permission === 'default') {
+    // fire-and-forget; the snackbar fallback covers an undecided/denied state
+    Notification.requestPermission().catch(() => undefined)
+  }
+  connect(baseHref)
+}
+
+export default startBrowserNotifications

--- a/ui/src/containers/AdminNotifications.vue
+++ b/ui/src/containers/AdminNotifications.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+  <div class="notifications-container">
+    <div class="page-header">
+      <h1 class="page-title">Notifications</h1>
+      <OnmsIconButton
+        v-if="adminRole"
+        text
+        rounded
+        :icon="SettingsIcon"
+        title="Configure Notifications"
+        aria-label="Configure Notifications"
+        data-test="configure-notifications-button"
+        @click="showConfigDialog = true"
+      />
+    </div>
+
+    <NotificationExplanationsCard />
+    <NotificationQueriesCard />
+    <NoticesTable />
+
+    <ConfigureNotificationsDialog
+      v-if="adminRole"
+      v-model:visible="showConfigDialog"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+import { OnmsIconButton } from '@opennms/onms-ui'
+
+import { whenever } from '@vueuse/core'
+
+import ConfigureNotificationsDialog from '@/components/AdminNotifications/ConfigureNotificationsDialog.vue'
+import NoticesTable from '@/components/AdminNotifications/NoticesTable.vue'
+import NotificationExplanationsCard from '@/components/AdminNotifications/NotificationExplanationsCard.vue'
+import NotificationQueriesCard from '@/components/AdminNotifications/NotificationQueriesCard.vue'
+import SettingsIcon from '@/components/icons/action/Settings.vue'
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import useRole from '@/composables/useRole'
+import { useAuthStore } from '@/stores/authStore'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNoticesStore } from '@/stores/noticesStore'
+import { BreadCrumb } from '@/types'
+
+const authStore = useAuthStore()
+const menuStore = useMenuStore()
+const noticesStore = useNoticesStore()
+const { adminRole } = useRole()
+
+const showConfigDialog = ref(false)
+
+const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
+
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Notifications', to: '#', position: 'last' }
+  ]
+})
+
+// The default preset filters by the logged-in user; whoAmI is fetched
+// fire-and-forget at app startup, so wait for it or the first query would
+// silently drop the user filter and show every user's notices.
+const authLoaded = computed<boolean>(() => authStore.loaded)
+
+onMounted(() => {
+  if (authLoaded.value) {
+    noticesStore.load()
+  } else {
+    whenever(authLoaded, () => noticesStore.load(), { once: true })
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.notifications-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 2px 2rem 2px;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .page-title {
+    font-size: 1.4rem;
+    font-weight: 600;
+    margin: 0;
+  }
+}
+
+</style>

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -26,9 +26,11 @@
   setup
   lang="ts"
 >
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
+import { whenever } from '@vueuse/core'
 
 import { OnmsToastHost } from '@opennms/onms-ui'
+import startBrowserNotifications from '@/composables/useBrowserNotifications'
 import OnmsAppLayout from '@/components/Layout/OnmsAppLayout.vue'
 import Footer from '@/components/Layout/Footer.vue'
 import Menubar from '@/components/Menu/Menubar.vue'
@@ -47,6 +49,10 @@ const menuStore = useMenuStore()
 const monitoringSystemStore = useMonitoringSystemStore()
 const nodeStructureStore = useNodeStructureStore()
 const pluginStore = usePluginStore()
+
+// notifd 'browser' method delivery for /ui pages; needs baseHref from the menu
+const baseHref = computed<string>(() => menuStore.mainMenu?.baseHref ?? '')
+whenever(() => !!baseHref.value, () => startBrowserNotifications(baseHref.value), { once: true })
 
 onMounted(() => {
   authStore.getWhoAmI()

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -159,6 +159,11 @@ const router = createRouter({
       }
     },
     {
+      path: '/admin/notifications',
+      name: 'Notifications',
+      component: () => import('@/containers/AdminNotifications.vue')
+    },
+    {
       path: '/map',
       name: 'Map',
       component: () => import('@/containers/Map.vue'),

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -75,9 +75,17 @@ import {
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
 import {
+  addDestinationPath,
+  deleteDestinationPath,
   getDestinationPaths,
+  getNotificationCommands,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  getNotificationGroups,
+  getNotificationUsers,
+  getOnCallRoles,
+  setNotificationConfigStatus,
+  testDestinationPath,
+  updateDestinationPath
 } from './notificationConfigService'
 import { acknowledgeNotice, browseNotices } from './noticesService'
 
@@ -143,8 +151,16 @@ export default {
   getZenithRegistrations,
   performLogout,
   acknowledgeNotice,
+  addDestinationPath,
   browseNotices,
+  getNotificationGroups,
+  getNotificationUsers,
+  getOnCallRoles,
+  updateDestinationPath,
+  deleteDestinationPath,
   getDestinationPaths,
+  getNotificationCommands,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  setNotificationConfigStatus,
+  testDestinationPath
 }

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -74,6 +74,12 @@ import {
   setUsageStatisticsStatus
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
+import {
+  getDestinationPaths,
+  getNotificationConfigStatus,
+  setNotificationConfigStatus
+} from './notificationConfigService'
+import { acknowledgeNotice, browseNotices } from './noticesService'
 
 export default {
   search,
@@ -135,5 +141,10 @@ export default {
   setUsageStatisticsStatus,
   addZenithRegistration,
   getZenithRegistrations,
-  performLogout
+  performLogout,
+  acknowledgeNotice,
+  browseNotices,
+  getDestinationPaths,
+  getNotificationConfigStatus,
+  setNotificationConfigStatus
 }

--- a/ui/src/services/noticesService.ts
+++ b/ui/src/services/noticesService.ts
@@ -1,0 +1,87 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+import useSpinner from '@/composables/useSpinner'
+import { NoticeAckType, NoticeBrowseResult, OnmsNotice } from '@/types/notices'
+import { rest } from './axiosInstances'
+
+const { showSnackBar } = useSnackbar()
+const { startSpinner, stopSpinner } = useSpinner()
+const endpoint = '/notifications'
+
+interface BrowseNoticesParams {
+  acktype: NoticeAckType
+  user?: string | null
+  limit: number
+  offset: number
+}
+
+const browseNotices = async (params: BrowseNoticesParams): Promise<NoticeBrowseResult> => {
+  try {
+    startSpinner()
+    const query = new URLSearchParams()
+    query.set('limit', String(params.limit))
+    query.set('offset', String(params.offset))
+    query.set('orderBy', 'pageTime')
+    query.set('order', 'desc')
+    if (params.acktype === 'unack') {
+      query.set('answeredBy', 'null')
+    } else if (params.acktype === 'ack') {
+      query.set('answeredBy', 'notnull')
+    }
+    if (params.user) {
+      query.set('usersNotified.userId', params.user)
+    }
+    const resp = await rest.get(`${endpoint}?${query.toString()}`)
+    // 204 No Content when nothing matches
+    if (!resp.data || typeof resp.data !== 'object') {
+      return { notices: [], totalCount: 0 }
+    }
+    const raw = resp.data.notification ?? []
+    const notices: OnmsNotice[] = Array.isArray(raw) ? raw : [raw]
+    return { notices, totalCount: Number(resp.data.totalCount ?? notices.length) }
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load notices.' })
+    return { notices: [], totalCount: 0 }
+  } finally {
+    stopSpinner()
+  }
+}
+
+const acknowledgeNotice = async (noticeId: number, ack: boolean): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.put(`${endpoint}/${noticeId}`, new URLSearchParams({ ack: String(ack) }), {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    })
+    showSnackBar({ msg: `Notice ${noticeId} ${ack ? 'acknowledged' : 'unacknowledged'}.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to ${ack ? 'acknowledge' : 'unacknowledge'} notice ${noticeId}.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+export { acknowledgeNotice, browseNotices }

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -22,7 +22,7 @@
 
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
-import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { DestinationPath, NotifdStatus, NotificationCommand } from '@/types/notificationConfig'
 import { rest } from './axiosInstances'
 
 const { showSnackBar } = useSnackbar()
@@ -69,9 +69,120 @@ const getDestinationPaths = async (): Promise<DestinationPath[]> => {
   }
 }
 
+const deleteDestinationPath = async (name: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.delete(`${endpoint}/destination-paths/${encodeURIComponent(name)}`)
+    showSnackBar({ msg: `Destination path '${name}' deleted.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to delete destination path '${name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const testDestinationPath = async (name: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.post(`/notifications/destination-paths/${encodeURIComponent(name)}/trigger`)
+    showSnackBar({ msg: `Test notification triggered for '${name}'.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to trigger test notification for '${name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const addDestinationPath = async (path: DestinationPath): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.post(`${endpoint}/destination-paths`, path)
+    showSnackBar({ msg: `Destination path '${path.name}' added.` })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : `Failed to add destination path '${path.name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const updateDestinationPath = async (originalName: string, path: DestinationPath): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.put(`${endpoint}/destination-paths/${encodeURIComponent(originalName)}`, path)
+    showSnackBar({ msg: `Destination path '${path.name}' updated.` })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : `Failed to update destination path '${path.name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+// Users and groups for destination path target pickers (v1 users/groups REST).
+const getNotificationUsers = async (): Promise<string[]> => {
+  try {
+    const resp = await rest.get('/users?limit=0')
+    const users = resp.data?.user ?? []
+    return (Array.isArray(users) ? users : [users]).map((u: any) => u['user-id']).filter(Boolean)
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load users.' })
+    return []
+  }
+}
+
+const getNotificationGroups = async (): Promise<string[]> => {
+  try {
+    const resp = await rest.get('/groups?limit=0')
+    const groups = resp.data?.group ?? []
+    return (Array.isArray(groups) ? groups : [groups]).map((g: any) => g.name).filter(Boolean)
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load groups.' })
+    return []
+  }
+}
+
+const getOnCallRoles = async (): Promise<string[]> => {
+  try {
+    const resp = await rest.get(`${endpoint}/on-call-roles`)
+    return Array.isArray(resp.data) ? resp.data : []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load on-call roles.' })
+    return []
+  }
+}
+
+const getNotificationCommands = async (): Promise<NotificationCommand[]> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/commands`)
+    return resp.data ?? []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load notification commands.' })
+    return []
+  } finally {
+    stopSpinner()
+  }
+}
 
 export {
+  addDestinationPath,
+  deleteDestinationPath,
   getDestinationPaths,
+  getNotificationCommands,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  getNotificationGroups,
+  getNotificationUsers,
+  getOnCallRoles,
+  setNotificationConfigStatus,
+  testDestinationPath,
+  updateDestinationPath
 }

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -1,0 +1,77 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+import useSpinner from '@/composables/useSpinner'
+import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { rest } from './axiosInstances'
+
+const { showSnackBar } = useSnackbar()
+const { startSpinner, stopSpinner } = useSpinner()
+const endpoint = '/notification-config'
+
+const getNotificationConfigStatus = async (): Promise<NotifdStatus | null> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/status`)
+    return resp.data?.status ?? null
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load notification status.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.put(`${endpoint}/status`, { status })
+    showSnackBar({ msg: `Notifications turned ${status}.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to update notification status.' })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const getDestinationPaths = async (): Promise<DestinationPath[]> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/destination-paths`)
+    return resp.data?.path ?? []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load destination paths.' })
+    return []
+  } finally {
+    stopSpinner()
+  }
+}
+
+
+export {
+  getDestinationPaths,
+  getNotificationConfigStatus,
+  setNotificationConfigStatus
+}

--- a/ui/src/stores/noticesStore.ts
+++ b/ui/src/stores/noticesStore.ts
@@ -1,0 +1,120 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import API from '@/services'
+import { useAuthStore } from '@/stores/authStore'
+import { NoticeQueryPreset, OnmsNotice } from '@/types/notices'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export const useNoticesStore = defineStore('noticesStore', () => {
+  const authStore = useAuthStore()
+
+  const preset = ref<NoticeQueryPreset>('yourOutstanding')
+  const userFilter = ref<string | null>(null)
+  const notices = ref([] as OnmsNotice[])
+  const totalCount = ref(0)
+  const rows = ref(10)
+  const first = ref(0)
+  const loading = ref(false)
+
+  const currentUser = computed<string>(() => authStore.whoAmI.id)
+
+  const acktype = computed<'unack' | 'ack'>(() => (preset.value === 'allAcknowledged' ? 'ack' : 'unack'))
+
+  const effectiveUser = computed<string | null>(() => {
+    if (preset.value === 'yourOutstanding') {
+      return currentUser.value || null
+    }
+    if (preset.value === 'userSearch') {
+      return userFilter.value
+    }
+    return null
+  })
+
+  const title = computed<string>(() => {
+    switch (preset.value) {
+      case 'yourOutstanding':
+        return 'Your Outstanding Notices'
+      case 'allOutstanding':
+        return 'All Outstanding Notices'
+      case 'allAcknowledged':
+        return 'All Acknowledged Notices'
+      case 'userSearch':
+        return `Outstanding Notices for '${userFilter.value}'`
+    }
+    return 'Notices'
+  })
+
+  const load = async () => {
+    loading.value = true
+    try {
+      const result = await API.browseNotices({
+        acktype: acktype.value,
+        user: effectiveUser.value,
+        limit: rows.value,
+        offset: first.value
+      })
+      notices.value = result.notices
+      totalCount.value = result.totalCount
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const applyPreset = async (newPreset: NoticeQueryPreset, user?: string) => {
+    preset.value = newPreset
+    userFilter.value = newPreset === 'userSearch' ? (user ?? null) : null
+    first.value = 0
+    await load()
+  }
+
+  const onPage = async (newFirst: number, newRows: number) => {
+    first.value = newFirst
+    rows.value = newRows
+    await load()
+  }
+
+  const acknowledge = async (notice: OnmsNotice) => {
+    const ok = await API.acknowledgeNotice(notice.id, true)
+    if (ok) {
+      await load()
+    }
+    return ok
+  }
+
+  return {
+    preset,
+    userFilter,
+    notices,
+    totalCount,
+    rows,
+    first,
+    loading,
+    currentUser,
+    title,
+    load,
+    applyPreset,
+    onPage,
+    acknowledge
+  }
+})

--- a/ui/src/stores/notificationConfigStore.ts
+++ b/ui/src/stores/notificationConfigStore.ts
@@ -21,13 +21,17 @@
 ///
 
 import API from '@/services'
-import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { DestinationPath, NotifdStatus, NotificationCommand } from '@/types/notificationConfig'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useNotificationConfigStore = defineStore('notificationConfigStore', () => {
   const notifdStatus = ref<NotifdStatus | null>(null)
   const destinationPaths = ref([] as DestinationPath[])
+  const commands = ref([] as NotificationCommand[])
+  const users = ref([] as string[])
+  const groups = ref([] as string[])
+  const roles = ref([] as string[])
 
   const getStatus = async () => {
     notifdStatus.value = await API.getNotificationConfigStatus()
@@ -45,16 +49,65 @@ export const useNotificationConfigStore = defineStore('notificationConfigStore',
     destinationPaths.value = await API.getDestinationPaths()
   }
 
+  const addDestinationPath = async (path: DestinationPath) => {
+    const ok = await API.addDestinationPath(path)
+    if (ok) {
+      await getDestinationPaths()
+    }
+    return ok
+  }
+
+  const updateDestinationPath = async (originalName: string, path: DestinationPath) => {
+    const ok = await API.updateDestinationPath(originalName, path)
+    if (ok) {
+      await getDestinationPaths()
+    }
+    return ok
+  }
+
+  const getUsersAndGroups = async () => {
+    const [u, g, r] = await Promise.all([API.getNotificationUsers(), API.getNotificationGroups(), API.getOnCallRoles()])
+    users.value = u
+    groups.value = g
+    roles.value = r
+  }
+
+  const deleteDestinationPath = async (name: string) => {
+    const ok = await API.deleteDestinationPath(name)
+    if (ok) {
+      await getDestinationPaths()
+    }
+    return ok
+  }
+
+  const testDestinationPath = async (name: string) => {
+    return await API.testDestinationPath(name)
+  }
+
+  const getCommands = async () => {
+    commands.value = await API.getNotificationCommands()
+  }
+
   const populate = async () => {
-    await Promise.all([getStatus(), getDestinationPaths()])
+    await Promise.all([getStatus(), getDestinationPaths(), getCommands(), getUsersAndGroups()])
   }
 
   return {
     notifdStatus,
     destinationPaths,
+    commands,
     getStatus,
     setStatus,
     getDestinationPaths,
+    addDestinationPath,
+    updateDestinationPath,
+    deleteDestinationPath,
+    testDestinationPath,
+    getCommands,
+    users,
+    groups,
+    roles,
+    getUsersAndGroups,
     populate
   }
 })

--- a/ui/src/stores/notificationConfigStore.ts
+++ b/ui/src/stores/notificationConfigStore.ts
@@ -1,0 +1,60 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import API from '@/services'
+import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useNotificationConfigStore = defineStore('notificationConfigStore', () => {
+  const notifdStatus = ref<NotifdStatus | null>(null)
+  const destinationPaths = ref([] as DestinationPath[])
+
+  const getStatus = async () => {
+    notifdStatus.value = await API.getNotificationConfigStatus()
+  }
+
+  const setStatus = async (status: NotifdStatus) => {
+    const ok = await API.setNotificationConfigStatus(status)
+    if (ok) {
+      notifdStatus.value = status
+    }
+    return ok
+  }
+
+  const getDestinationPaths = async () => {
+    destinationPaths.value = await API.getDestinationPaths()
+  }
+
+  const populate = async () => {
+    await Promise.all([getStatus(), getDestinationPaths()])
+  }
+
+  return {
+    notifdStatus,
+    destinationPaths,
+    getStatus,
+    setStatus,
+    getDestinationPaths,
+    populate
+  }
+})

--- a/ui/src/types/notices.ts
+++ b/ui/src/types/notices.ts
@@ -1,0 +1,72 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Notices (sent notifications) served by /rest/notifications — DB-backed,
+// distinct from the notification *configuration* in types/notificationConfig.ts.
+// Field names follow the wire format of the v1 REST serializer, which differs
+// from the entity/DB names (id, textMessage, ackUser/ackTime, destinations).
+
+export type NoticeAckType = 'unack' | 'ack' | 'all'
+
+export type NoticeQueryPreset = 'yourOutstanding' | 'allOutstanding' | 'allAcknowledged' | 'userSearch'
+
+export interface OnmsNoticeServiceType {
+  id?: number
+  name?: string
+}
+
+export interface OnmsNoticeDestination {
+  id?: number
+  userId?: string
+  media?: string | null
+  contactInfo?: string | null
+  notifyTime?: number | string | null
+  autoNotify?: string | null
+}
+
+export interface OnmsNotice {
+  id: number
+  subject?: string | null
+  textMessage?: string | null
+  uei?: string | null
+  severity?: string | null
+  pageTime?: number | string | null
+  ackTime?: number | string | null
+  ackUser?: string | null
+  eventId?: number | null
+  nodeId?: number | null
+  nodeLabel?: string | null
+  ipAddress?: string | null
+  serviceType?: OnmsNoticeServiceType | null
+  queueId?: string | null
+  destinations?: OnmsNoticeDestination[]
+}
+
+export interface NoticeBrowseFilter {
+  acktype: NoticeAckType
+  user: string | null
+}
+
+export interface NoticeBrowseResult {
+  notices: OnmsNotice[]
+  totalCount: number
+}

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -1,0 +1,48 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// JSON mirrors of the JAXB config models behind /rest/notification-config.
+// Field names follow the XML element/attribute names in notifications.xml,
+// destinationPaths.xml and notificationCommands.xml — the files stay the
+// system of record, this API is a 1:1 view of them.
+
+export type NotifdStatus = 'on' | 'off'
+
+export interface DestinationPathTarget {
+  interval?: string
+  name: string
+  autoNotify?: string
+  command: string[]
+}
+
+export interface DestinationPathEscalate {
+  delay: string
+  target: DestinationPathTarget[]
+}
+
+export interface DestinationPath {
+  name: string
+  'initial-delay'?: string
+  target: DestinationPathTarget[]
+  escalate?: DestinationPathEscalate[]
+}
+

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -46,3 +46,18 @@ export interface DestinationPath {
   escalate?: DestinationPathEscalate[]
 }
 
+export interface NotificationCommandArgument {
+  streamed?: string
+  substitution?: string
+  switch?: string
+}
+
+export interface NotificationCommand {
+  binary?: string
+  'service-registry'?: string
+  name: string
+  execute?: string
+  comment?: string
+  'contact-type'?: string
+  argument?: NotificationCommandArgument[]
+}

--- a/ui/tests/stores/noticesStore.test.ts
+++ b/ui/tests/stores/noticesStore.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useNoticesStore } from '@/stores/noticesStore'
+import { useAuthStore } from '@/stores/authStore'
+import API from '@/services'
+import { OnmsNotice } from '@/types/notices'
+
+vi.mock('@/services', () => ({
+  default: {
+    browseNotices: vi.fn(),
+    acknowledgeNotice: vi.fn()
+  }
+}))
+
+describe('useNoticesStore', () => {
+  let store: ReturnType<typeof useNoticesStore>
+
+  const mockNotices: OnmsNotice[] = [
+    {
+      id: 1,
+      subject: 'Notice #1: node down',
+      severity: 'MAJOR',
+      pageTime: 1785327487410,
+      nodeId: 16,
+      nodeLabel: 'Core-Router-01'
+    },
+    {
+      id: 2,
+      subject: 'Notice #2: interface down',
+      severity: 'MAJOR',
+      pageTime: 1785327487000,
+      ipAddress: '10.0.0.5'
+    }
+  ]
+
+  const mockResult = { notices: mockNotices, totalCount: 5 }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    const authStore = useAuthStore()
+    authStore.whoAmI = { id: 'admin', fullName: 'Administrator', internal: true, roles: ['ROLE_ADMIN'] }
+    store = useNoticesStore()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('should default to the current user outstanding notices', () => {
+      expect(store.preset).toBe('yourOutstanding')
+      expect(store.notices).toEqual([])
+      expect(store.totalCount).toBe(0)
+      expect(store.first).toBe(0)
+      expect(store.rows).toBe(10)
+      expect(store.title).toBe('Your Outstanding Notices')
+    })
+  })
+
+  describe('load', () => {
+    it('should query outstanding notices for the current user', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.load()
+
+      expect(API.browseNotices).toHaveBeenCalledWith({
+        acktype: 'unack',
+        user: 'admin',
+        limit: 10,
+        offset: 0
+      })
+      expect(store.notices).toEqual(mockNotices)
+      expect(store.totalCount).toBe(5)
+    })
+  })
+
+  describe('applyPreset', () => {
+    it('allOutstanding should drop the user filter and reset paging', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+      store.first = 30
+
+      await store.applyPreset('allOutstanding')
+
+      expect(store.preset).toBe('allOutstanding')
+      expect(store.first).toBe(0)
+      expect(API.browseNotices).toHaveBeenCalledWith({
+        acktype: 'unack',
+        user: null,
+        limit: 10,
+        offset: 0
+      })
+      expect(store.title).toBe('All Outstanding Notices')
+    })
+
+    it('allAcknowledged should query acknowledged notices', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.applyPreset('allAcknowledged')
+
+      expect(API.browseNotices).toHaveBeenCalledWith(
+        expect.objectContaining({ acktype: 'ack', user: null })
+      )
+      expect(store.title).toBe('All Acknowledged Notices')
+    })
+
+    it('userSearch should filter outstanding notices by the given user', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.applyPreset('userSearch', 'operator')
+
+      expect(store.userFilter).toBe('operator')
+      expect(API.browseNotices).toHaveBeenCalledWith(
+        expect.objectContaining({ acktype: 'unack', user: 'operator' })
+      )
+      expect(store.title).toBe("Outstanding Notices for 'operator'")
+    })
+  })
+
+  describe('onPage', () => {
+    it('should reload with the new offset and page size', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.onPage(20, 20)
+
+      expect(store.first).toBe(20)
+      expect(store.rows).toBe(20)
+      expect(API.browseNotices).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 20, offset: 20 })
+      )
+    })
+  })
+
+  describe('acknowledge', () => {
+    it('should acknowledge and reload on success', async () => {
+      vi.mocked(API.acknowledgeNotice).mockResolvedValue(true)
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      const ok = await store.acknowledge(mockNotices[0])
+
+      expect(ok).toBe(true)
+      expect(API.acknowledgeNotice).toHaveBeenCalledWith(1, true)
+      expect(API.browseNotices).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not reload when acknowledging fails', async () => {
+      vi.mocked(API.acknowledgeNotice).mockResolvedValue(false)
+
+      const ok = await store.acknowledge(mockNotices[0])
+
+      expect(ok).toBe(false)
+      expect(API.browseNotices).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/ui/tests/stores/notificationConfigStore.test.ts
+++ b/ui/tests/stores/notificationConfigStore.test.ts
@@ -8,7 +8,15 @@ vi.mock('@/services', () => ({
   default: {
     getNotificationConfigStatus: vi.fn(),
     setNotificationConfigStatus: vi.fn(),
-    getDestinationPaths: vi.fn()
+    getDestinationPaths: vi.fn(),
+    addDestinationPath: vi.fn(),
+    updateDestinationPath: vi.fn(),
+    deleteDestinationPath: vi.fn(),
+    testDestinationPath: vi.fn(),
+    getNotificationCommands: vi.fn(),
+    getNotificationUsers: vi.fn(),
+    getNotificationGroups: vi.fn(),
+    getOnCallRoles: vi.fn()
   }
 }))
 
@@ -35,6 +43,7 @@ describe('useNotificationConfigStore', () => {
     it('should start empty with unknown notifd status', () => {
       expect(store.notifdStatus).toBeNull()
       expect(store.destinationPaths).toEqual([])
+      expect(store.commands).toEqual([])
     })
   })
 
@@ -67,15 +76,49 @@ describe('useNotificationConfigStore', () => {
     })
   })
 
+  describe('destination paths', () => {
+    it('should refresh after add, update and delete', async () => {
+      vi.mocked(API.addDestinationPath).mockResolvedValue(true)
+      vi.mocked(API.updateDestinationPath).mockResolvedValue(true)
+      vi.mocked(API.deleteDestinationPath).mockResolvedValue(true)
+      vi.mocked(API.getDestinationPaths).mockResolvedValue([mockPath])
+
+      await store.addDestinationPath(mockPath)
+      await store.updateDestinationPath('Email-Admin', mockPath)
+      await store.deleteDestinationPath('Email-Admin')
+
+      expect(API.getDestinationPaths).toHaveBeenCalledTimes(3)
+      expect(store.destinationPaths).toEqual([mockPath])
+    })
+
+    it('should pass the original name when renaming', async () => {
+      vi.mocked(API.updateDestinationPath).mockResolvedValue(true)
+      vi.mocked(API.getDestinationPaths).mockResolvedValue([])
+
+      const renamed = { ...mockPath, name: 'Email-Ops' }
+      await store.updateDestinationPath('Email-Admin', renamed)
+
+      expect(API.updateDestinationPath).toHaveBeenCalledWith('Email-Admin', renamed)
+    })
+  })
+
   describe('populate', () => {
     it('should load everything the dialog needs', async () => {
       vi.mocked(API.getNotificationConfigStatus).mockResolvedValue('off')
       vi.mocked(API.getDestinationPaths).mockResolvedValue([mockPath])
+      vi.mocked(API.getNotificationCommands).mockResolvedValue([{ name: 'javaEmail' }])
+      vi.mocked(API.getNotificationUsers).mockResolvedValue(['admin'])
+      vi.mocked(API.getNotificationGroups).mockResolvedValue(['Admin'])
+      vi.mocked(API.getOnCallRoles).mockResolvedValue(['oncall'])
 
       await store.populate()
 
       expect(store.notifdStatus).toBe('off')
       expect(store.destinationPaths).toEqual([mockPath])
+      expect(store.commands).toEqual([{ name: 'javaEmail' }])
+      expect(store.users).toEqual(['admin'])
+      expect(store.groups).toEqual(['Admin'])
+      expect(store.roles).toEqual(['oncall'])
     })
   })
 })

--- a/ui/tests/stores/notificationConfigStore.test.ts
+++ b/ui/tests/stores/notificationConfigStore.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import API from '@/services'
+import { DestinationPath } from '@/types/notificationConfig'
+
+vi.mock('@/services', () => ({
+  default: {
+    getNotificationConfigStatus: vi.fn(),
+    setNotificationConfigStatus: vi.fn(),
+    getDestinationPaths: vi.fn()
+  }
+}))
+
+describe('useNotificationConfigStore', () => {
+  let store: ReturnType<typeof useNotificationConfigStore>
+
+  const mockPath: DestinationPath = {
+    name: 'Email-Admin',
+    'initial-delay': '0s',
+    target: [{ name: 'Admin', command: ['javaEmail'] }]
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useNotificationConfigStore()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('should start empty with unknown notifd status', () => {
+      expect(store.notifdStatus).toBeNull()
+      expect(store.destinationPaths).toEqual([])
+    })
+  })
+
+  describe('notifd status', () => {
+    it('should load the status', async () => {
+      vi.mocked(API.getNotificationConfigStatus).mockResolvedValue('on')
+
+      await store.getStatus()
+
+      expect(store.notifdStatus).toBe('on')
+    })
+
+    it('should update the status on success', async () => {
+      vi.mocked(API.setNotificationConfigStatus).mockResolvedValue(true)
+
+      const ok = await store.setStatus('on')
+
+      expect(ok).toBe(true)
+      expect(store.notifdStatus).toBe('on')
+    })
+
+    it('should keep the old status on failure', async () => {
+      store.notifdStatus = 'off'
+      vi.mocked(API.setNotificationConfigStatus).mockResolvedValue(false)
+
+      const ok = await store.setStatus('on')
+
+      expect(ok).toBe(false)
+      expect(store.notifdStatus).toBe('off')
+    })
+  })
+
+  describe('populate', () => {
+    it('should load everything the dialog needs', async () => {
+      vi.mocked(API.getNotificationConfigStatus).mockResolvedValue('off')
+      vi.mocked(API.getDestinationPaths).mockResolvedValue([mockPath])
+
+      await store.populate()
+
+      expect(store.notifdStatus).toBe('off')
+      expect(store.destinationPaths).toEqual([mockPath])
+    })
+  })
+})


### PR DESCRIPTION
Adds the Destination Paths tab to the Configure Notifications dialog. Depends on #8693 (the base Notifications page PR); review the last commit only until that merges.

- Tab with the path list and a test-trigger action.
- Editor covering initial delay, targets (users, groups, on-call roles, email addresses) with per-target commands, intervals and auto-notify, and escalations; the Browser notification method is selectable end to end.
- /rest/notification-config destination-path mutations, commands and on-call-roles endpoints wrap the same destinationPaths.xml, notificationCommands.xml and groups.xml factories the legacy wizard uses; a path rename follows into the event notifications that reference it.
- GroupManager rebuilds its role map on every parse so removing the last role in groups.xml is not masked by a stale cache.
