### PR TITLE
NMS-20100: Path Outages tab

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.netmgt.config.DestinationPathFactory;
+import org.opennms.netmgt.config.NotifdConfigFactory;
+import org.opennms.netmgt.config.destinationPaths.DestinationPaths;
+import org.opennms.netmgt.events.api.EventProxy;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.web.api.Authentication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST access to the notification configuration that has historically only been
+ * reachable through the admin JSP wizards. All operations delegate to the same
+ * file-backed config factories the legacy servlets use, so the XML files
+ * (notifications.xml, destinationPaths.xml, notificationCommands.xml,
+ * notifd-configuration.xml) remain the system of record and stay fully
+ * editable by hand.
+ *
+ * <ul>
+ * <li><b>GET /notification-config/status</b> global notifd on/off status</li>
+ * <li><b>PUT /notification-config/status</b> turn notifd on or off</li>
+ * <li><b>GET /notification-config/destination-paths</b> all destination paths</li>
+ * </ul>
+ */
+@Component("notificationConfigRestService")
+@Path("notification-config")
+@Tag(name = "Notification-config", description = "Notification Configuration API")
+public class NotificationConfigRestService extends OnmsRestService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationConfigRestService.class);
+
+    @Autowired
+    @Qualifier("eventProxy")
+    protected EventProxy m_eventProxy;
+
+    @XmlRootElement(name = "notification-status")
+    public static class NotificationStatus {
+        private String m_status;
+
+        public NotificationStatus() {
+        }
+
+        public NotificationStatus(final String status) {
+            m_status = status;
+        }
+
+        @XmlAttribute(name = "status")
+        public String getStatus() {
+            return m_status;
+        }
+
+        public void setStatus(final String status) {
+            m_status = status;
+        }
+    }
+
+    @GET
+    @Path("status")
+    @Produces(MediaType.APPLICATION_JSON)
+    public NotificationStatus getStatus(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read the notification status");
+        try {
+            return new NotificationStatus(getNotifdConfigFactory().getNotificationStatus());
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read notifd status: {}", e.getMessage());
+        }
+    }
+
+    @PUT
+    @Path("status")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response setStatus(@Context final SecurityContext securityContext, final NotificationStatus status) {
+        assertAdmin(securityContext, "change the notification status");
+        if (status == null || !("on".equals(status.getStatus()) || "off".equals(status.getStatus()))) {
+            throw getException(Status.BAD_REQUEST, "Status must be 'on' or 'off'");
+        }
+        writeLock();
+        try {
+            LOG.info("Setting notifd status to {} for user {}", status.getStatus(), securityContext.getUserPrincipal().getName());
+            if ("on".equals(status.getStatus())) {
+                getNotifdConfigFactory().turnNotifdOn();
+                sendStatusEvent("uei.opennms.org/internal/notificationsTurnedOn", securityContext);
+            } else {
+                getNotifdConfigFactory().turnNotifdOff();
+                sendStatusEvent("uei.opennms.org/internal/notificationsTurnedOff", securityContext);
+            }
+            return Response.noContent().build();
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't update notifd status: {}", e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @GET
+    @Path("destination-paths")
+    @Produces(MediaType.APPLICATION_JSON)
+    public DestinationPaths getDestinationPaths(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read destination paths");
+        readLock();
+        try {
+            final DestinationPaths paths = new DestinationPaths();
+            final List<org.opennms.netmgt.config.destinationPaths.Path> list = new ArrayList<>(getDestinationPathFactory().getPaths().values());
+            list.sort(Comparator.comparing(org.opennms.netmgt.config.destinationPaths.Path::getName, String.CASE_INSENSITIVE_ORDER));
+            paths.setPaths(list);
+            return paths;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read destination paths: {}", e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @GET
+    @Path("destination-paths/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public org.opennms.netmgt.config.destinationPaths.Path getDestinationPath(@Context final SecurityContext securityContext, @PathParam("name") final String name) {
+        assertAdmin(securityContext, "read destination paths");
+        readLock();
+        try {
+            final org.opennms.netmgt.config.destinationPaths.Path path = getDestinationPathFactory().getPath(name);
+            if (path == null) {
+                throw getException(Status.NOT_FOUND, "Destination path {} was not found.", name);
+            }
+            return path;
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read destination path {}: {}", name, e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    private static void assertAdmin(final SecurityContext securityContext, final String operation) {
+        if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
+            throw getException(Status.FORBIDDEN, "User {} does not have access to {}.", securityContext.getUserPrincipal().getName(), operation);
+        }
+    }
+
+    private void sendStatusEvent(final String uei, final SecurityContext securityContext) {
+        final EventBuilder bldr = new EventBuilder(uei, "ReST");
+        bldr.addParam("remoteUser", securityContext.getUserPrincipal().getName());
+        try {
+            m_eventProxy.send(bldr.getEvent());
+        } catch (final Exception e) {
+            LOG.warn("Can't send event {}", uei, e);
+        }
+    }
+
+    private static NotifdConfigFactory getNotifdConfigFactory() throws Exception {
+        NotifdConfigFactory.init();
+        return NotifdConfigFactory.getInstance();
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static DestinationPathFactory getDestinationPathFactory() throws Exception {
+        DestinationPathFactory.init();
+        return DestinationPathFactory.getInstance();
+    }
+
+
+
+
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -21,9 +21,15 @@
  */
 package org.opennms.web.rest.v1;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -41,10 +47,15 @@ import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.opennms.core.db.DataSourceFactory;
+import org.opennms.core.utils.DBUtils;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.DestinationPathFactory;
 import org.opennms.netmgt.config.NotifdConfigFactory;
 import org.opennms.netmgt.config.destinationPaths.DestinationPaths;
 import org.opennms.netmgt.events.api.EventProxy;
+import org.opennms.netmgt.filter.FilterDaoFactory;
+import org.opennms.netmgt.filter.api.FilterParseException;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.web.api.Authentication;
 import org.slf4j.Logger;
@@ -209,7 +220,286 @@ public class NotificationConfigRestService extends OnmsRestService {
         return DestinationPathFactory.getInstance();
     }
 
+    // ------------------------------------------------------------------
+    // Path outages (critical paths). Storage is and stays the pathoutage
+    // DB table; the logic below mirrors the legacy NotificationWizardServlet
+    // (filter rule -> node set; per node delete + optional insert; blank
+    // critical IP clears the path for the matching nodes).
+    // ------------------------------------------------------------------
 
+    private static final String SQL_LIST_PATH_OUTAGES = "SELECT p.nodeid, n.nodelabel, p.criticalpathip, p.criticalpathservicename FROM pathoutage p LEFT JOIN node n ON n.nodeid = p.nodeid ORDER BY n.nodelabel, p.nodeid";
+    private static final String SQL_SET_CRITICAL_PATH = "INSERT INTO pathoutage (nodeid, criticalpathip, criticalpathservicename) VALUES (?, ?, ?)";
+    private static final String SQL_DELETE_CRITICAL_PATH = "DELETE FROM pathoutage WHERE nodeid=?";
+
+    private static final int PREVIEW_NODE_LIMIT = 200;
+
+    @XmlRootElement(name = "path-outage")
+    public static class PathOutageDTO {
+        private Integer m_nodeId;
+        private String m_nodeLabel;
+        private String m_criticalPathIp;
+        private String m_criticalPathServiceName;
+
+        public Integer getNodeId() {
+            return m_nodeId;
+        }
+
+        public void setNodeId(final Integer nodeId) {
+            m_nodeId = nodeId;
+        }
+
+        public String getNodeLabel() {
+            return m_nodeLabel;
+        }
+
+        public void setNodeLabel(final String nodeLabel) {
+            m_nodeLabel = nodeLabel;
+        }
+
+        public String getCriticalPathIp() {
+            return m_criticalPathIp;
+        }
+
+        public void setCriticalPathIp(final String criticalPathIp) {
+            m_criticalPathIp = criticalPathIp;
+        }
+
+        public String getCriticalPathServiceName() {
+            return m_criticalPathServiceName;
+        }
+
+        public void setCriticalPathServiceName(final String criticalPathServiceName) {
+            m_criticalPathServiceName = criticalPathServiceName;
+        }
+    }
+
+    @XmlRootElement(name = "path-outage-preview")
+    public static class PathOutagePreviewDTO {
+        private int m_totalCount;
+        private List<PathOutageDTO> m_nodes = new ArrayList<>();
+
+        public int getTotalCount() {
+            return m_totalCount;
+        }
+
+        public void setTotalCount(final int totalCount) {
+            m_totalCount = totalCount;
+        }
+
+        public List<PathOutageDTO> getNodes() {
+            return m_nodes;
+        }
+
+        public void setNodes(final List<PathOutageDTO> nodes) {
+            m_nodes = nodes;
+        }
+    }
+
+    @XmlRootElement(name = "path-outage-request")
+    public static class PathOutageRequestDTO {
+        private String m_rule;
+        private String m_criticalIp;
+        private String m_criticalSvc;
+
+        public String getRule() {
+            return m_rule;
+        }
+
+        public void setRule(final String rule) {
+            m_rule = rule;
+        }
+
+        public String getCriticalIp() {
+            return m_criticalIp;
+        }
+
+        public void setCriticalIp(final String criticalIp) {
+            m_criticalIp = criticalIp;
+        }
+
+        public String getCriticalSvc() {
+            return m_criticalSvc;
+        }
+
+        public void setCriticalSvc(final String criticalSvc) {
+            m_criticalSvc = criticalSvc;
+        }
+    }
+
+    @GET
+    @Path("path-outages")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<PathOutageDTO> getPathOutages(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read path outages");
+        readLock();
+        try {
+            final List<PathOutageDTO> result = new ArrayList<>();
+            final Connection conn = DataSourceFactory.getInstance().getConnection();
+            final DBUtils d = new DBUtils(getClass(), conn);
+            try {
+                final PreparedStatement stmt = conn.prepareStatement(SQL_LIST_PATH_OUTAGES);
+                d.watch(stmt);
+                final ResultSet rs = stmt.executeQuery();
+                d.watch(rs);
+                while (rs.next()) {
+                    final PathOutageDTO dto = new PathOutageDTO();
+                    dto.setNodeId(rs.getInt(1));
+                    dto.setNodeLabel(rs.getString(2));
+                    dto.setCriticalPathIp(rs.getString(3));
+                    dto.setCriticalPathServiceName(rs.getString(4));
+                    result.add(dto);
+                }
+            } finally {
+                d.cleanUp();
+            }
+            return result;
+        } catch (final SQLException e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read path outages: {}", e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @GET
+    @Path("path-outages/preview")
+    @Produces(MediaType.APPLICATION_JSON)
+    public PathOutagePreviewDTO previewPathOutageRule(@Context final SecurityContext securityContext, @javax.ws.rs.QueryParam("rule") final String rule) {
+        assertAdmin(securityContext, "preview path outage rules");
+        if (rule == null || rule.isBlank()) {
+            throw getException(Status.BAD_REQUEST, "A filter rule is required");
+        }
+        readLock();
+        try {
+            final SortedMap<Integer, String> nodes = getMatchingNodes(rule);
+            final PathOutagePreviewDTO preview = new PathOutagePreviewDTO();
+            preview.setTotalCount(nodes.size());
+            for (final Map.Entry<Integer, String> entry : nodes.entrySet()) {
+                if (preview.getNodes().size() >= PREVIEW_NODE_LIMIT) {
+                    break;
+                }
+                final PathOutageDTO dto = new PathOutageDTO();
+                dto.setNodeId(entry.getKey());
+                dto.setNodeLabel(entry.getValue());
+                preview.getNodes().add(dto);
+            }
+            return preview;
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @POST
+    @Path("path-outages")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response applyPathOutage(@Context final SecurityContext securityContext, final PathOutageRequestDTO request) {
+        assertAdmin(securityContext, "configure path outages");
+        if (request == null || request.getRule() == null || request.getRule().isBlank()) {
+            throw getException(Status.BAD_REQUEST, "A filter rule is required");
+        }
+        String criticalIp = request.getCriticalIp() == null ? "" : request.getCriticalIp().trim();
+        final String criticalSvc = request.getCriticalSvc() == null || request.getCriticalSvc().isBlank() ? "ICMP" : request.getCriticalSvc().trim();
+        if (!criticalIp.isEmpty()) {
+            try {
+                FilterDaoFactory.getInstance().validateRule("IPADDR IPLIKE " + criticalIp);
+                // store the canonical form, matching the legacy wizard
+                criticalIp = InetAddressUtils.normalize(criticalIp);
+            } catch (final FilterParseException | IllegalArgumentException e) {
+                throw getException(Status.BAD_REQUEST, "Invalid critical path IP address: {}", criticalIp);
+            }
+        }
+        writeLock();
+        try {
+            final SortedMap<Integer, String> nodes = getMatchingNodes(request.getRule());
+            final Connection conn = DataSourceFactory.getInstance().getConnection();
+            final DBUtils d = new DBUtils(getClass(), conn);
+            try {
+                // one transaction so a mid-loop failure can't leave some nodes
+                // stripped of their old critical path with no new one written
+                conn.setAutoCommit(false);
+                try (PreparedStatement delete = conn.prepareStatement(SQL_DELETE_CRITICAL_PATH);
+                     PreparedStatement insert = conn.prepareStatement(SQL_SET_CRITICAL_PATH)) {
+                    for (final Integer nodeId : nodes.keySet()) {
+                        delete.setInt(1, nodeId);
+                        delete.addBatch();
+                        if (!criticalIp.isEmpty()) {
+                            insert.setInt(1, nodeId);
+                            insert.setString(2, criticalIp);
+                            insert.setString(3, criticalSvc);
+                            insert.addBatch();
+                        }
+                    }
+                    delete.executeBatch();
+                    if (!criticalIp.isEmpty()) {
+                        insert.executeBatch();
+                    }
+                    conn.commit();
+                } catch (final SQLException e) {
+                    conn.rollback();
+                    throw e;
+                } finally {
+                    conn.setAutoCommit(true);
+                }
+            } finally {
+                d.cleanUp();
+            }
+            LOG.info("Path outage {} applied to {} nodes (rule '{}') by user {}",
+                    criticalIp.isEmpty() ? "cleared" : "critical path " + criticalIp + "/" + criticalSvc,
+                    nodes.size(), request.getRule(), securityContext.getUserPrincipal().getName());
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't apply path outage: {}", e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @DELETE
+    @Path("path-outages/{nodeId}")
+    public Response deletePathOutage(@Context final SecurityContext securityContext, @PathParam("nodeId") final Integer nodeId) {
+        assertAdmin(securityContext, "remove path outages");
+        writeLock();
+        try {
+            final Connection conn = DataSourceFactory.getInstance().getConnection();
+            final DBUtils d = new DBUtils(getClass(), conn);
+            try {
+                deleteCriticalPath(nodeId, conn);
+            } finally {
+                d.cleanUp();
+            }
+            return Response.noContent().build();
+        } catch (final SQLException e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't remove path outage for node {}: {}", String.valueOf(nodeId), e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    private static SortedMap<Integer, String> getMatchingNodes(final String rule) {
+        try {
+            FilterDaoFactory.getInstance().validateRule(rule);
+        } catch (final FilterParseException e) {
+            throw getException(Status.BAD_REQUEST, "Invalid filter rule: {}", e.getMessage());
+        }
+        try {
+            return FilterDaoFactory.getInstance().getNodeMap(rule);
+        } catch (final FilterParseException e) {
+            throw getException(Status.BAD_REQUEST, "Invalid filter rule: {}", e.getMessage());
+        }
+    }
+
+    private static void deleteCriticalPath(final int nodeId, final Connection conn) throws SQLException {
+        final DBUtils d = new DBUtils(NotificationConfigRestService.class);
+        try {
+            final PreparedStatement stmt = conn.prepareStatement(SQL_DELETE_CRITICAL_PATH);
+            d.watch(stmt);
+            stmt.setInt(1, nodeId);
+            stmt.execute();
+        } finally {
+            d.cleanUp();
+        }
+    }
 
 
 }

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -262,7 +262,7 @@
         {
           "id": "notifications",
           "name": "Notifications",
-          "url": "notification/index.jsp",
+          "url": "ui/index.html#/admin/notifications",
           "locationMatch": "notification",
           "roles": null
         },

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -21,9 +21,16 @@
  */
 package org.opennms.web.rest.v1;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.sql.Connection;
+import java.sql.Statement;
 import java.nio.charset.Charset;
+import java.util.TreeMap;
+import java.util.SortedMap;
 
 import javax.ws.rs.core.MediaType;
 
@@ -38,6 +45,10 @@ import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.core.db.DataSourceFactory;
+import org.opennms.netmgt.filter.FilterDaoFactory;
+import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.filter.api.FilterParseException;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -64,9 +75,11 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @JUnitTemporaryDatabase
 public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
+    private static final String INVALID_RULE = "this is not a rule";
 
     private String m_onmsHome;
 
+    private FilterDao m_filterDao;
 
     @Override
     protected void beforeServletStart() throws Exception {
@@ -122,6 +135,12 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
                 + "<roles><role name=\"junit-oncall\" supervisor=\"admin\" membership-group=\"Admin\"/></roles>"
                 + "</groupinfo>", Charset.defaultCharset());
 
+        m_filterDao = mock(FilterDao.class);
+        final SortedMap<Integer, String> nodeMap = new TreeMap<>();
+        nodeMap.put(1, "node1");
+        when(m_filterDao.getNodeMap("IPADDR IPLIKE *.*.*.*")).thenReturn(nodeMap);
+        doThrow(new FilterParseException("invalid rule")).when(m_filterDao).validateRule(INVALID_RULE);
+        FilterDaoFactory.setInstance(m_filterDao);
     }
 
     // Required so context initialization can't repoint opennms.home at
@@ -130,6 +149,14 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
     public void afterServletStart() throws Exception {
         System.setProperty("opennms.home", m_onmsHome);
         ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+        // Seed the node row for the pathoutage foreign key through the same
+        // DataSource the service uses, so it is committed and visible to the
+        // service's own connections regardless of test transactions.
+        try (Connection conn = DataSourceFactory.getInstance().getConnection();
+             Statement st = conn.createStatement()) {
+            st.execute("INSERT INTO monitoringlocations (id, monitoringarea) VALUES ('Default', 'Default') ON CONFLICT (id) DO NOTHING");
+            st.execute("INSERT INTO node (nodeid, nodecreatetime, nodelabel, location) VALUES (1, now(), 'node1', 'Default') ON CONFLICT (nodeid) DO NOTHING");
+        }
     }
 
     @Test
@@ -143,6 +170,46 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
 
         // only on/off are valid
         sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"maybe\"}", 400);
+    }
+
+    @Test
+    public void testPathOutageLifecycle() throws Exception {
+        JSONArray outages = new JSONArray(getJson("/notification-config/path-outages"));
+        Assert.assertEquals(0, outages.length());
+
+        JSONObject preview = new JSONObject(getJson("/notification-config/path-outages/preview?rule=IPADDR%20IPLIKE%20*.*.*.*"));
+        Assert.assertEquals(1, preview.getInt("totalCount"));
+        Assert.assertEquals("node1", preview.getJSONArray("nodes").getJSONObject(0).getString("nodeLabel"));
+
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"IPADDR IPLIKE *.*.*.*\",\"criticalIp\":\"192.168.1.1\",\"criticalSvc\":\"ICMP\"}", 204);
+        outages = new JSONArray(getJson("/notification-config/path-outages"));
+        Assert.assertEquals(1, outages.length());
+        Assert.assertEquals("192.168.1.1", outages.getJSONObject(0).getString("criticalPathIp"));
+
+        sendRequest(DELETE, "/notification-config/path-outages/1", 204);
+        outages = new JSONArray(getJson("/notification-config/path-outages"));
+        Assert.assertEquals(0, outages.length());
+    }
+
+    @Test
+    public void testPathOutageClearsWithBlankIp() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"IPADDR IPLIKE *.*.*.*\",\"criticalIp\":\"192.168.1.1\"}", 204);
+        Assert.assertEquals(1, new JSONArray(getJson("/notification-config/path-outages")).length());
+
+        // blank critical IP clears the path for the matching nodes
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"IPADDR IPLIKE *.*.*.*\"}", 204);
+        Assert.assertEquals(0, new JSONArray(getJson("/notification-config/path-outages")).length());
+    }
+
+    @Test
+    public void testPathOutageValidation() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"" + INVALID_RULE + "\",\"criticalIp\":\"192.168.1.1\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages", "{}", 400);
+        sendRequest(GET, "/notification-config/path-outages/preview", 400);
     }
 
     @Test
@@ -164,6 +231,8 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
         try {
             sendRequest(GET, "/notification-config/status", 403);
             sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"on\"}", 403);
+            sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                    "{\"rule\":\"IPADDR IPLIKE *.*.*.*\"}", 403);
         } finally {
             setUser("admin", new String[]{ "ROLE_ADMIN" });
         }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1;
+
+
+import java.io.File;
+import java.nio.charset.Charset;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.io.FileUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.ConfigurationTestUtils;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties="org.opennms.timeseries.strategy=integration")
+@JUnitTemporaryDatabase
+public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTestCase {
+
+
+    private String m_onmsHome;
+
+
+    @Override
+    protected void beforeServletStart() throws Exception {
+        MockLogAppender.setupLogging();
+        File etc = new File("target/test-work-dir/etc");
+        etc.mkdirs();
+        m_onmsHome = etc.getParent();
+        System.setProperty("opennms.home", m_onmsHome);
+        ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+
+        FileUtils.writeStringToFile(new File(etc, "notifd-configuration.xml"), "<?xml version=\"1.0\"?>"
+                + "<notifd-configuration status=\"off\" match-all=\"true\">"
+                + "<queue><queue-id>default</queue-id><interval>20s</interval>"
+                + "<handler-class><name>org.opennms.netmgt.notifd.DefaultQueueHandler</name></handler-class>"
+                + "</queue>"
+                + "</notifd-configuration>", Charset.defaultCharset());
+        // deliberately NOT calling NotifdConfigFactory.init() here: the service
+        // must initialize it itself (cold-start ordering regression guard)
+
+        FileUtils.writeStringToFile(new File(etc, "notifications.xml"), "<?xml version=\"1.0\"?>"
+                + "<notifications xmlns=\"http://xmlns.opennms.org/xsd/notifications\">"
+                + "<header><rev>1.2</rev><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<notification name=\"junitNotification\" status=\"on\">"
+                + "<uei>uei.opennms.org/nodes/nodeDown</uei>"
+                + "<rule>IPADDR != '0.0.0.0'</rule>"
+                + "<destinationPath>Email-Admin</destinationPath>"
+                + "<text-message>node down</text-message>"
+                + "</notification>"
+                + "</notifications>", Charset.defaultCharset());
+
+        FileUtils.writeStringToFile(new File(etc, "destinationPaths.xml"), "<?xml version=\"1.0\"?>"
+                + "<destinationPaths>"
+                + "<header><rev>1.2</rev><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<path name=\"Email-Admin\">"
+                + "<target><name>Admin</name><command>javaEmail</command></target>"
+                + "</path>"
+                + "</destinationPaths>", Charset.defaultCharset());
+
+        FileUtils.writeStringToFile(new File(etc, "notificationCommands.xml"), "<?xml version=\"1.0\"?>"
+                + "<notification-commands xmlns=\"http://xmlns.opennms.org/xsd/notificationCommands\">"
+                + "<header><ver>.9</ver><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<command binary=\"false\">"
+                + "<name>javaEmail</name>"
+                + "<execute>org.opennms.netmgt.notifd.JavaMailNotificationStrategy</execute>"
+                + "<comment>send an email</comment>"
+                + "</command>"
+                + "</notification-commands>", Charset.defaultCharset());
+
+        FileUtils.writeStringToFile(new File(etc, "groups.xml"), "<?xml version=\"1.0\"?>"
+                + "<groupinfo xmlns=\"http://xmlns.opennms.org/xsd/groups\">"
+                + "<header><rev>1.3</rev><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<groups><group><name>Admin</name><user>admin</user></group></groups>"
+                + "<roles><role name=\"junit-oncall\" supervisor=\"admin\" membership-group=\"Admin\"/></roles>"
+                + "</groupinfo>", Charset.defaultCharset());
+
+    }
+
+    // Required so context initialization can't repoint opennms.home at
+    // opennms-base-assembly between servlet start and the first request.
+    @Override
+    public void afterServletStart() throws Exception {
+        System.setProperty("opennms.home", m_onmsHome);
+        ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+    }
+
+    @Test
+    public void testNotifdStatus() throws Exception {
+        JSONObject status = new JSONObject(getJson("/notification-config/status"));
+        Assert.assertEquals("off", status.getString("status"));
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"on\"}", 204);
+        status = new JSONObject(getJson("/notification-config/status"));
+        Assert.assertEquals("on", status.getString("status"));
+
+        // only on/off are valid
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"maybe\"}", 400);
+    }
+
+    @Test
+    public void testDestinationPathsReadable() throws Exception {
+        // the read side ships in the base PR: the event-notification editor
+        // needs the path list for its destination picker
+        // order-independent: sibling tests may add or rename paths
+        JSONObject list = new JSONObject(getJson("/notification-config/destination-paths"));
+        Assert.assertTrue(list.getJSONArray("path").length() >= 1);
+        final String firstName = list.getJSONArray("path").getJSONObject(0).getString("name");
+        JSONObject path = new JSONObject(getJson("/notification-config/destination-paths/"
+                + java.net.URLEncoder.encode(firstName, java.nio.charset.StandardCharsets.UTF_8)));
+        Assert.assertEquals(firstName, path.getString("name"));
+    }
+
+    @Test
+    public void testForbiddenForNonAdmin() throws Exception {
+        setUser("nobody", new String[]{ "ROLE_USER" });
+        try {
+            sendRequest(GET, "/notification-config/status", 403);
+            sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"on\"}", 403);
+        } finally {
+            setUser("admin", new String[]{ "ROLE_ADMIN" });
+        }
+    }
+
+    private String getJson(final String url) throws Exception {
+        // the instance createRequest carries the setUser() user AND roles
+        final MockHttpServletRequest request = createRequest(GET, url);
+        request.addHeader("Accept", MediaType.APPLICATION_JSON);
+        return sendRequest(request, 200);
+    }
+}

--- a/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
+++ b/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
@@ -1,0 +1,106 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    maximizable
+    header="Configure Notifications"
+    class="configure-notifications-dialog"
+    :style="{ width: '1100px', maxWidth: '95vw' }"
+    data-test="configure-notifications-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <Tabs v-model:value="activeTab">
+      <TabList>
+        <Tab value="general" data-test="tab-general">General</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel value="general">
+          <div class="general-tab">
+            <div class="status-toggle">
+              <PToggleSwitch
+                :modelValue="store.notifdStatus === 'on'"
+                :disabled="store.notifdStatus === null || statusPending"
+                aria-label="Turn notifications on or off"
+                data-test="notifd-status-toggle"
+                @update:modelValue="onStatusToggle"
+              />
+              <span class="status-label">Notifications are <strong>{{ store.notifdStatus ?? 'unknown' }}</strong></span>
+            </div>
+            <p class="status-hint">
+              System-wide switch. While off, OpenNMS will not create outgoing notices for any
+              event. The current status is also reflected by the bell icon in the top bar.
+            </p>
+          </div>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import Dialog from 'primevue/dialog'
+import Tab from 'primevue/tab'
+import TabList from 'primevue/tablist'
+import TabPanel from 'primevue/tabpanel'
+import TabPanels from 'primevue/tabpanels'
+import Tabs from 'primevue/tabs'
+import ToggleSwitch from 'primevue/toggleswitch'
+
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { NotifdStatus } from '@/types/notificationConfig'
+
+const PToggleSwitch = ToggleSwitch
+
+const props = defineProps<{
+  visible: boolean
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useNotificationConfigStore()
+
+const activeTab = ref('general')
+const statusPending = ref(false)
+const populated = ref(false)
+
+watch(
+  () => props.visible,
+  async (isVisible) => {
+    if (isVisible && !populated.value) {
+      await store.populate()
+      populated.value = true
+    }
+  }
+)
+
+const onStatusToggle = async (value: boolean) => {
+  statusPending.value = true
+  try {
+    await store.setStatus((value ? 'on' : 'off') as NotifdStatus)
+  } finally {
+    statusPending.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.general-tab {
+  padding: 1rem 0;
+
+  .status-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .status-hint {
+    margin-top: 1rem;
+    color: var(--p-text-muted-color);
+    font-size: 0.9rem;
+    max-width: 60ch;
+  }
+}
+
+</style>

--- a/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
+++ b/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
@@ -11,9 +11,13 @@
   >
     <Tabs v-model:value="activeTab">
       <TabList>
+        <Tab value="path-outages" data-test="tab-path-outages">Path Outages</Tab>
         <Tab value="general" data-test="tab-general">General</Tab>
       </TabList>
       <TabPanels>
+        <TabPanel value="path-outages">
+          <PathOutagesTab />
+        </TabPanel>
         <TabPanel value="general">
           <div class="general-tab">
             <div class="status-toggle">
@@ -48,6 +52,7 @@ import TabPanels from 'primevue/tabpanels'
 import Tabs from 'primevue/tabs'
 import ToggleSwitch from 'primevue/toggleswitch'
 
+import PathOutagesTab from '@/components/AdminNotifications/PathOutagesTab.vue'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import { NotifdStatus } from '@/types/notificationConfig'
 

--- a/ui/src/components/AdminNotifications/NoticesTable.vue
+++ b/ui/src/components/AdminNotifications/NoticesTable.vue
@@ -1,0 +1,308 @@
+<template>
+  <TableCard class="notices-table">
+    <div class="header">
+      <div class="card-title" data-test="notices-title">{{ store.title }}</div>
+      <div class="header-right">
+        <div class="count" data-test="notices-count">{{ store.totalCount }} notice{{ store.totalCount === 1 ? '' : 's' }}</div>
+        <OnmsIconButton
+          text
+          :icon="DownloadFileIcon"
+          iconSize="1.2rem"
+          title="Download as CSV"
+          aria-label="Download notices as CSV"
+          data-test="csv-download-button"
+          :disabled="!store.totalCount"
+          @click="downloadCsv"
+        />
+        <OnmsIconButton
+          text
+          :icon="PrintIcon"
+          iconSize="1.2rem"
+          title="Print / save as PDF"
+          aria-label="Print notices"
+          data-test="print-button"
+          :disabled="!store.totalCount"
+          @click="printNotices"
+        />
+      </div>
+    </div>
+
+    <DataTable
+      v-if="store.notices.length"
+      lazy
+      :value="store.notices"
+      :totalRecords="store.totalCount"
+      :loading="store.loading"
+      paginator
+      dataKey="id"
+      :first="store.first"
+      :rows="store.rows"
+      :rowsPerPageOptions="[10, 20, 50, 100]"
+      class="data-table"
+      data-test="notices-table"
+      @page="onPage"
+    >
+      <Column
+        field="id"
+        header="ID"
+      >
+        <template #body="{ data }">
+          <a
+            :href="`${baseHref}notification/detail.jsp?notice=${data.id}`"
+            :data-test="`notice-link-${data.id}`"
+          >{{ data.id }}</a>
+        </template>
+      </Column>
+      <Column header="Severity">
+        <template #body="{ data }">
+          <Tag
+            v-if="data.severity"
+            :value="data.severity"
+            :severity="severityMap[String(data.severity).toLowerCase()] ?? 'secondary'"
+          />
+          <span v-else>-</span>
+        </template>
+      </Column>
+      <Column header="Subject">
+        <template #body="{ data }">
+          <span :title="data.textMessage ?? ''">{{ truncate(data.subject || data.textMessage || '-') }}</span>
+        </template>
+      </Column>
+      <Column header="Sent Time">
+        <template #body="{ data }">
+          {{ formatTime(data.pageTime) }}
+        </template>
+      </Column>
+      <Column header="Node">
+        <template #body="{ data }">
+          <a
+            v-if="data.nodeId"
+            :href="`${baseHref}element/node.jsp?node=${data.nodeId}`"
+          >{{ data.nodeLabel ?? data.nodeId }}</a>
+          <span v-else>-</span>
+        </template>
+      </Column>
+      <Column header="Interface">
+        <template #body="{ data }">
+          {{ data.ipAddress ?? '-' }}
+        </template>
+      </Column>
+      <Column header="Service">
+        <template #body="{ data }">
+          {{ data.serviceType?.name ?? '-' }}
+        </template>
+      </Column>
+      <Column
+        v-if="showAckColumns"
+        header="Responder"
+      >
+        <template #body="{ data }">
+          {{ data.ackUser ?? '-' }}
+        </template>
+      </Column>
+      <Column
+        v-if="showAckColumns"
+        header="Respond Time"
+      >
+        <template #body="{ data }">
+          {{ formatTime(data.ackTime) }}
+        </template>
+      </Column>
+      <Column
+        v-if="!showAckColumns"
+        header="Actions"
+      >
+        <template #body="{ data }">
+          <Button
+            text
+            label="Acknowledge"
+            :aria-label="`Acknowledge notice ${data.id}`"
+            :data-test="`ack-button-${data.id}`"
+            :disabled="store.loading"
+            @click="store.acknowledge(data)"
+          />
+        </template>
+      </Column>
+    </DataTable>
+
+    <div v-if="!store.notices.length">
+      <EmptyList
+        :content="emptyListContent"
+        data-test="empty-list"
+      />
+    </div>
+  </TableCard>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { OnmsIconButton } from '@opennms/onms-ui'
+
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable, { DataTablePageEvent } from 'primevue/datatable'
+import Tag from 'primevue/tag'
+
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import DownloadFileIcon from '@/components/icons/action/DownloadFile.vue'
+import PrintIcon from '@/components/icons/action/Print.vue'
+import API from '@/services'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNoticesStore } from '@/stores/noticesStore'
+import { OnmsNotice } from '@/types/notices'
+
+const menuStore = useMenuStore()
+const store = useNoticesStore()
+
+// Cap for export/print fetches; the table itself stays server-paginated.
+const EXPORT_LIMIT = 1000
+
+const baseHref = computed<string>(() => menuStore.mainMenu.baseHref)
+const showAckColumns = computed<boolean>(() => store.preset === 'allAcknowledged')
+
+const emptyListContent = computed(() => ({
+  msg: store.preset === 'allAcknowledged' ? 'No acknowledged notices found.' : 'No outstanding notices found.'
+}))
+
+const severityMap: Record<string, string> = {
+  critical: 'danger',
+  major: 'danger',
+  minor: 'warn',
+  warning: 'warn',
+  normal: 'success',
+  cleared: 'success',
+  indeterminate: 'secondary'
+}
+
+const truncate = (text: string, max = 90) => {
+  return text.length > max ? `${text.slice(0, max)}…` : text
+}
+
+const formatTime = (value?: number | string | null) => {
+  if (value === null || value === undefined || value === '') {
+    return '-'
+  }
+  const date = new Date(value)
+  return isNaN(date.getTime()) ? '-' : date.toLocaleString()
+}
+
+const onPage = (event: DataTablePageEvent) => {
+  store.onPage(event.first, event.rows)
+}
+
+const fetchAllForExport = async (): Promise<OnmsNotice[]> => {
+  const result = await API.browseNotices({
+    acktype: store.preset === 'allAcknowledged' ? 'ack' : 'unack',
+    user: store.preset === 'yourOutstanding' ? store.currentUser : store.preset === 'userSearch' ? store.userFilter : null,
+    limit: EXPORT_LIMIT,
+    offset: 0
+  })
+  return result.notices
+}
+
+const exportColumns = (notice: OnmsNotice): Record<string, string> => ({
+  'ID': String(notice.id),
+  'Severity': notice.severity ?? '',
+  'Subject': notice.subject ?? '',
+  'Text Message': notice.textMessage ?? '',
+  'Sent Time': formatTime(notice.pageTime),
+  'Node': notice.nodeLabel ?? '',
+  'Interface': notice.ipAddress ?? '',
+  'Service': notice.serviceType?.name ?? '',
+  'Responder': notice.ackUser ?? '',
+  'Respond Time': formatTime(notice.ackTime)
+})
+
+const downloadCsv = async () => {
+  const notices = await fetchAllForExport()
+  if (!notices.length) {
+    return
+  }
+  const rows = notices.map(exportColumns)
+  const headers = Object.keys(rows[0])
+  const escapeCell = (value: string) => `"${value.replaceAll('"', '""')}"`
+  const csv = [
+    headers.map(escapeCell).join(','),
+    ...rows.map((row) => headers.map((h) => escapeCell(row[h] === '-' ? '' : row[h])).join(','))
+  ].join('\r\n')
+  const blob = new Blob([`﻿${csv}`], { type: 'text/csv;charset=utf-8' })
+  const link = document.createElement('a')
+  link.href = URL.createObjectURL(blob)
+  link.download = `notices-${store.preset}-${new Date().toISOString().slice(0, 19).replaceAll(':', '-')}.csv`
+  link.click()
+  URL.revokeObjectURL(link.href)
+}
+
+const printNotices = async () => {
+  const notices = await fetchAllForExport()
+  if (!notices.length) {
+    return
+  }
+  const rows = notices.map(exportColumns)
+  const headers = Object.keys(rows[0])
+  const escapeHtml = (value: string) =>
+    value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+<title>${escapeHtml(store.title)}</title>
+<style>
+  body { font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; margin: 24px; color: #222; }
+  h1 { font-size: 18px; margin: 0 0 4px 0; }
+  .meta { color: #666; font-size: 12px; margin-bottom: 16px; }
+  table { border-collapse: collapse; width: 100%; font-size: 12px; }
+  th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; vertical-align: top; }
+  th { background: #f0f0f5; }
+  @media print { body { margin: 8px; } }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(store.title)}</h1>
+<div class="meta">OpenNMS Horizon — generated ${escapeHtml(new Date().toLocaleString())} — ${rows.length} notice${rows.length === 1 ? '' : 's'}</div>
+<table>
+<thead><tr>${headers.map((h) => `<th>${escapeHtml(h)}</th>`).join('')}</tr></thead>
+<tbody>${rows.map((row) => `<tr>${headers.map((h) => `<td>${escapeHtml(row[h])}</td>`).join('')}</tr>`).join('')}</tbody>
+</table>
+</body>
+</html>`
+  const printWindow = window.open('', '_blank')
+  if (!printWindow) {
+    return
+  }
+  printWindow.document.write(html)
+  printWindow.document.close()
+  printWindow.focus()
+  printWindow.print()
+}
+</script>
+
+<style lang="scss" scoped>
+.notices-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.count {
+  color: var(--p-text-muted-color);
+  font-size: 0.9rem;
+}
+</style>

--- a/ui/src/components/AdminNotifications/NotificationExplanationsCard.vue
+++ b/ui/src/components/AdminNotifications/NotificationExplanationsCard.vue
@@ -1,0 +1,115 @@
+<template>
+  <TogglePanel
+    :collapsed="collapsed"
+    class="notification-explanations-panel"
+    data-test="explanations-panel"
+    @update:collapsed="onCollapsedChange"
+  >
+    <template #header>
+      <span class="panel-header">
+        <i class="pi pi-question-circle" aria-hidden="true" />
+        About Notices and Escalation
+      </span>
+    </template>
+    <div class="explanation-columns">
+      <div class="explanation-section">
+        <div class="section-title">Outstanding and Acknowledged Notices</div>
+        <p>
+          When important events are detected by OpenNMS, users may receive a <em>notice</em>, a
+          descriptive message sent automatically to a pager, an email address, or both. In order to
+          receive notices, the user must have their notification information configured in their
+          user profile (see your Administrator for assistance), notices must be <em>on</em>, and an
+          important event must be received.
+        </p>
+        <p>
+          From this panel, you may: <strong>Check your outstanding notices</strong>, which displays
+          all unacknowledged notices sent to your user ID; <strong>View all outstanding
+          notices</strong>, which displays all unacknowledged notices for all users; or
+          <strong>View all acknowledged notices</strong>, which provides a summary of all notices
+          sent and acknowledged for all users.
+        </p>
+        <p>
+          You may also search for notices associated with a specific user ID by entering that user
+          ID in the <strong>Check notices for user</strong> text box. And finally, you can jump
+          immediately to a page with details specific to a given notice identifier by entering that
+          numeric identifier in the <strong>Get details for notice</strong> text box. Note that
+          this is particularly useful if you are using a numeric paging service and receive the
+          numeric notice identifier as part of the page.
+        </p>
+      </div>
+      <div class="explanation-section">
+        <div class="section-title">Notification Escalation</div>
+        <p>
+          Once a notice is sent, it is considered <em>outstanding</em> until someone
+          <em>acknowledge</em>s receipt of the notice via the OpenNMS Notification interface. If
+          the event that triggered the notice was related to managed network devices or systems,
+          the <strong>Network/Systems</strong> group will be notified, one by one, with a notice
+          sent to the next member on the list only after 15 minutes has elapsed since the last
+          message was sent. This progression through the list, or <em>escalation</em>, can be
+          stopped at any time by acknowledging the notice. Note that this is <strong>not</strong>
+          the same as acknowledging the event which triggered the notice. If all members of the
+          group have been notified and the notice has not been acknowledged, the notice will be
+          escalated to the <strong>Management</strong> group, where all members of that group will
+          be notified at once with no 15 minute escalation interval.
+        </p>
+      </div>
+    </div>
+  </TogglePanel>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+
+// Starts collapsed — the "?" in the header invites first-time users to expand;
+// the notices list keeps the screen real estate by default.
+const collapsed = ref(true)
+
+const onCollapsedChange = (value: boolean) => {
+  collapsed.value = value
+}
+</script>
+
+<style lang="scss" scoped>
+// Line the +/- toggle up with the page-header gear button above it: both sit
+// on the page's right edge, but the Panel header's default right padding puts
+// the toggle ~10px left of the gear's icon center.
+.notification-explanations-panel :deep(.p-panel-header) {
+  padding-right: 0.5rem;
+}
+
+.panel-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+
+  .pi-question-circle {
+    color: var(--p-primary-color);
+  }
+}
+
+.explanation-columns {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+
+  .explanation-section {
+    flex: 1;
+    min-width: 320px;
+  }
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+</style>

--- a/ui/src/components/AdminNotifications/NotificationQueriesCard.vue
+++ b/ui/src/components/AdminNotifications/NotificationQueriesCard.vue
@@ -1,0 +1,150 @@
+<template>
+  <TableCard class="notification-queries-bar">
+    <div class="bar-content">
+      <div class="query-links">
+        <a
+          :class="{ active: store.preset === 'yourOutstanding' }"
+          data-test="query-your-outstanding"
+          @click.prevent="store.applyPreset('yourOutstanding')"
+        >Your outstanding notices</a>
+        <span class="separator">|</span>
+        <a
+          :class="{ active: store.preset === 'allOutstanding' }"
+          data-test="query-all-outstanding"
+          @click.prevent="store.applyPreset('allOutstanding')"
+        >All outstanding notices</a>
+        <span class="separator">|</span>
+        <a
+          :class="{ active: store.preset === 'allAcknowledged' }"
+          data-test="query-all-acknowledged"
+          @click.prevent="store.applyPreset('allAcknowledged')"
+        >All acknowledged notices</a>
+      </div>
+      <div class="query-forms">
+        <div class="search-row">
+          <IftaLabel>
+            <InputText
+              id="notification-user-search"
+              v-model="userSearch"
+              data-test="user-search-input"
+              @keyup.enter="searchByUser"
+            />
+            <label for="notification-user-search">Check notices for user</label>
+          </IftaLabel>
+          <Button
+            outlined
+            icon="pi pi-search"
+            aria-label="Show notices for user"
+            data-test="user-search-button"
+            @click="searchByUser"
+          />
+        </div>
+        <div class="search-row">
+          <IftaLabel>
+            <InputText
+              id="notification-notice-search"
+              v-model="noticeSearch"
+              data-test="notice-search-input"
+              @keyup.enter="goToNotice"
+            />
+            <label for="notification-notice-search">Get details for notice</label>
+          </IftaLabel>
+          <Button
+            outlined
+            icon="pi pi-search"
+            aria-label="Get notice detail"
+            data-test="notice-search-button"
+            @click="goToNotice"
+          />
+        </div>
+      </div>
+    </div>
+  </TableCard>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import Button from 'primevue/button'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+
+import TableCard from '@/components/Common/TableCard.vue'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNoticesStore } from '@/stores/noticesStore'
+
+const menuStore = useMenuStore()
+const store = useNoticesStore()
+
+const baseHref = computed<string>(() => menuStore.mainMenu.baseHref)
+
+const userSearch = ref('')
+const noticeSearch = ref('')
+
+const searchByUser = () => {
+  const user = userSearch.value.trim()
+  if (user) {
+    store.applyPreset('userSearch', user)
+  }
+}
+
+const goToNotice = () => {
+  const notice = noticeSearch.value.trim()
+  if (notice) {
+    window.location.href = `${baseHref.value}notification/detail.jsp?notice=${encodeURIComponent(notice)}`
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.notification-queries-bar {
+  padding: 12px 25px;
+}
+
+.bar-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.query-links {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+
+  .separator {
+    color: var(--p-text-muted-color);
+  }
+
+  a {
+    color: var(--p-primary-color);
+    cursor: pointer;
+    white-space: nowrap;
+
+    &.active {
+      font-weight: 700;
+      text-decoration: underline;
+    }
+  }
+}
+
+.query-forms {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+
+  .search-row {
+    display: flex;
+    align-items: stretch;
+    gap: 0.4rem;
+
+    :deep(input) {
+      min-width: 190px;
+    }
+  }
+}
+</style>

--- a/ui/src/components/AdminNotifications/PathOutagesTab.vue
+++ b/ui/src/components/AdminNotifications/PathOutagesTab.vue
@@ -1,0 +1,374 @@
+<template>
+  <div class="path-outages-tab">
+    <p class="intro">
+      Define a critical path for a group of nodes so node-down notifications are suppressed when
+      the critical path is unreachable. The rule selects the nodes; leaving the IP address blank
+      clears the critical path for the matching nodes.
+    </p>
+
+    <TogglePanel
+      :collapsed="helpCollapsed"
+      class="help-panel"
+      data-test="path-outages-help"
+      @update:collapsed="(value: boolean) => (helpCollapsed = value)"
+    >
+      <template #header>
+        <span class="help-header">
+          <i class="pi pi-question-circle" aria-hidden="true" />
+          About Critical Paths and Filter Rules
+        </span>
+      </template>
+      <div class="help-content">
+        <div class="help-section">
+          <div class="section-title">Critical Path IP Address</div>
+          <p>
+            Enter the critical path IP address in xxx.xxx.xxx.xxx or
+            xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx format. Or leave it blank to clear previously
+            set paths for the nodes matching the rule. The critical path service is typically ICMP,
+            and at this time ICMP is the only critical path service supported.
+          </p>
+        </div>
+        <div class="help-section">
+          <div class="section-title">Node Filter Rule</div>
+          <p>
+            Filtering on TCP/IP address uses a very flexible format, allowing you to separate the
+            four octets (fields) of a TCP/IP address into specific searches. An asterisk (*) in
+            place of any octet matches any value for that octet. Ranges are indicated by two
+            numbers separated by a dash (-), and commas are used for list demarcation.
+          </p>
+          <p>The following examples are all valid and yield the set of addresses from 192.168.0.0 through 192.168.3.255:</p>
+          <ul>
+            <li><code>192.168.0-3.*</code></li>
+            <li><code>192.168.0-3.0-255</code></li>
+            <li><code>192.168.0,1,2,3.*</code></li>
+          </ul>
+          <p>
+            To use a rule based on TCP/IP addresses as described above, enter
+            <code>IPADDR IPLIKE *.*.*.*</code> substituting your desired address fields for
+            <code>*.*.*.*</code>. Otherwise, you may enter any valid rule.
+          </p>
+        </div>
+      </div>
+    </TogglePanel>
+
+    <div class="form-row">
+      <FormField>
+        <IftaLabel>
+          <InputText
+            id="path-outage-ip"
+            v-model="criticalIp"
+            data-test="critical-ip-input"
+          />
+          <label for="path-outage-ip">Critical Path IP Address</label>
+        </IftaLabel>
+      </FormField>
+      <FormField>
+        <IftaLabel>
+          <Select
+            v-model="criticalSvc"
+            labelId="path-outage-service"
+            :options="serviceOptions"
+            data-test="critical-service-select"
+          />
+          <label for="path-outage-service">Critical Path Service</label>
+        </IftaLabel>
+      </FormField>
+      <FormField class="rule-field">
+        <IftaLabel>
+          <InputText
+            id="path-outage-rule"
+            v-model="rule"
+            data-test="rule-input"
+          />
+          <label for="path-outage-rule">Node Filter Rule</label>
+        </IftaLabel>
+      </FormField>
+      <Button
+        outlined
+        label="Preview Matching Nodes"
+        data-test="preview-button"
+        :disabled="!rule.trim()"
+        @click="preview"
+      />
+      <Button
+        :label="criticalIp.trim() ? 'Apply Critical Path' : 'Clear Critical Path'"
+        :severity="criticalIp.trim() ? undefined : 'danger'"
+        data-test="apply-button"
+        :disabled="!rule.trim()"
+        @click="askApply"
+      />
+    </div>
+
+    <div
+      v-if="previewResult"
+      class="preview-result"
+      data-test="preview-result"
+    >
+      <strong>{{ previewResult.totalCount }}</strong> node{{ previewResult.totalCount === 1 ? '' : 's' }} match the rule<span v-if="previewResult.totalCount > previewResult.nodes.length"> (showing first {{ previewResult.nodes.length }})</span>:
+      <div class="node-chips">
+        <Chip
+          v-for="node in previewResult.nodes"
+          :key="node.nodeId"
+          :label="`${node.nodeLabel ?? node.nodeId}`"
+        />
+      </div>
+    </div>
+
+    <div class="current-paths">
+      <div class="section-title">Current Critical Paths</div>
+      <DataTable
+        v-if="store.pathOutages.length"
+        :value="store.pathOutages"
+        dataKey="nodeId"
+        paginator
+        :rows="10"
+        :rowsPerPageOptions="[10, 20, 50]"
+        class="data-table"
+        data-test="path-outages-table"
+      >
+        <Column
+          field="nodeLabel"
+          header="Node"
+          sortable
+        >
+          <template #body="{ data }">
+            {{ data.nodeLabel ?? data.nodeId }}
+          </template>
+        </Column>
+        <Column
+          field="criticalPathIp"
+          header="Critical Path IP"
+          sortable
+        />
+        <Column
+          field="criticalPathServiceName"
+          header="Service"
+        />
+        <Column header="Actions">
+          <template #body="{ data }">
+            <Button
+              text
+              label="Remove"
+              severity="danger"
+              :aria-label="`Remove critical path for ${data.nodeLabel ?? data.nodeId}`"
+              data-test="remove-path-outage-button"
+              @click="askRemove(data)"
+            />
+          </template>
+        </Column>
+      </DataTable>
+      <div v-if="!store.pathOutages.length">
+        <EmptyList
+          :content="emptyListContent"
+          data-test="empty-list"
+        />
+      </div>
+    </div>
+  </div>
+
+  <OnmsConfirmationDialog
+    :visible="showApplyConfirmation"
+    :title="criticalIp.trim() ? 'Apply Critical Path' : 'Clear Critical Path'"
+    :actionButtonText="criticalIp.trim() ? 'Apply' : 'Clear'"
+    @ok="confirmApply"
+    @cancel="showApplyConfirmation = false"
+  >
+    <template #content>
+      <p v-if="criticalIp.trim()">
+        Set the critical path to <strong>{{ criticalIp }}</strong> ({{ criticalSvc }}) for the
+        <strong>{{ applyCount ?? '?' }}</strong> node{{ applyCount === 1 ? '' : 's' }} matching
+        <code>{{ rule }}</code>?
+      </p>
+      <p v-else>
+        Clear the critical path for the <strong>{{ applyCount ?? '?' }}</strong>
+        node{{ applyCount === 1 ? '' : 's' }} matching <code>{{ rule }}</code>?
+      </p>
+    </template>
+  </OnmsConfirmationDialog>
+  <OnmsConfirmationDialog
+    :visible="showRemoveConfirmation"
+    title="Remove Critical Path"
+    actionButtonText="Remove"
+    @ok="confirmRemove"
+    @cancel="cancelRemove"
+  >
+    <template #content>
+      <p>Remove the critical path for <strong>{{ outageToRemove?.nodeLabel ?? outageToRemove?.nodeId }}</strong>?</p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { OnmsConfirmationDialog } from '@opennms/onms-ui'
+
+import Button from 'primevue/button'
+import Chip from 'primevue/chip'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
+
+import EmptyList from '@/components/Common/EmptyList.vue'
+import FormField from '@/components/Common/FormField.vue'
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { PathOutage, PathOutagePreview } from '@/types/notificationConfig'
+
+const store = useNotificationConfigStore()
+
+// ICMP is the only supported critical path service (matches the legacy wizard).
+const serviceOptions = ['ICMP']
+
+const helpCollapsed = ref(true)
+const criticalIp = ref('')
+const criticalSvc = ref('ICMP')
+const rule = ref('IPADDR IPLIKE *.*.*.*')
+const previewResult = ref<PathOutagePreview | null>(null)
+
+const showApplyConfirmation = ref(false)
+const applyCount = ref<number | null>(null)
+const showRemoveConfirmation = ref(false)
+const outageToRemove = ref<PathOutage | null>(null)
+
+const emptyListContent = {
+  msg: 'No critical paths configured.'
+}
+
+const preview = async () => {
+  previewResult.value = await store.previewPathOutageRule(rule.value.trim())
+}
+
+const askApply = async () => {
+  const result = await store.previewPathOutageRule(rule.value.trim())
+  if (!result) {
+    return
+  }
+  previewResult.value = result
+  applyCount.value = result.totalCount
+  showApplyConfirmation.value = true
+}
+
+const confirmApply = async () => {
+  showApplyConfirmation.value = false
+  const ok = await store.applyPathOutage({
+    rule: rule.value.trim(),
+    criticalIp: criticalIp.value.trim() || undefined,
+    criticalSvc: criticalSvc.value
+  })
+  if (ok) {
+    previewResult.value = null
+  }
+}
+
+const askRemove = (outage: PathOutage) => {
+  outageToRemove.value = outage
+  showRemoveConfirmation.value = true
+}
+
+const confirmRemove = async () => {
+  if (outageToRemove.value) {
+    await store.deletePathOutage(outageToRemove.value.nodeId)
+  }
+  showRemoveConfirmation.value = false
+  outageToRemove.value = null
+}
+
+const cancelRemove = () => {
+  showRemoveConfirmation.value = false
+  outageToRemove.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.path-outages-tab {
+  padding: 1rem 0;
+}
+
+.intro {
+  margin: 0 0 1rem 0;
+  max-width: 80ch;
+  color: var(--p-text-muted-color);
+}
+
+.help-panel {
+  margin-bottom: 1rem;
+}
+
+.help-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+
+  .pi-question-circle {
+    color: var(--p-primary-color);
+  }
+}
+
+.help-content {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+
+  .help-section {
+    flex: 1;
+    min-width: 300px;
+  }
+
+  .section-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  p,
+  ul {
+    margin: 0 0 0.75rem 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+}
+
+.form-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+
+  :deep(.p-select) {
+    min-width: 200px;
+  }
+
+  .rule-field {
+    flex: 1;
+    min-width: 240px;
+
+    :deep(input) {
+      width: 100%;
+    }
+  }
+}
+
+.preview-result {
+  margin-top: 1rem;
+
+  .node-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+  }
+}
+
+.current-paths {
+  margin-top: 1.5rem;
+
+  .section-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+}
+</style>

--- a/ui/src/composables/useBrowserNotifications.ts
+++ b/ui/src/composables/useBrowserNotifications.ts
@@ -1,0 +1,93 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+
+// Consumes the notifd 'browser' notification method for the Vue app: the
+// BrowserNotificationStrategy publishes {id, head, body} messages per user on
+// the /notification/stream WebSocket. Legacy JSP pages have their own consumer
+// (core/web-assets notifications app); this one covers all /ui pages. Desktop
+// notifications are used when the user has granted permission, with an
+// in-page snackbar as the fallback so the message is never silently dropped.
+
+interface BrowserNotificationMessage {
+  id?: string | string[]
+  head?: string | string[]
+  body?: string | string[]
+}
+
+const { showSnackBar } = useSnackbar()
+
+let socket: WebSocket | null = null
+let started = false
+
+// the stream serializes each field as a single-element array
+const unwrap = (value?: string | string[]): string | undefined => {
+  if (Array.isArray(value)) {
+    return value.length ? String(value[0]) : undefined
+  }
+  return value ?? undefined
+}
+
+const display = (message: BrowserNotificationMessage) => {
+  const head = unwrap(message.head) ?? 'OpenNMS Notification'
+  const body = unwrap(message.body)
+  if ('Notification' in window && Notification.permission === 'granted') {
+    new Notification(head, {
+      body: body ?? '',
+      tag: `opennms:notification:${unwrap(message.id) ?? head}`
+    })
+  } else {
+    showSnackBar({ msg: body ? `${head} — ${body}` : head, timeout: 8000 })
+  }
+}
+
+const connect = (baseHref: string) => {
+  socket = new WebSocket(`${baseHref}notification/stream`.replace(/^http/, 'ws'))
+
+  socket.onmessage = (event: MessageEvent) => {
+    try {
+      display(JSON.parse(event.data))
+    } catch {
+      // not a notification payload; ignore
+    }
+  }
+
+  socket.onclose = () => {
+    socket = null
+    setTimeout(() => connect(baseHref), 5000)
+  }
+}
+
+const startBrowserNotifications = (baseHref: string) => {
+  if (started || !baseHref) {
+    return
+  }
+  started = true
+  if ('Notification' in window && Notification.permission === 'default') {
+    // fire-and-forget; the snackbar fallback covers an undecided/denied state
+    Notification.requestPermission().catch(() => undefined)
+  }
+  connect(baseHref)
+}
+
+export default startBrowserNotifications

--- a/ui/src/containers/AdminNotifications.vue
+++ b/ui/src/containers/AdminNotifications.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+  <div class="notifications-container">
+    <div class="page-header">
+      <h1 class="page-title">Notifications</h1>
+      <OnmsIconButton
+        v-if="adminRole"
+        text
+        rounded
+        :icon="SettingsIcon"
+        title="Configure Notifications"
+        aria-label="Configure Notifications"
+        data-test="configure-notifications-button"
+        @click="showConfigDialog = true"
+      />
+    </div>
+
+    <NotificationExplanationsCard />
+    <NotificationQueriesCard />
+    <NoticesTable />
+
+    <ConfigureNotificationsDialog
+      v-if="adminRole"
+      v-model:visible="showConfigDialog"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+import { OnmsIconButton } from '@opennms/onms-ui'
+
+import { whenever } from '@vueuse/core'
+
+import ConfigureNotificationsDialog from '@/components/AdminNotifications/ConfigureNotificationsDialog.vue'
+import NoticesTable from '@/components/AdminNotifications/NoticesTable.vue'
+import NotificationExplanationsCard from '@/components/AdminNotifications/NotificationExplanationsCard.vue'
+import NotificationQueriesCard from '@/components/AdminNotifications/NotificationQueriesCard.vue'
+import SettingsIcon from '@/components/icons/action/Settings.vue'
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import useRole from '@/composables/useRole'
+import { useAuthStore } from '@/stores/authStore'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNoticesStore } from '@/stores/noticesStore'
+import { BreadCrumb } from '@/types'
+
+const authStore = useAuthStore()
+const menuStore = useMenuStore()
+const noticesStore = useNoticesStore()
+const { adminRole } = useRole()
+
+const showConfigDialog = ref(false)
+
+const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
+
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Notifications', to: '#', position: 'last' }
+  ]
+})
+
+// The default preset filters by the logged-in user; whoAmI is fetched
+// fire-and-forget at app startup, so wait for it or the first query would
+// silently drop the user filter and show every user's notices.
+const authLoaded = computed<boolean>(() => authStore.loaded)
+
+onMounted(() => {
+  if (authLoaded.value) {
+    noticesStore.load()
+  } else {
+    whenever(authLoaded, () => noticesStore.load(), { once: true })
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.notifications-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 2px 2rem 2px;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .page-title {
+    font-size: 1.4rem;
+    font-weight: 600;
+    margin: 0;
+  }
+}
+
+</style>

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -26,9 +26,11 @@
   setup
   lang="ts"
 >
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
+import { whenever } from '@vueuse/core'
 
 import { OnmsToastHost } from '@opennms/onms-ui'
+import startBrowserNotifications from '@/composables/useBrowserNotifications'
 import OnmsAppLayout from '@/components/Layout/OnmsAppLayout.vue'
 import Footer from '@/components/Layout/Footer.vue'
 import Menubar from '@/components/Menu/Menubar.vue'
@@ -47,6 +49,10 @@ const menuStore = useMenuStore()
 const monitoringSystemStore = useMonitoringSystemStore()
 const nodeStructureStore = useNodeStructureStore()
 const pluginStore = usePluginStore()
+
+// notifd 'browser' method delivery for /ui pages; needs baseHref from the menu
+const baseHref = computed<string>(() => menuStore.mainMenu?.baseHref ?? '')
+whenever(() => !!baseHref.value, () => startBrowserNotifications(baseHref.value), { once: true })
 
 onMounted(() => {
   authStore.getWhoAmI()

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -159,6 +159,11 @@ const router = createRouter({
       }
     },
     {
+      path: '/admin/notifications',
+      name: 'Notifications',
+      component: () => import('@/containers/AdminNotifications.vue')
+    },
+    {
       path: '/map',
       name: 'Map',
       component: () => import('@/containers/Map.vue'),

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -75,8 +75,12 @@ import {
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
 import {
+  applyPathOutage,
+  deletePathOutage,
   getDestinationPaths,
   getNotificationConfigStatus,
+  getPathOutages,
+  previewPathOutageRule,
   setNotificationConfigStatus
 } from './notificationConfigService'
 import { acknowledgeNotice, browseNotices } from './noticesService'
@@ -143,7 +147,11 @@ export default {
   getZenithRegistrations,
   performLogout,
   acknowledgeNotice,
+  applyPathOutage,
   browseNotices,
+  deletePathOutage,
+  getPathOutages,
+  previewPathOutageRule,
   getDestinationPaths,
   getNotificationConfigStatus,
   setNotificationConfigStatus

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -74,6 +74,12 @@ import {
   setUsageStatisticsStatus
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
+import {
+  getDestinationPaths,
+  getNotificationConfigStatus,
+  setNotificationConfigStatus
+} from './notificationConfigService'
+import { acknowledgeNotice, browseNotices } from './noticesService'
 
 export default {
   search,
@@ -135,5 +141,10 @@ export default {
   setUsageStatisticsStatus,
   addZenithRegistration,
   getZenithRegistrations,
-  performLogout
+  performLogout,
+  acknowledgeNotice,
+  browseNotices,
+  getDestinationPaths,
+  getNotificationConfigStatus,
+  setNotificationConfigStatus
 }

--- a/ui/src/services/noticesService.ts
+++ b/ui/src/services/noticesService.ts
@@ -1,0 +1,87 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+import useSpinner from '@/composables/useSpinner'
+import { NoticeAckType, NoticeBrowseResult, OnmsNotice } from '@/types/notices'
+import { rest } from './axiosInstances'
+
+const { showSnackBar } = useSnackbar()
+const { startSpinner, stopSpinner } = useSpinner()
+const endpoint = '/notifications'
+
+interface BrowseNoticesParams {
+  acktype: NoticeAckType
+  user?: string | null
+  limit: number
+  offset: number
+}
+
+const browseNotices = async (params: BrowseNoticesParams): Promise<NoticeBrowseResult> => {
+  try {
+    startSpinner()
+    const query = new URLSearchParams()
+    query.set('limit', String(params.limit))
+    query.set('offset', String(params.offset))
+    query.set('orderBy', 'pageTime')
+    query.set('order', 'desc')
+    if (params.acktype === 'unack') {
+      query.set('answeredBy', 'null')
+    } else if (params.acktype === 'ack') {
+      query.set('answeredBy', 'notnull')
+    }
+    if (params.user) {
+      query.set('usersNotified.userId', params.user)
+    }
+    const resp = await rest.get(`${endpoint}?${query.toString()}`)
+    // 204 No Content when nothing matches
+    if (!resp.data || typeof resp.data !== 'object') {
+      return { notices: [], totalCount: 0 }
+    }
+    const raw = resp.data.notification ?? []
+    const notices: OnmsNotice[] = Array.isArray(raw) ? raw : [raw]
+    return { notices, totalCount: Number(resp.data.totalCount ?? notices.length) }
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load notices.' })
+    return { notices: [], totalCount: 0 }
+  } finally {
+    stopSpinner()
+  }
+}
+
+const acknowledgeNotice = async (noticeId: number, ack: boolean): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.put(`${endpoint}/${noticeId}`, new URLSearchParams({ ack: String(ack) }), {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    })
+    showSnackBar({ msg: `Notice ${noticeId} ${ack ? 'acknowledged' : 'unacknowledged'}.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to ${ack ? 'acknowledge' : 'unacknowledge'} notice ${noticeId}.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+export { acknowledgeNotice, browseNotices }

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -22,7 +22,7 @@
 
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
-import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { DestinationPath, NotifdStatus, PathOutage, PathOutagePreview, PathOutageRequest } from '@/types/notificationConfig'
 import { rest } from './axiosInstances'
 
 const { showSnackBar } = useSnackbar()
@@ -69,9 +69,69 @@ const getDestinationPaths = async (): Promise<DestinationPath[]> => {
   }
 }
 
+const getPathOutages = async (): Promise<PathOutage[]> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/path-outages`)
+    return resp.data ?? []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load path outages.' })
+    return []
+  } finally {
+    stopSpinner()
+  }
+}
+
+const previewPathOutageRule = async (rule: string): Promise<PathOutagePreview | null> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/path-outages/preview?rule=${encodeURIComponent(rule)}`)
+    return resp.data ?? null
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : 'Failed to validate the filter rule.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+const applyPathOutage = async (request: PathOutageRequest): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.post(`${endpoint}/path-outages`, request)
+    showSnackBar({ msg: request.criticalIp ? 'Critical path applied.' : 'Critical path cleared.' })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : 'Failed to apply the critical path.' })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const deletePathOutage = async (nodeId: number): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.delete(`${endpoint}/path-outages/${nodeId}`)
+    showSnackBar({ msg: 'Critical path removed.' })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to remove the critical path.' })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
 
 export {
+  applyPathOutage,
+  deletePathOutage,
   getDestinationPaths,
   getNotificationConfigStatus,
+  getPathOutages,
+  previewPathOutageRule,
   setNotificationConfigStatus
 }

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -1,0 +1,77 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+import useSpinner from '@/composables/useSpinner'
+import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { rest } from './axiosInstances'
+
+const { showSnackBar } = useSnackbar()
+const { startSpinner, stopSpinner } = useSpinner()
+const endpoint = '/notification-config'
+
+const getNotificationConfigStatus = async (): Promise<NotifdStatus | null> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/status`)
+    return resp.data?.status ?? null
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load notification status.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.put(`${endpoint}/status`, { status })
+    showSnackBar({ msg: `Notifications turned ${status}.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to update notification status.' })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const getDestinationPaths = async (): Promise<DestinationPath[]> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/destination-paths`)
+    return resp.data?.path ?? []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load destination paths.' })
+    return []
+  } finally {
+    stopSpinner()
+  }
+}
+
+
+export {
+  getDestinationPaths,
+  getNotificationConfigStatus,
+  setNotificationConfigStatus
+}

--- a/ui/src/stores/noticesStore.ts
+++ b/ui/src/stores/noticesStore.ts
@@ -1,0 +1,120 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import API from '@/services'
+import { useAuthStore } from '@/stores/authStore'
+import { NoticeQueryPreset, OnmsNotice } from '@/types/notices'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export const useNoticesStore = defineStore('noticesStore', () => {
+  const authStore = useAuthStore()
+
+  const preset = ref<NoticeQueryPreset>('yourOutstanding')
+  const userFilter = ref<string | null>(null)
+  const notices = ref([] as OnmsNotice[])
+  const totalCount = ref(0)
+  const rows = ref(10)
+  const first = ref(0)
+  const loading = ref(false)
+
+  const currentUser = computed<string>(() => authStore.whoAmI.id)
+
+  const acktype = computed<'unack' | 'ack'>(() => (preset.value === 'allAcknowledged' ? 'ack' : 'unack'))
+
+  const effectiveUser = computed<string | null>(() => {
+    if (preset.value === 'yourOutstanding') {
+      return currentUser.value || null
+    }
+    if (preset.value === 'userSearch') {
+      return userFilter.value
+    }
+    return null
+  })
+
+  const title = computed<string>(() => {
+    switch (preset.value) {
+      case 'yourOutstanding':
+        return 'Your Outstanding Notices'
+      case 'allOutstanding':
+        return 'All Outstanding Notices'
+      case 'allAcknowledged':
+        return 'All Acknowledged Notices'
+      case 'userSearch':
+        return `Outstanding Notices for '${userFilter.value}'`
+    }
+    return 'Notices'
+  })
+
+  const load = async () => {
+    loading.value = true
+    try {
+      const result = await API.browseNotices({
+        acktype: acktype.value,
+        user: effectiveUser.value,
+        limit: rows.value,
+        offset: first.value
+      })
+      notices.value = result.notices
+      totalCount.value = result.totalCount
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const applyPreset = async (newPreset: NoticeQueryPreset, user?: string) => {
+    preset.value = newPreset
+    userFilter.value = newPreset === 'userSearch' ? (user ?? null) : null
+    first.value = 0
+    await load()
+  }
+
+  const onPage = async (newFirst: number, newRows: number) => {
+    first.value = newFirst
+    rows.value = newRows
+    await load()
+  }
+
+  const acknowledge = async (notice: OnmsNotice) => {
+    const ok = await API.acknowledgeNotice(notice.id, true)
+    if (ok) {
+      await load()
+    }
+    return ok
+  }
+
+  return {
+    preset,
+    userFilter,
+    notices,
+    totalCount,
+    rows,
+    first,
+    loading,
+    currentUser,
+    title,
+    load,
+    applyPreset,
+    onPage,
+    acknowledge
+  }
+})

--- a/ui/src/stores/notificationConfigStore.ts
+++ b/ui/src/stores/notificationConfigStore.ts
@@ -21,13 +21,14 @@
 ///
 
 import API from '@/services'
-import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { DestinationPath, NotifdStatus, PathOutage, PathOutagePreview, PathOutageRequest } from '@/types/notificationConfig'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useNotificationConfigStore = defineStore('notificationConfigStore', () => {
   const notifdStatus = ref<NotifdStatus | null>(null)
   const destinationPaths = ref([] as DestinationPath[])
+  const pathOutages = ref([] as PathOutage[])
 
   const getStatus = async () => {
     notifdStatus.value = await API.getNotificationConfigStatus()
@@ -45,8 +46,32 @@ export const useNotificationConfigStore = defineStore('notificationConfigStore',
     destinationPaths.value = await API.getDestinationPaths()
   }
 
+  const getPathOutages = async () => {
+    pathOutages.value = await API.getPathOutages()
+  }
+
+  const previewPathOutageRule = async (rule: string): Promise<PathOutagePreview | null> => {
+    return await API.previewPathOutageRule(rule)
+  }
+
+  const applyPathOutage = async (request: PathOutageRequest) => {
+    const ok = await API.applyPathOutage(request)
+    if (ok) {
+      await getPathOutages()
+    }
+    return ok
+  }
+
+  const deletePathOutage = async (nodeId: number) => {
+    const ok = await API.deletePathOutage(nodeId)
+    if (ok) {
+      await getPathOutages()
+    }
+    return ok
+  }
+
   const populate = async () => {
-    await Promise.all([getStatus(), getDestinationPaths()])
+    await Promise.all([getStatus(), getDestinationPaths(), getPathOutages()])
   }
 
   return {
@@ -55,6 +80,11 @@ export const useNotificationConfigStore = defineStore('notificationConfigStore',
     getStatus,
     setStatus,
     getDestinationPaths,
+    pathOutages,
+    getPathOutages,
+    previewPathOutageRule,
+    applyPathOutage,
+    deletePathOutage,
     populate
   }
 })

--- a/ui/src/stores/notificationConfigStore.ts
+++ b/ui/src/stores/notificationConfigStore.ts
@@ -1,0 +1,60 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import API from '@/services'
+import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useNotificationConfigStore = defineStore('notificationConfigStore', () => {
+  const notifdStatus = ref<NotifdStatus | null>(null)
+  const destinationPaths = ref([] as DestinationPath[])
+
+  const getStatus = async () => {
+    notifdStatus.value = await API.getNotificationConfigStatus()
+  }
+
+  const setStatus = async (status: NotifdStatus) => {
+    const ok = await API.setNotificationConfigStatus(status)
+    if (ok) {
+      notifdStatus.value = status
+    }
+    return ok
+  }
+
+  const getDestinationPaths = async () => {
+    destinationPaths.value = await API.getDestinationPaths()
+  }
+
+  const populate = async () => {
+    await Promise.all([getStatus(), getDestinationPaths()])
+  }
+
+  return {
+    notifdStatus,
+    destinationPaths,
+    getStatus,
+    setStatus,
+    getDestinationPaths,
+    populate
+  }
+})

--- a/ui/src/types/notices.ts
+++ b/ui/src/types/notices.ts
@@ -1,0 +1,72 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Notices (sent notifications) served by /rest/notifications — DB-backed,
+// distinct from the notification *configuration* in types/notificationConfig.ts.
+// Field names follow the wire format of the v1 REST serializer, which differs
+// from the entity/DB names (id, textMessage, ackUser/ackTime, destinations).
+
+export type NoticeAckType = 'unack' | 'ack' | 'all'
+
+export type NoticeQueryPreset = 'yourOutstanding' | 'allOutstanding' | 'allAcknowledged' | 'userSearch'
+
+export interface OnmsNoticeServiceType {
+  id?: number
+  name?: string
+}
+
+export interface OnmsNoticeDestination {
+  id?: number
+  userId?: string
+  media?: string | null
+  contactInfo?: string | null
+  notifyTime?: number | string | null
+  autoNotify?: string | null
+}
+
+export interface OnmsNotice {
+  id: number
+  subject?: string | null
+  textMessage?: string | null
+  uei?: string | null
+  severity?: string | null
+  pageTime?: number | string | null
+  ackTime?: number | string | null
+  ackUser?: string | null
+  eventId?: number | null
+  nodeId?: number | null
+  nodeLabel?: string | null
+  ipAddress?: string | null
+  serviceType?: OnmsNoticeServiceType | null
+  queueId?: string | null
+  destinations?: OnmsNoticeDestination[]
+}
+
+export interface NoticeBrowseFilter {
+  acktype: NoticeAckType
+  user: string | null
+}
+
+export interface NoticeBrowseResult {
+  notices: OnmsNotice[]
+  totalCount: number
+}

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -46,3 +46,23 @@ export interface DestinationPath {
   escalate?: DestinationPathEscalate[]
 }
 
+// Path outages (critical paths) — DB-backed (pathoutage table), unlike the
+// XML-backed config above. Wire shapes of /rest/notification-config/path-outages.
+export interface PathOutage {
+  nodeId: number
+  nodeLabel?: string | null
+  criticalPathIp?: string | null
+  criticalPathServiceName?: string | null
+}
+
+export interface PathOutagePreview {
+  totalCount: number
+  nodes: PathOutage[]
+}
+
+export interface PathOutageRequest {
+  rule: string
+  criticalIp?: string
+  criticalSvc?: string
+}
+

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -1,0 +1,48 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// JSON mirrors of the JAXB config models behind /rest/notification-config.
+// Field names follow the XML element/attribute names in notifications.xml,
+// destinationPaths.xml and notificationCommands.xml — the files stay the
+// system of record, this API is a 1:1 view of them.
+
+export type NotifdStatus = 'on' | 'off'
+
+export interface DestinationPathTarget {
+  interval?: string
+  name: string
+  autoNotify?: string
+  command: string[]
+}
+
+export interface DestinationPathEscalate {
+  delay: string
+  target: DestinationPathTarget[]
+}
+
+export interface DestinationPath {
+  name: string
+  'initial-delay'?: string
+  target: DestinationPathTarget[]
+  escalate?: DestinationPathEscalate[]
+}
+

--- a/ui/tests/stores/noticesStore.test.ts
+++ b/ui/tests/stores/noticesStore.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useNoticesStore } from '@/stores/noticesStore'
+import { useAuthStore } from '@/stores/authStore'
+import API from '@/services'
+import { OnmsNotice } from '@/types/notices'
+
+vi.mock('@/services', () => ({
+  default: {
+    browseNotices: vi.fn(),
+    acknowledgeNotice: vi.fn()
+  }
+}))
+
+describe('useNoticesStore', () => {
+  let store: ReturnType<typeof useNoticesStore>
+
+  const mockNotices: OnmsNotice[] = [
+    {
+      id: 1,
+      subject: 'Notice #1: node down',
+      severity: 'MAJOR',
+      pageTime: 1785327487410,
+      nodeId: 16,
+      nodeLabel: 'Core-Router-01'
+    },
+    {
+      id: 2,
+      subject: 'Notice #2: interface down',
+      severity: 'MAJOR',
+      pageTime: 1785327487000,
+      ipAddress: '10.0.0.5'
+    }
+  ]
+
+  const mockResult = { notices: mockNotices, totalCount: 5 }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    const authStore = useAuthStore()
+    authStore.whoAmI = { id: 'admin', fullName: 'Administrator', internal: true, roles: ['ROLE_ADMIN'] }
+    store = useNoticesStore()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('should default to the current user outstanding notices', () => {
+      expect(store.preset).toBe('yourOutstanding')
+      expect(store.notices).toEqual([])
+      expect(store.totalCount).toBe(0)
+      expect(store.first).toBe(0)
+      expect(store.rows).toBe(10)
+      expect(store.title).toBe('Your Outstanding Notices')
+    })
+  })
+
+  describe('load', () => {
+    it('should query outstanding notices for the current user', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.load()
+
+      expect(API.browseNotices).toHaveBeenCalledWith({
+        acktype: 'unack',
+        user: 'admin',
+        limit: 10,
+        offset: 0
+      })
+      expect(store.notices).toEqual(mockNotices)
+      expect(store.totalCount).toBe(5)
+    })
+  })
+
+  describe('applyPreset', () => {
+    it('allOutstanding should drop the user filter and reset paging', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+      store.first = 30
+
+      await store.applyPreset('allOutstanding')
+
+      expect(store.preset).toBe('allOutstanding')
+      expect(store.first).toBe(0)
+      expect(API.browseNotices).toHaveBeenCalledWith({
+        acktype: 'unack',
+        user: null,
+        limit: 10,
+        offset: 0
+      })
+      expect(store.title).toBe('All Outstanding Notices')
+    })
+
+    it('allAcknowledged should query acknowledged notices', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.applyPreset('allAcknowledged')
+
+      expect(API.browseNotices).toHaveBeenCalledWith(
+        expect.objectContaining({ acktype: 'ack', user: null })
+      )
+      expect(store.title).toBe('All Acknowledged Notices')
+    })
+
+    it('userSearch should filter outstanding notices by the given user', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.applyPreset('userSearch', 'operator')
+
+      expect(store.userFilter).toBe('operator')
+      expect(API.browseNotices).toHaveBeenCalledWith(
+        expect.objectContaining({ acktype: 'unack', user: 'operator' })
+      )
+      expect(store.title).toBe("Outstanding Notices for 'operator'")
+    })
+  })
+
+  describe('onPage', () => {
+    it('should reload with the new offset and page size', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.onPage(20, 20)
+
+      expect(store.first).toBe(20)
+      expect(store.rows).toBe(20)
+      expect(API.browseNotices).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 20, offset: 20 })
+      )
+    })
+  })
+
+  describe('acknowledge', () => {
+    it('should acknowledge and reload on success', async () => {
+      vi.mocked(API.acknowledgeNotice).mockResolvedValue(true)
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      const ok = await store.acknowledge(mockNotices[0])
+
+      expect(ok).toBe(true)
+      expect(API.acknowledgeNotice).toHaveBeenCalledWith(1, true)
+      expect(API.browseNotices).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not reload when acknowledging fails', async () => {
+      vi.mocked(API.acknowledgeNotice).mockResolvedValue(false)
+
+      const ok = await store.acknowledge(mockNotices[0])
+
+      expect(ok).toBe(false)
+      expect(API.browseNotices).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/ui/tests/stores/notificationConfigStore.test.ts
+++ b/ui/tests/stores/notificationConfigStore.test.ts
@@ -2,13 +2,17 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import API from '@/services'
-import { DestinationPath } from '@/types/notificationConfig'
+import { DestinationPath, PathOutage } from '@/types/notificationConfig'
 
 vi.mock('@/services', () => ({
   default: {
     getNotificationConfigStatus: vi.fn(),
     setNotificationConfigStatus: vi.fn(),
-    getDestinationPaths: vi.fn()
+    getDestinationPaths: vi.fn(),
+    getPathOutages: vi.fn(),
+    previewPathOutageRule: vi.fn(),
+    applyPathOutage: vi.fn(),
+    deletePathOutage: vi.fn()
   }
 }))
 
@@ -20,6 +24,10 @@ describe('useNotificationConfigStore', () => {
     'initial-delay': '0s',
     target: [{ name: 'Admin', command: ['javaEmail'] }]
   }
+
+  const mockPathOutages: PathOutage[] = [
+    { nodeId: 1, nodeLabel: 'localhost', criticalPathIp: '192.168.1.1', criticalPathServiceName: 'ICMP' }
+  ]
 
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -35,6 +43,7 @@ describe('useNotificationConfigStore', () => {
     it('should start empty with unknown notifd status', () => {
       expect(store.notifdStatus).toBeNull()
       expect(store.destinationPaths).toEqual([])
+      expect(store.pathOutages).toEqual([])
     })
   })
 
@@ -67,15 +76,55 @@ describe('useNotificationConfigStore', () => {
     })
   })
 
+  describe('path outages', () => {
+    it('should load path outages', async () => {
+      vi.mocked(API.getPathOutages).mockResolvedValue(mockPathOutages)
+
+      await store.getPathOutages()
+
+      expect(store.pathOutages).toEqual(mockPathOutages)
+    })
+
+    it('should refresh after apply and delete', async () => {
+      vi.mocked(API.applyPathOutage).mockResolvedValue(true)
+      vi.mocked(API.deletePathOutage).mockResolvedValue(true)
+      vi.mocked(API.getPathOutages).mockResolvedValue(mockPathOutages)
+
+      await store.applyPathOutage({ rule: 'IPADDR IPLIKE *.*.*.*', criticalIp: '192.168.1.1' })
+      await store.deletePathOutage(1)
+
+      expect(API.getPathOutages).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not refresh after a failed apply', async () => {
+      vi.mocked(API.applyPathOutage).mockResolvedValue(false)
+
+      await store.applyPathOutage({ rule: 'bogus rule' })
+
+      expect(API.getPathOutages).not.toHaveBeenCalled()
+    })
+
+    it('should pass the preview through', async () => {
+      const preview = { totalCount: 3, nodes: mockPathOutages }
+      vi.mocked(API.previewPathOutageRule).mockResolvedValue(preview)
+
+      const result = await store.previewPathOutageRule('IPADDR IPLIKE *.*.*.*')
+
+      expect(result).toEqual(preview)
+    })
+  })
+
   describe('populate', () => {
     it('should load everything the dialog needs', async () => {
       vi.mocked(API.getNotificationConfigStatus).mockResolvedValue('off')
       vi.mocked(API.getDestinationPaths).mockResolvedValue([mockPath])
+      vi.mocked(API.getPathOutages).mockResolvedValue(mockPathOutages)
 
       await store.populate()
 
       expect(store.notifdStatus).toBe('off')
       expect(store.destinationPaths).toEqual([mockPath])
+      expect(store.pathOutages).toEqual(mockPathOutages)
     })
   })
 })

--- a/ui/tests/stores/notificationConfigStore.test.ts
+++ b/ui/tests/stores/notificationConfigStore.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import API from '@/services'
+import { DestinationPath } from '@/types/notificationConfig'
+
+vi.mock('@/services', () => ({
+  default: {
+    getNotificationConfigStatus: vi.fn(),
+    setNotificationConfigStatus: vi.fn(),
+    getDestinationPaths: vi.fn()
+  }
+}))
+
+describe('useNotificationConfigStore', () => {
+  let store: ReturnType<typeof useNotificationConfigStore>
+
+  const mockPath: DestinationPath = {
+    name: 'Email-Admin',
+    'initial-delay': '0s',
+    target: [{ name: 'Admin', command: ['javaEmail'] }]
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useNotificationConfigStore()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('should start empty with unknown notifd status', () => {
+      expect(store.notifdStatus).toBeNull()
+      expect(store.destinationPaths).toEqual([])
+    })
+  })
+
+  describe('notifd status', () => {
+    it('should load the status', async () => {
+      vi.mocked(API.getNotificationConfigStatus).mockResolvedValue('on')
+
+      await store.getStatus()
+
+      expect(store.notifdStatus).toBe('on')
+    })
+
+    it('should update the status on success', async () => {
+      vi.mocked(API.setNotificationConfigStatus).mockResolvedValue(true)
+
+      const ok = await store.setStatus('on')
+
+      expect(ok).toBe(true)
+      expect(store.notifdStatus).toBe('on')
+    })
+
+    it('should keep the old status on failure', async () => {
+      store.notifdStatus = 'off'
+      vi.mocked(API.setNotificationConfigStatus).mockResolvedValue(false)
+
+      const ok = await store.setStatus('on')
+
+      expect(ok).toBe(false)
+      expect(store.notifdStatus).toBe('off')
+    })
+  })
+
+  describe('populate', () => {
+    it('should load everything the dialog needs', async () => {
+      vi.mocked(API.getNotificationConfigStatus).mockResolvedValue('off')
+      vi.mocked(API.getDestinationPaths).mockResolvedValue([mockPath])
+
+      await store.populate()
+
+      expect(store.notifdStatus).toBe('off')
+      expect(store.destinationPaths).toEqual([mockPath])
+    })
+  })
+})


### PR DESCRIPTION
Adds the Path Outages tab to the Configure Notifications dialog. Depends on #8693 (the base Notifications page PR); review the last commit only until that merges.

- Tab with the list of configured critical paths and an apply/clear flow driven by a filter rule with a node-count preview.
- Storage is and stays the pathoutage table; the endpoints mirror the legacy NotificationWizardServlet semantics, including clearing the path when the critical IP is blank.
