### PR TITLE
NMS-20118: Event Notifications tab

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -53,6 +53,7 @@ import org.opennms.netmgt.config.NotifdConfigFactory;
 import org.opennms.netmgt.config.NotificationFactory;
 import org.opennms.netmgt.filter.FilterDaoFactory;
 import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.filter.api.FilterParseException;
 import org.opennms.netmgt.config.destinationPaths.DestinationPaths;
 import org.opennms.netmgt.config.notifications.Notification;
 import org.opennms.netmgt.config.notifications.Notifications;
@@ -399,12 +400,20 @@ public class NotificationConfigRestService extends OnmsRestService {
         final FilterDao filterDao = FilterDaoFactory.getInstance();
         try {
             filterDao.validateRule(rule);
-        } catch (final Exception e) {
+        } catch (final FilterParseException e) {
+            // A malformed rule is user input; report it as an invalid result.
+            // Infrastructure failures propagate to a 500 instead.
             result.setValid(false);
             result.setError(e.getMessage());
             return result;
         }
         result.setValid(true);
+        // The match preview materializes a Map over every interface/service the
+        // rule selects, so only build it when the caller explicitly asks. The
+        // save path leaves preview false and pays only for validateRule above.
+        if (request == null || !request.isPreview()) {
+            return result;
+        }
         try {
             final Map<InetAddress, Set<String>> map = filterDao.getIPAddressServiceMap(rule);
             result.setMatchCount(map.size());
@@ -431,6 +440,7 @@ public class NotificationConfigRestService extends OnmsRestService {
     @XmlRootElement(name = "rule-request")
     public static class RuleRequestDTO {
         private String m_rule;
+        private boolean m_preview;
 
         @XmlElement(name = "rule")
         public String getRule() {
@@ -439,6 +449,18 @@ public class NotificationConfigRestService extends OnmsRestService {
 
         public void setRule(final String rule) {
             m_rule = rule;
+        }
+
+        // When false (the default, used by the save path), the endpoint only
+        // validates the rule; the caller must opt in to the match preview, which
+        // materializes the full interface/service map.
+        @XmlElement(name = "preview")
+        public boolean isPreview() {
+            return m_preview;
+        }
+
+        public void setPreview(final boolean preview) {
+            m_preview = preview;
         }
     }
 
@@ -533,9 +555,11 @@ public class NotificationConfigRestService extends OnmsRestService {
         }
         try {
             FilterDaoFactory.getInstance().validateRule(notification.getRule().getContent());
-        } catch (final Exception e) {
+        } catch (final FilterParseException e) {
             throw getException(Status.BAD_REQUEST, "The rule is not a valid filter: {}", e.getMessage());
         }
+        // Infrastructure failures (uninitialized factory, DB outage) are not the
+        // caller's fault; let them propagate to a 500 rather than a 400.
         if (isBlank(notification.getDestinationPath())) {
             throw getException(Status.BAD_REQUEST, "The event notification requires a destinationPath");
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -21,14 +21,19 @@
  */
 package org.opennms.web.rest.v1;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -39,11 +44,18 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.DestinationPathFactory;
 import org.opennms.netmgt.config.NotifdConfigFactory;
+import org.opennms.netmgt.config.NotificationFactory;
+import org.opennms.netmgt.filter.FilterDaoFactory;
+import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.config.destinationPaths.DestinationPaths;
+import org.opennms.netmgt.config.notifications.Notification;
+import org.opennms.netmgt.config.notifications.Notifications;
 import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.web.api.Authentication;
@@ -65,6 +77,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * <ul>
  * <li><b>GET /notification-config/status</b> global notifd on/off status</li>
  * <li><b>PUT /notification-config/status</b> turn notifd on or off</li>
+ * <li><b>GET/POST/PUT/DELETE /notification-config/event-notifications[/{name}]</b> event notification CRUD (notifications.xml)</li>
+ * <li><b>PUT /notification-config/event-notifications/{name}/status</b> toggle one event notification</li>
  * <li><b>GET /notification-config/destination-paths</b> all destination paths</li>
  * <li><b>GET /notification-config/destination-paths/{name}</b> one destination path</li>
  * </ul>
@@ -75,6 +89,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class NotificationConfigRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationConfigRestService.class);
+
+    private static final int RULE_PREVIEW_LIMIT = 250;
 
     @Autowired
     @Qualifier("eventProxy")
@@ -134,6 +150,145 @@ public class NotificationConfigRestService extends OnmsRestService {
             return Response.noContent().build();
         } catch (final Exception e) {
             throw getException(Status.INTERNAL_SERVER_ERROR, "Can't update notifd status: {}", e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @GET
+    @Path("event-notifications")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Notifications getEventNotifications(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read event notifications");
+        readLock();
+        try {
+            final Notifications notifications = new Notifications();
+            final List<Notification> list = new ArrayList<>(getNotificationFactory().getNotifications().values());
+            list.sort(Comparator.comparing(Notification::getName, String.CASE_INSENSITIVE_ORDER));
+            notifications.setNotifications(list);
+            return notifications;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read event notifications: {}", e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @GET
+    @Path("event-notifications/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Notification getEventNotification(@Context final SecurityContext securityContext, @PathParam("name") final String name) {
+        assertAdmin(securityContext, "read event notifications");
+        readLock();
+        try {
+            final Notification notification = getNotificationFactory().getNotification(name);
+            if (notification == null) {
+                throw getException(Status.NOT_FOUND, "Event notification {} was not found.", name);
+            }
+            return notification;
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read event notification {}: {}", name, e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @POST
+    @Path("event-notifications")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response addEventNotification(@Context final SecurityContext securityContext, final Notification notification) {
+        assertAdmin(securityContext, "add event notifications");
+        validateEventNotification(notification);
+        writeLock();
+        try {
+            final boolean exists = getNotificationFactory().getNotification(notification.getName()) != null;
+            if (exists) {
+                throw getException(Status.BAD_REQUEST, "Event notification {} already exists.", notification.getName());
+            }
+            getNotificationFactory().addNotification(notification);
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't add event notification {}: {}", notification.getName(), e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @PUT
+    @Path("event-notifications/{name}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateEventNotification(@Context final SecurityContext securityContext, @PathParam("name") final String name, final Notification notification) {
+        assertAdmin(securityContext, "update event notifications");
+        validateEventNotification(notification);
+        writeLock();
+        try {
+            if (getNotificationFactory().getNotification(name) == null) {
+                throw getException(Status.NOT_FOUND, "Event notification {} was not found.", name);
+            }
+            if (!name.equals(notification.getName()) && getNotificationFactory().getNotification(notification.getName()) != null) {
+                throw getException(Status.BAD_REQUEST, "Event notification {} already exists.", notification.getName());
+            }
+            getNotificationFactory().replaceNotification(name, notification);
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't update event notification {}: {}", name, e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @PUT
+    @Path("event-notifications/{name}/status")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateEventNotificationStatus(@Context final SecurityContext securityContext, @PathParam("name") final String name, final NotificationStatus status) {
+        assertAdmin(securityContext, "toggle event notifications");
+        if (status == null || !("on".equals(status.getStatus()) || "off".equals(status.getStatus()))) {
+            throw getException(Status.BAD_REQUEST, "Status must be 'on' or 'off'");
+        }
+        writeLock();
+        try {
+            if (getNotificationFactory().getNotification(name) == null) {
+                throw getException(Status.NOT_FOUND, "Event notification {} was not found.", name);
+            }
+            getNotificationFactory().updateStatus(name, status.getStatus());
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't update status of event notification {}: {}", name, e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @DELETE
+    @Path("event-notifications/{name}")
+    public Response deleteEventNotification(@Context final SecurityContext securityContext, @PathParam("name") final String name) {
+        assertAdmin(securityContext, "delete event notifications");
+        writeLock();
+        try {
+            if (getNotificationFactory().getNotification(name) == null) {
+                throw getException(Status.NOT_FOUND, "Event notification {} was not found.", name);
+            }
+            // notifications.xsd requires at least one notification: removing
+            // the last one empties memory, then the schema-validated save
+            // throws, and the divergence survives until a restart
+            if (getNotificationFactory().getNotifications().size() <= 1) {
+                throw getException(Status.BAD_REQUEST,
+                        "The last event notification cannot be deleted; turn it off instead.");
+            }
+            getNotificationFactory().removeNotification(name);
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't delete event notification {}: {}", name, e.getMessage());
         } finally {
             writeUnlock();
         }
@@ -205,6 +360,201 @@ public class NotificationConfigRestService extends OnmsRestService {
     private static NotifdConfigFactory getNotifdConfigFactory() throws Exception {
         NotifdConfigFactory.init();
         return NotifdConfigFactory.getInstance();
+    }
+
+    private static NotificationFactory getNotificationFactory() throws Exception {
+        // NotificationFactory's constructor requires an initialized NotifdConfigFactory
+        NotifdConfigFactory.init();
+        NotificationFactory.init();
+        return NotificationFactory.getInstance();
+    }
+
+    @GET
+    @Path("services")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getServiceNames(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read the service list");
+        try {
+            final List<String> services = new ArrayList<>(getNotificationFactory().getServiceNames());
+            services.sort(String.CASE_INSENSITIVE_ORDER);
+            return services;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read the service list: {}", e.getMessage());
+        }
+    }
+
+    @POST
+    @Path("rule/validate")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RuleValidationDTO validateRule(@Context final SecurityContext securityContext, final RuleRequestDTO request) {
+        assertAdmin(securityContext, "validate a notification rule");
+        final RuleValidationDTO result = new RuleValidationDTO();
+        final String rule = request == null ? null : request.getRule();
+        if (rule == null || rule.trim().isEmpty()) {
+            result.setValid(false);
+            result.setError("A rule is required");
+            return result;
+        }
+        final FilterDao filterDao = FilterDaoFactory.getInstance();
+        try {
+            filterDao.validateRule(rule);
+        } catch (final Exception e) {
+            result.setValid(false);
+            result.setError(e.getMessage());
+            return result;
+        }
+        result.setValid(true);
+        try {
+            final Map<InetAddress, Set<String>> map = filterDao.getIPAddressServiceMap(rule);
+            result.setMatchCount(map.size());
+            final List<RuleMatchDTO> matches = new ArrayList<>();
+            for (final Map.Entry<InetAddress, Set<String>> entry : map.entrySet()) {
+                if (matches.size() >= RULE_PREVIEW_LIMIT) {
+                    break;
+                }
+                final RuleMatchDTO match = new RuleMatchDTO();
+                match.setIpAddress(InetAddressUtils.str(entry.getKey()));
+                final List<String> svcs = new ArrayList<>(entry.getValue());
+                svcs.sort(String.CASE_INSENSITIVE_ORDER);
+                match.setServices(svcs);
+                matches.add(match);
+            }
+            result.setMatches(matches);
+        } catch (final Exception e) {
+            // The rule parsed but the address/service preview failed; it is still valid to save.
+            result.setError("Rule is valid, but the match preview could not be built: " + e.getMessage());
+        }
+        return result;
+    }
+
+    @XmlRootElement(name = "rule-request")
+    public static class RuleRequestDTO {
+        private String m_rule;
+
+        @XmlElement(name = "rule")
+        public String getRule() {
+            return m_rule;
+        }
+
+        public void setRule(final String rule) {
+            m_rule = rule;
+        }
+    }
+
+    @XmlRootElement(name = "rule-validation")
+    public static class RuleValidationDTO {
+        private boolean m_valid;
+        private String m_error;
+        private int m_matchCount;
+        private List<RuleMatchDTO> m_matches = new ArrayList<>();
+
+        @XmlElement(name = "valid")
+        public boolean isValid() {
+            return m_valid;
+        }
+
+        public void setValid(final boolean valid) {
+            m_valid = valid;
+        }
+
+        @XmlElement(name = "error")
+        public String getError() {
+            return m_error;
+        }
+
+        public void setError(final String error) {
+            m_error = error;
+        }
+
+        @XmlElement(name = "matchCount")
+        public int getMatchCount() {
+            return m_matchCount;
+        }
+
+        public void setMatchCount(final int matchCount) {
+            m_matchCount = matchCount;
+        }
+
+        @XmlElement(name = "matches")
+        public List<RuleMatchDTO> getMatches() {
+            return m_matches;
+        }
+
+        public void setMatches(final List<RuleMatchDTO> matches) {
+            m_matches = matches;
+        }
+    }
+
+    @XmlRootElement(name = "rule-match")
+    public static class RuleMatchDTO {
+        private String m_ipAddress;
+        private List<String> m_services = new ArrayList<>();
+
+        @XmlElement(name = "ipAddress")
+        public String getIpAddress() {
+            return m_ipAddress;
+        }
+
+        public void setIpAddress(final String ipAddress) {
+            m_ipAddress = ipAddress;
+        }
+
+        @XmlElement(name = "services")
+        public List<String> getServices() {
+            return m_services;
+        }
+
+        public void setServices(final List<String> services) {
+            m_services = services;
+        }
+    }
+
+    /**
+     * Rejects payloads the factories would die on halfway: addNotification
+     * removes any existing entry before saving, and replaceNotification
+     * mutates the live entry in place through setters that assert non-empty
+     * (name, status, uei, rule, destinationPath, text-message, parameters) —
+     * a mid-chain failure leaves a half-updated entry in memory that the next
+     * unrelated save persists. Every asserting setter must be covered here.
+     */
+    private static void validateEventNotification(final Notification notification) {
+        if (notification == null || isBlank(notification.getName())) {
+            throw getException(Status.BAD_REQUEST, "The event notification and its name are required");
+        }
+        if (!"on".equals(notification.getStatus()) && !"off".equals(notification.getStatus())) {
+            throw getException(Status.BAD_REQUEST, "The event notification requires a status of 'on' or 'off'");
+        }
+        if (isBlank(notification.getUei())) {
+            throw getException(Status.BAD_REQUEST, "The event notification requires a uei");
+        }
+        if (notification.getRule() == null || isBlank(notification.getRule().getContent())) {
+            throw getException(Status.BAD_REQUEST, "The event notification requires a rule");
+        }
+        try {
+            FilterDaoFactory.getInstance().validateRule(notification.getRule().getContent());
+        } catch (final Exception e) {
+            throw getException(Status.BAD_REQUEST, "The rule is not a valid filter: {}", e.getMessage());
+        }
+        if (isBlank(notification.getDestinationPath())) {
+            throw getException(Status.BAD_REQUEST, "The event notification requires a destinationPath");
+        }
+        if (isBlank(notification.getTextMessage())) {
+            throw getException(Status.BAD_REQUEST, "The event notification requires a text-message");
+        }
+        for (final org.opennms.netmgt.config.notifications.Parameter parameter : notification.getParameters()) {
+            if (isBlank(parameter.getName()) || isBlank(parameter.getValue())) {
+                throw getException(Status.BAD_REQUEST, "Every parameter requires a non-empty name and value");
+            }
+        }
+        final org.opennms.netmgt.config.notifications.Varbind varbind = notification.getVarbind();
+        if (varbind != null && (isBlank(varbind.getVbname()) || isBlank(varbind.getVbvalue()))) {
+            throw getException(Status.BAD_REQUEST, "A varbind requires both a name and a value");
+        }
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.isBlank();
     }
 
     private static DestinationPathFactory getDestinationPathFactory() throws Exception {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
@@ -19,7 +19,7 @@
  * language governing permissions and limitations under the
  * License.
  */
-package org.opennms.web.rest.v1;
+package org.opennms.web.rest.v2;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -27,6 +27,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -38,14 +39,12 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.DestinationPathFactory;
@@ -62,9 +61,13 @@ import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.web.api.Authentication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import com.googlecode.concurentlocks.ReadWriteUpdateLock;
+import com.googlecode.concurentlocks.ReentrantReadWriteUpdateLock;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -87,7 +90,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Component("notificationConfigRestService")
 @Path("notification-config")
 @Tag(name = "Notification-config", description = "Notification Configuration API")
-public class NotificationConfigRestService extends OnmsRestService {
+public class NotificationConfigRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationConfigRestService.class);
 
@@ -97,24 +100,55 @@ public class NotificationConfigRestService extends OnmsRestService {
     @Qualifier("eventProxy")
     protected EventProxy m_eventProxy;
 
-    @XmlRootElement(name = "notification-status")
+    // Per-instance read/write/update lock serializing config mutations, carried
+    // over from the base REST service this was split out of when it moved to v2.
+    private final ReadWriteUpdateLock m_globalLock = new ReentrantReadWriteUpdateLock();
+    private final Lock m_readLock = m_globalLock.updateLock();
+    private final Lock m_writeLock = m_globalLock.writeLock();
+
+    private void readLock() {
+        m_readLock.lock();
+    }
+
+    private void readUnlock() {
+        m_readLock.unlock();
+    }
+
+    private void writeLock() {
+        m_writeLock.lock();
+    }
+
+    private void writeUnlock() {
+        m_writeLock.unlock();
+    }
+
+    private static WebApplicationException getException(final Status status, final String msg, final String... params) {
+        final String formatted = params != null ? MessageFormatter.arrayFormat(msg, params).getMessage() : msg;
+        LOG.error(formatted);
+        return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(formatted).build());
+    }
+
+    private static WebApplicationException getException(final Status status, final Throwable t) {
+        LOG.error(t.getMessage(), t);
+        return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(t.getMessage()).build());
+    }
+
     public static class NotificationStatus {
-        private String m_status;
+        private String status;
 
         public NotificationStatus() {
         }
 
         public NotificationStatus(final String status) {
-            m_status = status;
+            this.status = status;
         }
 
-        @XmlAttribute(name = "status")
         public String getStatus() {
-            return m_status;
+            return status;
         }
 
         public void setStatus(final String status) {
-            m_status = status;
+            this.status = status;
         }
     }
 
@@ -437,98 +471,87 @@ public class NotificationConfigRestService extends OnmsRestService {
         return result;
     }
 
-    @XmlRootElement(name = "rule-request")
     public static class RuleRequestDTO {
-        private String m_rule;
-        private boolean m_preview;
+        private String rule;
+        private boolean preview;
 
-        @XmlElement(name = "rule")
         public String getRule() {
-            return m_rule;
+            return rule;
         }
 
         public void setRule(final String rule) {
-            m_rule = rule;
+            this.rule = rule;
         }
 
         // When false (the default, used by the save path), the endpoint only
         // validates the rule; the caller must opt in to the match preview, which
         // materializes the full interface/service map.
-        @XmlElement(name = "preview")
         public boolean isPreview() {
-            return m_preview;
+            return preview;
         }
 
         public void setPreview(final boolean preview) {
-            m_preview = preview;
+            this.preview = preview;
         }
     }
 
-    @XmlRootElement(name = "rule-validation")
     public static class RuleValidationDTO {
-        private boolean m_valid;
-        private String m_error;
-        private int m_matchCount;
-        private List<RuleMatchDTO> m_matches = new ArrayList<>();
+        private boolean valid;
+        private String error;
+        private int matchCount;
+        private List<RuleMatchDTO> matches = new ArrayList<>();
 
-        @XmlElement(name = "valid")
         public boolean isValid() {
-            return m_valid;
+            return valid;
         }
 
         public void setValid(final boolean valid) {
-            m_valid = valid;
+            this.valid = valid;
         }
 
-        @XmlElement(name = "error")
         public String getError() {
-            return m_error;
+            return error;
         }
 
         public void setError(final String error) {
-            m_error = error;
+            this.error = error;
         }
 
-        @XmlElement(name = "matchCount")
         public int getMatchCount() {
-            return m_matchCount;
+            return matchCount;
         }
 
         public void setMatchCount(final int matchCount) {
-            m_matchCount = matchCount;
+            this.matchCount = matchCount;
         }
 
-        @XmlElement(name = "matches")
         public List<RuleMatchDTO> getMatches() {
-            return m_matches;
+            return matches;
         }
 
         public void setMatches(final List<RuleMatchDTO> matches) {
-            m_matches = matches;
+            this.matches = matches;
         }
     }
 
-    @XmlRootElement(name = "rule-match")
     public static class RuleMatchDTO {
-        private String m_ipAddress;
-        private List<String> m_services = new ArrayList<>();
+        private String ipAddress;
+        private List<String> services = new ArrayList<>();
 
-        @XmlElement(name = "ipAddress")
         public String getIpAddress() {
-            return m_ipAddress;
+            return ipAddress;
         }
 
         public void setIpAddress(final String ipAddress) {
-            m_ipAddress = ipAddress;
+            this.ipAddress = ipAddress;
         }
 
-        @XmlElement(name = "services")
         public List<String> getServices() {
-            return m_services;
+            return services;
         }
 
         public void setServices(final List<String> services) {
-            m_services = services;
+            this.services = services;
         }
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
@@ -46,6 +46,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 
+import org.apache.commons.lang.StringUtils;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.DestinationPathFactory;
 import org.opennms.netmgt.config.NotifdConfigFactory;
@@ -63,7 +64,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.googlecode.concurentlocks.ReadWriteUpdateLock;
@@ -97,29 +97,28 @@ public class NotificationConfigRestService {
     private static final int RULE_PREVIEW_LIMIT = 250;
 
     @Autowired
-    @Qualifier("eventProxy")
-    protected EventProxy m_eventProxy;
+    protected EventProxy eventProxy;
 
     // Per-instance read/write/update lock serializing config mutations, carried
     // over from the base REST service this was split out of when it moved to v2.
-    private final ReadWriteUpdateLock m_globalLock = new ReentrantReadWriteUpdateLock();
-    private final Lock m_readLock = m_globalLock.updateLock();
-    private final Lock m_writeLock = m_globalLock.writeLock();
+    private final ReadWriteUpdateLock globalLock = new ReentrantReadWriteUpdateLock();
+    private final Lock readLock = globalLock.updateLock();
+    private final Lock writeLock = globalLock.writeLock();
 
     private void readLock() {
-        m_readLock.lock();
+        readLock.lock();
     }
 
     private void readUnlock() {
-        m_readLock.unlock();
+        readLock.unlock();
     }
 
     private void writeLock() {
-        m_writeLock.lock();
+        writeLock.lock();
     }
 
     private void writeUnlock() {
-        m_writeLock.unlock();
+        writeLock.unlock();
     }
 
     private static WebApplicationException getException(final Status status, final String msg, final String... params) {
@@ -386,7 +385,7 @@ public class NotificationConfigRestService {
             bldr.addParam("remoteUser", securityContext.getUserPrincipal().getName());
             bldr.addParam("remoteHost", request.getRemoteHost());
             bldr.addParam("remoteAddr", request.getRemoteAddr());
-            m_eventProxy.send(bldr.getEvent());
+            eventProxy.send(bldr.getEvent());
         } catch (final Exception e) {
             LOG.warn("Can't send event {}", uei, e);
         }
@@ -564,16 +563,16 @@ public class NotificationConfigRestService {
      * unrelated save persists. Every asserting setter must be covered here.
      */
     private static void validateEventNotification(final Notification notification) {
-        if (notification == null || isBlank(notification.getName())) {
+        if (notification == null || StringUtils.isBlank(notification.getName())) {
             throw getException(Status.BAD_REQUEST, "The event notification and its name are required");
         }
         if (!"on".equals(notification.getStatus()) && !"off".equals(notification.getStatus())) {
             throw getException(Status.BAD_REQUEST, "The event notification requires a status of 'on' or 'off'");
         }
-        if (isBlank(notification.getUei())) {
+        if (StringUtils.isBlank(notification.getUei())) {
             throw getException(Status.BAD_REQUEST, "The event notification requires a uei");
         }
-        if (notification.getRule() == null || isBlank(notification.getRule().getContent())) {
+        if (notification.getRule() == null || StringUtils.isBlank(notification.getRule().getContent())) {
             throw getException(Status.BAD_REQUEST, "The event notification requires a rule");
         }
         try {
@@ -583,25 +582,21 @@ public class NotificationConfigRestService {
         }
         // Infrastructure failures (uninitialized factory, DB outage) are not the
         // caller's fault; let them propagate to a 500 rather than a 400.
-        if (isBlank(notification.getDestinationPath())) {
+        if (StringUtils.isBlank(notification.getDestinationPath())) {
             throw getException(Status.BAD_REQUEST, "The event notification requires a destinationPath");
         }
-        if (isBlank(notification.getTextMessage())) {
+        if (StringUtils.isBlank(notification.getTextMessage())) {
             throw getException(Status.BAD_REQUEST, "The event notification requires a text-message");
         }
         for (final org.opennms.netmgt.config.notifications.Parameter parameter : notification.getParameters()) {
-            if (isBlank(parameter.getName()) || isBlank(parameter.getValue())) {
+            if (StringUtils.isBlank(parameter.getName()) || StringUtils.isBlank(parameter.getValue())) {
                 throw getException(Status.BAD_REQUEST, "Every parameter requires a non-empty name and value");
             }
         }
         final org.opennms.netmgt.config.notifications.Varbind varbind = notification.getVarbind();
-        if (varbind != null && (isBlank(varbind.getVbname()) || isBlank(varbind.getVbvalue()))) {
+        if (varbind != null && (StringUtils.isBlank(varbind.getVbname()) || StringUtils.isBlank(varbind.getVbvalue()))) {
             throw getException(Status.BAD_REQUEST, "A varbind requires both a name and a value");
         }
-    }
-
-    private static boolean isBlank(final String value) {
-        return value == null || value.isBlank();
     }
 
     private static DestinationPathFactory getDestinationPathFactory() throws Exception {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -166,6 +166,88 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
     }
 
     @Test
+    public void testEventNotificationLifecycle() throws Exception {
+        JSONObject list = new JSONObject(getJson("/notification-config/event-notifications"));
+        Assert.assertEquals(1, list.getJSONArray("notification").length());
+
+        final String newNotification = "{\"name\":\"junit-added\",\"status\":\"off\","
+                + "\"uei\":\"uei.opennms.org/nodes/nodeUp\","
+                + "\"rule\":{\"value\":\"IPADDR IPLIKE *.*.*.*\"},"
+                + "\"destinationPath\":\"Email-Admin\","
+                + "\"text-message\":\"node up\"}";
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/event-notifications", newNotification, 204);
+
+        JSONObject added = new JSONObject(getJson("/notification-config/event-notifications/junit-added"));
+        Assert.assertEquals("uei.opennms.org/nodes/nodeUp", added.getString("uei"));
+
+        // duplicate name is rejected
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/event-notifications", newNotification, 400);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/event-notifications/junit-added/status", "{\"status\":\"on\"}", 204);
+        added = new JSONObject(getJson("/notification-config/event-notifications/junit-added"));
+        Assert.assertEquals("on", added.getString("status"));
+
+        sendRequest(DELETE, "/notification-config/event-notifications/junit-added", 204);
+        sendRequest(GET, "/notification-config/event-notifications/junit-added", 404);
+    }
+
+    @Test
+    public void testEventNotificationValidation() throws Exception {
+        // missing text-message must be rejected before it can poison the config
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/event-notifications",
+                "{\"name\":\"junit-invalid\",\"status\":\"on\",\"uei\":\"uei.opennms.org/nodes/nodeUp\","
+                        + "\"rule\":{\"value\":\"IPADDR IPLIKE *.*.*.*\"},\"destinationPath\":\"Email-Admin\"}", 400);
+        sendRequest(GET, "/notification-config/event-notifications/junit-invalid", 404);
+    }
+
+    @Test
+    public void testDeleteLastEventNotificationRejected() throws Exception {
+        // reduce to a single notification, deterministically
+        final JSONObject list = new JSONObject(getJson("/notification-config/event-notifications"));
+        final org.json.JSONArray items = list.getJSONArray("notification");
+        for (int i = 0; i < items.length(); i++) {
+            final String name = items.getJSONObject(i).getString("name");
+            if (!"junitNotification".equals(name)) {
+                sendRequest(DELETE, "/notification-config/event-notifications/"
+                        + java.net.URLEncoder.encode(name, java.nio.charset.StandardCharsets.UTF_8), 204);
+            }
+        }
+        // notifications.xsd requires at least one notification element
+        sendRequest(DELETE, "/notification-config/event-notifications/junitNotification", 400);
+        Assert.assertEquals(1, new JSONObject(getJson("/notification-config/event-notifications"))
+                .getJSONArray("notification").length());
+    }
+
+    @Test
+    public void testEventNotificationMissingStatusRejected() throws Exception {
+        // a missing status would die inside the factory's in-place setter
+        // chain after several fields were already written to the live object
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/event-notifications",
+                "{\"name\":\"junit-nostatus\",\"uei\":\"uei.opennms.org/nodes/nodeUp\","
+                        + "\"rule\":{\"value\":\"IPADDR IPLIKE *.*.*.*\"},\"destinationPath\":\"Email-Admin\",\"text-message\":\"x\"}", 400);
+        sendRequest(GET, "/notification-config/event-notifications/junit-nostatus", 404);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/event-notifications/junitNotification",
+                "{\"name\":\"junitNotification\",\"uei\":\"uei.opennms.org/nodes/nodeDown\","
+                        + "\"rule\":{\"value\":\"IPADDR != '0.0.0.0'\"},\"destinationPath\":\"Email-Admin\",\"text-message\":\"node down\"}", 400);
+        final JSONObject unchanged = new JSONObject(getJson("/notification-config/event-notifications/junitNotification"));
+        Assert.assertEquals("on", unchanged.getString("status"));
+    }
+
+    @Test
+    public void testEventNotificationRenameCollisionRejected() throws Exception {
+        final String other = "{\"name\":\"junit-other\",\"status\":\"off\",\"uei\":\"uei.opennms.org/nodes/nodeUp\","
+                + "\"rule\":{\"value\":\"IPADDR IPLIKE *.*.*.*\"},\"destinationPath\":\"Email-Admin\",\"text-message\":\"x\"}";
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/event-notifications", other, 204);
+
+        // renaming junitNotification onto the existing junit-other must not create a duplicate name
+        final String renamed = "{\"name\":\"junit-other\",\"status\":\"on\",\"uei\":\"uei.opennms.org/nodes/nodeDown\","
+                + "\"rule\":{\"value\":\"IPADDR != '0.0.0.0'\"},\"destinationPath\":\"Email-Admin\",\"text-message\":\"node down\"}";
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/event-notifications/junitNotification", renamed, 400);
+        sendRequest(GET, "/notification-config/event-notifications/junitNotification", 200);
+    }
+
+    @Test
     public void testDestinationPathsReadable() throws Exception {
         // the read side ships in the base PR: the event-notification editor
         // needs the path list for its destination picker
@@ -183,6 +265,7 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
         setUser("nobody", new String[]{ "ROLE_USER" });
         try {
             sendRequest(GET, "/notification-config/status", 403);
+            sendRequest(GET, "/notification-config/event-notifications", 403);
             sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"on\"}", 403);
         } finally {
             setUser("admin", new String[]{ "ROLE_ADMIN" });

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -266,10 +266,47 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
         try {
             sendRequest(GET, "/notification-config/status", 403);
             sendRequest(GET, "/notification-config/event-notifications", 403);
+            sendRequest(GET, "/notification-config/services", 403);
             sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"on\"}", 403);
+            sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/rule/validate",
+                    "{\"rule\":\"IPADDR IPLIKE *.*.*.*\"}", 403);
+            sendRequest(DELETE, "/notification-config/event-notifications/junitNotification", 403);
         } finally {
             setUser("admin", new String[]{ "ROLE_ADMIN" });
         }
+    }
+
+    @Test
+    public void testGetServiceNames() throws Exception {
+        // Admin can read the service list; the value depends on the fixture, so
+        // assert only that the endpoint returns a well-formed JSON array.
+        final JSONArray services = new JSONArray(getJson("/notification-config/services"));
+        Assert.assertNotNull(services);
+    }
+
+    @Test
+    public void testValidateRule() throws Exception {
+        // Valid rule, default (no preview): valid true and the expensive match
+        // map is not built.
+        final JSONObject validated = new JSONObject(sendData(POST, MediaType.APPLICATION_JSON,
+                "/notification-config/rule/validate", "{\"rule\":\"IPADDR IPLIKE *.*.*.*\"}", 200)
+                .getContentAsString());
+        Assert.assertTrue(validated.getBoolean("valid"));
+        Assert.assertEquals(0, validated.optInt("matchCount", 0));
+
+        // Same rule with preview requested: still valid, and the match count is
+        // now populated (>= 0).
+        final JSONObject previewed = new JSONObject(sendData(POST, MediaType.APPLICATION_JSON,
+                "/notification-config/rule/validate", "{\"rule\":\"IPADDR IPLIKE *.*.*.*\",\"preview\":true}", 200)
+                .getContentAsString());
+        Assert.assertTrue(previewed.getBoolean("valid"));
+        Assert.assertTrue(previewed.getInt("matchCount") >= 0);
+
+        // A blank rule is rejected as invalid input, not an error.
+        final JSONObject blank = new JSONObject(sendData(POST, MediaType.APPLICATION_JSON,
+                "/notification-config/rule/validate", "{\"rule\":\"\"}", 200)
+                .getContentAsString());
+        Assert.assertFalse(blank.getBoolean("valid"));
     }
 
     private String getJson(final String url) throws Exception {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NotificationConfigRestServiceIT.java
@@ -19,7 +19,7 @@
  * language governing permissions and limitations under the
  * License.
  */
-package org.opennms.web.rest.v1;
+package org.opennms.web.rest.v2;
 
 
 import java.io.File;
@@ -64,6 +64,9 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @JUnitTemporaryDatabase
 public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
+    public NotificationConfigRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
 
     private String m_onmsHome;
 

--- a/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
+++ b/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
@@ -19,9 +19,7 @@
       </OnmsTabList>
       <OnmsTabPanels>
         <OnmsTabPanel value="event-notifications">
-          <p class="tab-placeholder" data-test="placeholder-event-notifications">
-            Event notification management arrives with NMS-20118.
-          </p>
+          <EventNotificationsTable />
         </OnmsTabPanel>
         <OnmsTabPanel value="destination-paths">
           <p class="tab-placeholder" data-test="placeholder-destination-paths">
@@ -61,6 +59,7 @@ import { ref, watch } from 'vue'
 
 import { OnmsDialog, OnmsTabs, OnmsTabList, OnmsTab, OnmsTabPanels, OnmsTabPanel, OnmsToggleSwitch } from '@opennms/onms-ui'
 
+import EventNotificationsTable from '@/components/AdminNotifications/EventNotificationsTable.vue'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import { NotifdStatus } from '@/types/notificationConfig'
 
@@ -72,9 +71,8 @@ const emit = defineEmits(['update:visible'])
 
 const store = useNotificationConfigStore()
 
-// Event Notifications is first in the final tab order but is only a placeholder
-// until NMS-20118 lands, so open on General (the one live tab) for now.
-const activeTab = ref('general')
+// Open on Event Notifications, the first tab in the final order (now live).
+const activeTab = ref('event-notifications')
 
 const statusPending = ref(false)
 
@@ -84,6 +82,10 @@ const statusPending = ref(false)
 const loadedTabs = ref(new Set<string>())
 
 const TAB_LOADERS: Record<string, () => Promise<boolean>> = {
+  'event-notifications': async () =>
+    // destination paths feed the editor's path picker; every fetch must succeed or
+    // the tab retries instead of latching (a failed fetch returns null/false)
+    (await Promise.all([store.getEventNotifications(), store.getDestinationPaths()])).every(Boolean),
   general: () => store.getStatus()
 }
 

--- a/ui/src/components/AdminNotifications/EventNotificationEditorDialog.vue
+++ b/ui/src/components/AdminNotifications/EventNotificationEditorDialog.vue
@@ -313,7 +313,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, nextTick, reactive, ref, watch } from 'vue'
 
 import { OnmsAutoComplete, OnmsButton, OnmsDialog, OnmsIconButton, OnmsInputText, OnmsMultiSelect, OnmsSelect, OnmsTextarea, OnmsToggleSwitch } from '@opennms/onms-ui'
 
@@ -432,6 +432,12 @@ const isFullyGrouped = (s: string): boolean => {
   return depth === 0
 }
 
+// A service clause becomes the filter token is<Name>; only names made of the
+// identifier characters the filter grammar accepts (matching parseRule's charset)
+// can be emitted — a name with whitespace or other illegal characters would
+// produce an unparseable token, so it is skipped.
+const isLegalServiceName = (s: string): boolean => /^[\w.-]+$/.test(s)
+
 // Assemble the rule the way the legacy wizard did: (ip filter) & (isA | isB) & (!isC & !isD).
 const buildRule = (): string => {
   let base = ipFilter.value.trim() || 'IPADDR IPLIKE *.*.*.*'
@@ -439,11 +445,13 @@ const buildRule = (): string => {
     base = `(${base})`
   }
   let out = base
-  if (ruleServices.value.length) {
-    out += ` & (${ruleServices.value.map(s => `is${s}`).join(' | ')})`
+  const svc = ruleServices.value.filter(isLegalServiceName)
+  if (svc.length) {
+    out += ` & (${svc.map(s => `is${s}`).join(' | ')})`
   }
-  if (ruleNotServices.value.length) {
-    out += ` & (${ruleNotServices.value.map(s => `!is${s}`).join(' & ')})`
+  const notSvc = ruleNotServices.value.filter(isLegalServiceName)
+  if (notSvc.length) {
+    out += ` & (${notSvc.map(s => `!is${s}`).join(' & ')})`
   }
   return out
 }
@@ -499,9 +507,16 @@ const doValidateRule = async () => {
   validating.value = false
 }
 
+// Populating the pickers from an existing rule mutates ipFilter/ruleServices/
+// ruleNotServices, which would fire the sync below and rewrite form.rule (e.g.
+// wrapping the IP filter in parens) — an unrequested mutation. Suppress the sync
+// during initial population so opening and saving with no edit leaves the rule
+// byte-identical; genuine user input to a builder field clears the guard.
+const suppressRuleBuild = ref(false)
+
 // While in Builder mode the pickers own the rule string.
 watch([ipFilter, ruleServices, ruleNotServices], () => {
-  if (ruleMode.value === 'builder') {
+  if (ruleMode.value === 'builder' && !suppressRuleBuild.value) {
     form.rule = buildRule()
   }
 })
@@ -575,6 +590,7 @@ watch(
     ueiSuggestions.value = []
     advancedCollapsed.value = true
     clearErrors()
+    suppressRuleBuild.value = true
     if (props.notification) {
       const n = props.notification
       Object.assign(form, {
@@ -601,6 +617,11 @@ watch(
     ruleParseNote.value = ''
     loadServices()
     ruleMode.value = parseRule(form.rule) ? 'builder' : 'raw'
+    // Release the guard only after the pending picker mutations have flushed,
+    // so the suppressed sync never rewrites the freshly loaded rule.
+    nextTick(() => {
+      suppressRuleBuild.value = false
+    })
   }
 )
 
@@ -620,8 +641,10 @@ const save = async () => {
     const originalRule = typeof props.notification?.rule === 'object' && props.notification?.rule !== null
       ? props.notification.rule
       : {}
+    // The server (Parameter.setValue) rejects an empty value with a 400, so drop
+    // any row missing either cell — mirroring the varbind's both-or-neither rule.
     const params = form.parameters
-      .filter(p => p.name.trim())
+      .filter(p => p.name.trim() && p.value.trim())
       .map(p => ({ name: p.name.trim(), value: p.value }))
     const varbind = form.varbindName.trim() && form.varbindValue.trim()
       ? { vbname: form.varbindName.trim(), vbvalue: form.varbindValue.trim() }

--- a/ui/src/components/AdminNotifications/EventNotificationEditorDialog.vue
+++ b/ui/src/components/AdminNotifications/EventNotificationEditorDialog.vue
@@ -494,7 +494,8 @@ const loadServices = async () => {
 
 const doValidateRule = async () => {
   validating.value = true
-  ruleValidation.value = await API.validateNotificationRule(form.rule.trim() || 'IPADDR IPLIKE *.*.*.*')
+  // Explicit user action: opt into the match preview (matchCount + matches).
+  ruleValidation.value = await API.validateNotificationRule(form.rule.trim() || 'IPADDR IPLIKE *.*.*.*', true)
   validating.value = false
 }
 

--- a/ui/src/components/AdminNotifications/EventNotificationEditorDialog.vue
+++ b/ui/src/components/AdminNotifications/EventNotificationEditorDialog.vue
@@ -1,0 +1,847 @@
+<template>
+  <OnmsDialog
+    :visible="visible"
+    modal
+    :header="isEditing ? `Edit Event Notification: ${originalName}` : 'Add Event Notification'"
+    class="event-notification-editor-dialog"
+    width="min(1040px, 95vw)"
+    data-test="event-notification-editor-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div v-if="errors.general" class="error-banner" data-test="save-error">{{ errors.general }}</div>
+
+    <!-- Event UEI: full-width, friendly label first (how the legacy chooser
+         listed them) with the UEI beneath; free-typed UEIs/regexes still work. -->
+    <FormField
+      class="uei-field"
+      label="Event UEI"
+      required
+      for="new-notification-uei"
+      :error="errors.uei || undefined"
+    >
+      <OnmsAutoComplete
+        v-model="ueiValue"
+        inputId="new-notification-uei"
+        :suggestions="ueiSuggestions"
+        optionLabel="uei"
+        dropdown
+        dropdownMode="current"
+        completeOnFocus
+        data-test="uei-input"
+        fluid
+        @complete="onUeiComplete"
+      >
+        <template #option="{ option }">
+          <div class="uei-option">
+            <div class="label">{{ option.eventLabel || '(no friendly label)' }}</div>
+            <div class="uei">{{ option.uei }}</div>
+          </div>
+        </template>
+      </OnmsAutoComplete>
+      <small v-if="selectedLabel" class="hint" data-test="uei-friendly">Event: <strong>{{ selectedLabel }}</strong></small>
+      <small v-else class="hint">Search by UEI. Enter a literal UEI, or a <code>~</code>-prefixed regular expression to match several.</small>
+    </FormField>
+
+    <div class="form-grid">
+      <FormField
+        label="Name"
+        required
+        for="new-notification-name"
+        :error="errors.name || undefined"
+      >
+        <OnmsInputText id="new-notification-name" v-model="form.name" :maxlength="NAME_MAX" data-test="name-input" />
+      </FormField>
+      <FormField
+        label="Destination Path"
+        required
+        for="new-notification-path"
+        :error="errors.destinationPath || undefined"
+      >
+        <template #label-suffix>
+          <HelpBadge :content="pathHelp" ariaLabel="Destination Path help" />
+        </template>
+        <OnmsSelect
+          v-model="form.destinationPath"
+          inputId="new-notification-path"
+          :options="pathOptions"
+          data-test="destination-path-select"
+          fluid
+        />
+      </FormField>
+      <FormField
+        label="Description"
+        for="new-notification-description"
+      >
+        <OnmsInputText id="new-notification-description" v-model="form.description" :maxlength="512" data-test="description-input" />
+      </FormField>
+      <FormField
+        label="Subject"
+        for="new-notification-subject"
+      >
+        <OnmsInputText id="new-notification-subject" v-model="form.subject" :maxlength="512" data-test="subject-input" />
+      </FormField>
+      <FormField
+        label="Numeric (pager) Message"
+        for="new-notification-numeric"
+      >
+        <OnmsInputText id="new-notification-numeric" v-model="form.numericMessage" :maxlength="512" data-test="numeric-message-input" />
+        <small class="hint">
+          Numeric-only message for pagers
+          <HelpBadge :content="numericHelp" ariaLabel="Numeric message help" />
+        </small>
+      </FormField>
+      <FormField
+        class="full-width"
+        label="Text Message"
+        required
+        for="new-notification-text"
+        :error="errors.textMessage || undefined"
+      >
+        <OnmsTextarea id="new-notification-text" v-model="form.textMessage" rows="4" :maxlength="8000" data-test="text-message-input" fluid />
+        <small class="hint">
+          Supports event replacement tokens such as %nodelabel%, %interface%, %parm[...]%
+          <HelpBadge :content="replacementHelp" ariaLabel="Event replacement tokens help" />
+        </small>
+      </FormField>
+    </div>
+
+    <div class="rule-block" data-test="rule-block">
+      <div class="rule-header">
+        <span class="rule-header__label">Rule</span>
+        <div class="mode-toggle">
+          <OnmsButton
+            :variant="ruleMode === 'builder' ? 'filled' : 'text'"
+            label="Builder"
+            data-test="rule-mode-builder"
+            @click="setRuleMode('builder')"
+          />
+          <OnmsButton
+            :variant="ruleMode === 'raw' ? 'filled' : 'text'"
+            label="Raw"
+            data-test="rule-mode-raw"
+            @click="setRuleMode('raw')"
+          />
+          <HelpBadge :content="ruleHelp" />
+        </div>
+      </div>
+
+        <template v-if="ruleMode === 'builder'">
+          <FormField
+            label="IP address filter"
+            for="rule-ipfilter"
+            hint="Octets accept * (any), ranges (0-3) and lists (0,1,2), e.g. IPADDR IPLIKE 192.168.0-3.*"
+          >
+            <OnmsInputText id="rule-ipfilter" v-model="ipFilter" data-test="rule-ipfilter" />
+          </FormField>
+          <div class="svc-grid">
+            <FormField
+              label="Services (match ANY)"
+              for="rule-services"
+            >
+              <OnmsMultiSelect
+                v-model="ruleServices"
+                inputId="rule-services"
+                :options="availableServices"
+                filter
+                display="chip"
+                data-test="rule-services"
+                fluid
+              />
+            </FormField>
+            <FormField
+              label="Exclude services (NOT)"
+              for="rule-not-services"
+            >
+              <OnmsMultiSelect
+                v-model="ruleNotServices"
+                inputId="rule-not-services"
+                :options="availableServices"
+                filter
+                display="chip"
+                data-test="rule-not-services"
+                fluid
+              />
+            </FormField>
+          </div>
+          <div class="rule-generated">
+            <span class="rule-generated__label">Generated rule:</span>
+            <code data-test="rule-generated">{{ form.rule || '(empty)' }}</code>
+          </div>
+        </template>
+
+        <FormField
+          v-else
+          label="Rule expression"
+          for="new-notification-rule"
+        >
+          <OnmsInputText id="new-notification-rule" v-model="form.rule" data-test="rule-input" />
+          <small class="hint">The filter that limits which nodes/interfaces trigger this notification.</small>
+          <small v-if="ruleParseNote" class="rule-note" data-test="rule-note">{{ ruleParseNote }}</small>
+        </FormField>
+
+        <small v-if="errors.rule" class="field-error" data-test="rule-error">{{ errors.rule }}</small>
+
+        <div class="rule-validate">
+          <OnmsButton
+            variant="outlined"
+            label="Validate"
+            :loading="validating"
+            data-test="rule-validate"
+            @click="doValidateRule"
+          />
+          <template v-if="ruleValidation">
+            <span v-if="!ruleValidation.valid" class="rule-invalid" data-test="rule-invalid">
+              Invalid: {{ ruleValidation.error }}
+            </span>
+            <span v-else class="rule-valid" data-test="rule-valid">
+              Valid — {{ ruleValidation.matchCount }} interface{{ ruleValidation.matchCount === 1 ? '' : 's' }} match
+              <template v-if="ruleValidation.error"> ({{ ruleValidation.error }})</template>
+            </span>
+          </template>
+        </div>
+
+        <div v-if="ruleValidation?.valid && ruleValidation.matches.length" class="rule-matches" data-test="rule-matches">
+          <table>
+            <thead><tr><th>Interface</th><th>Services</th></tr></thead>
+            <tbody>
+              <tr v-for="m in ruleValidation.matches" :key="m.ipAddress">
+                <td>{{ m.ipAddress }}</td>
+                <td>{{ m.services.join(', ') || 'All services' }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <small v-if="ruleValidation.matchCount > ruleValidation.matches.length" class="hint">
+            Showing first {{ ruleValidation.matches.length }} of {{ ruleValidation.matchCount }}.
+          </small>
+        </div>
+    </div>
+
+    <TogglePanel
+      :collapsed="advancedCollapsed"
+      class="advanced-panel"
+      data-test="advanced-options"
+      @update:collapsed="(value: boolean) => (advancedCollapsed = value)"
+    >
+      <template #header>
+        <span class="panel-header">Advanced options</span>
+      </template>
+
+      <div class="advanced-body">
+        <p class="advanced-hint">
+          Rarely-needed fields carried in <code>notifications.xml</code>. Leave blank unless you need them.
+        </p>
+
+        <div class="params-block">
+          <div class="params-title">Notification parameters <HelpBadge :content="paramsHelp" /></div>
+          <div v-for="(p, i) in form.parameters" :key="i" class="param-row" :data-test="`param-row-${i}`">
+            <OnmsInputText v-model="p.name" placeholder="Name" :data-test="`param-name-${i}`" />
+            <OnmsInputText v-model="p.value" placeholder="Value" :data-test="`param-value-${i}`" />
+            <OnmsIconButton
+              :icon="Delete"
+              title="Remove parameter"
+              severity="danger"
+              :data-test="`param-remove-${i}`"
+              @click="form.parameters.splice(i, 1)"
+            />
+          </div>
+          <OnmsButton
+            variant="text"
+            label="Add parameter"
+            data-test="add-param"
+            @click="form.parameters.push({ name: '', value: '' })"
+          />
+        </div>
+
+        <div class="form-grid">
+          <FormField
+            label="Varbind name"
+            for="new-notification-vbname"
+          >
+            <template #label-suffix>
+              <HelpBadge :content="varbindHelp" ariaLabel="Varbind name help" />
+            </template>
+            <OnmsInputText id="new-notification-vbname" v-model="form.varbindName" data-test="varbind-name-input" />
+          </FormField>
+          <FormField
+            label="Varbind value"
+            for="new-notification-vbvalue"
+          >
+            <OnmsInputText id="new-notification-vbvalue" v-model="form.varbindValue" data-test="varbind-value-input" />
+          </FormField>
+          <FormField
+            label="Event severity"
+            for="new-notification-severity"
+          >
+            <OnmsSelect
+              v-model="form.eventSeverity"
+              inputId="new-notification-severity"
+              :options="severityOptions"
+              showClear
+              data-test="event-severity-select"
+              fluid
+            />
+            <small class="hint">Only notify when the event carries this severity.</small>
+          </FormField>
+          <FormField
+            label="Notice queue"
+            for="new-notification-queue"
+          >
+            <template #label-suffix>
+              <HelpBadge :content="queueHelp" ariaLabel="Notice queue help" />
+            </template>
+            <OnmsInputText id="new-notification-queue" v-model="form.noticeQueue" data-test="notice-queue-input" />
+          </FormField>
+        </div>
+      </div>
+    </TogglePanel>
+
+    <div class="status-row">
+      <OnmsToggleSwitch v-model="form.enabled" aria-label="Enable this notification" data-test="enabled-toggle" />
+      <span>Notification {{ form.enabled ? 'on' : 'off' }}</span>
+    </div>
+
+    <template #footer>
+      <OnmsButton variant="text" label="Cancel" data-test="cancel-button" @click="emit('update:visible', false)" />
+      <OnmsButton
+        :label="isEditing ? 'Save Notification' : 'Add Notification'"
+        :disabled="saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </OnmsDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+
+import { OnmsAutoComplete, OnmsButton, OnmsDialog, OnmsIconButton, OnmsInputText, OnmsMultiSelect, OnmsSelect, OnmsTextarea, OnmsToggleSwitch } from '@opennms/onms-ui'
+
+import Delete from '@/components/icons/action/Delete.vue'
+import FormField from '@/components/Common/FormField.vue'
+import HelpBadge from '@/components/Common/HelpBadge.vue'
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+import API from '@/services'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { EventNotification, RuleValidation, UeiSuggestion } from '@/types/notificationConfig'
+
+const props = defineProps<{
+  visible: boolean
+  notification: EventNotification | null
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useNotificationConfigStore()
+
+const ruleHelp = 'A filter rule, e.g. IPADDR IPLIKE *.*.*.*. Octets accept * (any), ranges (0-3) and lists (0,1,2). '
+  + 'Combine with service checks, e.g. (IPADDR IPLIKE *.*.*.*) & (isHTTP). Leave the default to match every node.'
+const numericHelp = 'For numeric-only pager destinations that can display digits (and a few symbols) but not letters. '
+  + 'Typically a callback or PIN number plus the notice id, e.g. 111-%noticeid%. It is a free string, not enforced to be '
+  + 'digits, but alphanumeric pagers and SMS should use the Text Message above instead.'
+const replacementHelp = 'Event replacement tokens are substituted when the notice is sent. Common ones: '
+  + '%noticeid% %eventid% %uei% %nodeid% %nodelabel% %foreignsource% %foreignid% %interface% %interfaceresolve% '
+  + '%service% %severity% %time% %shorttime% %descr% %logmsg% %operinstruct% %ifalias% %parm[NAME]% %parm[#N]% '
+  + '%parm[all]% %parm[names]%. Any %parm[...]% pulls a named parameter off the triggering event.'
+const pathHelp = 'The escalation chain of who is notified and how (email, browser, …). Create and edit these on the Destination Paths tab.'
+const paramsHelp = 'Extra name/value pairs passed through to the notification command — most methods need none. '
+  + 'They are available to the command as additional %parm[name]% tokens.'
+const varbindHelp = 'Restricts this notification to events that carry an SNMP varbind (event parameter) with this exact name AND value. '
+  + 'Set both or neither; leave blank to match regardless of varbinds.'
+const queueHelp = 'Which notifd queue processes this notice. Leave blank for the default in-memory queue unless you have configured extra queues in notifd-configuration.xml.'
+
+const severityOptions = ['Indeterminate', 'Cleared', 'Normal', 'Warning', 'Minor', 'Major', 'Critical']
+
+const defaultForm = () => ({
+  name: '',
+  description: '',
+  rule: 'IPADDR IPLIKE *.*.*.*',
+  destinationPath: '',
+  subject: 'Notice #%noticeid%',
+  textMessage: '',
+  numericMessage: '111-%noticeid%',
+  enabled: true,
+  eventSeverity: '',
+  noticeQueue: '',
+  varbindName: '',
+  varbindValue: '',
+  parameters: [] as { name: string, value: string }[]
+})
+
+const form = reactive(defaultForm())
+// AutoComplete's model holds either the free-typed string or a selected suggestion object.
+const ueiValue = ref<string | UeiSuggestion>('')
+const ueiSuggestions = ref<UeiSuggestion[]>([])
+const saving = ref(false)
+
+const NAME_MAX = 255
+const errors = reactive({ name: '', uei: '', destinationPath: '', textMessage: '', rule: '', general: '' })
+const clearErrors = () => {
+  errors.name = ''
+  errors.uei = ''
+  errors.destinationPath = ''
+  errors.textMessage = ''
+  errors.rule = ''
+  errors.general = ''
+}
+const advancedCollapsed = ref(true)
+
+const ruleParseNote = ref('')
+const ruleMode = ref<'builder' | 'raw'>('builder')
+
+// Switch modes without letting the two representations diverge: entering Builder
+// only succeeds if the current rule parses into the pickers, otherwise stay Raw.
+const setRuleMode = (mode: 'builder' | 'raw') => {
+  if (mode === 'builder') {
+    if (parseRule(form.rule)) {
+      ruleParseNote.value = ''
+      ruleMode.value = 'builder'
+    } else {
+      ruleParseNote.value = 'This rule is too advanced for the builder — edit it as raw text.'
+      ruleMode.value = 'raw'
+    }
+  } else {
+    ruleMode.value = 'raw'
+  }
+}
+const ipFilter = ref('IPADDR IPLIKE *.*.*.*')
+const ruleServices = ref<string[]>([])
+const ruleNotServices = ref<string[]>([])
+const availableServices = ref<string[]>([])
+const ruleValidation = ref<RuleValidation | null>(null)
+const validating = ref(false)
+
+// A filter is already grouped only when a single outer paren pair encloses the
+// whole thing; testing just for a leading '(' mis-reads "(A) | (B)" as grouped
+// and, once a service clause is appended, silently drops the OR grouping.
+const isFullyGrouped = (s: string): boolean => {
+  if (!s.startsWith('(') || !s.endsWith(')')) {
+    return false
+  }
+  let depth = 0
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '(') {
+      depth++
+    } else if (s[i] === ')') {
+      depth--
+      if (depth === 0 && i < s.length - 1) {
+        return false
+      }
+    }
+  }
+  return depth === 0
+}
+
+// Assemble the rule the way the legacy wizard did: (ip filter) & (isA | isB) & (!isC & !isD).
+const buildRule = (): string => {
+  let base = ipFilter.value.trim() || 'IPADDR IPLIKE *.*.*.*'
+  if (!isFullyGrouped(base)) {
+    base = `(${base})`
+  }
+  let out = base
+  if (ruleServices.value.length) {
+    out += ` & (${ruleServices.value.map(s => `is${s}`).join(' | ')})`
+  }
+  if (ruleNotServices.value.length) {
+    out += ` & (${ruleNotServices.value.map(s => `!is${s}`).join(' & ')})`
+  }
+  return out
+}
+
+// Best-effort round-trip: strip the trailing service clauses and treat the
+// remainder as the IP filter. Anything we can't represent falls back to Raw.
+const parseRule = (rule: string): boolean => {
+  let s = rule.trim()
+  // service names can contain hyphens/dots (e.g. OpenNMS-DB-Stats), so match more than \w
+  const notRe = /\s*&\s*\(\s*(!is[\w.-]+(?:\s*&\s*!is[\w.-]+)*)\s*\)\s*$/
+  const orRe = /\s*&\s*\(\s*(is[\w.-]+(?:\s*\|\s*is[\w.-]+)*)\s*\)\s*$/
+  const not: string[] = []
+  const svc: string[] = []
+  let m = s.match(notRe)
+  if (m) {
+    not.push(...m[1].split(/\s*&\s*/).map(x => x.replace(/^!is/, '')))
+    s = s.slice(0, m.index).trim()
+  }
+  m = s.match(orRe)
+  if (m) {
+    svc.push(...m[1].split(/\s*\|\s*/).map(x => x.replace(/^is/, '')))
+    s = s.slice(0, m.index).trim()
+  }
+  let ip = s
+  if (ip.startsWith('(') && ip.endsWith(')')) {
+    ip = ip.slice(1, -1).trim()
+  }
+  // Detect a leftover service clause (isSSH, isHTTP) as a whole word; a plain
+  // substring test also trips on IP filters containing dist/list/history.
+  if (/\bis[A-Za-z]|[|&]/.test(ip)) {
+    return false
+  }
+  ipFilter.value = ip || 'IPADDR IPLIKE *.*.*.*'
+  ruleServices.value = svc
+  ruleNotServices.value = not
+  return true
+}
+
+const loadServices = async () => {
+  if (availableServices.value.length) {
+    return
+  }
+  const svcs = await API.getNotificationServices()
+  if (svcs) {
+    availableServices.value = svcs
+  }
+}
+
+const doValidateRule = async () => {
+  validating.value = true
+  ruleValidation.value = await API.validateNotificationRule(form.rule.trim() || 'IPADDR IPLIKE *.*.*.*')
+  validating.value = false
+}
+
+// While in Builder mode the pickers own the rule string.
+watch([ipFilter, ruleServices, ruleNotServices], () => {
+  if (ruleMode.value === 'builder') {
+    form.rule = buildRule()
+  }
+})
+
+const pathOptions = computed(() => store.destinationPaths.map(p => p.name))
+
+const isEditing = computed(() => props.notification !== null)
+const originalName = computed(() => props.notification?.name ?? '')
+
+const uei = computed<string>(() =>
+  typeof ueiValue.value === 'string' ? ueiValue.value.trim() : ueiValue.value?.uei ?? '')
+
+const selectedLabel = computed<string>(() =>
+  typeof ueiValue.value === 'object' && ueiValue.value ? ueiValue.value.eventLabel ?? '' : '')
+
+const validateForm = async (): Promise<boolean> => {
+  clearErrors()
+  const name = form.name.trim()
+  if (!name) {
+    errors.name = 'Name is required.'
+  } else if (name.length > NAME_MAX) {
+    errors.name = `Name must be ${NAME_MAX} characters or fewer.`
+  } else if (!isEditing.value && store.eventNotifications.some(n => n.name === name)) {
+    errors.name = 'A notification with this name already exists.'
+  }
+  if (!uei.value) {
+    errors.uei = 'Event UEI is required.'
+  } else if (uei.value.startsWith('~')) {
+    try {
+      RegExp(uei.value.slice(1))
+    } catch {
+      errors.uei = 'The ~ regular expression is not valid.'
+    }
+  }
+  if (!form.destinationPath) {
+    errors.destinationPath = 'Destination Path is required.'
+  }
+  if (!form.textMessage.trim()) {
+    errors.textMessage = 'Text Message is required.'
+  }
+  // Only pay for the rule round-trip once the cheap checks pass.
+  if (!errors.name && !errors.uei && !errors.destinationPath && !errors.textMessage) {
+    const result = await API.validateNotificationRule(form.rule.trim() || 'IPADDR IPLIKE *.*.*.*')
+    if (result && !result.valid) {
+      errors.rule = `Rule is not a valid filter: ${result.error ?? 'unknown error'}`
+    }
+  }
+  return !errors.name && !errors.uei && !errors.destinationPath && !errors.textMessage && !errors.rule
+}
+
+// Clear surfaced errors as soon as the user starts fixing anything.
+watch([() => form.name, () => form.destinationPath, () => form.textMessage, () => form.rule, ueiValue], () => {
+  if (errors.name || errors.uei || errors.destinationPath || errors.textMessage || errors.rule || errors.general) {
+    clearErrors()
+  }
+})
+
+const ruleValue = (rule: EventNotification['rule']): string => {
+  if (typeof rule === 'string') {
+    return rule
+  }
+  return rule?.value ?? ''
+}
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (!isVisible) {
+      return
+    }
+    ueiSuggestions.value = []
+    advancedCollapsed.value = true
+    clearErrors()
+    if (props.notification) {
+      const n = props.notification
+      Object.assign(form, {
+        name: n.name,
+        description: n.description ?? '',
+        rule: ruleValue(n.rule) || 'IPADDR IPLIKE *.*.*.*',
+        destinationPath: n.destinationPath ?? '',
+        subject: n.subject ?? '',
+        textMessage: n['text-message'] ?? '',
+        numericMessage: n['numeric-message'] ?? '',
+        enabled: n.status === 'on',
+        eventSeverity: n['event-severity'] ?? '',
+        noticeQueue: n['notice-queue'] ?? '',
+        varbindName: n.varbind?.vbname ?? '',
+        varbindValue: n.varbind?.vbvalue ?? '',
+        parameters: (n.parameter ?? []).map(p => ({ name: p.name, value: p.value }))
+      })
+      ueiValue.value = n.uei ?? ''
+    } else {
+      Object.assign(form, defaultForm())
+      ueiValue.value = ''
+    }
+    ruleValidation.value = null
+    ruleParseNote.value = ''
+    loadServices()
+    ruleMode.value = parseRule(form.rule) ? 'builder' : 'raw'
+  }
+)
+
+const onUeiComplete = async (query: string) => {
+  ueiSuggestions.value = await API.searchEventConfUeis(query)
+}
+
+const save = async () => {
+  saving.value = true
+  try {
+    if (!(await validateForm())) {
+      return
+    }
+    // Spread the original first so fields the form still doesn't expose
+    // (writeable, rule.strict) survive the round-trip into notifications.xml.
+    const original = props.notification ?? {}
+    const originalRule = typeof props.notification?.rule === 'object' && props.notification?.rule !== null
+      ? props.notification.rule
+      : {}
+    const params = form.parameters
+      .filter(p => p.name.trim())
+      .map(p => ({ name: p.name.trim(), value: p.value }))
+    const varbind = form.varbindName.trim() && form.varbindValue.trim()
+      ? { vbname: form.varbindName.trim(), vbvalue: form.varbindValue.trim() }
+      : undefined
+    const notification: EventNotification = {
+      ...original,
+      name: form.name.trim(),
+      status: form.enabled ? 'on' : 'off',
+      uei: uei.value,
+      description: form.description.trim() || undefined,
+      rule: { ...originalRule, value: form.rule.trim() || 'IPADDR IPLIKE *.*.*.*' },
+      destinationPath: form.destinationPath,
+      subject: form.subject.trim() || undefined,
+      'text-message': form.textMessage,
+      'numeric-message': form.numericMessage.trim() || undefined,
+      'event-severity': form.eventSeverity || undefined,
+      'notice-queue': form.noticeQueue.trim() || undefined,
+      parameter: params,
+      varbind
+    }
+    const ok = isEditing.value
+      ? await store.updateEventNotification(originalName.value, notification)
+      : await store.addEventNotification(notification)
+    if (ok) {
+      emit('update:visible', false)
+    } else {
+      errors.general = 'Could not save the notification. Please review the fields and try again.'
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.uei-field {
+  margin-bottom: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding-top: 0.25rem;
+
+  .full-width {
+    grid-column: 1 / -1;
+  }
+}
+
+:deep(input),
+:deep(textarea),
+:deep(.p-select),
+:deep(.p-autocomplete) {
+  width: 100%;
+}
+
+.hint {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-text-muted-color);
+}
+
+.field-error {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-red-400, #e57373);
+  font-size: 0.85rem;
+}
+
+.error-banner {
+  margin-bottom: 1rem;
+  padding: 0.6rem 0.85rem;
+  border: 1px solid var(--p-red-400, #e57373);
+  border-radius: 4px;
+  color: var(--p-red-400, #e57373);
+  background: color-mix(in srgb, var(--p-red-400, #e57373) 12%, transparent);
+}
+
+.uei-option {
+  .label {
+    font-weight: 600;
+  }
+
+  .uei {
+    font-size: 0.8rem;
+    color: var(--p-text-muted-color);
+  }
+}
+
+.advanced-panel {
+  margin-top: 1rem;
+
+  .panel-header {
+    font-weight: 600;
+  }
+
+  .advanced-body {
+    padding-top: 0.5rem;
+  }
+
+  .advanced-hint {
+    margin: 0 0 1rem 0;
+    color: var(--p-text-muted-color);
+    font-size: 0.85rem;
+  }
+
+  .params-block {
+    margin-bottom: 1rem;
+
+    .params-title {
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .param-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr auto;
+      gap: 0.5rem;
+      align-items: center;
+      margin-bottom: 0.5rem;
+    }
+  }
+}
+
+.status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.rule-block {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  border: 1px solid var(--p-content-border-color, #e0e0e0);
+  border-radius: 6px;
+
+  .rule-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+
+    &__label {
+      font-weight: 600;
+    }
+  }
+
+  .rule-note {
+    display: block;
+    margin-top: 0.25rem;
+    color: var(--p-orange-600, #c77700);
+  }
+
+  .mode-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .svc-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-top: 0.5rem;
+  }
+
+  .rule-generated {
+    margin-top: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--p-content-border-color, #ccc);
+    border-radius: 4px;
+    font-size: 0.85rem;
+    color: var(--p-text-color, inherit);
+
+    &__label {
+      font-weight: 600;
+      margin-right: 0.5rem;
+      color: var(--p-text-muted-color);
+    }
+
+    code {
+      color: var(--p-text-color, inherit);
+      word-break: break-all;
+    }
+  }
+
+  .rule-validate {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .rule-valid {
+    color: var(--p-green-600, #2e7d32);
+  }
+
+  .rule-invalid {
+    color: var(--p-red-500, #b00020);
+  }
+
+  .rule-matches {
+    margin-top: 0.75rem;
+    max-height: 180px;
+    overflow: auto;
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+    }
+
+    th,
+    td {
+      text-align: left;
+      padding: 0.25rem 0.5rem;
+      border-bottom: 1px solid var(--p-content-border-color, #eee);
+    }
+  }
+}
+</style>

--- a/ui/src/components/AdminNotifications/EventNotificationsTable.vue
+++ b/ui/src/components/AdminNotifications/EventNotificationsTable.vue
@@ -4,11 +4,12 @@
       <div class="card-title">Event Notifications</div>
       <OnmsButton
         variant="outlined"
-        label="Add New Event Notification"
-        icon="pi pi-plus"
         data-test="add-event-notification-button"
         @click="openEditor(null)"
-      />
+      >
+        <OnmsIcon :icon="AddIcon" />
+        Add New Event Notification
+      </OnmsButton>
     </div>
 
     <OnmsTable
@@ -124,6 +125,7 @@ import {
   OnmsConfirmationDialog,
   OnmsButton,
   OnmsColumn,
+  OnmsIcon,
   OnmsIconButton,
   OnmsMenu,
   OnmsMenuItem,
@@ -134,6 +136,7 @@ import {
 import EventNotificationEditorDialog from '@/components/AdminNotifications/EventNotificationEditorDialog.vue'
 import EmptyList from '@/components/Common/EmptyList.vue'
 import TableCard from '@/components/Common/TableCard.vue'
+import AddIcon from '@/components/icons/action/Add.vue'
 import EditIcon from '@/components/icons/action/Edit.vue'
 import DeleteIcon from '@/components/icons/action/Delete.vue'
 import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'

--- a/ui/src/components/AdminNotifications/EventNotificationsTable.vue
+++ b/ui/src/components/AdminNotifications/EventNotificationsTable.vue
@@ -1,0 +1,265 @@
+<template>
+  <TableCard class="event-notifications-table">
+    <div class="header">
+      <div class="card-title">Event Notifications</div>
+      <OnmsButton
+        variant="outlined"
+        label="Add New Event Notification"
+        icon="pi pi-plus"
+        data-test="add-event-notification-button"
+        @click="openEditor(null)"
+      />
+    </div>
+
+    <OnmsTable
+      v-if="store.eventNotifications.length"
+      :value="store.eventNotifications"
+      paginator
+      dataKey="name"
+      :rows="10"
+      :rowsPerPageOptions="[10, 20, 50, 100]"
+      class="data-table"
+      data-test="event-notifications-table"
+    >
+      <OnmsColumn
+        field="status"
+        header="Status"
+        sortable
+      >
+        <template #body="{ data }">
+          <OnmsTag
+            :class="data.status === 'on' ? 'enabled-tag' : 'disabled-tag'"
+            :value="data.status === 'on' ? 'Enabled' : 'Disabled'"
+            data-test="notification-status-tag"
+          />
+        </template>
+      </OnmsColumn>
+      <OnmsColumn
+        field="name"
+        header="Notification"
+        sortable
+      />
+      <OnmsColumn
+        field="uei"
+        header="UEI"
+        sortable
+      >
+        <template #body="{ data }">
+          <span
+            class="uei-cell"
+            :title="data.uei"
+          >{{ data.uei }}</span>
+        </template>
+      </OnmsColumn>
+      <OnmsColumn
+        field="destinationPath"
+        header="Destination Path"
+        sortable
+      />
+      <OnmsColumn header="Actions">
+        <template #body="{ data }">
+          <div class="action-container">
+            <OnmsIconButton
+              :title="`Edit ${data.name}`"
+              :aria-label="`Edit ${data.name}`"
+              data-test="edit-event-notification-button"
+              :icon="EditIcon"
+              @click="openEditor(data)"
+            />
+            <OnmsIconButton
+              :title="store.eventNotifications.length <= 1 ? 'At least one notification must remain; disable it instead.' : `Delete ${data.name}`"
+              :aria-label="`Delete ${data.name}`"
+              data-test="delete-event-notification-button"
+              :icon="DeleteIcon"
+              :disabled="store.eventNotifications.length <= 1"
+              @click="askDelete(data)"
+            />
+            <OnmsIconButton
+              aria-haspopup="true"
+              aria-controls="event-notification-row-menu"
+              :title="`More actions for ${data.name}`"
+              data-test="row-menu-button"
+              :icon="MenuIcon"
+              @click="toggleRowMenu($event, data)"
+            />
+          </div>
+        </template>
+      </OnmsColumn>
+    </OnmsTable>
+
+    <OnmsMenu
+      id="event-notification-row-menu"
+      ref="rowMenu"
+      :items="rowMenuItems"
+    />
+
+    <div v-if="!store.eventNotifications.length">
+      <EmptyList
+        :content="emptyListContent"
+        data-test="empty-list"
+      />
+    </div>
+  </TableCard>
+  <EventNotificationEditorDialog
+    v-model:visible="showEditor"
+    :notification="notificationToEdit"
+  />
+  <OnmsConfirmationDialog
+    :visible="showDeleteConfirmation"
+    title="Delete Event Notification"
+    actionButtonText="Delete"
+    @ok="confirmDelete"
+    @cancel="cancelDelete"
+  >
+    <template #content>
+      <p>Are you sure you want to delete the event notification <strong>{{ notificationToDelete?.name }}</strong>? This action cannot be undone.</p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import {
+  OnmsConfirmationDialog,
+  OnmsButton,
+  OnmsColumn,
+  OnmsIconButton,
+  OnmsMenu,
+  OnmsMenuItem,
+  OnmsTable,
+  OnmsTag
+} from '@opennms/onms-ui'
+
+import EventNotificationEditorDialog from '@/components/AdminNotifications/EventNotificationEditorDialog.vue'
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import EditIcon from '@/components/icons/action/Edit.vue'
+import DeleteIcon from '@/components/icons/action/Delete.vue'
+import MenuIcon from '@/components/icons/navigation/MoreHoriz.vue'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { EventNotification } from '@/types/notificationConfig'
+
+const store = useNotificationConfigStore()
+
+const showEditor = ref(false)
+const notificationToEdit = ref<EventNotification | null>(null)
+const showDeleteConfirmation = ref(false)
+
+const openEditor = (notification: EventNotification | null) => {
+  notificationToEdit.value = notification
+  showEditor.value = true
+}
+const notificationToDelete = ref<EventNotification | null>(null)
+// Guards against a second click racing the in-flight status update.
+const pendingName = ref<string | null>(null)
+
+const emptyListContent = {
+  msg: 'No event notifications configured.'
+}
+
+// Row overflow menu: expose only the status action opposite the current state.
+const rowMenu = ref()
+const rowMenuTarget = ref<EventNotification | null>(null)
+const rowMenuItems = computed<OnmsMenuItem[]>(() => {
+  const target = rowMenuTarget.value
+  if (!target) {
+    return []
+  }
+  return [
+    {
+      label: target.status === 'on' ? 'Disable' : 'Enable',
+      command: () => onToggle(target, target.status !== 'on')
+    }
+  ]
+})
+
+const toggleRowMenu = (event: Event, notification: EventNotification) => {
+  rowMenuTarget.value = notification
+  rowMenu.value?.toggle(event)
+}
+
+const onToggle = async (notification: EventNotification, value: boolean) => {
+  if (pendingName.value === notification.name) {
+    return
+  }
+  pendingName.value = notification.name
+  try {
+    await store.setEventNotificationStatus(notification.name, value ? 'on' : 'off')
+  } finally {
+    pendingName.value = null
+  }
+}
+
+const askDelete = (notification: EventNotification) => {
+  notificationToDelete.value = notification
+  showDeleteConfirmation.value = true
+}
+
+const confirmDelete = async () => {
+  if (notificationToDelete.value) {
+    await store.deleteEventNotification(notificationToDelete.value.name)
+  }
+  showDeleteConfirmation.value = false
+  notificationToDelete.value = null
+}
+
+const cancelDelete = () => {
+  showDeleteConfirmation.value = false
+  notificationToDelete.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.event-notifications-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.action-container {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+// Long UEIs (e.g. uei.opennms.org/... URLs) would otherwise force the table
+// wider than its container and produce a horizontal scrollbar; clamp the cell
+// and surface the full value on hover.
+.uei-cell {
+  display: inline-block;
+  max-width: 28rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.enabled-tag {
+  border-radius: 4px;
+  background-color: #0B720C1F;
+
+  :deep(.p-tag-label) {
+    color: #0B720C !important;
+  }
+}
+
+.disabled-tag {
+  border-radius: 4px;
+  background-color: #7575751F;
+
+  :deep(.p-tag-label) {
+    color: #757575 !important;
+  }
+}
+</style>

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -76,9 +76,17 @@ import {
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
 import {
+  addEventNotification,
+  deleteEventNotification,
   getDestinationPaths,
+  getEventNotifications,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  getNotificationServices,
+  searchEventConfUeis,
+  setEventNotificationStatus,
+  setNotificationConfigStatus,
+  updateEventNotification,
+  validateNotificationRule
 } from './notificationConfigService'
 import { acknowledgeNotice, browseNotices } from './noticesService'
 
@@ -146,8 +154,16 @@ export default {
   getZenithRegistrations,
   performLogout,
   acknowledgeNotice,
+  addEventNotification,
   browseNotices,
+  searchEventConfUeis,
+  updateEventNotification,
+  deleteEventNotification,
   getDestinationPaths,
+  getEventNotifications,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  getNotificationServices,
+  setEventNotificationStatus,
+  setNotificationConfigStatus,
+  validateNotificationRule
 }

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -22,8 +22,8 @@
 
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
-import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
-import { rest } from './axiosInstances'
+import { DestinationPath, EventNotification, NotifdStatus, RuleValidation, UeiSuggestion } from '@/types/notificationConfig'
+import { rest, v2 } from './axiosInstances'
 
 const { showSnackBar } = useSnackbar()
 const { startSpinner, stopSpinner } = useSpinner()
@@ -56,6 +56,96 @@ const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolea
   }
 }
 
+const getEventNotifications = async (): Promise<EventNotification[] | null> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/event-notifications`)
+    return resp.data?.notification ?? []
+  } catch (_err) {
+    // null (not []) so a failed load is distinguishable from an empty one and the
+    // tab loader can retry instead of latching
+    showSnackBar({ msg: 'Failed to load event notifications.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+const setEventNotificationStatus = async (name: string, status: NotifdStatus): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.put(`${endpoint}/event-notifications/${encodeURIComponent(name)}/status`, { status })
+    showSnackBar({ msg: `Event notification '${name}' turned ${status}.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to update event notification '${name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const addEventNotification = async (notification: EventNotification): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.post(`${endpoint}/event-notifications`, notification)
+    showSnackBar({ msg: `Event notification '${notification.name}' added.` })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : `Failed to add event notification '${notification.name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const updateEventNotification = async (originalName: string, notification: EventNotification): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.put(`${endpoint}/event-notifications/${encodeURIComponent(originalName)}`, notification)
+    showSnackBar({ msg: `Event notification '${notification.name}' updated.` })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : `Failed to update event notification '${notification.name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+// Type-ahead UEI suggestions from the event configuration (DB-backed eventconf REST).
+const searchEventConfUeis = async (query: string): Promise<UeiSuggestion[]> => {
+  try {
+    const resp = await v2.get(`/eventconf/filter?uei=${encodeURIComponent(query)}&limit=25&offset=0`)
+    const items = Array.isArray(resp.data) ? resp.data : []
+    return items
+      .filter((item: any) => !!item?.uei)
+      .map((item: any) => ({ uei: item.uei, eventLabel: item.eventLabel ?? '' }))
+  } catch (_err) {
+    // suggestions are best-effort; free-text UEIs remain valid
+    return []
+  }
+}
+
+const deleteEventNotification = async (name: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.delete(`${endpoint}/event-notifications/${encodeURIComponent(name)}`)
+    showSnackBar({ msg: `Event notification '${name}' deleted.` })
+    return true
+  } catch (err: any) {
+    // surface the server's reason (e.g. the last notification cannot be deleted)
+    // instead of a generic failure
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : `Failed to delete event notification '${name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
 const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
   try {
     startSpinner()
@@ -72,8 +162,36 @@ const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
 }
 
 
+const getNotificationServices = async (): Promise<string[] | null> => {
+  try {
+    const resp = await rest.get(`${endpoint}/services`)
+    return Array.isArray(resp.data) ? resp.data : []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load the service list.' })
+    return null
+  }
+}
+
+const validateNotificationRule = async (rule: string): Promise<RuleValidation | null> => {
+  try {
+    const resp = await rest.post(`${endpoint}/rule/validate`, { rule })
+    return resp.data ?? null
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to validate the rule.' })
+    return null
+  }
+}
+
 export {
+  addEventNotification,
+  deleteEventNotification,
   getDestinationPaths,
+  getEventNotifications,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  getNotificationServices,
+  searchEventConfUeis,
+  setEventNotificationStatus,
+  setNotificationConfigStatus,
+  updateEventNotification,
+  validateNotificationRule
 }

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -23,7 +23,7 @@
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
 import { DestinationPath, EventNotification, NotifdStatus, RuleValidation, UeiSuggestion } from '@/types/notificationConfig'
-import { rest, v2 } from './axiosInstances'
+import { v2 } from './axiosInstances'
 
 const { showSnackBar } = useSnackbar()
 const { startSpinner, stopSpinner } = useSpinner()
@@ -32,7 +32,7 @@ const endpoint = '/notification-config'
 const getNotificationConfigStatus = async (): Promise<NotifdStatus | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/status`)
+    const resp = await v2.get(`${endpoint}/status`)
     return resp.data?.status ?? null
   } catch (_err) {
     showSnackBar({ msg: 'Failed to load notification status.' })
@@ -45,7 +45,7 @@ const getNotificationConfigStatus = async (): Promise<NotifdStatus | null> => {
 const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.put(`${endpoint}/status`, { status })
+    await v2.put(`${endpoint}/status`, { status })
     showSnackBar({ msg: `Notifications turned ${status}.` })
     return true
   } catch (_err) {
@@ -59,7 +59,7 @@ const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolea
 const getEventNotifications = async (): Promise<EventNotification[] | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/event-notifications`)
+    const resp = await v2.get(`${endpoint}/event-notifications`)
     return resp.data?.notification ?? []
   } catch (_err) {
     // null (not []) so a failed load is distinguishable from an empty one and the
@@ -74,7 +74,7 @@ const getEventNotifications = async (): Promise<EventNotification[] | null> => {
 const setEventNotificationStatus = async (name: string, status: NotifdStatus): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.put(`${endpoint}/event-notifications/${encodeURIComponent(name)}/status`, { status })
+    await v2.put(`${endpoint}/event-notifications/${encodeURIComponent(name)}/status`, { status })
     showSnackBar({ msg: `Event notification '${name}' turned ${status}.` })
     return true
   } catch (_err) {
@@ -88,7 +88,7 @@ const setEventNotificationStatus = async (name: string, status: NotifdStatus): P
 const addEventNotification = async (notification: EventNotification): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.post(`${endpoint}/event-notifications`, notification)
+    await v2.post(`${endpoint}/event-notifications`, notification)
     showSnackBar({ msg: `Event notification '${notification.name}' added.` })
     return true
   } catch (err: any) {
@@ -103,7 +103,7 @@ const addEventNotification = async (notification: EventNotification): Promise<bo
 const updateEventNotification = async (originalName: string, notification: EventNotification): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.put(`${endpoint}/event-notifications/${encodeURIComponent(originalName)}`, notification)
+    await v2.put(`${endpoint}/event-notifications/${encodeURIComponent(originalName)}`, notification)
     showSnackBar({ msg: `Event notification '${notification.name}' updated.` })
     return true
   } catch (err: any) {
@@ -132,7 +132,7 @@ const searchEventConfUeis = async (query: string): Promise<UeiSuggestion[]> => {
 const deleteEventNotification = async (name: string): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.delete(`${endpoint}/event-notifications/${encodeURIComponent(name)}`)
+    await v2.delete(`${endpoint}/event-notifications/${encodeURIComponent(name)}`)
     showSnackBar({ msg: `Event notification '${name}' deleted.` })
     return true
   } catch (err: any) {
@@ -149,7 +149,7 @@ const deleteEventNotification = async (name: string): Promise<boolean> => {
 const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/destination-paths`)
+    const resp = await v2.get(`${endpoint}/destination-paths`)
     return resp.data?.path ?? []
   } catch (_err) {
     // null (not []) so a failed load is distinguishable from an empty one and the
@@ -164,7 +164,7 @@ const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
 
 const getNotificationServices = async (): Promise<string[] | null> => {
   try {
-    const resp = await rest.get(`${endpoint}/services`)
+    const resp = await v2.get(`${endpoint}/services`)
     return Array.isArray(resp.data) ? resp.data : []
   } catch (_err) {
     showSnackBar({ msg: 'Failed to load the service list.' })
@@ -176,7 +176,7 @@ const getNotificationServices = async (): Promise<string[] | null> => {
 // false so validation costs only a rule parse on the server.
 const validateNotificationRule = async (rule: string, preview = false): Promise<RuleValidation | null> => {
   try {
-    const resp = await rest.post(`${endpoint}/rule/validate`, { rule, preview })
+    const resp = await v2.post(`${endpoint}/rule/validate`, { rule, preview })
     return resp.data ?? null
   } catch (_err) {
     showSnackBar({ msg: 'Failed to validate the rule.' })

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -172,9 +172,11 @@ const getNotificationServices = async (): Promise<string[] | null> => {
   }
 }
 
-const validateNotificationRule = async (rule: string): Promise<RuleValidation | null> => {
+// preview builds the (potentially large) match list; the save path leaves it
+// false so validation costs only a rule parse on the server.
+const validateNotificationRule = async (rule: string, preview = false): Promise<RuleValidation | null> => {
   try {
-    const resp = await rest.post(`${endpoint}/rule/validate`, { rule })
+    const resp = await rest.post(`${endpoint}/rule/validate`, { rule, preview })
     return resp.data ?? null
   } catch (_err) {
     showSnackBar({ msg: 'Failed to validate the rule.' })

--- a/ui/src/stores/notificationConfigStore.ts
+++ b/ui/src/stores/notificationConfigStore.ts
@@ -21,12 +21,15 @@
 ///
 
 import API from '@/services'
-import { NotifdStatus } from '@/types/notificationConfig'
+import { DestinationPath, EventNotification, NotifdStatus } from '@/types/notificationConfig'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useNotificationConfigStore = defineStore('notificationConfigStore', () => {
   const notifdStatus = ref<NotifdStatus | null>(null)
+  const eventNotifications = ref([] as EventNotification[])
+  // the event-notification editor's destination picker needs the path list
+  const destinationPaths = ref([] as DestinationPath[])
 
   const getStatus = async (): Promise<boolean> => {
     notifdStatus.value = await API.getNotificationConfigStatus()
@@ -41,9 +44,70 @@ export const useNotificationConfigStore = defineStore('notificationConfigStore',
     return ok
   }
 
+  const getEventNotifications = async (): Promise<boolean> => {
+    const result = await API.getEventNotifications()
+    if (result === null) {
+      return false
+    }
+    eventNotifications.value = result
+    return true
+  }
+
+  const setEventNotificationStatus = async (name: string, status: NotifdStatus) => {
+    const ok = await API.setEventNotificationStatus(name, status)
+    if (ok) {
+      const notification = eventNotifications.value.find(n => n.name === name)
+      if (notification) {
+        notification.status = status
+      }
+    }
+    return ok
+  }
+
+  const addEventNotification = async (notification: EventNotification) => {
+    const ok = await API.addEventNotification(notification)
+    if (ok) {
+      await getEventNotifications()
+    }
+    return ok
+  }
+
+  const updateEventNotification = async (originalName: string, notification: EventNotification) => {
+    const ok = await API.updateEventNotification(originalName, notification)
+    if (ok) {
+      await getEventNotifications()
+    }
+    return ok
+  }
+
+  const deleteEventNotification = async (name: string) => {
+    const ok = await API.deleteEventNotification(name)
+    if (ok) {
+      await getEventNotifications()
+    }
+    return ok
+  }
+
+  const getDestinationPaths = async (): Promise<boolean> => {
+    const result = await API.getDestinationPaths()
+    if (result === null) {
+      return false
+    }
+    destinationPaths.value = result
+    return true
+  }
+
   return {
     notifdStatus,
+    eventNotifications,
+    destinationPaths,
     getStatus,
-    setStatus
+    setStatus,
+    getEventNotifications,
+    setEventNotificationStatus,
+    addEventNotification,
+    updateEventNotification,
+    deleteEventNotification,
+    getDestinationPaths
   }
 })

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -20,7 +20,7 @@
 /// License.
 ///
 
-// JSON mirrors of the JAXB config models behind /rest/notification-config.
+// JSON mirrors of the config models behind /api/v2/notification-config.
 // Field names follow the XML element/attribute names in notifications.xml,
 // destinationPaths.xml and notificationCommands.xml — the files stay the
 // system of record, this API is a 1:1 view of them.

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -55,7 +55,7 @@ export interface EventNotificationVarbind {
 export interface EventNotification {
   name: string
   status: NotifdStatus
-  writeable?: string
+  writeable?: boolean
   uei: string
   description?: string
   rule?: EventNotificationRule | string

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -27,6 +27,48 @@
 
 export type NotifdStatus = 'on' | 'off'
 
+export interface EventNotificationRule {
+  strict?: boolean
+  value?: string
+}
+export interface RuleMatch {
+  ipAddress: string
+  services: string[]
+}
+export interface RuleValidation {
+  valid: boolean
+  error?: string
+  matchCount: number
+  matches: RuleMatch[]
+}
+
+export interface EventNotificationParameter {
+  name: string
+  value: string
+}
+
+export interface EventNotificationVarbind {
+  vbname: string
+  vbvalue: string
+}
+
+export interface EventNotification {
+  name: string
+  status: NotifdStatus
+  writeable?: string
+  uei: string
+  description?: string
+  rule?: EventNotificationRule | string
+  'notice-queue'?: string
+  destinationPath: string
+  'text-message'?: string
+  subject?: string
+  'numeric-message'?: string
+  'event-severity'?: string
+  parameter?: EventNotificationParameter[]
+  varbind?: EventNotificationVarbind
+}
+
 export interface DestinationPathTarget {
   interval?: string
   name: string
@@ -44,4 +86,9 @@ export interface DestinationPath {
   'initial-delay'?: string
   target: DestinationPathTarget[]
   escalate?: DestinationPathEscalate[]
+}
+
+export interface UeiSuggestion {
+  uei: string
+  eventLabel: string
 }

--- a/ui/tests/stores/notificationConfigStore.test.ts
+++ b/ui/tests/stores/notificationConfigStore.test.ts
@@ -2,16 +2,44 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import API from '@/services'
+import { DestinationPath, EventNotification } from '@/types/notificationConfig'
 
 vi.mock('@/services', () => ({
   default: {
     getNotificationConfigStatus: vi.fn(),
-    setNotificationConfigStatus: vi.fn()
+    setNotificationConfigStatus: vi.fn(),
+    getEventNotifications: vi.fn(),
+    setEventNotificationStatus: vi.fn(),
+    addEventNotification: vi.fn(),
+    updateEventNotification: vi.fn(),
+    deleteEventNotification: vi.fn(),
+    getDestinationPaths: vi.fn()
   }
 }))
 
 describe('useNotificationConfigStore', () => {
   let store: ReturnType<typeof useNotificationConfigStore>
+
+  const mockNotifications: EventNotification[] = [
+    {
+      name: 'nodeDown',
+      status: 'on',
+      uei: 'uei.opennms.org/nodes/nodeDown',
+      destinationPath: 'Email-Admin'
+    },
+    {
+      name: 'High Threshold',
+      status: 'off',
+      uei: 'uei.opennms.org/threshold/highThresholdExceeded',
+      destinationPath: 'Email-Admin'
+    }
+  ]
+
+  const mockPath: DestinationPath = {
+    name: 'Email-Admin',
+    'initial-delay': '0s',
+    target: [{ name: 'Admin', command: ['javaEmail'] }]
+  }
 
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -26,6 +54,8 @@ describe('useNotificationConfigStore', () => {
   describe('Initial State', () => {
     it('should start empty with unknown notifd status', () => {
       expect(store.notifdStatus).toBeNull()
+      expect(store.eventNotifications).toEqual([])
+      expect(store.destinationPaths).toEqual([])
     })
   })
 
@@ -62,6 +92,97 @@ describe('useNotificationConfigStore', () => {
 
       expect(ok).toBe(false)
       expect(store.notifdStatus).toBe('off')
+    })
+  })
+
+  describe('event notifications', () => {
+    it('should load event notifications', async () => {
+      vi.mocked(API.getEventNotifications).mockResolvedValue(mockNotifications)
+
+      const ok = await store.getEventNotifications()
+
+      expect(ok).toBe(true)
+      expect(store.eventNotifications).toEqual(mockNotifications)
+    })
+
+    it('reports failure so the tab loader does not latch', async () => {
+      vi.mocked(API.getEventNotifications).mockResolvedValueOnce(mockNotifications)
+      await store.getEventNotifications()
+      // a failed reload returns false and keeps the prior data
+      vi.mocked(API.getEventNotifications).mockResolvedValueOnce(null)
+
+      expect(await store.getEventNotifications()).toBe(false)
+      expect(store.eventNotifications).toEqual(mockNotifications)
+    })
+
+    it('should update the local status on a successful toggle', async () => {
+      store.eventNotifications = mockNotifications.map(n => ({ ...n }))
+      vi.mocked(API.setEventNotificationStatus).mockResolvedValue(true)
+
+      const ok = await store.setEventNotificationStatus('nodeDown', 'off')
+
+      expect(ok).toBe(true)
+      expect(store.eventNotifications.find(n => n.name === 'nodeDown')?.status).toBe('off')
+    })
+
+    it('should leave the local status alone on a failed toggle', async () => {
+      store.eventNotifications = mockNotifications.map(n => ({ ...n }))
+      vi.mocked(API.setEventNotificationStatus).mockResolvedValue(false)
+
+      await store.setEventNotificationStatus('nodeDown', 'off')
+
+      expect(store.eventNotifications.find(n => n.name === 'nodeDown')?.status).toBe('on')
+    })
+
+    it('should refresh the list after adding', async () => {
+      vi.mocked(API.addEventNotification).mockResolvedValue(true)
+      vi.mocked(API.getEventNotifications).mockResolvedValue(mockNotifications)
+
+      const ok = await store.addEventNotification(mockNotifications[0])
+
+      expect(ok).toBe(true)
+      expect(API.getEventNotifications).toHaveBeenCalledTimes(1)
+    })
+
+    it('should refresh the list after updating and pass the original name', async () => {
+      vi.mocked(API.updateEventNotification).mockResolvedValue(true)
+      vi.mocked(API.getEventNotifications).mockResolvedValue(mockNotifications)
+
+      const renamed = { ...mockNotifications[0], name: 'nodeDown-renamed' }
+      const ok = await store.updateEventNotification('nodeDown', renamed)
+
+      expect(ok).toBe(true)
+      expect(API.updateEventNotification).toHaveBeenCalledWith('nodeDown', renamed)
+      expect(API.getEventNotifications).toHaveBeenCalledTimes(1)
+    })
+
+    it('should refresh the list after deleting', async () => {
+      vi.mocked(API.deleteEventNotification).mockResolvedValue(true)
+      vi.mocked(API.getEventNotifications).mockResolvedValue([mockNotifications[1]])
+
+      const ok = await store.deleteEventNotification('nodeDown')
+
+      expect(ok).toBe(true)
+      expect(store.eventNotifications).toEqual([mockNotifications[1]])
+    })
+
+    it('should not refresh after a failed delete', async () => {
+      vi.mocked(API.deleteEventNotification).mockResolvedValue(false)
+
+      const ok = await store.deleteEventNotification('nodeDown')
+
+      expect(ok).toBe(false)
+      expect(API.getEventNotifications).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('destination paths', () => {
+    it('should load the destination paths for the editor picker', async () => {
+      vi.mocked(API.getDestinationPaths).mockResolvedValue([mockPath])
+
+      await store.getDestinationPaths()
+
+      expect(store.destinationPaths).toEqual([mockPath])
     })
   })
 })


### PR DESCRIPTION
**Tickets:** NMS-20118 (epic NMS-20100).

Adds the Event Notifications tab to Configure Notifications, rebased onto the epic with the review feedback applied.

- Table shows a read-only status tag, icon Edit/Delete actions, and an overflow menu offering only the opposite enable/disable action.
- Long UEIs are truncated so the table no longer scrolls horizontally.
- Editor dialog covers the UEI, targets, rule and advanced parameters; every field uses the FormField seam with inline info-icon help (no direct-PrimeVue IftaLabel).
- Backed by new NotificationConfig REST endpoints (with IT) plus store/service/type support.
