### PR TITLE
NMS-20119: Destination Paths tab

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DestinationPathManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DestinationPathManager.java
@@ -60,7 +60,7 @@ public abstract class DestinationPathManager {
      * @param stream a {@link java.io.InputStream} object.
      * @throws IOException 
      */
-    protected void parseXML(final InputStream stream) throws IOException {
+    protected synchronized void parseXML(final InputStream stream) throws IOException {
         try (final InputStreamReader isr = new InputStreamReader(stream)) {
             allPaths = JaxbUtils.unmarshal(DestinationPaths.class, isr);
             oldHeader = allPaths.getHeader();
@@ -69,9 +69,16 @@ public abstract class DestinationPathManager {
     }
 
     private void initializeDestinationPaths() {
+        // Build the replacement map and swap the field reference in one
+        // assignment rather than clearing in place: a reload replaces memory
+        // with the file (instead of merging over it), while a reader holding an
+        // earlier unmodifiableMap keeps a consistent snapshot and saveCurrent()'s
+        // iteration is never emptied mid-flight.
+        final Map<String, Path> paths = new TreeMap<>();
         for (Path curPath : allPaths.getPaths()) {
-            m_destinationPaths.put(curPath.getName(), curPath);
+            paths.put(curPath.getName(), curPath);
         }
+        m_destinationPaths = paths;
     }
 
     /**

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/GroupManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/GroupManager.java
@@ -144,11 +144,11 @@ public abstract class GroupManager implements GroupConfig {
         }
         buildDutySchedules(m_groups);
         
-        if (groupinfo.getRoles().size() > 0) {
-            m_roles = new LinkedHashMap<String, Role>();
-            for (final Role role : groupinfo.getRoles()) {
-                m_roles.put(role.getName(), role);
-            }
+        // always rebuild, so removing the last role from groups.xml doesn't
+        // leave the previous roles cached until restart
+        m_roles = new LinkedHashMap<String, Role>();
+        for (final Role role : groupinfo.getRoles()) {
+            m_roles.put(role.getName(), role);
         }
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -228,18 +228,35 @@ public class NotificationConfigRestService extends OnmsRestService {
             if (renamed && getDestinationPathFactory().getPath(path.getName()) != null) {
                 throw getException(Status.BAD_REQUEST, "Destination path {} already exists.", path.getName());
             }
+            final org.opennms.netmgt.config.destinationPaths.Path oldPath = getDestinationPathFactory().getPath(name);
             getDestinationPathFactory().replacePath(name, path);
             if (renamed) {
                 // keep event notifications pointing at the renamed path
-                boolean changed = false;
+                final List<Notification> touched = new ArrayList<>();
                 for (final Notification n : getNotificationFactory().getNotifications().values()) {
                     if (name.equals(n.getDestinationPath())) {
                         n.setDestinationPath(path.getName());
-                        changed = true;
+                        touched.add(n);
                     }
                 }
-                if (changed) {
-                    getNotificationFactory().saveCurrent();
+                if (!touched.isEmpty()) {
+                    try {
+                        getNotificationFactory().saveCurrent();
+                    } catch (final Exception notifSaveError) {
+                        // The path rename already persisted; undo it and revert the
+                        // in-memory notifications so destinationPaths.xml and
+                        // notifications.xml stay consistent instead of leaving
+                        // notifications pointing at a name that no longer exists.
+                        try {
+                            getDestinationPathFactory().replacePath(path.getName(), oldPath);
+                        } catch (final Exception rollbackError) {
+                            notifSaveError.addSuppressed(rollbackError);
+                        }
+                        for (final Notification n : touched) {
+                            n.setDestinationPath(name);
+                        }
+                        throw notifSaveError;
+                    }
                 }
             }
             return Response.noContent().build();
@@ -261,6 +278,12 @@ public class NotificationConfigRestService extends OnmsRestService {
         try {
             if (getDestinationPathFactory().getPath(name) == null) {
                 throw getException(Status.NOT_FOUND, "Destination path {} was not found.", name);
+            }
+            // destinationPaths.xsd requires at least one path, so removing the
+            // last one would fail schema validation on marshal (a raw 500).
+            // Reject it up front with an explanation instead.
+            if (getDestinationPathFactory().getPaths().size() <= 1) {
+                throw getException(Status.BAD_REQUEST, "Destination path {} is the only one configured; at least one must remain.", name);
             }
             getDestinationPathFactory().removePath(name);
             return Response.noContent().build();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -28,7 +28,9 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -42,8 +44,14 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.netmgt.config.DestinationPathFactory;
+import org.opennms.netmgt.config.GroupFactory;
+import org.opennms.netmgt.config.GroupManager;
 import org.opennms.netmgt.config.NotifdConfigFactory;
+import org.opennms.netmgt.config.NotificationCommandFactory;
+import org.opennms.netmgt.config.NotificationFactory;
 import org.opennms.netmgt.config.destinationPaths.DestinationPaths;
+import org.opennms.netmgt.config.notificationCommands.Command;
+import org.opennms.netmgt.config.notifications.Notification;
 import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.web.api.Authentication;
@@ -67,6 +75,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * <li><b>PUT /notification-config/status</b> turn notifd on or off</li>
  * <li><b>GET /notification-config/destination-paths</b> all destination paths</li>
  * <li><b>GET /notification-config/destination-paths/{name}</b> one destination path</li>
+ * <li><b>POST/PUT/DELETE /notification-config/destination-paths[/{name}]</b> destination path mutations (destinationPaths.xml)</li>
+ * <li><b>GET /notification-config/commands</b> notification commands (notificationCommands.xml, read-only)</li>
+ * <li><b>GET /notification-config/on-call-roles</b> on-call role names (groups.xml, read-only)</li>
  * </ul>
  */
 @Component("notificationConfigRestService")
@@ -179,6 +190,127 @@ public class NotificationConfigRestService extends OnmsRestService {
         }
     }
 
+    @POST
+    @Path("destination-paths")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response addDestinationPath(@Context final SecurityContext securityContext, final org.opennms.netmgt.config.destinationPaths.Path path) {
+        assertAdmin(securityContext, "add destination paths");
+        validateDestinationPath(path);
+        writeLock();
+        try {
+            if (getDestinationPathFactory().getPath(path.getName()) != null) {
+                throw getException(Status.BAD_REQUEST, "Destination path {} already exists.", path.getName());
+            }
+            getDestinationPathFactory().addPath(path);
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            reloadDestinationPathsQuietly();
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't add destination path {}: {}", path.getName(), e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @PUT
+    @Path("destination-paths/{name}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateDestinationPath(@Context final SecurityContext securityContext, @PathParam("name") final String name, final org.opennms.netmgt.config.destinationPaths.Path path) {
+        assertAdmin(securityContext, "update destination paths");
+        validateDestinationPath(path);
+        writeLock();
+        try {
+            if (getDestinationPathFactory().getPath(name) == null) {
+                throw getException(Status.NOT_FOUND, "Destination path {} was not found.", name);
+            }
+            final boolean renamed = !name.equals(path.getName());
+            if (renamed && getDestinationPathFactory().getPath(path.getName()) != null) {
+                throw getException(Status.BAD_REQUEST, "Destination path {} already exists.", path.getName());
+            }
+            getDestinationPathFactory().replacePath(name, path);
+            if (renamed) {
+                // keep event notifications pointing at the renamed path
+                boolean changed = false;
+                for (final Notification n : getNotificationFactory().getNotifications().values()) {
+                    if (name.equals(n.getDestinationPath())) {
+                        n.setDestinationPath(path.getName());
+                        changed = true;
+                    }
+                }
+                if (changed) {
+                    getNotificationFactory().saveCurrent();
+                }
+            }
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            reloadDestinationPathsQuietly();
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't update destination path {}: {}", name, e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @DELETE
+    @Path("destination-paths/{name}")
+    public Response deleteDestinationPath(@Context final SecurityContext securityContext, @PathParam("name") final String name) {
+        assertAdmin(securityContext, "delete destination paths");
+        writeLock();
+        try {
+            if (getDestinationPathFactory().getPath(name) == null) {
+                throw getException(Status.NOT_FOUND, "Destination path {} was not found.", name);
+            }
+            getDestinationPathFactory().removePath(name);
+            return Response.noContent().build();
+        } catch (final javax.ws.rs.WebApplicationException e) {
+            throw e;
+        } catch (final Exception e) {
+            reloadDestinationPathsQuietly();
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't delete destination path {}: {}", name, e.getMessage());
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @GET
+    @Path("commands")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Command> getCommands(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read notification commands");
+        readLock();
+        try {
+            final List<Command> commands = new ArrayList<>(getNotificationCommandFactory().getCommands().values());
+            commands.sort(Comparator.comparing(Command::getName, String.CASE_INSENSITIVE_ORDER));
+            return commands;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read notification commands: {}", e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @GET
+    @Path("on-call-roles")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getOnCallRoles(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read on-call roles");
+        readLock();
+        try {
+            final GroupManager manager = getGroupManager();
+            // getRoleNames() reads cached state without checking the file
+            manager.update();
+            final List<String> roles = new ArrayList<>(java.util.Arrays.asList(manager.getRoleNames()));
+            roles.sort(String.CASE_INSENSITIVE_ORDER);
+            return roles;
+        } catch (final Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read on-call roles: {}", e.getMessage());
+        } finally {
+            readUnlock();
+        }
+    }
+
     private static void assertAdmin(final SecurityContext securityContext, final String operation) {
         if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
             throw getException(Status.FORBIDDEN, "User {} does not have access to {}.", securityContext.getUserPrincipal().getName(), operation);
@@ -207,8 +339,73 @@ public class NotificationConfigRestService extends OnmsRestService {
         return NotifdConfigFactory.getInstance();
     }
 
+    private static NotificationFactory getNotificationFactory() throws Exception {
+        // NotificationFactory's constructor requires an initialized NotifdConfigFactory
+        NotifdConfigFactory.init();
+        NotificationFactory.init();
+        return NotificationFactory.getInstance();
+    }
+
+    private static void validateDestinationPath(final org.opennms.netmgt.config.destinationPaths.Path path) {
+        if (path == null || isBlank(path.getName())) {
+            throw getException(Status.BAD_REQUEST, "The destination path and its name are required");
+        }
+        if (path.getTargets().isEmpty()) {
+            throw getException(Status.BAD_REQUEST, "The destination path requires at least one target");
+        }
+        validateTargets(path.getTargets());
+        for (final org.opennms.netmgt.config.destinationPaths.Escalate escalate : path.getEscalates()) {
+            if (isBlank(escalate.getDelay())) {
+                throw getException(Status.BAD_REQUEST, "Every escalation requires a delay");
+            }
+            if (escalate.getTargets().isEmpty()) {
+                throw getException(Status.BAD_REQUEST, "Every escalation requires at least one target");
+            }
+            validateTargets(escalate.getTargets());
+        }
+    }
+
+    private static void validateTargets(final List<org.opennms.netmgt.config.destinationPaths.Target> targets) {
+        for (final org.opennms.netmgt.config.destinationPaths.Target target : targets) {
+            if (isBlank(target.getName())) {
+                throw getException(Status.BAD_REQUEST, "Every target requires a name");
+            }
+            if (target.getCommands().isEmpty() || target.getCommands().stream().anyMatch(NotificationConfigRestService::isBlank)) {
+                throw getException(Status.BAD_REQUEST, "Every target requires at least one non-empty command");
+            }
+        }
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.isBlank();
+    }
+
     private static DestinationPathFactory getDestinationPathFactory() throws Exception {
         DestinationPathFactory.init();
         return DestinationPathFactory.getInstance();
+    }
+
+    // addPath/replacePath/removePath mutate the in-memory map and only then
+    // saveCurrent(); if the save throws (I/O error, or the marshalled XML fails
+    // schema validation — e.g. removing the last path), memory is left ahead of
+    // the file and the factory won't re-read until a restart. Reload from disk
+    // on any mutation failure so memory matches what actually persisted.
+    private static void reloadDestinationPathsQuietly() {
+        try {
+            getDestinationPathFactory().reload();
+        } catch (final Exception e) {
+            LOG.warn("Failed to reload destination paths after a save error; "
+                    + "in-memory notification config may diverge from disk until restart", e);
+        }
+    }
+
+    private static NotificationCommandFactory getNotificationCommandFactory() throws Exception {
+        NotificationCommandFactory.init();
+        return NotificationCommandFactory.getInstance();
+    }
+
+    private static GroupManager getGroupManager() throws Exception {
+        GroupFactory.init();
+        return GroupFactory.getInstance();
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 
+import org.apache.commons.lang.StringUtils;
 import org.opennms.netmgt.config.DestinationPathFactory;
 import org.opennms.netmgt.config.GroupFactory;
 import org.opennms.netmgt.config.GroupManager;
@@ -59,7 +60,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.googlecode.concurentlocks.ReadWriteUpdateLock;
@@ -92,29 +92,28 @@ public class NotificationConfigRestService {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationConfigRestService.class);
 
     @Autowired
-    @Qualifier("eventProxy")
-    protected EventProxy m_eventProxy;
+    protected EventProxy eventProxy;
 
     // Per-instance read/write/update lock serializing config mutations, carried
     // over from the base REST service this was split out of when it moved to v2.
-    private final ReadWriteUpdateLock m_globalLock = new ReentrantReadWriteUpdateLock();
-    private final Lock m_readLock = m_globalLock.updateLock();
-    private final Lock m_writeLock = m_globalLock.writeLock();
+    private final ReadWriteUpdateLock globalLock = new ReentrantReadWriteUpdateLock();
+    private final Lock readLock = globalLock.updateLock();
+    private final Lock writeLock = globalLock.writeLock();
 
     private void readLock() {
-        m_readLock.lock();
+        readLock.lock();
     }
 
     private void readUnlock() {
-        m_readLock.unlock();
+        readLock.unlock();
     }
 
     private void writeLock() {
-        m_writeLock.lock();
+        writeLock.lock();
     }
 
     private void writeUnlock() {
-        m_writeLock.unlock();
+        writeLock.unlock();
     }
 
     private static WebApplicationException getException(final Status status, final String msg, final String... params) {
@@ -386,7 +385,7 @@ public class NotificationConfigRestService {
             bldr.addParam("remoteUser", securityContext.getUserPrincipal().getName());
             bldr.addParam("remoteHost", request.getRemoteHost());
             bldr.addParam("remoteAddr", request.getRemoteAddr());
-            m_eventProxy.send(bldr.getEvent());
+            eventProxy.send(bldr.getEvent());
         } catch (final Exception e) {
             LOG.warn("Can't send event {}", uei, e);
         }
@@ -405,7 +404,7 @@ public class NotificationConfigRestService {
     }
 
     private static void validateDestinationPath(final org.opennms.netmgt.config.destinationPaths.Path path) {
-        if (path == null || isBlank(path.getName())) {
+        if (path == null || StringUtils.isBlank(path.getName())) {
             throw getException(Status.BAD_REQUEST, "The destination path and its name are required");
         }
         if (path.getTargets().isEmpty()) {
@@ -413,7 +412,7 @@ public class NotificationConfigRestService {
         }
         validateTargets(path.getTargets());
         for (final org.opennms.netmgt.config.destinationPaths.Escalate escalate : path.getEscalates()) {
-            if (isBlank(escalate.getDelay())) {
+            if (StringUtils.isBlank(escalate.getDelay())) {
                 throw getException(Status.BAD_REQUEST, "Every escalation requires a delay");
             }
             if (escalate.getTargets().isEmpty()) {
@@ -425,17 +424,13 @@ public class NotificationConfigRestService {
 
     private static void validateTargets(final List<org.opennms.netmgt.config.destinationPaths.Target> targets) {
         for (final org.opennms.netmgt.config.destinationPaths.Target target : targets) {
-            if (isBlank(target.getName())) {
+            if (StringUtils.isBlank(target.getName())) {
                 throw getException(Status.BAD_REQUEST, "Every target requires a name");
             }
-            if (target.getCommands().isEmpty() || target.getCommands().stream().anyMatch(NotificationConfigRestService::isBlank)) {
+            if (target.getCommands().isEmpty() || target.getCommands().stream().anyMatch(StringUtils::isBlank)) {
                 throw getException(Status.BAD_REQUEST, "Every target requires at least one non-empty command");
             }
         }
-    }
-
-    private static boolean isBlank(final String value) {
-        return value == null || value.isBlank();
     }
 
     private static DestinationPathFactory getDestinationPathFactory() throws Exception {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
@@ -19,11 +19,12 @@
  * language governing permissions and limitations under the
  * License.
  */
-package org.opennms.web.rest.v1;
+package org.opennms.web.rest.v2;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -35,13 +36,12 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.netmgt.config.DestinationPathFactory;
 import org.opennms.netmgt.config.GroupFactory;
@@ -57,9 +57,13 @@ import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.web.api.Authentication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import com.googlecode.concurentlocks.ReadWriteUpdateLock;
+import com.googlecode.concurentlocks.ReentrantReadWriteUpdateLock;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -83,7 +87,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Component("notificationConfigRestService")
 @Path("notification-config")
 @Tag(name = "Notification-config", description = "Notification Configuration API")
-public class NotificationConfigRestService extends OnmsRestService {
+public class NotificationConfigRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationConfigRestService.class);
 
@@ -91,24 +95,55 @@ public class NotificationConfigRestService extends OnmsRestService {
     @Qualifier("eventProxy")
     protected EventProxy m_eventProxy;
 
-    @XmlRootElement(name = "notification-status")
+    // Per-instance read/write/update lock serializing config mutations, carried
+    // over from the base REST service this was split out of when it moved to v2.
+    private final ReadWriteUpdateLock m_globalLock = new ReentrantReadWriteUpdateLock();
+    private final Lock m_readLock = m_globalLock.updateLock();
+    private final Lock m_writeLock = m_globalLock.writeLock();
+
+    private void readLock() {
+        m_readLock.lock();
+    }
+
+    private void readUnlock() {
+        m_readLock.unlock();
+    }
+
+    private void writeLock() {
+        m_writeLock.lock();
+    }
+
+    private void writeUnlock() {
+        m_writeLock.unlock();
+    }
+
+    private static WebApplicationException getException(final Status status, final String msg, final String... params) {
+        final String formatted = params != null ? MessageFormatter.arrayFormat(msg, params).getMessage() : msg;
+        LOG.error(formatted);
+        return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(formatted).build());
+    }
+
+    private static WebApplicationException getException(final Status status, final Throwable t) {
+        LOG.error(t.getMessage(), t);
+        return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(t.getMessage()).build());
+    }
+
     public static class NotificationStatus {
-        private String m_status;
+        private String status;
 
         public NotificationStatus() {
         }
 
         public NotificationStatus(final String status) {
-            m_status = status;
+            this.status = status;
         }
 
-        @XmlAttribute(name = "status")
         public String getStatus() {
-            return m_status;
+            return status;
         }
 
         public void setStatus(final String status) {
-            m_status = status;
+            this.status = status;
         }
     }
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -195,6 +195,20 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
     }
 
     @Test
+    public void testDeleteLastDestinationPathRejected() throws Exception {
+        // Whittle down to a single path, then confirm the last one is rejected
+        // (destinationPaths.xsd requires at least one) rather than 500ing.
+        final JSONArray paths = new JSONObject(getJson("/notification-config/destination-paths")).getJSONArray("path");
+        for (int i = 1; i < paths.length(); i++) {
+            sendRequest(DELETE, "/notification-config/destination-paths/"
+                    + java.net.URLEncoder.encode(paths.getJSONObject(i).getString("name"), java.nio.charset.StandardCharsets.UTF_8), 204);
+        }
+        final String last = paths.getJSONObject(0).getString("name");
+        sendRequest(DELETE, "/notification-config/destination-paths/"
+                + java.net.URLEncoder.encode(last, java.nio.charset.StandardCharsets.UTF_8), 400);
+    }
+
+    @Test
     public void testCommands() throws Exception {
         JSONArray commands = new JSONArray(getJson("/notification-config/commands"));
         Assert.assertEquals(1, commands.length());

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -38,6 +38,7 @@ import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.netmgt.config.GroupFactory;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -135,6 +136,10 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
     public void afterServletStart() throws Exception {
         System.setProperty("opennms.home", m_onmsHome);
         ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+        // Webapp beans may have initialized GroupFactory while context startup
+        // had opennms.home pointed elsewhere; pin a factory built against the
+        // test home so the seeded roles are visible.
+        GroupFactory.setInstance(new GroupFactory());
     }
 
     // Restore opennms.home for later suites sharing this JVM fork.
@@ -163,6 +168,94 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
 
         // only on/off are valid
         sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"maybe\"}", 400);
+    }
+
+    @Test
+    public void testDestinationPathLifecycle() throws Exception {
+        JSONObject list = new JSONObject(getJson("/notification-config/destination-paths"));
+        Assert.assertEquals(1, list.getJSONArray("path").length());
+
+        final String newPath = "{\"name\":\"junit-path\",\"initial-delay\":\"30s\","
+                + "\"target\":[{\"name\":\"noc@example.com\",\"command\":[\"javaEmail\"]}],"
+                + "\"escalate\":[{\"delay\":\"15m\",\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}]}]}";
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/destination-paths", newPath, 204);
+
+        JSONObject added = new JSONObject(getJson("/notification-config/destination-paths/junit-path"));
+        Assert.assertEquals("30s", added.getString("initial-delay"));
+        Assert.assertEquals(1, added.getJSONArray("escalate").length());
+
+        final String updatedPath = "{\"name\":\"junit-path\",\"initial-delay\":\"1m\","
+                + "\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}],\"escalate\":[]}";
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/junit-path", updatedPath, 204);
+        added = new JSONObject(getJson("/notification-config/destination-paths/junit-path"));
+        Assert.assertEquals("1m", added.getString("initial-delay"));
+
+        sendRequest(DELETE, "/notification-config/destination-paths/junit-path", 204);
+        sendRequest(GET, "/notification-config/destination-paths/junit-path", 404);
+    }
+
+    @Test
+    public void testCommands() throws Exception {
+        JSONArray commands = new JSONArray(getJson("/notification-config/commands"));
+        Assert.assertEquals(1, commands.length());
+        Assert.assertEquals("javaEmail", commands.getJSONObject(0).getString("name"));
+    }
+
+    @Test
+    public void testDestinationPathInvalidUpdateKeepsExistingPath() throws Exception {
+        // a target with no commands would fail the schema-validated save AFTER
+        // the factory already removed the old entry — must be rejected up front
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/Email-Admin",
+                "{\"name\":\"Email-Admin\",\"target\":[{\"name\":\"Admin\",\"command\":[]}]}", 400);
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/Email-Admin",
+                "{\"name\":\"Email-Admin\",\"target\":[]}", 400);
+        JSONObject unchanged = new JSONObject(getJson("/notification-config/destination-paths/Email-Admin"));
+        Assert.assertEquals(1, unchanged.getJSONArray("target").length());
+    }
+
+    @Test
+    public void testDestinationPathRenameCollisionRejected() throws Exception {
+        final String other = "{\"name\":\"junit-p2\",\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}]}";
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/destination-paths", other, 204);
+
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/Email-Admin",
+                "{\"name\":\"junit-p2\",\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}]}", 400);
+        // both paths still intact
+        sendRequest(GET, "/notification-config/destination-paths/Email-Admin", 200);
+        sendRequest(GET, "/notification-config/destination-paths/junit-p2", 200);
+    }
+
+    @Test
+    public void testDestinationPathRenameUpdatesReferences() throws Exception {
+        sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/destination-paths/Email-Admin",
+                "{\"name\":\"Email-Ops\",\"target\":[{\"name\":\"Admin\",\"command\":[\"javaEmail\"]}]}", 204);
+        sendRequest(GET, "/notification-config/destination-paths/Email-Admin", 404);
+        sendRequest(GET, "/notification-config/destination-paths/Email-Ops", 200);
+        // the notification that referenced the old name follows the rename
+        org.opennms.netmgt.config.NotificationFactory.init();
+        Assert.assertEquals("Email-Ops", org.opennms.netmgt.config.NotificationFactory.getInstance()
+                .getNotification("junitNotification").getDestinationPath());
+    }
+
+    @Test
+    public void testOnCallRoles() throws Exception {
+        JSONArray roles = new JSONArray(getJson("/notification-config/on-call-roles"));
+        Assert.assertEquals(1, roles.length());
+        Assert.assertEquals("junit-oncall", roles.getString(0));
+    }
+
+    @Test
+    public void testOnCallRolesFollowFileChanges() throws Exception {
+        Assert.assertEquals(1, new JSONArray(getJson("/notification-config/on-call-roles")).length());
+        // removing the last role from groups.xml must not leave it cached
+        final File groupsFile = new File("target/test-work-dir/etc/groups.xml");
+        FileUtils.writeStringToFile(groupsFile, "<?xml version=\"1.0\"?>"
+                + "<groupinfo xmlns=\"http://xmlns.opennms.org/xsd/groups\">"
+                + "<header><rev>1.3</rev><created>Wednesday, February 6, 2002 10:10:00 AM EST</created><mstation>localhost</mstation></header>"
+                + "<groups><group><name>Admin</name><user>admin</user></group></groups>"
+                + "</groupinfo>", Charset.defaultCharset());
+        groupsFile.setLastModified(System.currentTimeMillis() + 1000);
+        Assert.assertEquals(0, new JSONArray(getJson("/notification-config/on-call-roles")).length());
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NotificationConfigRestServiceIT.java
@@ -19,7 +19,7 @@
  * language governing permissions and limitations under the
  * License.
  */
-package org.opennms.web.rest.v1;
+package org.opennms.web.rest.v2;
 
 
 import java.io.File;
@@ -65,6 +65,9 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @JUnitTemporaryDatabase
 public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
+    public NotificationConfigRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
 
     private String m_onmsHome;
 

--- a/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
+++ b/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
@@ -24,9 +24,7 @@
           </p>
         </OnmsTabPanel>
         <OnmsTabPanel value="destination-paths">
-          <p class="tab-placeholder" data-test="placeholder-destination-paths">
-            Destination path management arrives with NMS-20119.
-          </p>
+          <DestinationPathsTable />
         </OnmsTabPanel>
         <OnmsTabPanel value="path-outages">
           <p class="tab-placeholder" data-test="placeholder-path-outages">
@@ -61,6 +59,7 @@ import { ref, watch } from 'vue'
 
 import { OnmsDialog, OnmsTabs, OnmsTabList, OnmsTab, OnmsTabPanels, OnmsTabPanel, OnmsToggleSwitch } from '@opennms/onms-ui'
 
+import DestinationPathsTable from '@/components/AdminNotifications/DestinationPathsTable.vue'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import { NotifdStatus } from '@/types/notificationConfig'
 
@@ -84,6 +83,10 @@ const statusPending = ref(false)
 const loadedTabs = ref(new Set<string>())
 
 const TAB_LOADERS: Record<string, () => Promise<boolean>> = {
+  'destination-paths': async () => {
+    const results = await Promise.all([store.getDestinationPaths(), store.getCommands(), store.getUsersAndGroups()])
+    return results.every(Boolean)
+  },
   general: () => store.getStatus()
 }
 

--- a/ui/src/components/AdminNotifications/DestinationPathEditorDialog.vue
+++ b/ui/src/components/AdminNotifications/DestinationPathEditorDialog.vue
@@ -1,0 +1,430 @@
+<template>
+  <OnmsDialog
+    :visible="visible"
+    modal
+    :header="isEditing ? `Edit Destination Path: ${originalName}` : 'New Destination Path'"
+    class="destination-path-editor-dialog"
+    width="min(900px, 95vw)"
+    data-test="destination-path-editor-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="editor-body">
+      <div class="form-row">
+        <FormField
+          label="Path Name"
+          for="path-name"
+          required
+        >
+          <OnmsInputText
+            id="path-name"
+            v-model="name"
+            data-test="path-name-input"
+          />
+        </FormField>
+        <FormField
+          label="Initial Delay"
+          for="path-initial-delay"
+        >
+          <template #label-suffix>
+            <HelpBadge :content="delayHelp" ariaLabel="Initial Delay help" />
+          </template>
+          <OnmsSelect
+            v-model="initialDelay"
+            inputId="path-initial-delay"
+            :options="delayOptions"
+            editable
+            data-test="initial-delay-select"
+          />
+        </FormField>
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title">Initial Targets</div>
+          <OnmsButton
+            variant="outlined"
+            size="small"
+            label="Add Target"
+            icon="pi pi-plus"
+            data-test="add-target-button"
+            @click="addTarget(targets)"
+          />
+        </div>
+        <p class="section-hint">
+          Who gets notified first, and how. Each target is notified via the selected methods;
+          Email and Browser (on-screen, for logged-in users) methods are fully supported today —
+          the remaining methods are shown for completeness and will be enabled as their
+          configuration screens land.
+        </p>
+        <TargetRowEditor
+          v-for="(row, index) in targets"
+          :key="row.key"
+          :row="row"
+          :users="store.users"
+          :groups="store.groups"
+          :roles="store.roles"
+          :methodOptions="methodOptions"
+          :removable="targets.length > 1"
+          @remove="targets.splice(index, 1)"
+        />
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title">Escalations</div>
+          <OnmsButton
+            variant="outlined"
+            size="small"
+            label="Add Escalation"
+            icon="pi pi-plus"
+            data-test="add-escalation-button"
+            @click="addEscalation"
+          />
+        </div>
+        <p class="section-hint">
+          If the notice is still unacknowledged after the delay, the escalation's targets are
+          notified next.
+        </p>
+        <div
+          v-for="(escalation, eIndex) in escalations"
+          :key="escalation.key"
+          class="escalation-block"
+        >
+          <div class="escalation-header">
+            <FormField
+              label="Escalate After"
+              :for="`escalation-delay-${eIndex}`"
+            >
+              <template #label-suffix>
+                <HelpBadge :content="escalateHelp" ariaLabel="Escalate After help" />
+              </template>
+              <OnmsSelect
+                v-model="escalation.delay"
+                :inputId="`escalation-delay-${eIndex}`"
+                :options="delayOptions"
+                editable
+                data-test="escalation-delay-select"
+              />
+            </FormField>
+            <div class="escalation-actions">
+              <OnmsButton
+                variant="outlined"
+                size="small"
+                label="Add Target"
+                icon="pi pi-plus"
+                data-test="add-escalation-target-button"
+                @click="addTarget(escalation.targets)"
+              />
+              <OnmsButton
+                variant="text"
+                size="small"
+                label="Remove Escalation"
+                severity="danger"
+                data-test="remove-escalation-button"
+                @click="escalations.splice(eIndex, 1)"
+              />
+            </div>
+          </div>
+          <TargetRowEditor
+            v-for="(row, tIndex) in escalation.targets"
+            :key="row.key"
+            :row="row"
+            :users="store.users"
+            :groups="store.groups"
+            :roles="store.roles"
+            :methodOptions="methodOptions"
+            :removable="escalation.targets.length > 1"
+            @remove="escalation.targets.splice(tIndex, 1)"
+          />
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <OnmsButton
+        variant="text"
+        label="Cancel"
+        data-test="cancel-button"
+        @click="emit('update:visible', false)"
+      />
+      <OnmsButton
+        :label="isEditing ? 'Save Path' : 'Add Path'"
+        :disabled="!isValid || saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </OnmsDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import { OnmsButton, OnmsDialog, OnmsInputText, OnmsSelect } from '@opennms/onms-ui'
+
+import TargetRowEditor, { MethodOption, TargetRow } from '@/components/AdminNotifications/TargetRowEditor.vue'
+import FormField from '@/components/Common/FormField.vue'
+import HelpBadge from '@/components/Common/HelpBadge.vue'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { DestinationPath, DestinationPathTarget } from '@/types/notificationConfig'
+
+const props = defineProps<{
+  visible: boolean
+  path: DestinationPath | null
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useNotificationConfigStore()
+
+// Methods with a working configuration today. The rest of the commands from
+// notificationCommands.xml are listed but disabled until their config lands.
+const ENABLED_METHODS = new Set(['javaEmail', 'javaPagerEmail', 'browser'])
+
+// Methods deliberately hidden from the picker (no supported config path). A path
+// being edited that already carries one still shows it (originalLegacyCommands).
+const HIDDEN_METHODS = new Set([
+  'ircCat', 'microblogDM', 'microblogReply', 'microblogUpdate', 'xmppMessage', 'xmppGroupMessage'
+])
+
+const delayHelp = 'How long to wait after the notice is created before the first targets are notified (e.g. 30s, 5m, 1h). 0s notifies immediately.'
+const escalateHelp = 'If the notice is still unacknowledged after this delay, this escalation’s targets are notified next.'
+
+const METHOD_LABELS: Record<string, string> = {
+  javaEmail: 'Email',
+  javaPagerEmail: 'Pager Email',
+  textPage: 'Text Page',
+  numericPage: 'Numeric Page',
+  xmppMessage: 'XMPP Message',
+  xmppGroupMessage: 'XMPP Group Message',
+  microblogUpdate: 'Microblog Update',
+  microblogReply: 'Microblog Reply',
+  microblogDM: 'Microblog DM',
+  ircCat: 'IRC',
+  callWorkPhone: 'Call Work Phone',
+  callMobilePhone: 'Call Mobile Phone',
+  callHomePhone: 'Call Home Phone',
+  browser: 'Browser'
+}
+
+const delayOptions = ['0s', '30s', '1m', '2m', '5m', '10m', '15m', '30m', '1h', '2h', '6h', '12h', '1d']
+
+interface EscalationBlock {
+  key: number
+  delay: string
+  targets: TargetRow[]
+}
+
+let rowKey = 0
+
+const name = ref('')
+const initialDelay = ref('30s')
+const targets = ref<TargetRow[]>([])
+const escalations = ref<EscalationBlock[]>([])
+const saving = ref(false)
+
+// Legacy commands the edited path already used (e.g. textPage) that are not in
+// ENABLED_METHODS. They stay selectable for this edit so removing one is not a
+// one-way trip; brand-new paths cannot add them.
+const originalLegacyCommands = ref<Set<string>>(new Set())
+
+const isEditing = computed(() => props.path !== null)
+const originalName = computed(() => props.path?.name ?? '')
+
+const methodOptions = computed<MethodOption[]>(() => {
+  const commands = store.commands.length ? store.commands.map(c => c.name) : Array.from(ENABLED_METHODS)
+  return commands
+    .filter(command => !HIDDEN_METHODS.has(command) || originalLegacyCommands.value.has(command))
+    .map(command => ({
+      value: command,
+      label: METHOD_LABELS[command] ? `${METHOD_LABELS[command]} (${command})` : command,
+      disabled: !ENABLED_METHODS.has(command) && !originalLegacyCommands.value.has(command)
+    }))
+})
+
+const newTargetRow = (): TargetRow => ({
+  key: rowKey++,
+  type: 'user',
+  name: '',
+  commands: ['javaEmail'],
+  interval: undefined,
+  autoNotify: undefined
+})
+
+const addTarget = (list: TargetRow[]) => {
+  list.push(newTargetRow())
+}
+
+const addEscalation = () => {
+  escalations.value.push({ key: rowKey++, delay: '15m', targets: [newTargetRow()] })
+}
+
+const inferType = (targetName: string): TargetRow['type'] => {
+  if (targetName.includes('@')) {
+    return 'email'
+  }
+  if (store.groups.includes(targetName)) {
+    return 'group'
+  }
+  if (store.roles.includes(targetName)) {
+    return 'role'
+  }
+  return 'user'
+}
+
+const toRow = (target: DestinationPathTarget): TargetRow => ({
+  key: rowKey++,
+  type: inferType(target.name),
+  name: target.name,
+  commands: [...(target.command ?? [])],
+  interval: target.interval ?? undefined,
+  autoNotify: target.autoNotify ?? undefined
+})
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (!isVisible) {
+      return
+    }
+    if (props.path) {
+      name.value = props.path.name
+      initialDelay.value = props.path['initial-delay'] ?? '0s'
+      targets.value = (props.path.target ?? []).map(toRow)
+      escalations.value = (props.path.escalate ?? []).map(esc => ({
+        key: rowKey++,
+        delay: esc.delay ?? '15m',
+        targets: (esc.target ?? []).map(toRow)
+      }))
+      // remember which non-standard commands this path already carried so they
+      // remain re-addable while editing
+      const legacy = new Set<string>()
+      const collect = (rows: TargetRow[]) => rows.forEach(r => r.commands.forEach((c) => {
+        if (!ENABLED_METHODS.has(c)) {
+          legacy.add(c)
+        }
+      }))
+      collect(targets.value)
+      escalations.value.forEach(esc => collect(esc.targets))
+      originalLegacyCommands.value = legacy
+      if (!targets.value.length) {
+        targets.value = [newTargetRow()]
+      }
+    } else {
+      name.value = ''
+      initialDelay.value = '30s'
+      targets.value = [newTargetRow()]
+      escalations.value = []
+      originalLegacyCommands.value = new Set()
+    }
+  }
+)
+
+const rowIsValid = (row: TargetRow) => !!row.name.trim() && row.commands.length > 0
+
+const isValid = computed(() => {
+  if (!name.value.trim() || !targets.value.length) {
+    return false
+  }
+  if (!targets.value.every(rowIsValid)) {
+    return false
+  }
+  return escalations.value.every(esc => esc.targets.length > 0 && esc.targets.every(rowIsValid))
+})
+
+const toTarget = (row: TargetRow): DestinationPathTarget => ({
+  name: row.name.trim(),
+  command: [...row.commands],
+  ...(row.interval ? { interval: row.interval } : {}),
+  ...(row.autoNotify ? { autoNotify: row.autoNotify } : {})
+})
+
+const save = async () => {
+  saving.value = true
+  try {
+    const path: DestinationPath = {
+      name: name.value.trim(),
+      'initial-delay': initialDelay.value,
+      target: targets.value.map(toTarget),
+      escalate: escalations.value.map(esc => ({
+        delay: esc.delay,
+        target: esc.targets.map(toTarget)
+      }))
+    }
+    const ok = isEditing.value
+      ? await store.updateDestinationPath(originalName.value, path)
+      : await store.addDestinationPath(path)
+    if (ok) {
+      emit('update:visible', false)
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-top: 0.5rem;
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+
+  :deep(input),
+  :deep(.p-select) {
+    min-width: 220px;
+  }
+}
+
+.section {
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.25rem;
+
+    .section-title {
+      font-size: 1rem;
+      font-weight: 600;
+    }
+  }
+
+  .section-hint {
+    margin: 0 0 0.75rem 0;
+    font-size: 0.875rem;
+    color: var(--p-text-muted-color);
+    max-width: 80ch;
+  }
+}
+
+.escalation-block {
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+
+  .escalation-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+
+    :deep(.p-select) {
+      min-width: 160px;
+    }
+
+    .escalation-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+  }
+}
+</style>

--- a/ui/src/components/AdminNotifications/DestinationPathsTable.vue
+++ b/ui/src/components/AdminNotifications/DestinationPathsTable.vue
@@ -1,0 +1,196 @@
+<template>
+  <TableCard class="destination-paths-table">
+    <div class="header">
+      <div class="card-title">Destination Paths</div>
+      <OnmsButton
+        variant="outlined"
+        label="New Path"
+        icon="pi pi-plus"
+        data-test="add-destination-path-button"
+        @click="openEditor(null)"
+      />
+    </div>
+
+    <OnmsTable
+      v-if="store.destinationPaths.length"
+      :value="store.destinationPaths"
+      dataKey="name"
+      class="data-table"
+      data-test="destination-paths-table"
+    >
+      <OnmsColumn
+        field="name"
+        header="Name"
+        sortable
+      />
+      <OnmsColumn header="Initial Delay">
+        <template #body="{ data }">
+          {{ data['initial-delay'] ?? '0s' }}
+        </template>
+      </OnmsColumn>
+      <OnmsColumn header="Targets">
+        <template #body="{ data }">
+          {{ targetSummary(data) }}
+        </template>
+      </OnmsColumn>
+      <OnmsColumn header="Actions">
+        <template #body="{ data }">
+          <div class="action-container">
+            <OnmsButton
+              variant="text"
+              label="Edit"
+              :aria-label="`Edit ${data.name}`"
+              data-test="edit-destination-path-button"
+              @click="openEditor(data)"
+            />
+            <OnmsButton
+              variant="text"
+              label="Test"
+              :aria-label="`Send test notification via ${data.name}`"
+              data-test="test-destination-path-button"
+              @click="askTest(data)"
+            />
+            <OnmsButton
+              variant="text"
+              label="Delete"
+              severity="danger"
+              :aria-label="`Delete ${data.name}`"
+              data-test="delete-destination-path-button"
+              @click="askDelete(data)"
+            />
+          </div>
+        </template>
+      </OnmsColumn>
+    </OnmsTable>
+
+    <div v-if="!store.destinationPaths.length">
+      <EmptyList
+        :content="emptyListContent"
+        data-test="empty-list"
+      />
+    </div>
+  </TableCard>
+  <DestinationPathEditorDialog
+    v-model:visible="showEditor"
+    :path="pathToEdit"
+  />
+  <OnmsConfirmationDialog
+    :visible="showDeleteConfirmation"
+    title="Delete Destination Path"
+    actionButtonText="Delete"
+    @ok="confirmDelete"
+    @cancel="cancelDelete"
+  >
+    <template #content>
+      <p>Are you sure you want to delete the destination path <strong>{{ pathToDelete?.name }}</strong>? Event notifications referencing it will stop resolving targets. This action cannot be undone.</p>
+    </template>
+  </OnmsConfirmationDialog>
+  <OnmsConfirmationDialog
+    :visible="showTestConfirmation"
+    title="Send Test Notification"
+    actionButtonText="Send Test"
+    @ok="confirmTest"
+    @cancel="cancelTest"
+  >
+    <template #content>
+      <p>Send a test notification to every target of <strong>{{ pathToTest?.name }}</strong>? Real notifications (email, pager, etc.) will be delivered to the configured users and groups.</p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { OnmsConfirmationDialog, OnmsButton, OnmsColumn, OnmsTable } from '@opennms/onms-ui'
+
+import DestinationPathEditorDialog from '@/components/AdminNotifications/DestinationPathEditorDialog.vue'
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { DestinationPath } from '@/types/notificationConfig'
+
+const store = useNotificationConfigStore()
+
+const showEditor = ref(false)
+const pathToEdit = ref<DestinationPath | null>(null)
+
+const openEditor = (path: DestinationPath | null) => {
+  pathToEdit.value = path
+  showEditor.value = true
+}
+
+const showDeleteConfirmation = ref(false)
+const pathToDelete = ref<DestinationPath | null>(null)
+const showTestConfirmation = ref(false)
+const pathToTest = ref<DestinationPath | null>(null)
+
+const emptyListContent = {
+  msg: 'No destination paths configured.'
+}
+
+const targetSummary = (path: DestinationPath) => {
+  const targets = (path.target ?? []).map(t => t.name)
+  const escalations = path.escalate?.length ?? 0
+  const summary = targets.join(', ') || 'none'
+  return escalations ? `${summary} (+${escalations} escalation${escalations > 1 ? 's' : ''})` : summary
+}
+
+const askDelete = (path: DestinationPath) => {
+  pathToDelete.value = path
+  showDeleteConfirmation.value = true
+}
+
+const confirmDelete = async () => {
+  if (pathToDelete.value) {
+    await store.deleteDestinationPath(pathToDelete.value.name)
+  }
+  showDeleteConfirmation.value = false
+  pathToDelete.value = null
+}
+
+const cancelDelete = () => {
+  showDeleteConfirmation.value = false
+  pathToDelete.value = null
+}
+
+const askTest = (path: DestinationPath) => {
+  pathToTest.value = path
+  showTestConfirmation.value = true
+}
+
+const confirmTest = async () => {
+  if (pathToTest.value) {
+    await store.testDestinationPath(pathToTest.value.name)
+  }
+  showTestConfirmation.value = false
+  pathToTest.value = null
+}
+
+const cancelTest = () => {
+  showTestConfirmation.value = false
+  pathToTest.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.destination-paths-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.action-container {
+  display: flex;
+  gap: 0.25rem;
+}
+</style>

--- a/ui/src/components/AdminNotifications/TargetRowEditor.vue
+++ b/ui/src/components/AdminNotifications/TargetRowEditor.vue
@@ -1,0 +1,216 @@
+<template>
+  <div class="target-row">
+    <FormField
+      label="Target Type"
+      :for="`target-type-${row.key}`"
+    >
+      <OnmsSelect
+        v-model="row.type"
+        :inputId="`target-type-${row.key}`"
+        :options="typeOptions"
+        optionLabel="label"
+        optionValue="value"
+        optionDisabled="disabled"
+        data-test="target-type-select"
+        @update:modelValue="onTypeChange"
+      />
+    </FormField>
+
+    <FormField
+      class="target-name"
+      :label="nameLabel"
+      :for="`target-name-${row.key}`"
+    >
+      <OnmsSelect
+        v-if="row.type === 'user'"
+        v-model="row.name"
+        :inputId="`target-name-${row.key}`"
+        :options="users"
+        filter
+        data-test="target-user-select"
+      />
+      <OnmsSelect
+        v-else-if="row.type === 'group'"
+        v-model="row.name"
+        :inputId="`target-name-${row.key}`"
+        :options="groups"
+        filter
+        data-test="target-group-select"
+      />
+      <OnmsSelect
+        v-else-if="row.type === 'role'"
+        v-model="row.name"
+        :inputId="`target-name-${row.key}`"
+        :options="roles"
+        filter
+        data-test="target-role-select"
+      />
+      <OnmsInputText
+        v-else
+        :id="`target-name-${row.key}`"
+        v-model="row.name"
+        :placeholder="row.type === 'email' ? 'someone@example.com' : ''"
+        data-test="target-name-input"
+      />
+    </FormField>
+
+    <FormField
+      class="target-methods"
+      label="Notification Methods"
+      :for="`target-methods-${row.key}`"
+    >
+      <OnmsMultiSelect
+        v-model="row.commands"
+        :labelId="`target-methods-${row.key}`"
+        :options="rowMethodOptions"
+        optionLabel="label"
+        optionValue="value"
+        optionDisabled="disabled"
+        display="chip"
+        :showToggleAll="false"
+        data-test="target-methods-select"
+      />
+    </FormField>
+
+    <FormField
+      class="target-interval"
+      label="Interval"
+      :for="`target-interval-${row.key}`"
+    >
+      <template #label-suffix>
+        <HelpBadge :content="intervalHelp" ariaLabel="Interval help" />
+      </template>
+      <OnmsInputText
+        :id="`target-interval-${row.key}`"
+        v-model="row.interval"
+        placeholder="0s"
+        data-test="target-interval-input"
+      />
+    </FormField>
+
+    <OnmsIconButton
+      v-if="removable"
+      severity="danger"
+      :icon="Cancel"
+      aria-label="Remove target"
+      data-test="remove-target-button"
+      @click="emit('remove')"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+// Shared row model between the editor dialog and this row component.
+export interface TargetRow {
+  key: number
+  type: 'user' | 'group' | 'email' | 'role'
+  name: string
+  commands: string[]
+  interval?: string
+  autoNotify?: string
+}
+
+export interface MethodOption {
+  value: string
+  label: string
+  disabled: boolean
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { OnmsIconButton, OnmsInputText, OnmsMultiSelect, OnmsSelect } from '@opennms/onms-ui'
+
+import Cancel from '@/components/icons/navigation/Cancel.vue'
+import FormField from '@/components/Common/FormField.vue'
+import HelpBadge from '@/components/Common/HelpBadge.vue'
+
+// row is a model (the parent shares the object and reads the edited fields back);
+// using defineModel keeps that two-way flow without mutating a plain prop.
+const row = defineModel<TargetRow>('row', { required: true })
+
+const props = defineProps<{
+  users: string[]
+  groups: string[]
+  roles: string[]
+  methodOptions: MethodOption[]
+  removable: boolean
+}>()
+
+const emit = defineEmits(['remove'])
+
+const typeOptions = [
+  { label: 'User', value: 'user' },
+  { label: 'Group', value: 'group' },
+  { label: 'Email Address', value: 'email' },
+  { label: 'On-Call Role', value: 'role' }
+]
+
+const intervalHelp = 'For a group or role target, how long to wait between notifying each successive member (e.g. 30s), so they are paged in sequence rather than all at once. Leave blank to notify everyone immediately.'
+
+// Browser notifications are delivered to logged-in web sessions by user id.
+// Group and role targets resolve to users at send time, so only raw email
+// address targets can never receive them.
+const rowMethodOptions = computed<MethodOption[]>(() => {
+  if (row.value.type !== 'email') {
+    return props.methodOptions
+  }
+  return props.methodOptions.map(option =>
+    option.value === 'browser' ? { ...option, label: `${option.label} — not for email targets`, disabled: true } : option
+  )
+})
+
+const nameLabel = computed(() => {
+  switch (row.value.type) {
+    case 'user':
+      return 'User'
+    case 'group':
+      return 'Group'
+    case 'email':
+      return 'Email Address'
+    default:
+      return 'Role'
+  }
+})
+
+const onTypeChange = () => {
+  row.value.name = ''
+}
+</script>
+
+<style lang="scss" scoped>
+.target-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+
+  :deep(.p-select) {
+    min-width: 150px;
+  }
+
+  .target-name {
+    :deep(.p-select),
+    :deep(input) {
+      min-width: 200px;
+    }
+  }
+
+  .target-methods {
+    flex: 1;
+    min-width: 240px;
+
+    :deep(.p-multiselect) {
+      width: 100%;
+    }
+  }
+
+  .target-interval {
+    :deep(input) {
+      width: 90px;
+    }
+  }
+}
+</style>

--- a/ui/src/components/AdminNotifications/TargetRowEditor.vue
+++ b/ui/src/components/AdminNotifications/TargetRowEditor.vue
@@ -61,7 +61,7 @@
     >
       <OnmsMultiSelect
         v-model="row.commands"
-        :labelId="`target-methods-${row.key}`"
+        :inputId="`target-methods-${row.key}`"
         :options="rowMethodOptions"
         optionLabel="label"
         optionValue="value"

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -76,9 +76,17 @@ import {
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
 import {
+  addDestinationPath,
+  deleteDestinationPath,
   getDestinationPaths,
+  getNotificationCommands,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  getNotificationGroups,
+  getNotificationUsers,
+  getOnCallRoles,
+  setNotificationConfigStatus,
+  testDestinationPath,
+  updateDestinationPath
 } from './notificationConfigService'
 import { acknowledgeNotice, browseNotices } from './noticesService'
 
@@ -146,8 +154,16 @@ export default {
   getZenithRegistrations,
   performLogout,
   acknowledgeNotice,
+  addDestinationPath,
   browseNotices,
+  getNotificationGroups,
+  getNotificationUsers,
+  getOnCallRoles,
+  updateDestinationPath,
+  deleteDestinationPath,
   getDestinationPaths,
+  getNotificationCommands,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  setNotificationConfigStatus,
+  testDestinationPath
 }

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -23,7 +23,7 @@
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
 import { DestinationPath, NotifdStatus, NotificationCommand } from '@/types/notificationConfig'
-import { rest } from './axiosInstances'
+import { v2 } from './axiosInstances'
 
 const { showSnackBar } = useSnackbar()
 const { startSpinner, stopSpinner } = useSpinner()
@@ -32,7 +32,7 @@ const endpoint = '/notification-config'
 const getNotificationConfigStatus = async (): Promise<NotifdStatus | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/status`)
+    const resp = await v2.get(`${endpoint}/status`)
     return resp.data?.status ?? null
   } catch (_err) {
     showSnackBar({ msg: 'Failed to load notification status.' })
@@ -45,7 +45,7 @@ const getNotificationConfigStatus = async (): Promise<NotifdStatus | null> => {
 const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.put(`${endpoint}/status`, { status })
+    await v2.put(`${endpoint}/status`, { status })
     showSnackBar({ msg: `Notifications turned ${status}.` })
     return true
   } catch (_err) {
@@ -59,7 +59,7 @@ const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolea
 const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/destination-paths`)
+    const resp = await v2.get(`${endpoint}/destination-paths`)
     return resp.data?.path ?? []
   } catch (_err) {
     // null (not []) so a failed load is distinguishable from an empty one and the
@@ -74,7 +74,7 @@ const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
 const deleteDestinationPath = async (name: string): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.delete(`${endpoint}/destination-paths/${encodeURIComponent(name)}`)
+    await v2.delete(`${endpoint}/destination-paths/${encodeURIComponent(name)}`)
     showSnackBar({ msg: `Destination path '${name}' deleted.` })
     return true
   } catch (err: any) {
@@ -89,7 +89,7 @@ const deleteDestinationPath = async (name: string): Promise<boolean> => {
 const testDestinationPath = async (name: string): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.post(`/notifications/destination-paths/${encodeURIComponent(name)}/trigger`)
+    await v2.post(`/notifications/destination-paths/${encodeURIComponent(name)}/trigger`)
     showSnackBar({ msg: `Test notification triggered for '${name}'.` })
     return true
   } catch (_err) {
@@ -103,7 +103,7 @@ const testDestinationPath = async (name: string): Promise<boolean> => {
 const addDestinationPath = async (path: DestinationPath): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.post(`${endpoint}/destination-paths`, path)
+    await v2.post(`${endpoint}/destination-paths`, path)
     showSnackBar({ msg: `Destination path '${path.name}' added.` })
     return true
   } catch (err: any) {
@@ -118,7 +118,7 @@ const addDestinationPath = async (path: DestinationPath): Promise<boolean> => {
 const updateDestinationPath = async (originalName: string, path: DestinationPath): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.put(`${endpoint}/destination-paths/${encodeURIComponent(originalName)}`, path)
+    await v2.put(`${endpoint}/destination-paths/${encodeURIComponent(originalName)}`, path)
     showSnackBar({ msg: `Destination path '${path.name}' updated.` })
     return true
   } catch (err: any) {
@@ -133,7 +133,7 @@ const updateDestinationPath = async (originalName: string, path: DestinationPath
 // Users and groups for destination path target pickers (v1 users/groups REST).
 const getNotificationUsers = async (): Promise<string[] | null> => {
   try {
-    const resp = await rest.get('/users?limit=0')
+    const resp = await v2.get('/users?limit=0')
     const users = resp.data?.user ?? []
     return (Array.isArray(users) ? users : [users]).map((u: any) => u['user-id']).filter(Boolean)
   } catch (_err) {
@@ -144,7 +144,7 @@ const getNotificationUsers = async (): Promise<string[] | null> => {
 
 const getNotificationGroups = async (): Promise<string[] | null> => {
   try {
-    const resp = await rest.get('/groups?limit=0')
+    const resp = await v2.get('/groups?limit=0')
     const groups = resp.data?.group ?? []
     return (Array.isArray(groups) ? groups : [groups]).map((g: any) => g.name).filter(Boolean)
   } catch (_err) {
@@ -155,7 +155,7 @@ const getNotificationGroups = async (): Promise<string[] | null> => {
 
 const getOnCallRoles = async (): Promise<string[] | null> => {
   try {
-    const resp = await rest.get(`${endpoint}/on-call-roles`)
+    const resp = await v2.get(`${endpoint}/on-call-roles`)
     return Array.isArray(resp.data) ? resp.data : []
   } catch (_err) {
     showSnackBar({ msg: 'Failed to load on-call roles.' })
@@ -166,7 +166,7 @@ const getOnCallRoles = async (): Promise<string[] | null> => {
 const getNotificationCommands = async (): Promise<NotificationCommand[] | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/commands`)
+    const resp = await v2.get(`${endpoint}/commands`)
     return resp.data ?? []
   } catch (_err) {
     showSnackBar({ msg: 'Failed to load notification commands.' })

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -22,7 +22,7 @@
 
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
-import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { DestinationPath, NotifdStatus, NotificationCommand } from '@/types/notificationConfig'
 import { rest } from './axiosInstances'
 
 const { showSnackBar } = useSnackbar()
@@ -71,9 +71,120 @@ const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
   }
 }
 
+const deleteDestinationPath = async (name: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.delete(`${endpoint}/destination-paths/${encodeURIComponent(name)}`)
+    showSnackBar({ msg: `Destination path '${name}' deleted.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to delete destination path '${name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const testDestinationPath = async (name: string): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.post(`/notifications/destination-paths/${encodeURIComponent(name)}/trigger`)
+    showSnackBar({ msg: `Test notification triggered for '${name}'.` })
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to trigger test notification for '${name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const addDestinationPath = async (path: DestinationPath): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.post(`${endpoint}/destination-paths`, path)
+    showSnackBar({ msg: `Destination path '${path.name}' added.` })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : `Failed to add destination path '${path.name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const updateDestinationPath = async (originalName: string, path: DestinationPath): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.put(`${endpoint}/destination-paths/${encodeURIComponent(originalName)}`, path)
+    showSnackBar({ msg: `Destination path '${path.name}' updated.` })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : `Failed to update destination path '${path.name}'.` })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+// Users and groups for destination path target pickers (v1 users/groups REST).
+const getNotificationUsers = async (): Promise<string[] | null> => {
+  try {
+    const resp = await rest.get('/users?limit=0')
+    const users = resp.data?.user ?? []
+    return (Array.isArray(users) ? users : [users]).map((u: any) => u['user-id']).filter(Boolean)
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load users.' })
+    return null
+  }
+}
+
+const getNotificationGroups = async (): Promise<string[] | null> => {
+  try {
+    const resp = await rest.get('/groups?limit=0')
+    const groups = resp.data?.group ?? []
+    return (Array.isArray(groups) ? groups : [groups]).map((g: any) => g.name).filter(Boolean)
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load groups.' })
+    return null
+  }
+}
+
+const getOnCallRoles = async (): Promise<string[] | null> => {
+  try {
+    const resp = await rest.get(`${endpoint}/on-call-roles`)
+    return Array.isArray(resp.data) ? resp.data : []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load on-call roles.' })
+    return null
+  }
+}
+
+const getNotificationCommands = async (): Promise<NotificationCommand[] | null> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/commands`)
+    return resp.data ?? []
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load notification commands.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
 
 export {
+  addDestinationPath,
+  deleteDestinationPath,
   getDestinationPaths,
+  getNotificationCommands,
   getNotificationConfigStatus,
-  setNotificationConfigStatus
+  getNotificationGroups,
+  getNotificationUsers,
+  getOnCallRoles,
+  setNotificationConfigStatus,
+  testDestinationPath,
+  updateDestinationPath
 }

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -77,8 +77,9 @@ const deleteDestinationPath = async (name: string): Promise<boolean> => {
     await rest.delete(`${endpoint}/destination-paths/${encodeURIComponent(name)}`)
     showSnackBar({ msg: `Destination path '${name}' deleted.` })
     return true
-  } catch (_err) {
-    showSnackBar({ msg: `Failed to delete destination path '${name}'.` })
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : `Failed to delete destination path '${name}'.` })
     return false
   } finally {
     stopSpinner()

--- a/ui/src/stores/notificationConfigStore.ts
+++ b/ui/src/stores/notificationConfigStore.ts
@@ -21,12 +21,17 @@
 ///
 
 import API from '@/services'
-import { NotifdStatus } from '@/types/notificationConfig'
+import { DestinationPath, NotifdStatus, NotificationCommand } from '@/types/notificationConfig'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useNotificationConfigStore = defineStore('notificationConfigStore', () => {
   const notifdStatus = ref<NotifdStatus | null>(null)
+  const destinationPaths = ref([] as DestinationPath[])
+  const commands = ref([] as NotificationCommand[])
+  const users = ref([] as string[])
+  const groups = ref([] as string[])
+  const roles = ref([] as string[])
 
   const getStatus = async (): Promise<boolean> => {
     notifdStatus.value = await API.getNotificationConfigStatus()
@@ -41,9 +46,81 @@ export const useNotificationConfigStore = defineStore('notificationConfigStore',
     return ok
   }
 
+  const getDestinationPaths = async (): Promise<boolean> => {
+    const result = await API.getDestinationPaths()
+    if (result === null) {
+      return false
+    }
+    destinationPaths.value = result
+    return true
+  }
+
+  const addDestinationPath = async (path: DestinationPath) => {
+    const ok = await API.addDestinationPath(path)
+    if (ok) {
+      await getDestinationPaths()
+    }
+    return ok
+  }
+
+  const updateDestinationPath = async (originalName: string, path: DestinationPath) => {
+    const ok = await API.updateDestinationPath(originalName, path)
+    if (ok) {
+      await getDestinationPaths()
+    }
+    return ok
+  }
+
+  const getUsersAndGroups = async (): Promise<boolean> => {
+    const [u, g, r] = await Promise.all([API.getNotificationUsers(), API.getNotificationGroups(), API.getOnCallRoles()])
+    if (u) {
+      users.value = u
+    }
+    if (g) {
+      groups.value = g
+    }
+    if (r) {
+      roles.value = r
+    }
+    return u !== null && g !== null && r !== null
+  }
+
+  const deleteDestinationPath = async (name: string) => {
+    const ok = await API.deleteDestinationPath(name)
+    if (ok) {
+      await getDestinationPaths()
+    }
+    return ok
+  }
+
+  const testDestinationPath = async (name: string) => {
+    return await API.testDestinationPath(name)
+  }
+
+  const getCommands = async (): Promise<boolean> => {
+    const result = await API.getNotificationCommands()
+    if (result === null) {
+      return false
+    }
+    commands.value = result
+    return true
+  }
+
   return {
     notifdStatus,
+    destinationPaths,
+    commands,
     getStatus,
-    setStatus
+    setStatus,
+    getDestinationPaths,
+    addDestinationPath,
+    updateDestinationPath,
+    deleteDestinationPath,
+    testDestinationPath,
+    getCommands,
+    users,
+    groups,
+    roles,
+    getUsersAndGroups
   }
 })

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -20,7 +20,7 @@
 /// License.
 ///
 
-// JSON mirrors of the JAXB config models behind /rest/notification-config.
+// JSON mirrors of the config models behind /api/v2/notification-config.
 // Field names follow the XML element/attribute names in notifications.xml,
 // destinationPaths.xml and notificationCommands.xml — the files stay the
 // system of record, this API is a 1:1 view of them.

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -45,3 +45,19 @@ export interface DestinationPath {
   target: DestinationPathTarget[]
   escalate?: DestinationPathEscalate[]
 }
+
+export interface NotificationCommandArgument {
+  streamed?: string
+  substitution?: string
+  switch?: string
+}
+
+export interface NotificationCommand {
+  binary?: string
+  'service-registry'?: string
+  name: string
+  execute?: string
+  comment?: string
+  'contact-type'?: string
+  argument?: NotificationCommandArgument[]
+}

--- a/ui/tests/stores/notificationConfigStore.test.ts
+++ b/ui/tests/stores/notificationConfigStore.test.ts
@@ -2,16 +2,32 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import API from '@/services'
+import { DestinationPath } from '@/types/notificationConfig'
 
 vi.mock('@/services', () => ({
   default: {
     getNotificationConfigStatus: vi.fn(),
-    setNotificationConfigStatus: vi.fn()
+    setNotificationConfigStatus: vi.fn(),
+    getDestinationPaths: vi.fn(),
+    addDestinationPath: vi.fn(),
+    updateDestinationPath: vi.fn(),
+    deleteDestinationPath: vi.fn(),
+    testDestinationPath: vi.fn(),
+    getNotificationCommands: vi.fn(),
+    getNotificationUsers: vi.fn(),
+    getNotificationGroups: vi.fn(),
+    getOnCallRoles: vi.fn()
   }
 }))
 
 describe('useNotificationConfigStore', () => {
   let store: ReturnType<typeof useNotificationConfigStore>
+
+  const mockPath: DestinationPath = {
+    name: 'Email-Admin',
+    'initial-delay': '0s',
+    target: [{ name: 'Admin', command: ['javaEmail'] }]
+  }
 
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -26,6 +42,8 @@ describe('useNotificationConfigStore', () => {
   describe('Initial State', () => {
     it('should start empty with unknown notifd status', () => {
       expect(store.notifdStatus).toBeNull()
+      expect(store.destinationPaths).toEqual([])
+      expect(store.commands).toEqual([])
     })
   })
 
@@ -62,6 +80,73 @@ describe('useNotificationConfigStore', () => {
 
       expect(ok).toBe(false)
       expect(store.notifdStatus).toBe('off')
+    })
+  })
+
+  describe('destination paths', () => {
+    it('should refresh after add, update and delete', async () => {
+      vi.mocked(API.addDestinationPath).mockResolvedValue(true)
+      vi.mocked(API.updateDestinationPath).mockResolvedValue(true)
+      vi.mocked(API.deleteDestinationPath).mockResolvedValue(true)
+      vi.mocked(API.getDestinationPaths).mockResolvedValue([mockPath])
+
+      await store.addDestinationPath(mockPath)
+      await store.updateDestinationPath('Email-Admin', mockPath)
+      await store.deleteDestinationPath('Email-Admin')
+
+      expect(API.getDestinationPaths).toHaveBeenCalledTimes(3)
+      expect(store.destinationPaths).toEqual([mockPath])
+    })
+
+    it('should pass the original name when renaming', async () => {
+      vi.mocked(API.updateDestinationPath).mockResolvedValue(true)
+      vi.mocked(API.getDestinationPaths).mockResolvedValue([])
+
+      const renamed = { ...mockPath, name: 'Email-Ops' }
+      await store.updateDestinationPath('Email-Admin', renamed)
+
+      expect(API.updateDestinationPath).toHaveBeenCalledWith('Email-Admin', renamed)
+    })
+  })
+
+  describe('editor lookups', () => {
+    it('should load the notification commands', async () => {
+      vi.mocked(API.getNotificationCommands).mockResolvedValue([{ name: 'javaEmail' }])
+
+      await store.getCommands()
+
+      expect(store.commands).toEqual([{ name: 'javaEmail' }])
+    })
+
+    it('should load users, groups and roles for the target picker', async () => {
+      vi.mocked(API.getNotificationUsers).mockResolvedValue(['admin'])
+      vi.mocked(API.getNotificationGroups).mockResolvedValue(['Admin'])
+      vi.mocked(API.getOnCallRoles).mockResolvedValue(['oncall'])
+
+      const ok = await store.getUsersAndGroups()
+
+      expect(ok).toBe(true)
+      expect(store.users).toEqual(['admin'])
+      expect(store.groups).toEqual(['Admin'])
+      expect(store.roles).toEqual(['oncall'])
+    })
+
+    it('reports failure when a lookup errors so the tab loader can retry', async () => {
+      vi.mocked(API.getDestinationPaths).mockResolvedValueOnce([mockPath])
+      await store.getDestinationPaths()
+      // a failed reload returns false and keeps the prior data
+      vi.mocked(API.getDestinationPaths).mockResolvedValueOnce(null)
+      expect(await store.getDestinationPaths()).toBe(false)
+      expect(store.destinationPaths).toEqual([mockPath])
+
+      // getUsersAndGroups is false if ANY of the three lookups fails
+      vi.mocked(API.getNotificationUsers).mockResolvedValue(['admin'])
+      vi.mocked(API.getNotificationGroups).mockResolvedValue(null)
+      vi.mocked(API.getOnCallRoles).mockResolvedValue(['oncall'])
+      expect(await store.getUsersAndGroups()).toBe(false)
+
+      vi.mocked(API.getNotificationCommands).mockResolvedValueOnce(null)
+      expect(await store.getCommands()).toBe(false)
     })
   })
 })


### PR DESCRIPTION
**Tickets:** NMS-20119 (epic NMS-20100).

Adds the Destination Paths tab to Configure Notifications, rebased onto the epic with the review feedback applied.

- Table lists destination paths with add/edit/delete.
- Editor covers the initial delay, initial targets and escalations, with per-target notification methods and interval.
- Fields use the FormField seam with inline info-icon help (no direct-PrimeVue IftaLabel), and the editor's field alignment is fixed.
- Backed by new NotificationConfig REST endpoints (with IT), a GroupManager role-map fix, and store/service/type support.
