### PR TITLE
NMS-20120: Path Outages tab

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationConfigRestService.java
@@ -21,14 +21,22 @@
  */
 package org.opennms.web.rest.v1;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
 
 import javax.servlet.http.HttpServletRequest;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -42,10 +50,20 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.netmgt.config.DestinationPathFactory;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.NotifdConfigFactory;
 import org.opennms.netmgt.config.destinationPaths.DestinationPaths;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.PathOutageDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.events.api.EventProxy;
+import org.opennms.netmgt.filter.FilterDaoFactory;
+import org.opennms.netmgt.filter.api.FilterParseException;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsPathOutage;
 import org.opennms.netmgt.model.events.EventBuilder;
+import org.springframework.dao.DataAccessException;
 import org.opennms.web.api.Authentication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +85,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * <li><b>PUT /notification-config/status</b> turn notifd on or off</li>
  * <li><b>GET /notification-config/destination-paths</b> all destination paths</li>
  * <li><b>GET /notification-config/destination-paths/{name}</b> one destination path</li>
+ * <li><b>GET/POST/DELETE /notification-config/path-outages</b> critical paths (pathoutage table)</li>
  * </ul>
  */
 @Component("notificationConfigRestService")
@@ -79,6 +98,20 @@ public class NotificationConfigRestService extends OnmsRestService {
     @Autowired
     @Qualifier("eventProxy")
     protected EventProxy m_eventProxy;
+
+    @Autowired
+    private PathOutageDao m_pathOutageDao;
+
+    @Autowired
+    private NodeDao m_nodeDao;
+
+    @Autowired
+    private SessionUtils m_sessionUtils;
+
+    // Flush/clear the Hibernate session every N rows during a bulk path-outage
+    // apply so a rule that matches many nodes doesn't accumulate the whole batch
+    // in the persistence context.
+    private static final int PATH_OUTAGE_BATCH = 200;
 
     @XmlRootElement(name = "notification-status")
     public static class NotificationStatus {
@@ -211,4 +244,277 @@ public class NotificationConfigRestService extends OnmsRestService {
         DestinationPathFactory.init();
         return DestinationPathFactory.getInstance();
     }
+
+    // ------------------------------------------------------------------
+    // Path outages (critical paths). Storage is and stays the pathoutage
+    // DB table; the logic below mirrors the legacy NotificationWizardServlet
+    // (filter rule -> node set; per node delete + optional insert; blank
+    // critical IP clears the path for the matching nodes).
+    // ------------------------------------------------------------------
+
+    private static final int PREVIEW_NODE_LIMIT = 200;
+
+    @XmlRootElement(name = "path-outage")
+    public static class PathOutageDTO {
+        private Integer m_nodeId;
+        private String m_nodeLabel;
+        private String m_criticalPathIp;
+        private String m_criticalPathServiceName;
+
+        public Integer getNodeId() {
+            return m_nodeId;
+        }
+
+        public void setNodeId(final Integer nodeId) {
+            m_nodeId = nodeId;
+        }
+
+        public String getNodeLabel() {
+            return m_nodeLabel;
+        }
+
+        public void setNodeLabel(final String nodeLabel) {
+            m_nodeLabel = nodeLabel;
+        }
+
+        public String getCriticalPathIp() {
+            return m_criticalPathIp;
+        }
+
+        public void setCriticalPathIp(final String criticalPathIp) {
+            m_criticalPathIp = criticalPathIp;
+        }
+
+        public String getCriticalPathServiceName() {
+            return m_criticalPathServiceName;
+        }
+
+        public void setCriticalPathServiceName(final String criticalPathServiceName) {
+            m_criticalPathServiceName = criticalPathServiceName;
+        }
+    }
+
+    @XmlRootElement(name = "path-outage-preview")
+    public static class PathOutagePreviewDTO {
+        private int m_totalCount;
+        private List<PathOutageDTO> m_nodes = new ArrayList<>();
+
+        public int getTotalCount() {
+            return m_totalCount;
+        }
+
+        public void setTotalCount(final int totalCount) {
+            m_totalCount = totalCount;
+        }
+
+        public List<PathOutageDTO> getNodes() {
+            return m_nodes;
+        }
+
+        public void setNodes(final List<PathOutageDTO> nodes) {
+            m_nodes = nodes;
+        }
+    }
+
+    @XmlRootElement(name = "path-outage-request")
+    public static class PathOutageRequestDTO {
+        private String m_rule;
+        private String m_criticalIp;
+        private String m_criticalSvc;
+
+        public String getRule() {
+            return m_rule;
+        }
+
+        public void setRule(final String rule) {
+            m_rule = rule;
+        }
+
+        public String getCriticalIp() {
+            return m_criticalIp;
+        }
+
+        public void setCriticalIp(final String criticalIp) {
+            m_criticalIp = criticalIp;
+        }
+
+        public String getCriticalSvc() {
+            return m_criticalSvc;
+        }
+
+        public void setCriticalSvc(final String criticalSvc) {
+            m_criticalSvc = criticalSvc;
+        }
+    }
+
+    @GET
+    @Path("path-outages")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<PathOutageDTO> getPathOutages(@Context final SecurityContext securityContext) {
+        assertAdmin(securityContext, "read path outages");
+        return m_sessionUtils.withReadOnlyTransaction(() -> {
+            final List<OnmsPathOutage> outages = m_pathOutageDao.findAll();
+            // fetch the node labels in one query rather than a lazy select per
+            // row on the @OneToOne node association
+            final Set<Integer> nodeIds = new HashSet<>();
+            for (final OnmsPathOutage po : outages) {
+                nodeIds.add(po.getNodeId());
+            }
+            final Map<Integer, String> labelByNodeId = new HashMap<>();
+            if (!nodeIds.isEmpty()) {
+                for (final OnmsNode node : m_nodeDao.findMatching(new CriteriaBuilder(OnmsNode.class).in("id", nodeIds).toCriteria())) {
+                    labelByNodeId.put(node.getId(), node.getLabel());
+                }
+            }
+            final List<PathOutageDTO> result = new ArrayList<>();
+            for (final OnmsPathOutage po : outages) {
+                final PathOutageDTO dto = new PathOutageDTO();
+                dto.setNodeId(po.getNodeId());
+                dto.setNodeLabel(labelByNodeId.get(po.getNodeId()));
+                dto.setCriticalPathIp(InetAddressUtils.str(po.getCriticalPathIp()));
+                dto.setCriticalPathServiceName(po.getCriticalPathServiceName());
+                result.add(dto);
+            }
+            // preserve the prior ordering: node label, then node id
+            result.sort(Comparator
+                    .comparing((final PathOutageDTO dto) -> dto.getNodeLabel() == null ? "" : dto.getNodeLabel(), String.CASE_INSENSITIVE_ORDER)
+                    .thenComparing(PathOutageDTO::getNodeId));
+            return result;
+        });
+    }
+
+    @GET
+    @Path("path-outages/preview")
+    @Produces(MediaType.APPLICATION_JSON)
+    public PathOutagePreviewDTO previewPathOutageRule(@Context final SecurityContext securityContext, @javax.ws.rs.QueryParam("rule") final String rule) {
+        assertAdmin(securityContext, "preview path outage rules");
+        if (rule == null || rule.isBlank()) {
+            throw getException(Status.BAD_REQUEST, "A filter rule is required");
+        }
+        readLock();
+        try {
+            final SortedMap<Integer, String> nodes = getMatchingNodes(rule);
+            final PathOutagePreviewDTO preview = new PathOutagePreviewDTO();
+            preview.setTotalCount(nodes.size());
+            for (final Map.Entry<Integer, String> entry : nodes.entrySet()) {
+                if (preview.getNodes().size() >= PREVIEW_NODE_LIMIT) {
+                    break;
+                }
+                final PathOutageDTO dto = new PathOutageDTO();
+                dto.setNodeId(entry.getKey());
+                dto.setNodeLabel(entry.getValue());
+                preview.getNodes().add(dto);
+            }
+            return preview;
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @POST
+    @Path("path-outages")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response applyPathOutage(@Context final SecurityContext securityContext, final PathOutageRequestDTO request) {
+        assertAdmin(securityContext, "configure path outages");
+        if (request == null || request.getRule() == null || request.getRule().isBlank()) {
+            throw getException(Status.BAD_REQUEST, "A filter rule is required");
+        }
+        final boolean clearing = request.getCriticalIp() == null || request.getCriticalIp().trim().isEmpty();
+        final String requestedSvc = request.getCriticalSvc() == null || request.getCriticalSvc().isBlank() ? "ICMP" : request.getCriticalSvc().trim();
+        if (!"ICMP".equalsIgnoreCase(requestedSvc)) {
+            throw getException(Status.BAD_REQUEST, "Only ICMP is supported as a critical path service.");
+        }
+        // store the canonical service name: the path-outage joins compare
+        // criticalPathServiceName to serviceType.name case-sensitively, so a
+        // verbatim "icmp" would silently drop out of getNodesForPathOutage.
+        final String criticalSvc = "ICMP";
+        final InetAddress criticalIp;
+        if (clearing) {
+            criticalIp = null;
+        } else {
+            final String raw = request.getCriticalIp().trim();
+            try {
+                FilterDaoFactory.getInstance().validateRule("IPADDR IPLIKE " + raw);
+                // addr already parses/canonicalizes; normalize would be a redundant round-trip
+                criticalIp = InetAddressUtils.addr(raw);
+            } catch (final FilterParseException | IllegalArgumentException e) {
+                throw getException(Status.BAD_REQUEST, "Invalid critical path IP address: {}", raw);
+            }
+        }
+        final SortedMap<Integer, String> nodes = getMatchingNodes(request.getRule());
+        if (nodes.isEmpty()) {
+            throw getException(Status.BAD_REQUEST, "The filter rule matches no nodes.");
+        }
+        try {
+            // one transaction so a mid-loop failure can't leave some nodes
+            // stripped of their old critical path with no new one written
+            m_sessionUtils.withTransaction(() -> {
+                int count = 0;
+                for (final Integer nodeId : nodes.keySet()) {
+                    final OnmsPathOutage existing = m_pathOutageDao.get(nodeId);
+                    if (clearing) {
+                        if (existing != null) {
+                            m_pathOutageDao.delete(existing);
+                        }
+                    } else if (existing != null) {
+                        // update in place rather than delete+insert (same primary key)
+                        existing.setCriticalPathIp(criticalIp);
+                        existing.setCriticalPathServiceName(criticalSvc);
+                        m_pathOutageDao.update(existing);
+                    } else {
+                        // load() is a proxy (no query); the node came from the filter
+                        // evaluation so it exists
+                        m_pathOutageDao.save(new OnmsPathOutage(m_nodeDao.load(nodeId), criticalIp, criticalSvc));
+                    }
+                    if (++count % PATH_OUTAGE_BATCH == 0) {
+                        m_pathOutageDao.flush();
+                        m_pathOutageDao.clear();
+                    }
+                }
+                return null;
+            });
+        } catch (final DataAccessException e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Could not apply the path outage: {}", e.getMessage());
+        }
+        LOG.info("Path outage {} applied to {} nodes (rule '{}') by user {}",
+                clearing ? "cleared" : "critical path " + InetAddressUtils.str(criticalIp) + "/" + criticalSvc,
+                nodes.size(), request.getRule(), securityContext.getUserPrincipal().getName());
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Path("path-outages/{nodeId}")
+    public Response deletePathOutage(@Context final SecurityContext securityContext, @PathParam("nodeId") final Integer nodeId) {
+        assertAdmin(securityContext, "remove path outages");
+        final boolean removed;
+        try {
+            removed = m_sessionUtils.withTransaction(() -> {
+                final OnmsPathOutage existing = m_pathOutageDao.get(nodeId);
+                if (existing == null) {
+                    return false;
+                }
+                m_pathOutageDao.delete(existing);
+                return true;
+            });
+        } catch (final DataAccessException e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't remove path outage for node {}: {}", String.valueOf(nodeId), e.getMessage());
+        }
+        if (!removed) {
+            throw getException(Status.NOT_FOUND, "No critical path is configured for node {}.", String.valueOf(nodeId));
+        }
+        return Response.noContent().build();
+    }
+
+    private static SortedMap<Integer, String> getMatchingNodes(final String rule) {
+        // getNodeMap already parses/evaluates the rule; a preceding validateRule
+        // would be a second full evaluation, so rely on getNodeMap's own parse.
+        try {
+            return FilterDaoFactory.getInstance().getNodeMap(rule);
+        } catch (final FilterParseException e) {
+            throw getException(Status.BAD_REQUEST, "Invalid filter rule: {}", e.getMessage());
+        } catch (final DataAccessException e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Could not evaluate the filter rule: {}", e.getMessage());
+        }
+    }
+
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
@@ -49,6 +49,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 
+import org.apache.commons.lang.StringUtils;
 import org.opennms.netmgt.config.DestinationPathFactory;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.utils.InetAddressUtils;
@@ -69,7 +70,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.googlecode.concurentlocks.ReadWriteUpdateLock;
@@ -100,29 +100,28 @@ public class NotificationConfigRestService {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationConfigRestService.class);
 
     @Autowired
-    @Qualifier("eventProxy")
-    protected EventProxy m_eventProxy;
+    protected EventProxy eventProxy;
 
     // Per-instance read/write/update lock serializing config mutations, carried
     // over from the base REST service this was split out of when it moved to v2.
-    private final ReadWriteUpdateLock m_globalLock = new ReentrantReadWriteUpdateLock();
-    private final Lock m_readLock = m_globalLock.updateLock();
-    private final Lock m_writeLock = m_globalLock.writeLock();
+    private final ReadWriteUpdateLock globalLock = new ReentrantReadWriteUpdateLock();
+    private final Lock readLock = globalLock.updateLock();
+    private final Lock writeLock = globalLock.writeLock();
 
     private void readLock() {
-        m_readLock.lock();
+        readLock.lock();
     }
 
     private void readUnlock() {
-        m_readLock.unlock();
+        readLock.unlock();
     }
 
     private void writeLock() {
-        m_writeLock.lock();
+        writeLock.lock();
     }
 
     private void writeUnlock() {
-        m_writeLock.unlock();
+        writeLock.unlock();
     }
 
     private static WebApplicationException getException(final Status status, final String msg, final String... params) {
@@ -137,13 +136,13 @@ public class NotificationConfigRestService {
     }
 
     @Autowired
-    private PathOutageDao m_pathOutageDao;
+    private PathOutageDao pathOutageDao;
 
     @Autowired
-    private NodeDao m_nodeDao;
+    private NodeDao nodeDao;
 
     @Autowired
-    private SessionUtils m_sessionUtils;
+    private SessionUtils sessionUtils;
 
     // Flush/clear the Hibernate session every N rows during a bulk path-outage
     // apply so a rule that matches many nodes doesn't accumulate the whole batch
@@ -264,7 +263,7 @@ public class NotificationConfigRestService {
             bldr.addParam("remoteUser", securityContext.getUserPrincipal().getName());
             bldr.addParam("remoteHost", request.getRemoteHost());
             bldr.addParam("remoteAddr", request.getRemoteAddr());
-            m_eventProxy.send(bldr.getEvent());
+            eventProxy.send(bldr.getEvent());
         } catch (final Exception e) {
             LOG.warn("Can't send event {}", uei, e);
         }
@@ -384,8 +383,8 @@ public class NotificationConfigRestService {
     @Produces(MediaType.APPLICATION_JSON)
     public List<PathOutageDTO> getPathOutages(@Context final SecurityContext securityContext) {
         assertAdmin(securityContext, "read path outages");
-        return m_sessionUtils.withReadOnlyTransaction(() -> {
-            final List<OnmsPathOutage> outages = m_pathOutageDao.findAll();
+        return sessionUtils.withReadOnlyTransaction(() -> {
+            final List<OnmsPathOutage> outages = pathOutageDao.findAll();
             // fetch the node labels in one query rather than a lazy select per
             // row on the @OneToOne node association
             final Set<Integer> nodeIds = new HashSet<>();
@@ -394,7 +393,7 @@ public class NotificationConfigRestService {
             }
             final Map<Integer, String> labelByNodeId = new HashMap<>();
             if (!nodeIds.isEmpty()) {
-                for (final OnmsNode node : m_nodeDao.findMatching(new CriteriaBuilder(OnmsNode.class).in("id", nodeIds).toCriteria())) {
+                for (final OnmsNode node : nodeDao.findMatching(new CriteriaBuilder(OnmsNode.class).in("id", nodeIds).toCriteria())) {
                     labelByNodeId.put(node.getId(), node.getLabel());
                 }
             }
@@ -420,7 +419,7 @@ public class NotificationConfigRestService {
     @Produces(MediaType.APPLICATION_JSON)
     public PathOutagePreviewDTO previewPathOutageRule(@Context final SecurityContext securityContext, @javax.ws.rs.QueryParam("rule") final String rule) {
         assertAdmin(securityContext, "preview path outage rules");
-        if (rule == null || rule.isBlank()) {
+        if (StringUtils.isBlank(rule)) {
             throw getException(Status.BAD_REQUEST, "A filter rule is required");
         }
         readLock();
@@ -448,11 +447,11 @@ public class NotificationConfigRestService {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response applyPathOutage(@Context final SecurityContext securityContext, final PathOutageRequestDTO request) {
         assertAdmin(securityContext, "configure path outages");
-        if (request == null || request.getRule() == null || request.getRule().isBlank()) {
+        if (request == null || StringUtils.isBlank(request.getRule())) {
             throw getException(Status.BAD_REQUEST, "A filter rule is required");
         }
         final boolean clearing = request.getCriticalIp() == null || request.getCriticalIp().trim().isEmpty();
-        final String requestedSvc = request.getCriticalSvc() == null || request.getCriticalSvc().isBlank() ? "ICMP" : request.getCriticalSvc().trim();
+        final String requestedSvc = StringUtils.isBlank(request.getCriticalSvc()) ? "ICMP" : request.getCriticalSvc().trim();
         if (!"ICMP".equalsIgnoreCase(requestedSvc)) {
             throw getException(Status.BAD_REQUEST, "Only ICMP is supported as a critical path service.");
         }
@@ -480,27 +479,27 @@ public class NotificationConfigRestService {
         try {
             // one transaction so a mid-loop failure can't leave some nodes
             // stripped of their old critical path with no new one written
-            m_sessionUtils.withTransaction(() -> {
+            sessionUtils.withTransaction(() -> {
                 int count = 0;
                 for (final Integer nodeId : nodes.keySet()) {
-                    final OnmsPathOutage existing = m_pathOutageDao.get(nodeId);
+                    final OnmsPathOutage existing = pathOutageDao.get(nodeId);
                     if (clearing) {
                         if (existing != null) {
-                            m_pathOutageDao.delete(existing);
+                            pathOutageDao.delete(existing);
                         }
                     } else if (existing != null) {
                         // update in place rather than delete+insert (same primary key)
                         existing.setCriticalPathIp(criticalIp);
                         existing.setCriticalPathServiceName(criticalSvc);
-                        m_pathOutageDao.update(existing);
+                        pathOutageDao.update(existing);
                     } else {
                         // load() is a proxy (no query); the node came from the filter
                         // evaluation so it exists
-                        m_pathOutageDao.save(new OnmsPathOutage(m_nodeDao.load(nodeId), criticalIp, criticalSvc));
+                        pathOutageDao.save(new OnmsPathOutage(nodeDao.load(nodeId), criticalIp, criticalSvc));
                     }
                     if (++count % PATH_OUTAGE_BATCH == 0) {
-                        m_pathOutageDao.flush();
-                        m_pathOutageDao.clear();
+                        pathOutageDao.flush();
+                        pathOutageDao.clear();
                     }
                 }
                 return null;
@@ -520,12 +519,12 @@ public class NotificationConfigRestService {
         assertAdmin(securityContext, "remove path outages");
         final boolean removed;
         try {
-            removed = m_sessionUtils.withTransaction(() -> {
-                final OnmsPathOutage existing = m_pathOutageDao.get(nodeId);
+            removed = sessionUtils.withTransaction(() -> {
+                final OnmsPathOutage existing = pathOutageDao.get(nodeId);
                 if (existing == null) {
                     return false;
                 }
-                m_pathOutageDao.delete(existing);
+                pathOutageDao.delete(existing);
                 return true;
             });
         } catch (final DataAccessException e) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationConfigRestService.java
@@ -19,7 +19,7 @@
  * language governing permissions and limitations under the
  * License.
  */
-package org.opennms.web.rest.v1;
+package org.opennms.web.rest.v2;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.concurrent.locks.Lock;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -41,13 +42,12 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.netmgt.config.DestinationPathFactory;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -67,9 +67,13 @@ import org.springframework.dao.DataAccessException;
 import org.opennms.web.api.Authentication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import com.googlecode.concurentlocks.ReadWriteUpdateLock;
+import com.googlecode.concurentlocks.ReentrantReadWriteUpdateLock;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -91,13 +95,46 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Component("notificationConfigRestService")
 @Path("notification-config")
 @Tag(name = "Notification-config", description = "Notification Configuration API")
-public class NotificationConfigRestService extends OnmsRestService {
+public class NotificationConfigRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationConfigRestService.class);
 
     @Autowired
     @Qualifier("eventProxy")
     protected EventProxy m_eventProxy;
+
+    // Per-instance read/write/update lock serializing config mutations, carried
+    // over from the base REST service this was split out of when it moved to v2.
+    private final ReadWriteUpdateLock m_globalLock = new ReentrantReadWriteUpdateLock();
+    private final Lock m_readLock = m_globalLock.updateLock();
+    private final Lock m_writeLock = m_globalLock.writeLock();
+
+    private void readLock() {
+        m_readLock.lock();
+    }
+
+    private void readUnlock() {
+        m_readLock.unlock();
+    }
+
+    private void writeLock() {
+        m_writeLock.lock();
+    }
+
+    private void writeUnlock() {
+        m_writeLock.unlock();
+    }
+
+    private static WebApplicationException getException(final Status status, final String msg, final String... params) {
+        final String formatted = params != null ? MessageFormatter.arrayFormat(msg, params).getMessage() : msg;
+        LOG.error(formatted);
+        return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(formatted).build());
+    }
+
+    private static WebApplicationException getException(final Status status, final Throwable t) {
+        LOG.error(t.getMessage(), t);
+        return new WebApplicationException(Response.status(status).type(MediaType.TEXT_PLAIN).entity(t.getMessage()).build());
+    }
 
     @Autowired
     private PathOutageDao m_pathOutageDao;
@@ -113,24 +150,22 @@ public class NotificationConfigRestService extends OnmsRestService {
     // in the persistence context.
     private static final int PATH_OUTAGE_BATCH = 200;
 
-    @XmlRootElement(name = "notification-status")
     public static class NotificationStatus {
-        private String m_status;
+        private String status;
 
         public NotificationStatus() {
         }
 
         public NotificationStatus(final String status) {
-            m_status = status;
+            this.status = status;
         }
 
-        @XmlAttribute(name = "status")
         public String getStatus() {
-            return m_status;
+            return status;
         }
 
         public void setStatus(final String status) {
-            m_status = status;
+            this.status = status;
         }
     }
 
@@ -254,96 +289,93 @@ public class NotificationConfigRestService extends OnmsRestService {
 
     private static final int PREVIEW_NODE_LIMIT = 200;
 
-    @XmlRootElement(name = "path-outage")
     public static class PathOutageDTO {
-        private Integer m_nodeId;
-        private String m_nodeLabel;
-        private String m_criticalPathIp;
-        private String m_criticalPathServiceName;
+        private Integer nodeId;
+        private String nodeLabel;
+        private String criticalPathIp;
+        private String criticalPathServiceName;
 
         public Integer getNodeId() {
-            return m_nodeId;
+            return nodeId;
         }
 
         public void setNodeId(final Integer nodeId) {
-            m_nodeId = nodeId;
+            this.nodeId = nodeId;
         }
 
         public String getNodeLabel() {
-            return m_nodeLabel;
+            return nodeLabel;
         }
 
         public void setNodeLabel(final String nodeLabel) {
-            m_nodeLabel = nodeLabel;
+            this.nodeLabel = nodeLabel;
         }
 
         public String getCriticalPathIp() {
-            return m_criticalPathIp;
+            return criticalPathIp;
         }
 
         public void setCriticalPathIp(final String criticalPathIp) {
-            m_criticalPathIp = criticalPathIp;
+            this.criticalPathIp = criticalPathIp;
         }
 
         public String getCriticalPathServiceName() {
-            return m_criticalPathServiceName;
+            return criticalPathServiceName;
         }
 
         public void setCriticalPathServiceName(final String criticalPathServiceName) {
-            m_criticalPathServiceName = criticalPathServiceName;
+            this.criticalPathServiceName = criticalPathServiceName;
         }
     }
 
-    @XmlRootElement(name = "path-outage-preview")
     public static class PathOutagePreviewDTO {
-        private int m_totalCount;
-        private List<PathOutageDTO> m_nodes = new ArrayList<>();
+        private int totalCount;
+        private List<PathOutageDTO> nodes = new ArrayList<>();
 
         public int getTotalCount() {
-            return m_totalCount;
+            return totalCount;
         }
 
         public void setTotalCount(final int totalCount) {
-            m_totalCount = totalCount;
+            this.totalCount = totalCount;
         }
 
         public List<PathOutageDTO> getNodes() {
-            return m_nodes;
+            return nodes;
         }
 
         public void setNodes(final List<PathOutageDTO> nodes) {
-            m_nodes = nodes;
+            this.nodes = nodes;
         }
     }
 
-    @XmlRootElement(name = "path-outage-request")
     public static class PathOutageRequestDTO {
-        private String m_rule;
-        private String m_criticalIp;
-        private String m_criticalSvc;
+        private String rule;
+        private String criticalIp;
+        private String criticalSvc;
 
         public String getRule() {
-            return m_rule;
+            return rule;
         }
 
         public void setRule(final String rule) {
-            m_rule = rule;
+            this.rule = rule;
         }
 
         public String getCriticalIp() {
-            return m_criticalIp;
+            return criticalIp;
         }
 
         public void setCriticalIp(final String criticalIp) {
-            m_criticalIp = criticalIp;
+            this.criticalIp = criticalIp;
         }
 
         public String getCriticalSvc() {
-            return m_criticalSvc;
+            return criticalSvc;
         }
 
         public void setCriticalSvc(final String criticalSvc) {
-            m_criticalSvc = criticalSvc;
+            this.criticalSvc = criticalSvc;
         }
     }
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationConfigRestServiceIT.java
@@ -22,7 +22,13 @@
 package org.opennms.web.rest.v1;
 
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
+import java.util.TreeMap;
+import java.util.SortedMap;
 import java.nio.charset.Charset;
 
 import javax.ws.rs.core.MediaType;
@@ -38,7 +44,14 @@ import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.netmgt.filter.FilterDaoFactory;
+import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.filter.api.FilterParseException;
 import org.opennms.test.JUnitConfigurationEnvironment;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.model.OnmsNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ContextConfiguration;
@@ -65,7 +78,24 @@ import org.springframework.test.context.web.WebAppConfiguration;
 public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
 
+    private static final String INVALID_RULE = "this is not a rule";
+
     private String m_onmsHome;
+
+    private FilterDao m_filterDao;
+
+    @Autowired
+    private NodeDao m_nodeDao;
+
+    @Autowired
+    private MonitoringLocationDao m_locationDao;
+
+    @Autowired
+    private SessionUtils m_sessionUtils;
+
+    // the node the mocked filter matches; seeded via Hibernate so the service's
+    // PathOutageDao/NodeDao (which read through Hibernate) can see it
+    private int m_pathNodeId;
 
     private static String s_previousOpennmsHome;
 
@@ -127,6 +157,23 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
                 + "<roles><role name=\"junit-oncall\" supervisor=\"admin\" membership-group=\"Admin\"/></roles>"
                 + "</groupinfo>", Charset.defaultCharset());
 
+
+        m_filterDao = mock(FilterDao.class);
+        // the *.*.*.* -> node stub is added in afterServletStart, once the node
+        // has been seeded through Hibernate and its generated id is known
+        // a rule that matches nothing, for the zero-match apply case
+        when(m_filterDao.getNodeMap("IPADDR IPLIKE 1.1.1.1")).thenReturn(new TreeMap<>());
+        doThrow(new FilterParseException("invalid rule")).when(m_filterDao).validateRule(INVALID_RULE);
+        // getNodeMap now parses the rule itself (the redundant validateRule was dropped)
+        doThrow(new FilterParseException("invalid rule")).when(m_filterDao).getNodeMap(INVALID_RULE);
+        FilterDaoFactory.setInstance(m_filterDao);
+    }
+
+    @org.junit.After
+    public void restoreFilterDao() {
+        // the mock was pushed into the static factory in setUp; don't leak it
+        // into other ITs sharing this JVM
+        FilterDaoFactory.setInstance(null);
     }
 
     // Required so context initialization can't repoint opennms.home at
@@ -135,6 +182,17 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
     public void afterServletStart() throws Exception {
         System.setProperty("opennms.home", m_onmsHome);
         ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+        // Seed the node the mocked filter matches through Hibernate (a committed
+        // transaction), so the service's PathOutageDao/NodeDao — which read via
+        // Hibernate, not DataSourceFactory — can see it for the foreign key.
+        m_pathNodeId = m_sessionUtils.withTransaction(() -> {
+            final OnmsNode node = new OnmsNode(m_locationDao.getDefaultLocation(), "node1");
+            m_nodeDao.save(node);
+            return node.getId();
+        });
+        final SortedMap<Integer, String> nodeMap = new TreeMap<>();
+        nodeMap.put(m_pathNodeId, "node1");
+        when(m_filterDao.getNodeMap("IPADDR IPLIKE *.*.*.*")).thenReturn(nodeMap);
     }
 
     // Restore opennms.home for later suites sharing this JVM fork.
@@ -179,11 +237,61 @@ public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTes
     }
 
     @Test
+    public void testPathOutageLifecycle() throws Exception {
+        JSONArray outages = new JSONArray(getJson("/notification-config/path-outages"));
+        Assert.assertEquals(0, outages.length());
+
+        JSONObject preview = new JSONObject(getJson("/notification-config/path-outages/preview?rule=IPADDR%20IPLIKE%20*.*.*.*"));
+        Assert.assertEquals(1, preview.getInt("totalCount"));
+        Assert.assertEquals("node1", preview.getJSONArray("nodes").getJSONObject(0).getString("nodeLabel"));
+
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"IPADDR IPLIKE *.*.*.*\",\"criticalIp\":\"192.168.1.1\",\"criticalSvc\":\"ICMP\"}", 204);
+        outages = new JSONArray(getJson("/notification-config/path-outages"));
+        Assert.assertEquals(1, outages.length());
+        Assert.assertEquals("192.168.1.1", outages.getJSONObject(0).getString("criticalPathIp"));
+
+        sendRequest(DELETE, "/notification-config/path-outages/" + m_pathNodeId, 204);
+        outages = new JSONArray(getJson("/notification-config/path-outages"));
+        Assert.assertEquals(0, outages.length());
+    }
+
+    @Test
+    public void testPathOutageClearsWithBlankIp() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"IPADDR IPLIKE *.*.*.*\",\"criticalIp\":\"192.168.1.1\"}", 204);
+        Assert.assertEquals(1, new JSONArray(getJson("/notification-config/path-outages")).length());
+
+        // blank critical IP clears the path for the matching nodes
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"IPADDR IPLIKE *.*.*.*\"}", 204);
+        Assert.assertEquals(0, new JSONArray(getJson("/notification-config/path-outages")).length());
+    }
+
+    @Test
+    public void testPathOutageValidation() throws Exception {
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"" + INVALID_RULE + "\",\"criticalIp\":\"192.168.1.1\"}", 400);
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages", "{}", 400);
+        sendRequest(GET, "/notification-config/path-outages/preview", 400);
+        // a rule matching no nodes is rejected rather than silently succeeding
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"IPADDR IPLIKE 1.1.1.1\",\"criticalIp\":\"192.168.1.1\"}", 400);
+        // only ICMP is supported as the critical path service
+        sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                "{\"rule\":\"IPADDR IPLIKE *.*.*.*\",\"criticalIp\":\"192.168.1.1\",\"criticalSvc\":\"HTTP\"}", 400);
+        // deleting a critical path that isn't configured is a 404, not a silent 204
+        sendRequest(DELETE, "/notification-config/path-outages/999", 404);
+    }
+
+    @Test
     public void testForbiddenForNonAdmin() throws Exception {
         setUser("nobody", new String[]{ "ROLE_USER" });
         try {
             sendRequest(GET, "/notification-config/status", 403);
             sendData(PUT, MediaType.APPLICATION_JSON, "/notification-config/status", "{\"status\":\"on\"}", 403);
+            sendData(POST, MediaType.APPLICATION_JSON, "/notification-config/path-outages",
+                    "{\"rule\":\"IPADDR IPLIKE *.*.*.*\"}", 403);
         } finally {
             setUser("admin", new String[]{ "ROLE_ADMIN" });
         }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NotificationConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NotificationConfigRestServiceIT.java
@@ -19,7 +19,7 @@
  * language governing permissions and limitations under the
  * License.
  */
-package org.opennms.web.rest.v1;
+package org.opennms.web.rest.v2;
 
 
 import static org.mockito.Mockito.doThrow;
@@ -77,6 +77,9 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @JUnitTemporaryDatabase
 public class NotificationConfigRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
+    public NotificationConfigRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
 
     private static final String INVALID_RULE = "this is not a rule";
 

--- a/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
+++ b/ui/src/components/AdminNotifications/ConfigureNotificationsDialog.vue
@@ -29,9 +29,7 @@
           </p>
         </OnmsTabPanel>
         <OnmsTabPanel value="path-outages">
-          <p class="tab-placeholder" data-test="placeholder-path-outages">
-            Path outage management arrives with NMS-20120.
-          </p>
+          <PathOutagesTab />
         </OnmsTabPanel>
         <OnmsTabPanel value="general">
           <div class="general-tab">
@@ -61,6 +59,7 @@ import { ref, watch } from 'vue'
 
 import { OnmsDialog, OnmsTabs, OnmsTabList, OnmsTab, OnmsTabPanels, OnmsTabPanel, OnmsToggleSwitch } from '@opennms/onms-ui'
 
+import PathOutagesTab from '@/components/AdminNotifications/PathOutagesTab.vue'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import { NotifdStatus } from '@/types/notificationConfig'
 
@@ -84,6 +83,9 @@ const statusPending = ref(false)
 const loadedTabs = ref(new Set<string>())
 
 const TAB_LOADERS: Record<string, () => Promise<boolean>> = {
+  'path-outages': async () => {
+    return await store.getPathOutages()
+  },
   general: () => store.getStatus()
 }
 

--- a/ui/src/components/AdminNotifications/PathOutagesTab.vue
+++ b/ui/src/components/AdminNotifications/PathOutagesTab.vue
@@ -1,0 +1,426 @@
+<template>
+  <div class="path-outages-tab">
+    <p class="intro">
+      Define a critical path for a group of nodes so node-down notifications are suppressed when
+      the critical path is unreachable. The rule selects the nodes; leaving the IP address blank
+      clears the critical path for the matching nodes.
+    </p>
+
+    <TogglePanel
+      :collapsed="helpCollapsed"
+      class="help-panel"
+      data-test="path-outages-help"
+      @update:collapsed="(value: boolean) => (helpCollapsed = value)"
+    >
+      <template #header>
+        <span class="help-header">
+          <i class="pi pi-question-circle" aria-hidden="true" />
+          About Critical Paths and Filter Rules
+        </span>
+      </template>
+      <div class="help-content">
+        <div class="help-section">
+          <div class="section-title">Critical Path IP Address</div>
+          <p>
+            Enter the critical path IP address in xxx.xxx.xxx.xxx or
+            xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx format. Or leave it blank to clear previously
+            set paths for the nodes matching the rule. The critical path service is typically ICMP,
+            and at this time ICMP is the only critical path service supported.
+          </p>
+        </div>
+        <div class="help-section">
+          <div class="section-title">Node Filter Rule</div>
+          <p>
+            Filtering on TCP/IP address uses a very flexible format, allowing you to separate the
+            four octets (fields) of a TCP/IP address into specific searches. An asterisk (*) in
+            place of any octet matches any value for that octet. Ranges are indicated by two
+            numbers separated by a dash (-), and commas are used for list demarcation.
+          </p>
+          <p>The following examples are all valid and yield the set of addresses from 192.168.0.0 through 192.168.3.255:</p>
+          <ul>
+            <li><code>192.168.0-3.*</code></li>
+            <li><code>192.168.0-3.0-255</code></li>
+            <li><code>192.168.0,1,2,3.*</code></li>
+          </ul>
+          <p>
+            To use a rule based on TCP/IP addresses as described above, enter
+            <code>IPADDR IPLIKE *.*.*.*</code> substituting your desired address fields for
+            <code>*.*.*.*</code>. Otherwise, you may enter any valid rule.
+          </p>
+        </div>
+      </div>
+    </TogglePanel>
+
+    <div class="form-row">
+      <FormField
+        label="Critical Path IP Address"
+        for="path-outage-ip"
+        :error="!criticalIpValid ? 'Enter a valid IPv4 or IPv6 address, or leave blank to clear the path.' : undefined"
+      >
+        <OnmsInputText
+          id="path-outage-ip"
+          v-model="criticalIp"
+          :invalid="!criticalIpValid"
+          data-test="critical-ip-input"
+        />
+      </FormField>
+      <FormField
+        label="Critical Path Service"
+        for="path-outage-service"
+      >
+        <OnmsSelect
+          v-model="criticalSvc"
+          inputId="path-outage-service"
+          :options="serviceOptions"
+          data-test="critical-service-select"
+        />
+      </FormField>
+      <FormField
+        class="rule-field"
+        label="Node Filter Rule"
+        for="path-outage-rule"
+        :error="ruleError ? 'This rule could not be evaluated — check the syntax (e.g. IPADDR IPLIKE *.*.*.*).' : undefined"
+      >
+        <template #label-suffix>
+          <HelpBadge :content="ruleHelp" ariaLabel="Node Filter Rule help" />
+        </template>
+        <OnmsInputText
+          id="path-outage-rule"
+          v-model="rule"
+          :invalid="ruleError"
+          data-test="rule-input"
+        />
+      </FormField>
+      <OnmsButton
+        variant="outlined"
+        label="Preview Matching Nodes"
+        data-test="preview-button"
+        :disabled="!rule.trim()"
+        @click="preview"
+      />
+      <OnmsButton
+        :label="criticalIp.trim() ? 'Apply Critical Path' : 'Clear Critical Path'"
+        :severity="criticalIp.trim() ? undefined : 'danger'"
+        data-test="apply-button"
+        :disabled="!rule.trim() || !criticalIpValid"
+        @click="askApply"
+      />
+    </div>
+
+    <div
+      v-if="previewResult"
+      class="preview-result"
+      data-test="preview-result"
+    >
+      <strong>{{ previewResult.totalCount }}</strong> node{{ previewResult.totalCount === 1 ? '' : 's' }} match the rule<span v-if="previewResult.totalCount > previewResult.nodes.length"> (showing first {{ previewResult.nodes.length }})</span>:
+      <div class="node-chips">
+        <OnmsChip
+          v-for="node in previewResult.nodes"
+          :key="node.nodeId"
+          :label="`${node.nodeLabel ?? node.nodeId}`"
+        />
+      </div>
+    </div>
+
+    <div class="current-paths">
+      <div class="section-title">Current Critical Paths</div>
+      <OnmsTable
+        v-if="store.pathOutages.length"
+        :value="store.pathOutages"
+        dataKey="nodeId"
+        paginator
+        :rows="10"
+        :rowsPerPageOptions="[10, 20, 50]"
+        class="data-table"
+        data-test="path-outages-table"
+      >
+        <OnmsColumn
+          field="nodeLabel"
+          header="Node"
+          sortable
+        >
+          <template #body="{ data }">
+            {{ data.nodeLabel ?? data.nodeId }}
+          </template>
+        </OnmsColumn>
+        <OnmsColumn
+          field="criticalPathIp"
+          header="Critical Path IP"
+          sortable
+        />
+        <OnmsColumn
+          field="criticalPathServiceName"
+          header="Service"
+        />
+        <OnmsColumn header="Actions">
+          <template #body="{ data }">
+            <OnmsButton
+              variant="text"
+              label="Remove"
+              severity="danger"
+              :aria-label="`Remove critical path for ${data.nodeLabel ?? data.nodeId}`"
+              data-test="remove-path-outage-button"
+              @click="askRemove(data)"
+            />
+          </template>
+        </OnmsColumn>
+      </OnmsTable>
+      <div v-if="!store.pathOutages.length">
+        <EmptyList
+          :content="emptyListContent"
+          data-test="empty-list"
+        />
+      </div>
+    </div>
+  </div>
+
+  <OnmsConfirmationDialog
+    :visible="showApplyConfirmation"
+    :title="criticalIp.trim() ? 'Apply Critical Path' : 'Clear Critical Path'"
+    :actionButtonText="criticalIp.trim() ? 'Apply' : 'Clear'"
+    @ok="confirmApply"
+    @cancel="showApplyConfirmation = false"
+  >
+    <template #content>
+      <p v-if="criticalIp.trim()">
+        Set the critical path to <strong>{{ criticalIp }}</strong> ({{ criticalSvc }}) for the
+        <strong>{{ applyCount ?? '?' }}</strong> node{{ applyCount === 1 ? '' : 's' }} matching
+        <code>{{ rule }}</code>?
+      </p>
+      <p v-else>
+        Clear the critical path for every node matching <code>{{ rule }}</code> that currently has one?
+      </p>
+    </template>
+  </OnmsConfirmationDialog>
+  <OnmsConfirmationDialog
+    :visible="showRemoveConfirmation"
+    title="Remove Critical Path"
+    actionButtonText="Remove"
+    @ok="confirmRemove"
+    @cancel="cancelRemove"
+  >
+    <template #content>
+      <p>Remove the critical path for <strong>{{ outageToRemove?.nodeLabel ?? outageToRemove?.nodeId }}</strong>?</p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import { OnmsConfirmationDialog, OnmsButton, OnmsChip, OnmsColumn, OnmsInputText, OnmsSelect, OnmsTable } from '@opennms/onms-ui'
+
+import EmptyList from '@/components/Common/EmptyList.vue'
+import FormField from '@/components/Common/FormField.vue'
+import HelpBadge from '@/components/Common/HelpBadge.vue'
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
+import { PathOutage, PathOutagePreview } from '@/types/notificationConfig'
+
+const store = useNotificationConfigStore()
+
+// ICMP is the only supported critical path service (matches the legacy wizard).
+const serviceOptions = ['ICMP']
+
+const helpCollapsed = ref(true)
+const criticalIp = ref('')
+const criticalSvc = ref('ICMP')
+const rule = ref('')
+const previewResult = ref<PathOutagePreview | null>(null)
+
+// A backend rule evaluation that returns nothing marks the rule field invalid;
+// editing the rule clears it so the red state doesn't linger.
+const ruleError = ref(false)
+watch(rule, () => {
+  ruleError.value = false
+})
+
+const ruleHelp = 'An OpenNMS filter rule selecting the nodes, e.g. IPADDR IPLIKE *.*.*.*. Octets accept * (any), ranges (0-3) and lists (0,1,2). Use Preview to check what it matches.'
+
+// Client-side format check only; the server is authoritative when the path is applied.
+const isValidIp = (value: string): boolean => {
+  const isV4 = (v: string): boolean => {
+    const m = v.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+    return !!m && m.slice(1).every(octet => Number(octet) <= 255)
+  }
+  if (isV4(value)) {
+    return true
+  }
+  // IPv6: at most one "::"; between colons only hex groups (1-4 digits), with an
+  // optional embedded IPv4 tail (e.g. ::ffff:192.168.1.1). Rejects colon-only junk.
+  if (!value.includes(':') || (value.match(/::/g) || []).length > 1) {
+    return false
+  }
+  let body = value
+  const lastColon = value.lastIndexOf(':')
+  const tail = value.slice(lastColon + 1)
+  if (tail.includes('.')) {
+    if (!isV4(tail)) {
+      return false
+    }
+    body = value.slice(0, lastColon + 1)
+  }
+  return body.replace('::', ':').split(':').every(group => group === '' || /^[0-9a-fA-F]{1,4}$/.test(group))
+}
+const criticalIpValid = computed(() => {
+  const v = criticalIp.value.trim()
+  return v === '' || isValidIp(v)
+})
+
+const showApplyConfirmation = ref(false)
+const applyCount = ref<number | null>(null)
+const showRemoveConfirmation = ref(false)
+const outageToRemove = ref<PathOutage | null>(null)
+
+const emptyListContent = {
+  msg: 'No critical paths configured.'
+}
+
+const preview = async () => {
+  const result = await store.previewPathOutageRule(rule.value.trim())
+  ruleError.value = result === null
+  previewResult.value = result
+}
+
+const askApply = async () => {
+  const result = await store.previewPathOutageRule(rule.value.trim())
+  if (!result) {
+    ruleError.value = true
+    return
+  }
+  previewResult.value = result
+  // applying: every node matching the rule gets the critical path. The clear case
+  // affects an unknown subset (only nodes that already have a path) and the server
+  // caps the preview node list, so its confirmation shows no count.
+  applyCount.value = result.totalCount
+  showApplyConfirmation.value = true
+}
+
+const confirmApply = async () => {
+  showApplyConfirmation.value = false
+  const ok = await store.applyPathOutage({
+    rule: rule.value.trim(),
+    criticalIp: criticalIp.value.trim() || undefined,
+    criticalSvc: criticalSvc.value
+  })
+  if (ok) {
+    previewResult.value = null
+  }
+}
+
+const askRemove = (outage: PathOutage) => {
+  outageToRemove.value = outage
+  showRemoveConfirmation.value = true
+}
+
+const confirmRemove = async () => {
+  if (outageToRemove.value) {
+    await store.deletePathOutage(outageToRemove.value.nodeId)
+  }
+  showRemoveConfirmation.value = false
+  outageToRemove.value = null
+}
+
+const cancelRemove = () => {
+  showRemoveConfirmation.value = false
+  outageToRemove.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.path-outages-tab {
+  padding: 1rem 0;
+}
+
+.intro {
+  margin: 0 0 1rem 0;
+  max-width: 80ch;
+  color: var(--p-text-muted-color);
+}
+
+// Cap the interactive area so it doesn't sprawl across ultra-wide screens:
+// the About panel's toggle stops floating far to the right, and the form's
+// fields and action buttons stay grouped together instead of the rule input
+// stretching and pushing the buttons off toward (or past) the edge.
+.help-panel {
+  margin-bottom: 1rem;
+  max-width: 1200px;
+}
+
+.help-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+
+  .pi-question-circle {
+    color: var(--p-primary-color);
+  }
+}
+
+.help-content {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+
+  .help-section {
+    flex: 1;
+    min-width: 300px;
+  }
+
+  .section-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  p,
+  ul {
+    margin: 0 0 0.75rem 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+}
+
+.form-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  max-width: 1200px;
+
+  :deep(.p-select) {
+    min-width: 200px;
+  }
+
+  .rule-field {
+    flex: 1;
+    min-width: 240px;
+    max-width: 420px;
+
+    :deep(input) {
+      width: 100%;
+    }
+  }
+}
+
+.preview-result {
+  margin-top: 1rem;
+
+  .node-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+  }
+}
+
+.current-paths {
+  margin-top: 1.5rem;
+
+  .section-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+}
+</style>

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -76,8 +76,12 @@ import {
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
 import {
+  applyPathOutage,
+  deletePathOutage,
   getDestinationPaths,
   getNotificationConfigStatus,
+  getPathOutages,
+  previewPathOutageRule,
   setNotificationConfigStatus
 } from './notificationConfigService'
 import { acknowledgeNotice, browseNotices } from './noticesService'
@@ -146,7 +150,11 @@ export default {
   getZenithRegistrations,
   performLogout,
   acknowledgeNotice,
+  applyPathOutage,
   browseNotices,
+  deletePathOutage,
+  getPathOutages,
+  previewPathOutageRule,
   getDestinationPaths,
   getNotificationConfigStatus,
   setNotificationConfigStatus

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -23,7 +23,7 @@
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
 import { DestinationPath, NotifdStatus, PathOutage, PathOutagePreview, PathOutageRequest } from '@/types/notificationConfig'
-import { rest } from './axiosInstances'
+import { v2 } from './axiosInstances'
 
 const { showSnackBar } = useSnackbar()
 const { startSpinner, stopSpinner } = useSpinner()
@@ -32,7 +32,7 @@ const endpoint = '/notification-config'
 const getNotificationConfigStatus = async (): Promise<NotifdStatus | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/status`)
+    const resp = await v2.get(`${endpoint}/status`)
     return resp.data?.status ?? null
   } catch (_err) {
     showSnackBar({ msg: 'Failed to load notification status.' })
@@ -45,7 +45,7 @@ const getNotificationConfigStatus = async (): Promise<NotifdStatus | null> => {
 const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.put(`${endpoint}/status`, { status })
+    await v2.put(`${endpoint}/status`, { status })
     showSnackBar({ msg: `Notifications turned ${status}.` })
     return true
   } catch (_err) {
@@ -59,7 +59,7 @@ const setNotificationConfigStatus = async (status: NotifdStatus): Promise<boolea
 const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/destination-paths`)
+    const resp = await v2.get(`${endpoint}/destination-paths`)
     return resp.data?.path ?? []
   } catch (_err) {
     // null (not []) so a failed load is distinguishable from an empty one and the
@@ -74,7 +74,7 @@ const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
 const getPathOutages = async (): Promise<PathOutage[] | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/path-outages`)
+    const resp = await v2.get(`${endpoint}/path-outages`)
     return resp.data ?? []
   } catch (_err) {
     // null (not []) so the caller can tell a failed load from an empty one and retry
@@ -88,7 +88,7 @@ const getPathOutages = async (): Promise<PathOutage[] | null> => {
 const previewPathOutageRule = async (rule: string): Promise<PathOutagePreview | null> => {
   try {
     startSpinner()
-    const resp = await rest.get(`${endpoint}/path-outages/preview?rule=${encodeURIComponent(rule)}`)
+    const resp = await v2.get(`${endpoint}/path-outages/preview?rule=${encodeURIComponent(rule)}`)
     return resp.data ?? null
   } catch (err: any) {
     const detail = err?.response?.data
@@ -102,7 +102,7 @@ const previewPathOutageRule = async (rule: string): Promise<PathOutagePreview | 
 const applyPathOutage = async (request: PathOutageRequest): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.post(`${endpoint}/path-outages`, request)
+    await v2.post(`${endpoint}/path-outages`, request)
     showSnackBar({ msg: request.criticalIp ? 'Critical path applied.' : 'Critical path cleared.' })
     return true
   } catch (err: any) {
@@ -117,7 +117,7 @@ const applyPathOutage = async (request: PathOutageRequest): Promise<boolean> => 
 const deletePathOutage = async (nodeId: number): Promise<boolean> => {
   try {
     startSpinner()
-    await rest.delete(`${endpoint}/path-outages/${nodeId}`)
+    await v2.delete(`${endpoint}/path-outages/${nodeId}`)
     showSnackBar({ msg: 'Critical path removed.' })
     return true
   } catch (err: any) {

--- a/ui/src/services/notificationConfigService.ts
+++ b/ui/src/services/notificationConfigService.ts
@@ -22,7 +22,7 @@
 
 import useSnackbar from '@/composables/useSnackbar'
 import useSpinner from '@/composables/useSpinner'
-import { DestinationPath, NotifdStatus } from '@/types/notificationConfig'
+import { DestinationPath, NotifdStatus, PathOutage, PathOutagePreview, PathOutageRequest } from '@/types/notificationConfig'
 import { rest } from './axiosInstances'
 
 const { showSnackBar } = useSnackbar()
@@ -71,9 +71,71 @@ const getDestinationPaths = async (): Promise<DestinationPath[] | null> => {
   }
 }
 
+const getPathOutages = async (): Promise<PathOutage[] | null> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/path-outages`)
+    return resp.data ?? []
+  } catch (_err) {
+    // null (not []) so the caller can tell a failed load from an empty one and retry
+    showSnackBar({ msg: 'Failed to load path outages.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+const previewPathOutageRule = async (rule: string): Promise<PathOutagePreview | null> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(`${endpoint}/path-outages/preview?rule=${encodeURIComponent(rule)}`)
+    return resp.data ?? null
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : 'Failed to validate the filter rule.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+const applyPathOutage = async (request: PathOutageRequest): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.post(`${endpoint}/path-outages`, request)
+    showSnackBar({ msg: request.criticalIp ? 'Critical path applied.' : 'Critical path cleared.' })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : 'Failed to apply the critical path.' })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
+const deletePathOutage = async (nodeId: number): Promise<boolean> => {
+  try {
+    startSpinner()
+    await rest.delete(`${endpoint}/path-outages/${nodeId}`)
+    showSnackBar({ msg: 'Critical path removed.' })
+    return true
+  } catch (err: any) {
+    const detail = err?.response?.data
+    showSnackBar({ msg: typeof detail === 'string' && detail ? detail : 'Failed to remove critical path.' })
+    return false
+  } finally {
+    stopSpinner()
+  }
+}
+
 
 export {
+  applyPathOutage,
+  deletePathOutage,
   getDestinationPaths,
   getNotificationConfigStatus,
+  getPathOutages,
+  previewPathOutageRule,
   setNotificationConfigStatus
 }

--- a/ui/src/stores/notificationConfigStore.ts
+++ b/ui/src/stores/notificationConfigStore.ts
@@ -21,12 +21,13 @@
 ///
 
 import API from '@/services'
-import { NotifdStatus } from '@/types/notificationConfig'
+import { NotifdStatus, PathOutage, PathOutagePreview, PathOutageRequest } from '@/types/notificationConfig'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useNotificationConfigStore = defineStore('notificationConfigStore', () => {
   const notifdStatus = ref<NotifdStatus | null>(null)
+  const pathOutages = ref([] as PathOutage[])
 
   const getStatus = async (): Promise<boolean> => {
     notifdStatus.value = await API.getNotificationConfigStatus()
@@ -41,9 +42,43 @@ export const useNotificationConfigStore = defineStore('notificationConfigStore',
     return ok
   }
 
+  const getPathOutages = async (): Promise<boolean> => {
+    const result = await API.getPathOutages()
+    if (result === null) {
+      return false
+    }
+    pathOutages.value = result
+    return true
+  }
+
+  const previewPathOutageRule = async (rule: string): Promise<PathOutagePreview | null> => {
+    return await API.previewPathOutageRule(rule)
+  }
+
+  const applyPathOutage = async (request: PathOutageRequest) => {
+    const ok = await API.applyPathOutage(request)
+    if (ok) {
+      await getPathOutages()
+    }
+    return ok
+  }
+
+  const deletePathOutage = async (nodeId: number) => {
+    const ok = await API.deletePathOutage(nodeId)
+    if (ok) {
+      await getPathOutages()
+    }
+    return ok
+  }
+
   return {
     notifdStatus,
+    pathOutages,
     getStatus,
-    setStatus
+    setStatus,
+    getPathOutages,
+    previewPathOutageRule,
+    applyPathOutage,
+    deletePathOutage
   }
 })

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -45,3 +45,23 @@ export interface DestinationPath {
   target: DestinationPathTarget[]
   escalate?: DestinationPathEscalate[]
 }
+
+// Path outages (critical paths) — DB-backed (pathoutage table), unlike the
+// XML-backed config above. Wire shapes of /rest/notification-config/path-outages.
+export interface PathOutage {
+  nodeId: number
+  nodeLabel?: string | null
+  criticalPathIp?: string | null
+  criticalPathServiceName?: string | null
+}
+
+export interface PathOutagePreview {
+  totalCount: number
+  nodes: PathOutage[]
+}
+
+export interface PathOutageRequest {
+  rule: string
+  criticalIp?: string
+  criticalSvc?: string
+}

--- a/ui/src/types/notificationConfig.ts
+++ b/ui/src/types/notificationConfig.ts
@@ -20,7 +20,7 @@
 /// License.
 ///
 
-// JSON mirrors of the JAXB config models behind /rest/notification-config.
+// JSON mirrors of the config models behind /api/v2/notification-config.
 // Field names follow the XML element/attribute names in notifications.xml,
 // destinationPaths.xml and notificationCommands.xml — the files stay the
 // system of record, this API is a 1:1 view of them.
@@ -47,7 +47,7 @@ export interface DestinationPath {
 }
 
 // Path outages (critical paths) — DB-backed (pathoutage table), unlike the
-// XML-backed config above. Wire shapes of /rest/notification-config/path-outages.
+// XML-backed config above. Wire shapes of /api/v2/notification-config/path-outages.
 export interface PathOutage {
   nodeId: number
   nodeLabel?: string | null

--- a/ui/tests/stores/notificationConfigStore.test.ts
+++ b/ui/tests/stores/notificationConfigStore.test.ts
@@ -2,16 +2,25 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useNotificationConfigStore } from '@/stores/notificationConfigStore'
 import API from '@/services'
+import { PathOutage } from '@/types/notificationConfig'
 
 vi.mock('@/services', () => ({
   default: {
     getNotificationConfigStatus: vi.fn(),
-    setNotificationConfigStatus: vi.fn()
+    setNotificationConfigStatus: vi.fn(),
+    getPathOutages: vi.fn(),
+    previewPathOutageRule: vi.fn(),
+    applyPathOutage: vi.fn(),
+    deletePathOutage: vi.fn()
   }
 }))
 
 describe('useNotificationConfigStore', () => {
   let store: ReturnType<typeof useNotificationConfigStore>
+
+  const mockPathOutages: PathOutage[] = [
+    { nodeId: 1, nodeLabel: 'localhost', criticalPathIp: '192.168.1.1', criticalPathServiceName: 'ICMP' }
+  ]
 
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -26,6 +35,7 @@ describe('useNotificationConfigStore', () => {
   describe('Initial State', () => {
     it('should start empty with unknown notifd status', () => {
       expect(store.notifdStatus).toBeNull()
+      expect(store.pathOutages).toEqual([])
     })
   })
 
@@ -62,6 +72,57 @@ describe('useNotificationConfigStore', () => {
 
       expect(ok).toBe(false)
       expect(store.notifdStatus).toBe('off')
+    })
+  })
+
+  describe('path outages', () => {
+    it('should load path outages', async () => {
+      vi.mocked(API.getPathOutages).mockResolvedValue(mockPathOutages)
+
+      const ok = await store.getPathOutages()
+
+      expect(ok).toBe(true)
+      expect(store.pathOutages).toEqual(mockPathOutages)
+    })
+
+    it('should report failure and not clobber existing outages when the load errors', async () => {
+      vi.mocked(API.getPathOutages).mockResolvedValueOnce(mockPathOutages)
+      await store.getPathOutages()
+      vi.mocked(API.getPathOutages).mockResolvedValueOnce(null)
+
+      const ok = await store.getPathOutages()
+
+      expect(ok).toBe(false)
+      // prior data is preserved so the tab can retry instead of latching empty
+      expect(store.pathOutages).toEqual(mockPathOutages)
+    })
+
+    it('should refresh after apply and delete', async () => {
+      vi.mocked(API.applyPathOutage).mockResolvedValue(true)
+      vi.mocked(API.deletePathOutage).mockResolvedValue(true)
+      vi.mocked(API.getPathOutages).mockResolvedValue(mockPathOutages)
+
+      await store.applyPathOutage({ rule: 'IPADDR IPLIKE *.*.*.*', criticalIp: '192.168.1.1' })
+      await store.deletePathOutage(1)
+
+      expect(API.getPathOutages).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not refresh after a failed apply', async () => {
+      vi.mocked(API.applyPathOutage).mockResolvedValue(false)
+
+      await store.applyPathOutage({ rule: 'bogus rule' })
+
+      expect(API.getPathOutages).not.toHaveBeenCalled()
+    })
+
+    it('should pass the preview through', async () => {
+      const preview = { totalCount: 3, nodes: mockPathOutages }
+      vi.mocked(API.previewPathOutageRule).mockResolvedValue(preview)
+
+      const result = await store.previewPathOutageRule('IPADDR IPLIKE *.*.*.*')
+
+      expect(result).toEqual(preview)
     })
   })
 })


### PR DESCRIPTION
**Tickets:** NMS-20120 (epic NMS-20100).

Adds the Path Outages tab to Configure Notifications, rebased onto the epic with the review feedback applied.

- Critical-path editor with a filter-rule preview and an apply/clear flow (a blank IP clears the path for matching nodes).
- Fields use the FormField seam with inline info-icon help; the interactive area is width-capped so it no longer overflows horizontally.
- Backed by new NotificationConfig REST endpoints (with IT) plus store/service/type support.
