### PR TITLE
NMS-20124: point the notification bell at the new Notifications page

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
@@ -267,6 +267,23 @@ public class NotificationRestService extends OnmsRestService {
         builder.alias("event", "event", JoinType.LEFT_JOIN);
         builder.alias("usersNotified", "usersNotified", JoinType.LEFT_JOIN);
 
+        // "assigned to anyone but this user": same restriction the summary
+        // endpoint uses for teamUnacknowledgedCount, including notices that
+        // notified nobody; not expressible through the generic filters
+        final String excludeNotifiedUser = params.getFirst("excludeNotifiedUser");
+        if (excludeNotifiedUser != null) {
+            // always consume the param so a blank value isn't treated as an
+            // (unknown) entity property by applyQueryFilters below
+            params.remove("excludeNotifiedUser");
+            if (!excludeNotifiedUser.isBlank()) {
+                // distinct: the usersNotified LEFT_JOIN can match several rows per
+                // notice, which would otherwise duplicate notices and inflate the count
+                builder.distinct();
+                builder.or(Restrictions.ne("usersNotified.userId", excludeNotifiedUser),
+                        Restrictions.isNull("usersNotified.userId"));
+            }
+        }
+
         applyQueryFilters(params, builder);
         return builder;
     }

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -736,21 +736,21 @@
       {
         "id": "userNotificationConfiguration",
         "name": null,
-        "url": "admin/notification/index.jsp",
+        "url": "ui/index.html#/admin/notifications",
         "locationMatch": null,
         "roles": null
       },
       {
         "id": "userNotificationUser",
         "name": null,
-        "url": "notification/browse?acktype=unack&filter=user==$USER",
+        "url": "ui/index.html#/admin/notifications?preset=yourOutstanding",
         "locationMatch": null,
         "roles": null
       },
       {
         "id": "userNotificationTeam",
         "name": null,
-        "url": "notification/browse?acktype=unack",
+        "url": "ui/index.html#/admin/notifications?preset=teamOutstanding",
         "locationMatch": null,
         "roles": null
       },

--- a/ui/src/components/AdminNotifications/NotificationQueriesCard.vue
+++ b/ui/src/components/AdminNotifications/NotificationQueriesCard.vue
@@ -9,6 +9,12 @@
         >Your outstanding notices</a>
         <span class="separator">|</span>
         <a
+          :class="{ active: store.preset === 'teamOutstanding' }"
+          data-test="query-team-outstanding"
+          @click.prevent="store.applyPreset('teamOutstanding')"
+        >Outstanding for anyone but you</a>
+        <span class="separator">|</span>
+        <a
           :class="{ active: store.preset === 'allOutstanding' }"
           data-test="query-all-outstanding"
           @click.prevent="store.applyPreset('allOutstanding')"

--- a/ui/src/components/Menu/UserNotificationsMenuItem.vue
+++ b/ui/src/components/Menu/UserNotificationsMenuItem.vue
@@ -52,7 +52,7 @@
         <a :href="computeLink(item.url || '')" class="dropdown-menu-link dropdown-menu-wrapper final-menu-wrapper">
           <OnmsIcon :icon="IconPerson" class="user-notifications-icon" />
           <span class="left-margin-small">
-            {{ notificationSummary.userUnacknowledgedCount ?? 0 }} notices assigned to you
+            {{ notificationSummary.userUnacknowledgedCount ?? 0 }} notifications assigned to you
           </span>
         </a>
       </div>
@@ -207,14 +207,14 @@ const noticeStatusDisplay = computed<NoticeStatusDisplay>(() => {
       icon: 'fa-solid fa-bell',
       iconComponent: markRaw(IconNotificationSelected),
       colorClass: 'alarm-ok',
-      title: 'Notices: On'
+      title: 'Notifications: On'
     }
   } else if (status === 'Off') {
     return {
       icon: 'fa-solid fa-bell-slash',
       iconComponent: markRaw(IconNotificationsOff),
       colorClass: 'alarm-error',
-      title: 'Notices: Off'
+      title: 'Notifications: Off'
     }
   }
 
@@ -223,7 +223,7 @@ const noticeStatusDisplay = computed<NoticeStatusDisplay>(() => {
     icon: 'fa-solid fa-bell',
     iconComponent: markRaw(IconNotificationSelected),
     colorClass: 'alarm-unknown',
-    title: 'Notices: Unknown'
+    title: 'Notifications: Unknown'
   }
 })
 
@@ -266,9 +266,10 @@ const onMenuItemClick = (url: string) => {
   window.location.assign(link)
 }
 
-const onNotificationItemClick = (item: OnmsNotification) => {
-  const url = `notification/detail.jsp?notice=${item.id}`
-  onMenuItemClick(url)
+const onNotificationItemClick = (_item: OnmsNotification) => {
+  // open the new Notifications page filtered to the user's outstanding notices
+  // (which include this one) instead of the legacy per-notice detail page
+  onMenuItemClick('ui/index.html#/admin/notifications?preset=yourOutstanding')
 }
 </script>
 

--- a/ui/src/containers/Notifications.vue
+++ b/ui/src/containers/Notifications.vue
@@ -40,7 +40,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 
 import { OnmsButton, OnmsIconButton } from '@opennms/onms-ui'
 
@@ -57,8 +58,10 @@ import { useAuthStore } from '@/stores/authStore'
 import { useMenuStore } from '@/stores/menuStore'
 import { useNoticesStore } from '@/stores/noticesStore'
 import { BreadCrumb } from '@/types'
+import { NoticeQueryPreset } from '@/types/notices'
 
 const authStore = useAuthStore()
+const route = useRoute()
 const menuStore = useMenuStore()
 const noticesStore = useNoticesStore()
 const { adminRole } = useRole()
@@ -80,11 +83,30 @@ const breadcrumbs = computed<BreadCrumb[]>(() => {
 // silently drop the user filter and show every user's notices.
 const authLoaded = computed<boolean>(() => authStore.loaded)
 
+// the top-bar bell deep-links here with a preset (NMS-20124)
+const PRESETS = ['yourOutstanding', 'teamOutstanding', 'allOutstanding', 'allAcknowledged'] as const
+const initialLoad = () => {
+  const preset = route.query.preset as string
+  if ((PRESETS as readonly string[]).includes(preset)) {
+    noticesStore.applyPreset(preset as NoticeQueryPreset)
+  } else {
+    noticesStore.load()
+  }
+}
+
 onMounted(() => {
   if (authLoaded.value) {
-    noticesStore.load()
+    initialLoad()
   } else {
-    whenever(authLoaded, () => noticesStore.load(), { once: true })
+    whenever(authLoaded, () => initialLoad(), { once: true })
+  }
+})
+
+// Clicking a bell link while already on this page only changes the hash query,
+// so the component is not remounted — re-apply the preset when it changes.
+watch(() => route.query.preset, () => {
+  if (authLoaded.value) {
+    initialLoad()
   }
 })
 </script>

--- a/ui/src/services/noticesService.ts
+++ b/ui/src/services/noticesService.ts
@@ -32,6 +32,7 @@ const endpoint = '/notifications'
 interface BrowseNoticesParams {
   acktype: NoticeAckType
   user?: string | null
+  excludeUser?: string | null
   limit: number
   offset: number
 }
@@ -51,6 +52,9 @@ const browseNotices = async (params: BrowseNoticesParams): Promise<NoticeBrowseR
     }
     if (params.user) {
       query.set('usersNotified.userId', params.user)
+    }
+    if (params.excludeUser) {
+      query.set('excludeNotifiedUser', params.excludeUser)
     }
     const resp = await rest.get(`${endpoint}?${query.toString()}`)
     // 204 No Content when nothing matches

--- a/ui/src/stores/noticesStore.ts
+++ b/ui/src/stores/noticesStore.ts
@@ -52,10 +52,15 @@ export const useNoticesStore = defineStore('noticesStore', () => {
     return null
   })
 
+  const effectiveExcludeUser = computed<string | null>(() =>
+    preset.value === 'teamOutstanding' ? currentUser.value || null : null)
+
   const title = computed<string>(() => {
     switch (preset.value) {
       case 'yourOutstanding':
         return 'Your Outstanding Notices'
+      case 'teamOutstanding':
+        return 'Outstanding Notices Assigned to Anyone but You'
       case 'allOutstanding':
         return 'All Outstanding Notices'
       case 'allAcknowledged':
@@ -68,13 +73,12 @@ export const useNoticesStore = defineStore('noticesStore', () => {
 
   const { showSnackBar } = useSnackbar()
 
-  // a failed whoami leaves no user id; widening a user-scoped query to
-  // everyone's notices would be silently wrong, so callers must refuse
-  const missingRequiredUser = computed<boolean>(() =>
-    (preset.value === 'yourOutstanding' || preset.value === 'userSearch') && !effectiveUser.value)
 
   const load = async () => {
-    if (missingRequiredUser.value) {
+    // a failed whoami leaves no user id; widening a user-scoped query to
+    // everyone's notices would be silently wrong, so refuse instead
+    const needsUser = preset.value === 'yourOutstanding' || preset.value === 'userSearch' || preset.value === 'teamOutstanding'
+    if (needsUser && !effectiveUser.value && !effectiveExcludeUser.value) {
       notices.value = []
       totalCount.value = 0
       showSnackBar({ msg: 'Cannot determine the current user; showing no notices. Reload the page to retry.', error: true })
@@ -85,6 +89,7 @@ export const useNoticesStore = defineStore('noticesStore', () => {
       const result = await API.browseNotices({
         acktype: acktype.value,
         user: effectiveUser.value,
+        excludeUser: effectiveExcludeUser.value,
         limit: rows.value,
         offset: first.value
       })
@@ -111,13 +116,17 @@ export const useNoticesStore = defineStore('noticesStore', () => {
   // Export/print path: same user guard as load() so a failed whoami never
   // widens a user-scoped export to everyone's notices.
   const fetchForExport = async (limit: number): Promise<{ notices: OnmsNotice[], totalCount: number }> => {
-    if (missingRequiredUser.value) {
+    // Same guard as load(); the teamOutstanding preset is user-scoped via
+    // excludeUser, so a failed whoami must block it too rather than widen.
+    const needsUser = preset.value === 'yourOutstanding' || preset.value === 'userSearch' || preset.value === 'teamOutstanding'
+    if (needsUser && !effectiveUser.value && !effectiveExcludeUser.value) {
       showSnackBar({ msg: 'Cannot determine the current user; nothing to export. Reload the page to retry.', error: true })
       return { notices: [], totalCount: 0 }
     }
     const result = await API.browseNotices({
       acktype: acktype.value,
       user: effectiveUser.value,
+      excludeUser: effectiveExcludeUser.value,
       limit,
       offset: 0
     })

--- a/ui/src/types/notices.ts
+++ b/ui/src/types/notices.ts
@@ -27,7 +27,7 @@
 
 export type NoticeAckType = 'unack' | 'ack' | 'all'
 
-export type NoticeQueryPreset = 'yourOutstanding' | 'allOutstanding' | 'allAcknowledged' | 'userSearch'
+export type NoticeQueryPreset = 'yourOutstanding' | 'teamOutstanding' | 'allOutstanding' | 'allAcknowledged' | 'userSearch'
 
 export interface OnmsNoticeServiceType {
   id?: number

--- a/ui/tests/stores/noticesStore.test.ts
+++ b/ui/tests/stores/noticesStore.test.ts
@@ -72,6 +72,7 @@ describe('useNoticesStore', () => {
       expect(API.browseNotices).toHaveBeenCalledWith({
         acktype: 'unack',
         user: 'admin',
+        excludeUser: null,
         limit: 10,
         offset: 0
       })
@@ -81,6 +82,16 @@ describe('useNoticesStore', () => {
   })
 
   describe('applyPreset', () => {
+    it('teamOutstanding should exclude the current user', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+
+      await store.applyPreset('teamOutstanding')
+
+      expect(API.browseNotices).toHaveBeenCalledWith(
+        expect.objectContaining({ acktype: 'unack', user: null, excludeUser: 'admin' })
+      )
+    })
+
     it('allOutstanding should drop the user filter and reset paging', async () => {
       vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
       store.first = 30
@@ -92,6 +103,7 @@ describe('useNoticesStore', () => {
       expect(API.browseNotices).toHaveBeenCalledWith({
         acktype: 'unack',
         user: null,
+        excludeUser: null,
         limit: 10,
         offset: 0
       })
@@ -157,6 +169,9 @@ describe('useNoticesStore', () => {
       expect(API.browseNotices).not.toHaveBeenCalled()
       expect(store.notices).toEqual([])
       expect(showSnackBar).toHaveBeenCalledWith(expect.objectContaining({ error: true }))
+
+      await store.applyPreset('teamOutstanding')
+      expect(API.browseNotices).not.toHaveBeenCalled()
     })
 
     it('should clamp to the last valid page when the ack empties the current page', async () => {
@@ -209,10 +224,23 @@ describe('useNoticesStore', () => {
       expect(API.browseNotices).toHaveBeenCalledWith({
         acktype: 'unack',
         user: 'admin',
+        excludeUser: null,
         limit: 1000,
         offset: 0
       })
       expect(result).toEqual(mockResult)
+    })
+
+    it('carries excludeUser for a teamOutstanding export so it stays scoped', async () => {
+      vi.mocked(API.browseNotices).mockResolvedValue(mockResult)
+      await store.applyPreset('teamOutstanding')
+      vi.mocked(API.browseNotices).mockClear()
+
+      await store.fetchForExport(1000)
+
+      expect(API.browseNotices).toHaveBeenCalledWith(
+        expect.objectContaining({ user: null, excludeUser: 'admin', limit: 1000 })
+      )
     })
 
     it('refuses to export (no query) when a user-scoped preset has no user id', async () => {


### PR DESCRIPTION
**Tickets:** NMS-20124 (epic NMS-20100).

Points the top-bar notification bell at the new Notifications page instead of the legacy JSPs, rebased onto the epic.

- Bell entries deep-link to the notices page with a query preset (outstanding / team-outstanding views).
- The preset re-applies when it changes without remounting the page.
- Carries the supporting notices store and service changes.
