### PR TITLE
NMS-20105: Close the trouble ticket when the alarm clears

### DIFF
--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
@@ -1,15 +1,40 @@
 
 = Trouble Ticket Notifications
-:description: How to configure {page-component-title} to create trouble tickets from notifications.
+:description: How to configure {page-component-title} to create and close trouble tickets from notifications.
 
-{page-component-title} normally creates trouble tickets from alarms, either manually from the web UI or through the automations described in xref:operation:deep-dive/ticketing/introduction.adoc[Ticketing].
-The ticket notification strategy provides a third path: it creates a ticket for the alarm associated with a notification's event.
+{page-component-title} normally manages trouble tickets from alarms, either manually from the web UI or through the automations described in xref:operation:deep-dive/ticketing/introduction.adoc[Ticketing].
+The ticket notification strategy provides a third path: it creates a ticket for the alarm associated with a notification's event, and closes that ticket once the alarm clears.
 Because it runs through notifd, it can take advantage of notification features that alarm automations do not, such as destination paths, escalation, and path outage suppression.
+
+Notifd delivers the same command for resolutions as well as problems, so the strategy reads the alarm behind the event rather than the event itself:
+
+[caption=]
+.How the strategy acts on the alarm behind the notification's event
+[cols="1,2,1"]
+|===
+| Alarm | Ticket | Action
+
+| Not cleared
+| None, or closed, resolved, cancelled, or creation failed
+| Create a ticket
+
+| Not cleared
+| Active, or a create already in flight
+| Nothing
+
+| Cleared
+| Active
+| Close the ticket
+
+| Cleared
+| None, or already settled
+| Nothing
+|===
 
 == Requirements and caveats
 
 * A ticketer plugin must be configured.
-Without one, the create-ticket events that this strategy sends are not acted on.
+Without one, the ticket events that this strategy sends are not acted on.
 * The event that triggers the notification must have `alarm-data` in its event definition.
 Events without alarm data are skipped, and the notification completes without creating a ticket.
 * The strategy looks up the alarm for the event at delivery time, but alarmd performs that association asynchronously.
@@ -21,9 +46,13 @@ The strategy reads only event parameters, so the target serves to satisfy the de
 Notifd runs each command once per member of a group target, and each run sends its own create-ticket event.
 The strategy skips the create event when the alarm already has an active ticket; tickets that are closed, resolved, or cancelled, or whose creation failed, do not block a new one.
 Near-simultaneous deliveries can race the asynchronous ticket creation, so a group target can still produce duplicate tickets.
-* The create-ticket event carries a `user` parameter that defaults to `admin`.
+* The ticket events carry a `user` parameter that defaults to `admin`.
 You can override it with the optional `ticketUser` argument described below.
 Whether the value appears on the created ticket depends on the ticketer plugin.
+* The ticketer ignores close requests for alarms that are not cleared, controlled by `opennms.ticketer.skipCloseWhenNotCleared` (default `true`).
+The strategy applies the same condition, so it sends a close only once the alarm is cleared.
+* Closing a ticket leaves its id on the alarm with the state `Closed`.
+A later occurrence of the same alarm opens a new ticket rather than reopening the closed one.
 
 == Setup
 
@@ -32,9 +61,9 @@ Add the following command to `notificationCommands.xml`:
 [source, xml]
 ----
 <command binary="false">
-    <name>createTicket</name>
+    <name>troubleTicket</name>
     <execute>org.opennms.netmgt.notifd.TicketNotificationStrategy</execute>
-    <comment>class for creating a trouble ticket for the alarm associated with the notification's event</comment>
+    <comment>class for managing the trouble ticket for the alarm associated with the notification's event</comment>
     <argument streamed="false">
         <switch>eventID</switch>
     </argument>
@@ -57,7 +86,7 @@ Add a destination path with an initial delay to `destinationPaths.xml`:
 <path name="Create-Ticket" initial-delay="30s">
     <target>
         <name>admin</name>
-        <command>createTicket</command>
+        <command>troubleTicket</command>
     </target>
 </path>
 ----
@@ -75,3 +104,13 @@ To set the ticket user for a notification, add a `ticketUser` parameter to its d
 ----
 
 If the parameter is absent, the strategy uses `admin`.
+
+== Closing tickets
+
+Closing needs no additional configuration for the standard outage events.
+When the resolving event arrives, notifd acknowledges the notice that opened the ticket and re-runs its commands, which delivers this command a second time.
+The resolving event is reduced onto the same alarm as the problem event, and alarmd has cleared that alarm by then, so the strategy closes its ticket instead of opening another.
+
+Closing therefore relies on the `auto-acknowledge` pairing for the problem UEI in `notifd-configuration.xml`, which ships configured for the node, interface, and service outage events and defaults to `notify="true"`.
+A problem UEI with no such pairing, such as a threshold or a custom alarm, opens tickets that nothing closes.
+Add an `auto-acknowledge` entry naming its resolving UEI to close them.

--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/ticket.adoc
@@ -79,11 +79,18 @@ Add the following command to `notificationCommands.xml`:
 </command>
 ----
 
-Add a destination path with an initial delay to `destinationPaths.xml`:
+Add destination paths with an initial delay to `destinationPaths.xml`.
+Both run the same command, one for each direction:
 
 [source, xml]
 ----
 <path name="Create-Ticket" initial-delay="30s">
+    <target>
+        <name>admin</name>
+        <command>troubleTicket</command>
+    </target>
+</path>
+<path name="Close-Ticket" initial-delay="30s">
     <target>
         <name>admin</name>
         <command>troubleTicket</command>
@@ -94,7 +101,7 @@ Add a destination path with an initial delay to `destinationPaths.xml`:
 NOTE: Use a single user as the target, not a group.
 Notifd runs the command once per member of a group target, and near-simultaneous runs can each create a ticket for the same alarm.
 
-Reference the `Create-Ticket` destination path from each notification in `notifications.xml` that should open a ticket.
+Reference the `Create-Ticket` destination path from each notification in `notifications.xml` that should open a ticket, and `Close-Ticket` from the notifications for the events that resolve them.
 
 To set the ticket user for a notification, add a `ticketUser` parameter to its definition:
 
@@ -107,10 +114,21 @@ If the parameter is absent, the strategy uses `admin`.
 
 == Closing tickets
 
-Closing needs no additional configuration for the standard outage events.
-When the resolving event arrives, notifd acknowledges the notice that opened the ticket and re-runs its commands, which delivers this command a second time.
-The resolving event is reduced onto the same alarm as the problem event, and alarmd has cleared that alarm by then, so the strategy closes its ticket instead of opening another.
+Add a notification for the event that resolves the problem and point it at the `Close-Ticket` path:
 
-Closing therefore relies on the `auto-acknowledge` pairing for the problem UEI in `notifd-configuration.xml`, which ships configured for the node, interface, and service outage events and defaults to `notify="true"`.
-A problem UEI with no such pairing, such as a threshold or a custom alarm, opens tickets that nothing closes.
-Add an `auto-acknowledge` entry naming its resolving UEI to close them.
+[source, xml]
+----
+<notification name="nodeUp-ticket" status="on">
+    <uei>uei.opennms.org/nodes/nodeUp</uei>
+    <rule>IPADDR != '0.0.0.0'</rule>
+    <destinationPath>Close-Ticket</destinationPath>
+    <text-message>Closing the trouble ticket for node %nodelabel%.</text-message>
+    <parameter name="ticketUser" value="noc"/>
+</notification>
+----
+
+The resolving event is reduced onto the same alarm as the problem event, so the strategy finds that alarm's ticket and closes it.
+The `initial-delay` on the path is what makes this reliable: alarmd clears the alarm asynchronously, and the ticketer refuses to close a ticket whose alarm is not yet cleared.
+
+Notifd may also deliver this command a second time for the same resolution, because acknowledging the problem notice re-runs its commands.
+That delivery finds the ticket already closed and does nothing.

--- a/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
+++ b/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
@@ -34,6 +34,7 @@ import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
+import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.TroubleTicketState;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.notifd.Argument;
@@ -75,6 +76,7 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 		int m_alarmID;
 		String m_tticketID;
 		int m_tticketState;
+		int m_severity;
 		
 		AlarmState(int alarmID) {
 			m_alarmID = alarmID;
@@ -88,6 +90,11 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 			m_tticketState = tticketState;
 		}
 		
+		AlarmState(int alarmID, String tticketID, int tticketState, int severity) {
+			this(alarmID, tticketID, tticketState);
+			m_severity = severity;
+		}
+		
 		public int getAlarmID() {
 			return m_alarmID;
 		}
@@ -99,6 +106,10 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 		public int getTticketState() {
 			return m_tticketState;
 		}
+		
+		public int getSeverity() {
+			return m_severity;
+		}
 	}
 	
 	protected static class AlarmStateRowCallbackHandler implements RowCallbackHandler {
@@ -108,7 +119,7 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 		}
                 @Override
         public void processRow(ResultSet rs) throws SQLException {
-        	m_alarmState = new AlarmState(rs.getInt(1), rs.getString(2), rs.getInt(3));
+        	m_alarmState = new AlarmState(rs.getInt(1), rs.getString(2), rs.getInt(3), rs.getInt(4));
         }
         public AlarmState getAlarmState() {
         	return m_alarmState;
@@ -171,6 +182,23 @@ public class TicketNotificationStrategy implements NotificationStrategy {
         	return 1;
         }
 
+        // Log everything we know so far.
+        LOG.info("Got event-uei='{}' with event-id='{}', notice-id='{}', alarm-type='{}', alarm-id='{}', severity='{}', tticket-id='{}' and tticket-state='{}'", eventUEI, eventID, noticeID, alarmType, alarmState.getAlarmID(), alarmState.getSeverity(), alarmState.getTticketID(), alarmState.getTticketState());
+
+        /* Notifd delivers this command for resolutions as well as problems: an
+         * auto-acknowledge re-runs the original notification's commands with the
+         * problem event's parameters, so eventUEI cannot tell the two apart. The
+         * alarm's severity can, and it is also what the ticketer gates a close on.
+         */
+        if( isCleared(alarmState.getSeverity()) ) {
+            if( hasActiveTicket(alarmState) ) {
+                sendCloseTicketEvent(alarmState.getAlarmID(), eventUEI, ticketUser, alarmState.getTticketID());
+            } else {
+		LOG.info("Alarm-id='{}' is cleared but has no active ticket (tticket-id='{}', state='{}'). Nothing to close.", alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
+            }
+            return 0;
+        }
+
         /* Guard against duplicate tickets: a previous notification, an escalation,
          * or another member of a group target may already have created one.
          * Tickets in a terminal state (or whose creation failed) do not block a
@@ -178,14 +206,15 @@ public class TicketNotificationStrategy implements NotificationStrategy {
          * Near-simultaneous deliveries can still race the asynchronous ticket
          * creation, so single-user targets remain the recommended configuration.
          */
-        if( StringUtils.isNotBlank(alarmState.getTticketID()) && isTicketActive(alarmState.getTticketState()) ) {
+        if( hasActiveTicket(alarmState) ) {
 		LOG.info("Alarm-id='{}' already has an active ticket-id='{}' in state '{}'. Will not create another ticket.", alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
         	return 0;
         }
+        if( isTicketCreationPending(alarmState) ) {
+		LOG.info("Alarm-id='{}' has a ticket creation in flight. Will not create another ticket.", alarmState.getAlarmID());
+        	return 0;
+        }
 
-        // Log everything we know so far.
-        LOG.info("Got event-uei='{}' with event-id='{}', notice-id='{}', alarm-type='{}', alarm-id='{}', tticket-id='{}' and tticket-state='{}'", eventUEI, eventID, noticeID, alarmType, alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
-        
         sendCreateTicketEvent(alarmState.getAlarmID(), eventUEI, ticketUser);
 
         return 0;
@@ -206,6 +235,30 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 		return true;
 	}
 
+	private static boolean hasActiveTicket(final AlarmState alarmState) {
+		return StringUtils.isNotBlank(alarmState.getTticketID()) && isTicketActive(alarmState.getTticketState());
+	}
+
+    /**
+     * A create requested through the web UI or REST marks the alarm CREATE_PENDING
+     * before ticketd assigns an id, so an alarm can have a ticket on the way with
+     * nothing to point at yet. A NULL tticketstate reads as 0 (OPEN) rather than
+     * CREATE_PENDING, so a fresh alarm still gets its first ticket.
+     */
+	private static boolean isTicketCreationPending(final AlarmState alarmState) {
+		return StringUtils.isBlank(alarmState.getTticketID())
+				&& alarmState.getTticketState() == TroubleTicketState.CREATE_PENDING.getValue();
+	}
+
+    /**
+     * An alarm is cleared once its resolving event has been reduced onto it. The
+     * ticketer refuses to close a ticket whose alarm is not cleared, so this is
+     * the same condition it applies.
+     */
+	private static boolean isCleared(int severity) {
+		return severity == OnmsSeverity.CLEARED.getId();
+	}
+
     /**
      * <p>Helper function that gets the alarmid from the eventid</p>
      *
@@ -215,7 +268,7 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 		AlarmStateRowCallbackHandler callbackHandler = new AlarmStateRowCallbackHandler();
 
         JdbcTemplate template = new JdbcTemplate(DataSourceFactory.getInstance());
-        template.query("SELECT a.alarmid, a.tticketid, a.tticketstate FROM events AS e " +
+        template.query("SELECT a.alarmid, a.tticketid, a.tticketstate, a.severity FROM events AS e " +
 				       "LEFT JOIN alarms AS a ON a.alarmid = e.alarmid " +
 				       "WHERE e.eventid = ?", new Object[] {eventID}, callbackHandler);
         
@@ -272,7 +325,20 @@ public class TicketNotificationStrategy implements NotificationStrategy {
         ebldr.addParam(EventConstants.PARM_USER, ticketUser);
         m_eventManager.sendNow(ebldr.getEvent());
 	}
-	
+
+    /**
+     * <p>Helper function that sends the close ticket event</p>
+     */
+	public void sendCloseTicketEvent(int alarmID, String alarmUEI, String ticketUser, String ticketID) {
+        LOG.debug("Sending close ticket '{}' for alarm '{}' with id={} as user '{}'", ticketID, alarmUEI, alarmID, ticketUser);
+        EventBuilder ebldr = new EventBuilder(EventConstants.TROUBLETICKET_CLOSE_UEI, getName());
+        ebldr.addParam(EventConstants.PARM_ALARM_ID, alarmID);
+        ebldr.addParam(EventConstants.PARM_ALARM_UEI, alarmUEI);
+        ebldr.addParam(EventConstants.PARM_USER, ticketUser);
+        ebldr.addParam(EventConstants.PARM_TROUBLE_TICKET, ticketID);
+        m_eventManager.sendNow(ebldr.getEvent());
+	}
+
     /**
      * <p>Return an id for this notification strategy</p>
      *

--- a/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
+++ b/features/notifications/ticket-strategy/src/main/java/org/opennms/netmgt/notifd/TicketNotificationStrategy.java
@@ -76,8 +76,8 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 		int m_alarmID;
 		String m_tticketID;
 		int m_tticketState;
-		int m_severity;
-		
+		int m_severity = OnmsSeverity.INDETERMINATE.getId();
+
 		AlarmState(int alarmID) {
 			m_alarmID = alarmID;
 			m_tticketID = "";
@@ -191,10 +191,10 @@ public class TicketNotificationStrategy implements NotificationStrategy {
          * alarm's severity can, and it is also what the ticketer gates a close on.
          */
         if( isCleared(alarmState.getSeverity()) ) {
-            if( hasActiveTicket(alarmState) ) {
+            if( isCloseable(alarmState) ) {
                 sendCloseTicketEvent(alarmState.getAlarmID(), eventUEI, ticketUser, alarmState.getTticketID());
             } else {
-		LOG.info("Alarm-id='{}' is cleared but has no active ticket (tticket-id='{}', state='{}'). Nothing to close.", alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
+		LOG.info("Alarm-id='{}' is cleared but has no ticket to close (tticket-id='{}', state='{}'). Nothing to do.", alarmState.getAlarmID(), alarmState.getTticketID(), alarmState.getTticketState());
             }
             return 0;
         }
@@ -237,6 +237,17 @@ public class TicketNotificationStrategy implements NotificationStrategy {
 
 	private static boolean hasActiveTicket(final AlarmState alarmState) {
 		return StringUtils.isNotBlank(alarmState.getTticketID()) && isTicketActive(alarmState.getTticketState());
+	}
+
+    /**
+     * A close already requested through the web UI or REST leaves the alarm
+     * CLOSE_PENDING. Closing again would ask the ticketer to close a ticket it is
+     * already closing, and a plugin that rejects that leaves the alarm in
+     * CLOSE_FAILED.
+     */
+	private static boolean isCloseable(final AlarmState alarmState) {
+		return hasActiveTicket(alarmState)
+				&& alarmState.getTticketState() != TroubleTicketState.CLOSE_PENDING.getValue();
 	}
 
     /**

--- a/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
+++ b/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
@@ -253,6 +253,11 @@ public class TicketNotificationStrategyTest {
     	assertClearedStateSendsNothing("TICKET-1", TroubleTicketState.CLOSED);
     }
 
+    @Test
+    public void testClearedAlarmWithClosePendingTicketSendsNothing() {
+    	assertClearedStateSendsNothing("TICKET-1", TroubleTicketState.CLOSE_PENDING);
+    }
+
     private void assertClearedStateClosesTicket(TroubleTicketState state) {
     	EventBuilder closeTicketBuilder = new EventBuilder(EventConstants.TROUBLETICKET_CLOSE_UEI, m_ticketNotificationStrategy.getName());
     	closeTicketBuilder.setParam(EventConstants.PARM_ALARM_ID, "1");

--- a/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
+++ b/features/notifications/ticket-strategy/src/test/java/org/opennms/netmgt/notifd/TicketNotificationStrategyTest.java
@@ -41,6 +41,7 @@ import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
+import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.TroubleTicketState;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.notifd.Argument;
@@ -150,6 +151,15 @@ public class TicketNotificationStrategyTest {
     }
 
     @Test
+    public void testNoticeWithCreatePendingAndNoTicketIdDoesNotCreateAnother() {
+    	when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
+    	m_ticketNotificationStrategy.setAlarmState(new TicketNotificationStrategy.AlarmState(1, "", TroubleTicketState.CREATE_PENDING.getValue()));
+    	List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
+    	assertEquals("Strategy should succeed while a ticket creation is in flight.", 0, m_ticketNotificationStrategy.send(arguments));
+    	assertEquals("Strategy should not create a second ticket while creation is in flight.", 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    }
+
+    @Test
     public void testNoticeWithClosedTicketCreatesNewTicket() {
     	assertTicketStateAllowsCreate(TroubleTicketState.CLOSED);
     }
@@ -221,6 +231,56 @@ public class TicketNotificationStrategyTest {
         assertEquals(0, m_ticketNotificationStrategy.send(arguments));
         assertTrue("Expected events not forthcoming", m_eventIpcManager.getEventAnticipator().waitForAnticipated(0).isEmpty());
         assertEquals("Received unexpected events", 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    }
+
+    @Test
+    public void testClearedAlarmWithOpenTicketClosesIt() {
+    	assertClearedStateClosesTicket(TroubleTicketState.OPEN);
+    }
+
+    @Test
+    public void testClearedAlarmWithCloseFailedTicketClosesItAgain() {
+    	assertClearedStateClosesTicket(TroubleTicketState.CLOSE_FAILED);
+    }
+
+    @Test
+    public void testClearedAlarmWithoutTicketSendsNothing() {
+    	assertClearedStateSendsNothing("", TroubleTicketState.OPEN);
+    }
+
+    @Test
+    public void testClearedAlarmWithClosedTicketSendsNothing() {
+    	assertClearedStateSendsNothing("TICKET-1", TroubleTicketState.CLOSED);
+    }
+
+    private void assertClearedStateClosesTicket(TroubleTicketState state) {
+    	EventBuilder closeTicketBuilder = new EventBuilder(EventConstants.TROUBLETICKET_CLOSE_UEI, m_ticketNotificationStrategy.getName());
+    	closeTicketBuilder.setParam(EventConstants.PARM_ALARM_ID, "1");
+    	closeTicketBuilder.setParam(EventConstants.PARM_ALARM_UEI, EventConstants.NODE_DOWN_EVENT_UEI);
+    	closeTicketBuilder.setParam(EventConstants.PARM_USER, "noc");
+    	closeTicketBuilder.setParam(EventConstants.PARM_TROUBLE_TICKET, "TICKET-1");
+    	m_eventIpcManager.getEventAnticipator().anticipateEvent(closeTicketBuilder.getEvent());
+
+    	when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
+    	m_ticketNotificationStrategy.setAlarmState(buildClearedAlarmState("TICKET-1", state));
+    	List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
+    	arguments.add(new Argument("ticketUser", null, "noc", false));
+
+    	assertEquals("Strategy should succeed for ticket state " + state, 0, m_ticketNotificationStrategy.send(arguments));
+    	assertTrue("Strategy should send a close-ticket event for ticket state " + state, m_eventIpcManager.getEventAnticipator().waitForAnticipated(0).isEmpty());
+    	assertEquals("Received unexpected events for ticket state " + state, 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    }
+
+    private void assertClearedStateSendsNothing(String ticketID, TroubleTicketState state) {
+    	when(m_eventConfDao.findByUei(EventConstants.NODE_DOWN_EVENT_UEI)).thenReturn(buildAlarmEvent(1));
+    	m_ticketNotificationStrategy.setAlarmState(buildClearedAlarmState(ticketID, state));
+    	List<Argument> arguments = buildArguments("1", EventConstants.NODE_DOWN_EVENT_UEI);
+    	assertEquals("Strategy should succeed for ticket state " + state, 0, m_ticketNotificationStrategy.send(arguments));
+    	assertEquals("Strategy should not send an event for ticket state " + state, 0, m_eventIpcManager.getEventAnticipator().getUnanticipatedEvents().size());
+    }
+
+    private TicketNotificationStrategy.AlarmState buildClearedAlarmState(String ticketID, TroubleTicketState state) {
+    	return new TicketNotificationStrategy.AlarmState(1, ticketID, state.getValue(), OnmsSeverity.CLEARED.getId());
     }
 
     protected Event buildAlarmEvent(int alarmType) {

--- a/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
@@ -216,8 +216,9 @@
                 <command>growlMessage</command>
         </target>
     </path>
-    <!-- Creates a trouble ticket for the alarm associated with the notification's event.
-    The createTicket command is defined in the notificationCommands.xml example.  The
+    <!-- Manages the trouble ticket for the alarm associated with the notification's event:
+    creates one while the alarm is active, closes it once the alarm is cleared.  The
+    troubleTicket command is defined in the notificationCommands.xml example.  The
     initial-delay gives alarmd time to associate the event with an alarm; with 0s the
     ticket lookup can run before the alarm exists and the notification fails.  The target's
     contact information is not used.  Target a single user rather than a group: a group
@@ -225,7 +226,7 @@
     <path name="Create-Ticket" initial-delay="30s">
         <target>
                 <name>admin</name>
-                <command>createTicket</command>
+                <command>troubleTicket</command>
         </target>
     </path>
 </destinationPaths>

--- a/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/destinationPaths.xml
@@ -216,14 +216,22 @@
                 <command>growlMessage</command>
         </target>
     </path>
-    <!-- Manages the trouble ticket for the alarm associated with the notification's event:
-    creates one while the alarm is active, closes it once the alarm is cleared.  The
-    troubleTicket command is defined in the notificationCommands.xml example.  The
-    initial-delay gives alarmd time to associate the event with an alarm; with 0s the
-    ticket lookup can run before the alarm exists and the notification fails.  The target's
-    contact information is not used.  Target a single user rather than a group: a group
-    target runs the command once per member, which can create duplicate tickets. -->
+    <!-- Manages the trouble ticket for the alarm associated with the notification's event.
+    The troubleTicket command is defined in the notificationCommands.xml example; reference
+    Create-Ticket from problem notifications and Close-Ticket from the notifications for the
+    events that resolve them.  The initial-delay is required on both: on Create-Ticket it
+    gives alarmd time to associate the event with an alarm, and on Close-Ticket it gives
+    alarmd time to clear that alarm, which the ticketer requires before it will close a
+    ticket.  With 0s either lookup can run too early and the notification does nothing.  The
+    target's contact information is not used.  Target a single user rather than a group: a
+    group target runs the command once per member, which can duplicate tickets. -->
     <path name="Create-Ticket" initial-delay="30s">
+        <target>
+                <name>admin</name>
+                <command>troubleTicket</command>
+        </target>
+    </path>
+    <path name="Close-Ticket" initial-delay="30s">
         <target>
                 <name>admin</name>
                 <command>troubleTicket</command>

--- a/opennms-base-assembly/src/main/filtered/etc/examples/notificationCommands.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/notificationCommands.xml
@@ -248,16 +248,17 @@
     		<switch>trapVarbind</switch>
     	</argument>
     </command>
-    <!-- Use this notificationCommand to create a trouble ticket for the alarm associated with the
-    notification's event.  Requires a configured ticketer plugin, and the event must have alarm-data.
+    <!-- Use this notificationCommand to manage the trouble ticket for the alarm associated with the
+    notification's event: it creates a ticket while the alarm is active and closes that ticket once
+    the alarm is cleared.  Requires a configured ticketer plugin, and the event must have alarm-data.
     Use a destination path with a non-zero initial-delay so alarmd has associated the event with an
     alarm before the ticket lookup runs.  The optional ticketUser argument sets the user parameter
-    on the create-ticket event (defaults to "admin"); it can be supplied per notification with a
+    on the ticket events (defaults to "admin"); it can be supplied per notification with a
     parameter named "ticketUser" in notifications.xml. -->
     <command binary="false">
-        <name>createTicket</name>
+        <name>troubleTicket</name>
         <execute>org.opennms.netmgt.notifd.TicketNotificationStrategy</execute>
-        <comment>class for creating a trouble ticket for the alarm associated with the notification's event</comment>
+        <comment>class for managing the trouble ticket for the alarm associated with the notification's event</comment>
         <argument streamed="false">
             <switch>eventID</switch>
         </argument>


### PR DESCRIPTION
The notification command now sends a close for a cleared alarm that still has an active ticket, instead of creating another one, so the resolution delivery completes the workflow. Renames the example command to troubleTicket.


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20105

