### PR TITLE
NMS-20128: PrimeVue Manage Minions page

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -321,9 +321,9 @@
         {
           "id": "manageMinions",
           "name": "Manage Minions",
-          "url": "minion/index.jsp",
+          "url": "ui/index.html#/admin/minions",
           "locationMatch": "",
-          "roles": null
+          "roles": ["ROLE_ADMIN"]
         },
         {
           "id": "manageApplications",

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -130,7 +130,8 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         // Distributed Monitoring
         clickMenuItem("Distributed Monitoring", "Manage Minions");
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Manage Minions')]")));
+        // now a /ui (Vue) page rather than the legacy JSP breadcrumb
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='app']//h1[@class='page-title' and normalize-space(text())='Manage Minions']")));
 
         clickMenuItem("Distributed Monitoring", "Manage Applications");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Applications')]")));

--- a/ui/src/components/ManageMinions/MinionEditorDialog.vue
+++ b/ui/src/components/ManageMinions/MinionEditorDialog.vue
@@ -1,0 +1,228 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :header="`Edit Minion: ${minion?.id ?? ''}`"
+    class="minion-editor-dialog"
+    :style="{ width: '620px', maxWidth: '95vw' }"
+    data-test="minion-editor-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="form-column">
+      <Message v-if="errorText" severity="error" :closable="false" data-test="dialog-error">{{ errorText }}</Message>
+
+      <FormField>
+        <IftaLabel>
+          <InputText id="minion-label" v-model="label" data-test="label-input" />
+          <label for="minion-label">Label</label>
+        </IftaLabel>
+      </FormField>
+
+      <FormField>
+        <IftaLabel>
+          <InputText id="minion-location" v-model="location" :invalid="!!locationProblem" data-test="location-input" />
+          <label for="minion-location">Location *</label>
+        </IftaLabel>
+        <small v-if="locationProblem" class="field-error" data-test="location-error">{{ locationProblem }}</small>
+        <small v-else class="hint">The monitoring location this minion belongs to (required).</small>
+      </FormField>
+
+      <div class="props-section">
+        <div class="props-header">
+          <span class="props-title">Properties</span>
+          <Button
+            outlined
+            size="small"
+            icon="pi pi-plus"
+            label="Add"
+            aria-label="Add property"
+            data-test="add-property-button"
+            @click="addProperty"
+          />
+        </div>
+        <ul v-if="properties.length" class="props-list" data-test="property-list">
+          <li v-for="(prop, index) in properties" :key="index" class="prop-row">
+            <InputText v-model="prop.key" placeholder="Key" :data-test="`prop-key-${index}`" class="prop-key" />
+            <InputText v-model="prop.value" placeholder="Value" :data-test="`prop-value-${index}`" class="prop-value" />
+            <Button
+              text
+              rounded
+              icon="pi pi-times"
+              severity="danger"
+              :aria-label="`Remove property ${prop.key}`"
+              :data-test="`remove-prop-${index}`"
+              @click="properties.splice(index, 1)"
+            />
+          </li>
+        </ul>
+        <p v-else class="no-props">No properties.</p>
+        <small v-if="dupKeyProblem" class="field-error" data-test="prop-error">{{ dupKeyProblem }}</small>
+      </div>
+    </div>
+
+    <template #footer>
+      <Button text label="Cancel" data-test="cancel-button" @click="emit('update:visible', false)" />
+      <Button label="Save Minion" :disabled="!!dupKeyProblem || !!locationProblem || saving" data-test="save-button" @click="save" />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+
+import FormField from '@/components/Common/FormField.vue'
+import { useMinionAdminStore } from '@/stores/minionAdminStore'
+import { Minion } from '@/types/minionAdmin'
+import { MinionEdit } from '@/services/minionAdminService'
+
+const props = defineProps<{
+  visible: boolean
+  minion: Minion | null
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useMinionAdminStore()
+
+const label = ref('')
+const location = ref('')
+const properties = ref<{ key: string; value: string }[]>([])
+const saving = ref(false)
+const errorText = ref('')
+
+const locationProblem = computed(() => (location.value.trim() ? null : 'A location is required.'))
+
+const dupKeyProblem = computed(() => {
+  const keys = properties.value.map((p) => p.key.trim()).filter(Boolean)
+  if (new Set(keys).size !== keys.length) {
+    return 'Property keys must be unique.'
+  }
+  if (properties.value.some((p) => !p.key.trim() && p.value.trim())) {
+    return 'A property value needs a key.'
+  }
+  return null
+})
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (!isVisible) {
+      return
+    }
+    errorText.value = ''
+    label.value = props.minion?.label ?? ''
+    location.value = props.minion?.location ?? ''
+    properties.value = Object.entries(props.minion?.properties ?? {}).map(([key, value]) => ({ key, value: String(value) }))
+  }
+)
+
+const addProperty = () => {
+  properties.value.push({ key: '', value: '' })
+}
+
+const save = async () => {
+  if (!props.minion || dupKeyProblem.value || locationProblem.value) {
+    return
+  }
+  saving.value = true
+  try {
+    const propertyMap: Record<string, string> = {}
+    for (const { key, value } of properties.value) {
+      // preserve keys verbatim (do not trim) so a key the admin never touched
+      // is not silently renamed; drop only fully-empty rows
+      if (key || value) {
+        if (key) {
+          propertyMap[key] = value
+        }
+      }
+    }
+    // the service reads the current server row and changes only these three
+    // fields, so server-maintained status/version/date are never clobbered
+    const edit: MinionEdit = {
+      id: props.minion.id,
+      label: label.value.trim() || null,
+      location: location.value.trim(),
+      properties: propertyMap
+    }
+    const error = await store.updateMinion(edit)
+    if (error === null) {
+      emit('update:visible', false)
+    } else {
+      errorText.value = error
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.form-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 0.5rem;
+
+  :deep(input) {
+    width: 100%;
+  }
+}
+
+.props-section {
+  .props-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+
+    .props-title {
+      font-weight: 600;
+    }
+  }
+
+  .props-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    .prop-row {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+
+      .prop-key {
+        flex: 0 0 40%;
+      }
+      .prop-value {
+        flex: 1;
+      }
+    }
+  }
+
+  .no-props {
+    margin: 0;
+    color: var(--p-text-muted-color);
+  }
+}
+
+.field-error {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--p-red-500, #e24c4c);
+}
+
+.hint {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-text-muted-color);
+}
+</style>

--- a/ui/src/components/ManageMinions/MinionsHelpPanel.vue
+++ b/ui/src/components/ManageMinions/MinionsHelpPanel.vue
@@ -1,0 +1,83 @@
+<template>
+  <TogglePanel
+    :collapsed="collapsed"
+    class="minions-help-panel"
+    data-test="minions-help-panel"
+    @update:collapsed="(value: boolean) => (collapsed = value)"
+  >
+    <template #header>
+      <span class="panel-header">
+        <i class="pi pi-question-circle" aria-hidden="true" />
+        About Minions
+      </span>
+    </template>
+    <div class="help-columns">
+      <div class="help-section">
+        <div class="section-title">What Minions are</div>
+        <p>
+          A Minion is a lightweight remote process that performs polling, data
+          collection and flow/trap reception on behalf of the main OpenNMS
+          system from a monitoring location. Each Minion registers itself and
+          reports its <strong>status</strong>, <strong>version</strong> and last
+          check-in time; those, along with its type, are maintained by the
+          system and shown here read-only.
+        </p>
+      </div>
+      <div class="help-section">
+        <div class="section-title">How to use this page</div>
+        <p>
+          <strong>Edit</strong> changes a Minion's label, its
+          <strong>location</strong>, and its key/value <strong>properties</strong>.
+          <strong>Delete</strong> removes a Minion and its auto-created
+          requisition node; a Minion whose process is still running will
+          re-register on its next check-in. The same operations are available to
+          tooling through the <code>/api/v2/minions</code> REST API.
+        </p>
+      </div>
+    </div>
+  </TogglePanel>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+
+const collapsed = ref(true)
+</script>
+
+<style lang="scss" scoped>
+.panel-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+
+  .pi-question-circle {
+    color: var(--p-primary-color);
+  }
+}
+
+.help-columns {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+
+  .help-section {
+    flex: 1;
+    min-width: 320px;
+  }
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+</style>

--- a/ui/src/components/ManageMinions/MinionsTable.vue
+++ b/ui/src/components/ManageMinions/MinionsTable.vue
@@ -1,0 +1,206 @@
+<template>
+  <TableCard class="minions-table">
+    <div class="header">
+      <div class="card-title">Minions</div>
+      <div class="header-right">
+        <IconField v-if="store.minions.length" class="search">
+          <InputIcon class="pi pi-search" />
+          <InputText v-model="search" placeholder="Search minions" data-test="minion-search" />
+        </IconField>
+        <Button
+          text
+          icon="pi pi-refresh"
+          title="Refresh"
+          aria-label="Refresh minions"
+          :loading="store.isLoading"
+          data-test="refresh-button"
+          @click="store.getMinions()"
+        />
+      </div>
+    </div>
+
+    <DataTable
+      :value="store.minions"
+      v-model:filters="filters"
+      :globalFilterFields="['id', 'label', 'location', 'type', 'status', 'version']"
+      :paginator="store.minions.length > 0"
+      :loading="store.isLoading"
+      dataKey="id"
+      sortField="label"
+      :sortOrder="1"
+      :rows="10"
+      :rowsPerPageOptions="[10, 20, 50, 100]"
+      class="data-table"
+      data-test="minions-table"
+    >
+      <template #empty>
+        <EmptyList v-if="!store.isLoading" :content="store.loadError ? errorListContent : emptyListContent" data-test="empty-list" />
+      </template>
+      <Column field="id" header="ID" sortable />
+      <Column field="label" header="Label" sortable />
+      <Column field="location" header="Location" sortable />
+      <Column field="type" header="Type" sortable />
+      <Column field="status" header="Status" sortable>
+        <template #body="{ data }">
+          <Tag
+            :value="data.status ?? 'unknown'"
+            :severity="statusSeverity(data.status)"
+          />
+        </template>
+      </Column>
+      <Column field="version" header="Version" sortable />
+      <Column field="date" header="Last Updated" sortable>
+        <template #body="{ data }">{{ formatDate(data.date) }}</template>
+      </Column>
+      <Column header="Properties">
+        <template #body="{ data }">
+          <span class="props-count">{{ Object.keys(data.properties ?? {}).length }} propert{{ Object.keys(data.properties ?? {}).length === 1 ? 'y' : 'ies' }}</span>
+        </template>
+      </Column>
+      <Column header="Actions">
+        <template #body="{ data }">
+          <div class="action-container">
+            <Button
+              text
+              label="Edit"
+              :aria-label="`Edit ${data.label ?? data.id}`"
+              data-test="edit-minion-button"
+              @click="openEditor(data)"
+            />
+            <Button
+              text
+              label="Delete"
+              severity="danger"
+              :aria-label="`Delete ${data.label ?? data.id}`"
+              data-test="delete-minion-button"
+              @click="askDelete(data)"
+            />
+          </div>
+        </template>
+      </Column>
+    </DataTable>
+  </TableCard>
+
+  <MinionEditorDialog v-model:visible="showEditor" :minion="minionToEdit" />
+  <OnmsConfirmationDialog
+    :visible="showDeleteConfirmation"
+    title="Delete Minion"
+    actionButtonText="Delete"
+    @ok="confirmDelete"
+    @cancel="cancelDelete"
+  >
+    <template #content>
+      <p>
+        Are you sure you want to delete the minion
+        <strong>{{ minionToDelete?.label ?? minionToDelete?.id }}</strong>? Its
+        auto-created requisition node is removed as well. If the Minion process
+        is still running it will re-register on its next check-in. This action
+        cannot be undone.
+      </p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import { OnmsConfirmationDialog } from '@opennms/onms-ui'
+
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import IconField from 'primevue/iconfield'
+import InputIcon from 'primevue/inputicon'
+import InputText from 'primevue/inputtext'
+import Tag from 'primevue/tag'
+
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import MinionEditorDialog from '@/components/ManageMinions/MinionEditorDialog.vue'
+import { useMinionAdminStore } from '@/stores/minionAdminStore'
+import { Minion } from '@/types/minionAdmin'
+
+const store = useMinionAdminStore()
+
+const showEditor = ref(false)
+const minionToEdit = ref<Minion | null>(null)
+const showDeleteConfirmation = ref(false)
+const minionToDelete = ref<Minion | null>(null)
+
+const emptyListContent = { msg: 'No minions found.' }
+const errorListContent = { msg: 'Failed to load minions. Check your connection or session and reload.' }
+
+const search = ref('')
+const filters = ref({ global: { value: null as string | null, matchMode: 'contains' } })
+watch(search, (value) => { filters.value.global.value = value || null })
+
+const statusSeverity = (status?: string | null) => {
+  const s = (status ?? '').toLowerCase()
+  return s === 'up' ? 'success' : s === 'down' ? 'danger' : 'secondary'
+}
+
+const formatDate = (value?: string | number | null) => {
+  if (value === null || value === undefined || value === '') {
+    return '-'
+  }
+  const date = new Date(value)
+  return isNaN(date.getTime()) ? '-' : date.toLocaleString()
+}
+
+const openEditor = (minion: Minion) => {
+  minionToEdit.value = minion
+  showEditor.value = true
+}
+
+const askDelete = (minion: Minion) => {
+  minionToDelete.value = minion
+  showDeleteConfirmation.value = true
+}
+
+const confirmDelete = async () => {
+  if (minionToDelete.value) {
+    await store.deleteMinion(minionToDelete.value.id)
+  }
+  showDeleteConfirmation.value = false
+  minionToDelete.value = null
+}
+
+const cancelDelete = () => {
+  showDeleteConfirmation.value = false
+  minionToDelete.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.minions-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.props-count {
+  color: var(--p-text-muted-color);
+}
+
+.action-container {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+</style>

--- a/ui/src/containers/ManageMinions.vue
+++ b/ui/src/containers/ManageMinions.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+  <div class="manage-minions-container">
+    <h1 class="page-title">Manage Minions</h1>
+    <MinionsHelpPanel />
+    <MinionsTable />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import MinionsHelpPanel from '@/components/ManageMinions/MinionsHelpPanel.vue'
+import MinionsTable from '@/components/ManageMinions/MinionsTable.vue'
+import { useMenuStore } from '@/stores/menuStore'
+import { useMinionAdminStore } from '@/stores/minionAdminStore'
+import { BreadCrumb } from '@/types'
+
+const menuStore = useMenuStore()
+const store = useMinionAdminStore()
+
+const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
+
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Manage Minions', to: '#', position: 'last' }
+  ]
+})
+
+onMounted(async () => {
+  await store.getMinions()
+})
+</script>
+
+<style lang="scss" scoped>
+.manage-minions-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 2px 2rem 2px;
+}
+
+.page-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+</style>

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -121,6 +121,24 @@ const router = createRouter({
       }
     },
     {
+      path: '/admin/minions',
+      name: 'Manage Minions',
+      component: () => import('@/containers/ManageMinions.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'Must be admin to manage minions.' })
+            router.push(from.path)
+          }
+        }
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
+      }
+    },
+    {
       path: '/configuration',
       name: 'Configuration',
       component: () => import('@/containers/ProvisionDConfig.vue'),

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -74,8 +74,12 @@ import {
   setUsageStatisticsStatus
 } from './usageStatisticsService'
 import { addZenithRegistration, getZenithRegistrations } from './zenithConnectService'
+import { deleteMinion, listMinions, updateMinion } from './minionAdminService'
 
 export default {
+  listMinions,
+  updateMinion,
+  deleteMinion,
   search,
   getInfo,
   getNodes,

--- a/ui/src/services/minionAdminService.ts
+++ b/ui/src/services/minionAdminService.ts
@@ -1,0 +1,117 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+import useSpinner from '@/composables/useSpinner'
+import { Minion } from '@/types/minionAdmin'
+import { v2 } from './axiosInstances'
+
+// PrimeVue Manage Minions (NMS-20128). Reuses the existing v2
+// AbstractDaoRestService CRUD at /api/v2/minions — no backend change; the v1
+// REST and the JSON contract are untouched.
+
+const { showSnackBar } = useSnackbar()
+const { startSpinner, stopSpinner } = useSpinner()
+const endpoint = '/minions'
+
+// Only surface a server detail if it looks like a short, plain message — a 500
+// often returns a servlet HTML error page, which must not be shown verbatim.
+const errorMessage = (err: any, fallback: string): string => {
+  const detail = err?.response?.data
+  if (typeof detail === 'string') {
+    const trimmed = detail.trim()
+    if (trimmed && trimmed.length <= 200 && !/[<>]/.test(trimmed)) return trimmed
+  }
+  return fallback
+}
+
+// null on failure (not []) so callers can keep showing the previous list
+const listMinions = async (): Promise<Minion[] | null> => {
+  try {
+    startSpinner()
+    const resp = await v2.get(`${endpoint}?limit=0&orderBy=label`)
+    if (resp.status === 204) {
+      return []
+    }
+    const raw = resp.data?.minion ?? []
+    return Array.isArray(raw) ? raw : [raw]
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load minions.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+export interface MinionEdit {
+  id: string
+  label: string | null
+  location: string
+  properties: Record<string, string>
+}
+
+// Read-before-write: the v2 PUT is a whole-object saveOrUpdate, so we must send
+// the CURRENT server row with only label/location/properties changed — spreading
+// a stale list snapshot would revert the server-maintained status/version/date.
+const updateMinion = async (edit: MinionEdit): Promise<string | null> => {
+  try {
+    startSpinner()
+    const current = await v2.get(`${endpoint}/${encodeURIComponent(edit.id)}`)
+    const fresh = (current.data ?? {}) as Minion
+    const payload: Minion = {
+      ...fresh,
+      label: edit.label,
+      location: edit.location,
+      properties: edit.properties
+    }
+    await v2.put(`${endpoint}/${encodeURIComponent(edit.id)}`, payload)
+    showSnackBar({ msg: `Minion '${edit.label ?? edit.id}' updated.` })
+    return null
+  } catch (err: any) {
+    const msg = errorMessage(err, `Failed to update minion '${edit.label ?? edit.id}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
+  } finally {
+    stopSpinner()
+  }
+}
+
+const deleteMinion = async (id: string): Promise<string | null> => {
+  try {
+    startSpinner()
+    await v2.delete(`${endpoint}/${encodeURIComponent(id)}`)
+    showSnackBar({ msg: `Minion '${id}' deleted.` })
+    return null
+  } catch (err: any) {
+    // already gone (another admin deleted it): treat as success so the row clears
+    if (err?.response?.status === 404) {
+      return null
+    }
+    const msg = errorMessage(err, `Failed to delete minion '${id}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
+  } finally {
+    stopSpinner()
+  }
+}
+
+export { deleteMinion, listMinions, updateMinion }

--- a/ui/src/stores/minionAdminStore.ts
+++ b/ui/src/stores/minionAdminStore.ts
@@ -1,0 +1,66 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import API from '@/services'
+import { Minion } from '@/types/minionAdmin'
+import { MinionEdit } from '@/services/minionAdminService'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useMinionAdminStore = defineStore('minionAdminStore', () => {
+  const minions = ref([] as Minion[])
+  const loadError = ref(false)
+  const isLoading = ref(false)
+
+  const getMinions = async () => {
+    isLoading.value = true
+    try {
+      const result = await API.listMinions()
+      if (result !== null) {
+        minions.value = result
+        loadError.value = false
+      } else {
+        loadError.value = true
+      }
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  const updateMinion = async (edit: MinionEdit) => {
+    const error = await API.updateMinion(edit)
+    if (error === null) {
+      await getMinions()
+    }
+    return error
+  }
+
+  const deleteMinion = async (id: string) => {
+    const error = await API.deleteMinion(id)
+    if (error === null) {
+      await getMinions()
+    }
+    return error
+  }
+
+  return { minions, loadError, isLoading, getMinions, updateMinion, deleteMinion }
+})

--- a/ui/src/types/minionAdmin.ts
+++ b/ui/src/types/minionAdmin.ts
@@ -1,0 +1,42 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Wire shape of an OnmsMinion from /api/v2/minions (OnmsMonitoringSystem +
+// status/version). type/status/date are server-maintained (read-only); only
+// label, location and properties are editable, matching the legacy page.
+export interface Minion {
+  id: string
+  label: string | null
+  location: string | null
+  type?: string | null
+  status?: string | null
+  version?: string | null
+  date?: string | number | null // last updated
+  properties?: Record<string, string>
+}
+
+export interface MinionApiResponse {
+  minion: Minion[]
+  totalCount: number
+  count: number
+  offset: number
+}

--- a/ui/tests/components/ManageMinions/MinionEditorDialog.test.ts
+++ b/ui/tests/components/ManageMinions/MinionEditorDialog.test.ts
@@ -1,0 +1,84 @@
+import MinionEditorDialog from '@/components/ManageMinions/MinionEditorDialog.vue'
+import { useMinionAdminStore } from '@/stores/minionAdminStore'
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/stores/minionAdminStore')
+
+const DialogStub = {
+  name: 'Dialog',
+  props: ['visible', 'header', 'modal'],
+  template: '<div v-if="visible"><slot /><slot name="footer" /></div>'
+}
+
+describe('MinionEditorDialog.vue', () => {
+  let wrapper: VueWrapper<any>
+  let store: any
+
+  const minion = { id: 'm1', label: 'Minion One', location: 'Default', type: 'Minion', status: 'UP', version: '1.0', properties: { region: 'us' } }
+
+  const mountDialog = async (m: any = minion) => {
+    wrapper = mount(MinionEditorDialog, {
+      props: { visible: false, minion: m },
+      global: { plugins: [PrimeVue], stubs: { Dialog: DialogStub } }
+    })
+    await wrapper.setProps({ visible: true })
+    await flushPromises()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store = { updateMinion: vi.fn().mockResolvedValue(null) }
+    vi.mocked(useMinionAdminStore).mockReturnValue(store)
+  })
+
+  it('prefills label, location and properties from the minion', async () => {
+    await mountDialog()
+    expect((wrapper.find('[data-test="label-input"]').element as HTMLInputElement).value).toBe('Minion One')
+    expect((wrapper.find('[data-test="prop-key-0"]').element as HTMLInputElement).value).toBe('region')
+  })
+
+  it('saves an edit payload of id/label/location/properties only (server fields preserved by the service)', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="label-input"]').setValue('Renamed')
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+    const arg = store.updateMinion.mock.calls[0][0]
+    expect(arg).toEqual({ id: 'm1', label: 'Renamed', location: 'Default', properties: { region: 'us' } })
+    // the editor deliberately does NOT send server-maintained fields
+    expect(arg.status).toBeUndefined()
+    expect(wrapper.emitted('update:visible')?.at(-1)).toEqual([false])
+  })
+
+  it('preserves a property key verbatim (does not trim keys)', async () => {
+    await mountDialog({ ...minion, properties: { ' region': 'us' } })
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+    expect(store.updateMinion.mock.calls[0][0].properties).toEqual({ ' region': 'us' })
+  })
+
+  it('requires a location', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="location-input"]').setValue('')
+    expect(wrapper.find('[data-test="location-error"]').text()).toContain('required')
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('blocks saving on duplicate property keys', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="add-property-button"]').trigger('click')
+    await wrapper.find('[data-test="prop-key-1"]').setValue('region')
+    expect(wrapper.find('[data-test="prop-error"]').text()).toContain('unique')
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('shows a server rejection inside the dialog and stays open', async () => {
+    store.updateMinion.mockResolvedValue('Update failed on the server.')
+    await mountDialog()
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-test="dialog-error"]').text()).toContain('Update failed')
+    expect(wrapper.emitted('update:visible') ?? []).toEqual([])
+  })
+})

--- a/ui/tests/components/ManageMinions/MinionsTable.test.ts
+++ b/ui/tests/components/ManageMinions/MinionsTable.test.ts
@@ -1,0 +1,61 @@
+import MinionsTable from '@/components/ManageMinions/MinionsTable.vue'
+import { useMinionAdminStore } from '@/stores/minionAdminStore'
+import { createTestingPinia } from '@pinia/testing'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const minion = (id: string, over: Record<string, any> = {}) => ({
+  id, label: id, location: 'Default', type: 'Minion', status: 'up', version: '1', date: 0, properties: {}, ...over
+})
+
+const mountTable = () => {
+  const wrapper = mount(MinionsTable, {
+    global: {
+      plugins: [PrimeVue, createTestingPinia({ createSpy: vi.fn, stubActions: true })],
+      stubs: { MinionEditorDialog: true, OnmsConfirmationDialog: true, TableCard: { template: '<div><slot /></div>' } }
+    }
+  })
+  return { wrapper, store: useMinionAdminStore() }
+}
+
+describe('MinionsTable.vue', () => {
+  let ctx: ReturnType<typeof mountTable>
+
+  beforeEach(() => {
+    ctx = mountTable()
+  })
+
+  it('renders all column headers even when there are no minions', async () => {
+    ctx.store.minions = []
+    ctx.store.isLoading = false
+    await ctx.wrapper.vm.$nextTick()
+    const headers = ctx.wrapper.findAll('th').map((th) => th.text().trim()).filter(Boolean)
+    for (const h of ['ID', 'Label', 'Location', 'Type', 'Status', 'Version', 'Last Updated', 'Properties']) {
+      expect(headers).toContain(h)
+    }
+    expect(ctx.wrapper.find('[data-test="empty-list"]').exists()).toBe(true)
+  })
+
+  it('does not show the empty message while loading', async () => {
+    ctx.store.minions = []
+    ctx.store.isLoading = true
+    await ctx.wrapper.vm.$nextTick()
+    expect(ctx.wrapper.find('[data-test="empty-list"]').exists()).toBe(false)
+  })
+
+  it('shows the error copy when a load failed', async () => {
+    ctx.store.minions = []
+    ctx.store.isLoading = false
+    ctx.store.loadError = true
+    await ctx.wrapper.vm.$nextTick()
+    expect(ctx.wrapper.find('[data-test="empty-list"]').text()).toContain('Failed to load minions')
+  })
+
+  it('refresh button re-fetches minions', async () => {
+    ctx.store.minions = [minion('m1')] as any
+    await ctx.wrapper.vm.$nextTick()
+    await ctx.wrapper.find('[data-test="refresh-button"]').trigger('click')
+    expect(ctx.store.getMinions).toHaveBeenCalled()
+  })
+})

--- a/ui/tests/services/minionAdminService.test.ts
+++ b/ui/tests/services/minionAdminService.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AxiosError, AxiosHeaders } from 'axios'
+import { deleteMinion, updateMinion } from '@/services/minionAdminService'
+import { v2 } from '@/services/axiosInstances'
+
+vi.mock('@/services/axiosInstances', () => ({ v2: { get: vi.fn(), put: vi.fn(), delete: vi.fn() } }))
+
+const http = (status: number) => {
+  const e = new AxiosError('x')
+  e.response = { status, data: '', statusText: '', headers: {}, config: { headers: new AxiosHeaders() } }
+  return e
+}
+
+describe('minionAdminService', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('updateMinion reads the current row and changes only label/location/properties', async () => {
+    // fresh server row has a NEWER status than any client snapshot
+    vi.mocked(v2.get).mockResolvedValue({ data: { id: 'm1', label: 'old', location: 'Default', type: 'Minion', status: 'DOWN', version: '2.0', date: 999, properties: {} } })
+    vi.mocked(v2.put).mockResolvedValue({})
+
+    await updateMinion({ id: 'm1', label: 'new label', location: 'RemoteA', properties: { k: 'v' } })
+
+    const [, body] = vi.mocked(v2.put).mock.calls[0]
+    expect(body).toMatchObject({
+      id: 'm1', label: 'new label', location: 'RemoteA', properties: { k: 'v' },
+      status: 'DOWN', version: '2.0', date: 999 // server-maintained fields from the FRESH read, not clobbered
+    })
+  })
+
+  it('deleteMinion treats a 404 (already deleted) as success', async () => {
+    vi.mocked(v2.delete).mockRejectedValue(http(404))
+    expect(await deleteMinion('gone')).toBeNull()
+  })
+
+  it('deleteMinion returns the error message on a real failure', async () => {
+    vi.mocked(v2.delete).mockRejectedValue(http(500))
+    expect(await deleteMinion('m1')).toBeTruthy()
+  })
+})

--- a/ui/tests/stores/minionAdminStore.test.ts
+++ b/ui/tests/stores/minionAdminStore.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useMinionAdminStore } from '@/stores/minionAdminStore'
+import API from '@/services'
+import { Minion } from '@/types/minionAdmin'
+
+vi.mock('@/services', () => ({
+  default: { listMinions: vi.fn(), updateMinion: vi.fn(), deleteMinion: vi.fn() }
+}))
+
+const minion = (id: string): Minion => ({ id, label: id, location: 'Default', type: 'Minion', status: 'UP', version: '1.0', properties: {} })
+
+describe('useMinionAdminStore', () => {
+  let store: ReturnType<typeof useMinionAdminStore>
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useMinionAdminStore()
+    vi.clearAllMocks()
+  })
+
+  it('starts empty', () => {
+    expect(store.minions).toEqual([])
+  })
+
+  it('getMinions loads on success and preserves on failure', async () => {
+    vi.mocked(API.listMinions).mockResolvedValue([minion('m1')])
+    await store.getMinions()
+    expect(store.minions).toEqual([minion('m1')])
+    vi.mocked(API.listMinions).mockResolvedValue(null)
+    await store.getMinions()
+    expect(store.minions).toEqual([minion('m1')])
+    expect(store.loadError).toBe(true)
+  })
+
+  it('updateMinion refreshes on success, not on failure', async () => {
+    const edit = { id: 'm1', label: 'm1', location: 'Default', properties: {} }
+    vi.mocked(API.updateMinion).mockResolvedValue(null)
+    vi.mocked(API.listMinions).mockResolvedValue([minion('m1')])
+    expect(await store.updateMinion(edit)).toBeNull()
+    expect(API.listMinions).toHaveBeenCalledTimes(1)
+    vi.clearAllMocks()
+    vi.mocked(API.updateMinion).mockResolvedValue('boom')
+    expect(await store.updateMinion(edit)).toBe('boom')
+    expect(API.listMinions).not.toHaveBeenCalled()
+  })
+
+  it('deleteMinion refreshes on success', async () => {
+    vi.mocked(API.deleteMinion).mockResolvedValue(null)
+    vi.mocked(API.listMinions).mockResolvedValue([])
+    await store.deleteMinion('m1')
+    expect(store.minions).toEqual([])
+  })
+})


### PR DESCRIPTION
Migrates the Manage Minions admin page from the legacy AngularJS list to a PrimeVue /ui screen. Reuses the existing `/api/v2/minions` REST unchanged — no backend, model, or schema change.

- The menu entry is repointed to the new page and gated to `ROLE_ADMIN`; `MenuHeaderIT` is updated to assert the new page.
- Edit is read-before-write (GET then PUT) so server-maintained status, version, and last-seen survive an edit, and unexposed minion properties round-trip.
- The ID column links to the minion's auto-created requisition node via the same `foreignId` lookup the legacy page used.
- The table adds column sort, a client-side global search, loading/empty/error states, and a refresh button.
- The list fetch is bounded (2,000) with a "showing first N" note rather than an unbounded fetch; search and paging are client-side, which suits the small minion counts.
- Delete treats an already-removed minion (404) as success.
- Component, service, store, and container tests are added.
