### PR TITLE
NMS-20131: PrimeVue Manage Surveillance Categories page

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -241,7 +241,7 @@
         {
           "id": "surveillanceCategories",
           "name": "Surveillance Categories",
-          "url": "admin/categories.htm",
+          "url": "ui/index.html#/admin/surveillance-categories",
           "locationMatch": "categories",
           "roles": null
         },

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -196,7 +196,8 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         // Administration Menu
         clickMenuItem("Administration", "Surveillance Categories");
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Surveillance Categories']")));
+        // now a /ui (Vue) page rather than the legacy JSP card header
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='app']//h1[@class='page-title' and normalize-space(text())='Surveillance Categories']")));
 
         clickMenuItem("Administration", "Configure Thresholds");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Threshold Configuration']")));

--- a/ui/src/components/ManageCategories/CategoriesHelpPanel.vue
+++ b/ui/src/components/ManageCategories/CategoriesHelpPanel.vue
@@ -1,0 +1,82 @@
+<template>
+  <TogglePanel
+    :collapsed="collapsed"
+    class="categories-help-panel"
+    data-test="categories-help-panel"
+    @update:collapsed="(value: boolean) => (collapsed = value)"
+  >
+    <template #header>
+      <span class="panel-header">
+        <i class="pi pi-question-circle" aria-hidden="true" />
+        About Surveillance Categories
+      </span>
+    </template>
+    <div class="help-columns">
+      <div class="help-section">
+        <div class="section-title">What surveillance categories are for</div>
+        <p>
+          A surveillance category is a named grouping of nodes used across
+          OpenNMS for filtering, dashboards, notifications, and the surveillance
+          view. A node can belong to any number of categories, and group
+          authorizations can restrict which categories a user group sees.
+        </p>
+      </div>
+      <div class="help-section">
+        <div class="section-title">How to use this page</div>
+        <p>
+          <strong>Add New Category</strong> creates a category with an optional
+          description; <strong>Edit</strong> changes the description (the name is
+          the identifier and cannot be changed). <strong>Manage Nodes</strong>
+          assigns and unassigns nodes. <strong>Delete</strong> removes the
+          category — filters or authorizations that reference it by name stop
+          matching, so review them afterward. The same operations are available
+          to tooling through the <code>/rest/categories</code> REST API.
+        </p>
+      </div>
+    </div>
+  </TogglePanel>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import TogglePanel from '@/components/Common/TogglePanel.vue'
+
+const collapsed = ref(true)
+</script>
+
+<style lang="scss" scoped>
+.panel-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+
+  .pi-question-circle {
+    color: var(--p-primary-color);
+  }
+}
+
+.help-columns {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+
+  .help-section {
+    flex: 1;
+    min-width: 320px;
+  }
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+</style>

--- a/ui/src/components/ManageCategories/CategoriesTable.vue
+++ b/ui/src/components/ManageCategories/CategoriesTable.vue
@@ -1,0 +1,165 @@
+<template>
+  <TableCard class="categories-table">
+    <div class="header">
+      <div class="card-title">Surveillance Categories</div>
+      <Button
+        outlined
+        label="Add New Category"
+        icon="pi pi-plus"
+        data-test="add-category-button"
+        @click="openEditor(null)"
+      />
+    </div>
+
+    <DataTable
+      :value="store.categories"
+      :paginator="store.categories.length > 0"
+      dataKey="name"
+      sortField="name"
+      :sortOrder="1"
+      :rows="10"
+      :rowsPerPageOptions="[10, 20, 50, 100]"
+      class="data-table"
+      data-test="categories-table"
+    >
+      <template #empty>
+        <EmptyList
+          :content="store.loadError ? errorListContent : emptyListContent"
+          data-test="empty-list"
+        />
+      </template>
+      <Column field="name" header="Name" sortable />
+      <Column header="Description">
+        <template #body="{ data }">{{ data.description || '-' }}</template>
+      </Column>
+      <Column header="Actions">
+        <template #body="{ data }">
+          <div class="action-container">
+            <Button
+              text
+              label="Manage Nodes"
+              :aria-label="`Manage nodes in ${data.name}`"
+              data-test="manage-nodes-button"
+              @click="openNodes(data)"
+            />
+            <Button
+              text
+              label="Edit"
+              :aria-label="`Edit ${data.name}`"
+              data-test="edit-category-button"
+              @click="openEditor(data)"
+            />
+            <Button
+              text
+              label="Delete"
+              severity="danger"
+              :aria-label="`Delete ${data.name}`"
+              data-test="delete-category-button"
+              @click="askDelete(data)"
+            />
+          </div>
+        </template>
+      </Column>
+    </DataTable>
+  </TableCard>
+
+  <CategoryEditorDialog v-model:visible="showEditor" :category="categoryToEdit" />
+  <CategoryNodesDialog v-model:visible="showNodes" :categoryName="actionCategoryName" />
+  <OnmsConfirmationDialog
+    :visible="showDeleteConfirmation"
+    title="Delete Surveillance Category"
+    actionButtonText="Delete"
+    @ok="confirmDelete"
+    @cancel="cancelDelete"
+  >
+    <template #content>
+      <p>
+        Are you sure you want to delete the surveillance category
+        <strong>{{ categoryToDelete?.name }}</strong>? Nodes will lose this
+        category, and any group authorizations or filters that reference it by
+        name will no longer match. This action cannot be undone.
+      </p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { OnmsConfirmationDialog } from '@opennms/onms-ui'
+
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+
+import EmptyList from '@/components/Common/EmptyList.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import CategoryEditorDialog from '@/components/ManageCategories/CategoryEditorDialog.vue'
+import CategoryNodesDialog from '@/components/ManageCategories/CategoryNodesDialog.vue'
+import { useCategoryAdminStore } from '@/stores/categoryAdminStore'
+import { AdminCategory } from '@/services/categoryAdminService'
+
+const store = useCategoryAdminStore()
+
+const showEditor = ref(false)
+const categoryToEdit = ref<AdminCategory | null>(null)
+const showNodes = ref(false)
+const actionCategoryName = ref('')
+const showDeleteConfirmation = ref(false)
+const categoryToDelete = ref<AdminCategory | null>(null)
+
+const emptyListContent = { msg: 'No surveillance categories found.' }
+const errorListContent = { msg: 'Could not load surveillance categories. Please retry.' }
+
+const openEditor = (category: AdminCategory | null) => {
+  categoryToEdit.value = category
+  showEditor.value = true
+}
+
+const openNodes = (category: AdminCategory) => {
+  actionCategoryName.value = category.name
+  showNodes.value = true
+}
+
+const askDelete = (category: AdminCategory) => {
+  categoryToDelete.value = category
+  showDeleteConfirmation.value = true
+}
+
+const confirmDelete = async () => {
+  if (categoryToDelete.value) {
+    await store.deleteCategory(categoryToDelete.value.name)
+  }
+  showDeleteConfirmation.value = false
+  categoryToDelete.value = null
+}
+
+const cancelDelete = () => {
+  showDeleteConfirmation.value = false
+  categoryToDelete.value = null
+}
+</script>
+
+<style lang="scss" scoped>
+.categories-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.action-container {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+</style>

--- a/ui/src/components/ManageCategories/CategoryEditorDialog.vue
+++ b/ui/src/components/ManageCategories/CategoryEditorDialog.vue
@@ -1,0 +1,145 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    :header="isEditing ? `Edit Category: ${originalName}` : 'Add New Surveillance Category'"
+    class="category-editor-dialog"
+    :style="{ width: '520px', maxWidth: '95vw' }"
+    data-test="category-editor-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div class="form-column">
+      <Message v-if="errorText" severity="error" :closable="false" data-test="dialog-error">{{ errorText }}</Message>
+
+      <FormField v-if="!isEditing">
+        <IftaLabel>
+          <InputText id="category-name" v-model="name" :invalid="!!nameProblem" data-test="category-name-input" />
+          <label for="category-name">Category Name *</label>
+        </IftaLabel>
+        <small v-if="nameProblem" class="field-error" data-test="name-error">{{ nameProblem }}</small>
+      </FormField>
+
+      <FormField>
+        <IftaLabel>
+          <InputText id="category-description" v-model="description" data-test="category-description-input" />
+          <label for="category-description">Description</label>
+        </IftaLabel>
+        <small class="hint">The category name is the identifier and cannot be changed after creation.</small>
+      </FormField>
+    </div>
+
+    <template #footer>
+      <Button text label="Cancel" data-test="cancel-button" @click="emit('update:visible', false)" />
+      <Button
+        :label="isEditing ? 'Save Category' : 'Add Category'"
+        :disabled="!isValid || saving"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import IftaLabel from 'primevue/iftalabel'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+
+import FormField from '@/components/Common/FormField.vue'
+import { useCategoryAdminStore } from '@/stores/categoryAdminStore'
+import { AdminCategory } from '@/services/categoryAdminService'
+
+const props = defineProps<{
+  visible: boolean
+  category: AdminCategory | null
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const store = useCategoryAdminStore()
+
+const name = ref('')
+const description = ref('')
+const saving = ref(false)
+const errorText = ref('')
+
+const isEditing = computed(() => props.category !== null)
+const originalName = computed(() => props.category?.name ?? '')
+
+// the category name is a URL path segment on write and is matched by name in
+// filters; block characters that break addressing or markup
+const nameProblem = computed(() => {
+  if (isEditing.value) {
+    return null
+  }
+  const trimmed = name.value.trim()
+  if (!trimmed) {
+    return null
+  }
+  // / \ % ? # break URL/path addressing; markup chars are unsafe; , ; = ( ) ! +
+  // break the FIQL category.name== search used to load this category's members
+  if (/[/\\%?#\s&<>"'`,;=()!+]/.test(trimmed)) {
+    return 'The category name must not contain whitespace, markup, or the characters / \\ % ? # , ; = ( ) ! +'
+  }
+  return null
+})
+
+const isValid = computed(() => (isEditing.value || !!name.value.trim()) && !nameProblem.value)
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (!isVisible) {
+      return
+    }
+    errorText.value = ''
+    name.value = props.category?.name ?? ''
+    description.value = props.category?.description ?? ''
+  }
+)
+
+const save = async () => {
+  saving.value = true
+  try {
+    const error = isEditing.value
+      ? await store.updateCategoryDescription(originalName.value, description.value.trim())
+      : await store.createCategory({ name: name.value.trim(), description: description.value.trim() || undefined })
+    if (error === null) {
+      emit('update:visible', false)
+    } else {
+      errorText.value = error
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.form-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 0.5rem;
+
+  :deep(input) {
+    width: 100%;
+  }
+}
+
+.field-error {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-red-500, #e24c4c);
+}
+
+.hint {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-text-muted-color);
+}
+</style>

--- a/ui/src/components/ManageCategories/CategoryNodesDialog.vue
+++ b/ui/src/components/ManageCategories/CategoryNodesDialog.vue
@@ -1,0 +1,318 @@
+<template>
+  <Dialog
+    :visible="visible"
+    modal
+    maximizable
+    :header="`Manage Nodes: ${categoryName}`"
+    class="category-nodes-dialog"
+    :style="{ width: '900px', maxWidth: '95vw' }"
+    data-test="category-nodes-dialog"
+    @update:visible="(value: boolean) => emit('update:visible', value)"
+  >
+    <div v-if="loading" class="loading" data-test="nodes-loading">Loading nodes…</div>
+    <div v-else-if="loadError" class="loading" data-test="nodes-load-error">
+      Could not load nodes for this category. Close the dialog and try again.
+    </div>
+    <template v-else>
+      <p class="hint">
+        Select nodes and move them between <strong>Available</strong> and
+        <strong>In this category</strong>, then Save. Use the search box on either
+        list to narrow it down. Changes are applied per node against the category
+        membership API.
+      </p>
+      <p v-if="hasRequisitioned" class="warn" data-test="requisitioned-warning">
+        Nodes marked <em>(requisitioned)</em> are managed by a requisition —
+        category changes on them are overwritten on the next provisioning
+        synchronization. Set their categories in the requisition instead.
+      </p>
+      <div class="dual-list" data-test="node-dual-list">
+        <div class="list-col">
+          <div class="list-title">Available nodes ({{ available.length }})</div>
+          <Listbox
+            v-model="selectedAvailable"
+            :options="available"
+            optionLabel="label"
+            multiple
+            filter
+            :filterFields="['label']"
+            filterPlaceholder="Search available nodes"
+            listStyle="height: 320px"
+            :virtualScrollerOptions="{ itemSize: 34 }"
+            data-test="available-listbox"
+          >
+            <template #option="{ option }">
+              <span class="node-label">{{ option.label }}</span>
+              <span v-if="option.requisitioned" class="req-tag">(requisitioned)</span>
+            </template>
+          </Listbox>
+        </div>
+
+        <div class="list-actions">
+          <Button
+            icon="pi pi-angle-right"
+            :disabled="!selectedAvailable.length"
+            aria-label="Add selected nodes to the category"
+            title="Add selected"
+            data-test="add-selected"
+            @click="addSelected"
+          />
+          <Button
+            icon="pi pi-angle-double-right"
+            :disabled="!available.length"
+            aria-label="Add all listed available nodes to the category"
+            title="Add all"
+            data-test="add-all"
+            @click="addAll"
+          />
+          <Button
+            icon="pi pi-angle-left"
+            :disabled="!selectedMembers.length"
+            aria-label="Remove selected nodes from the category"
+            title="Remove selected"
+            data-test="remove-selected"
+            @click="removeSelected"
+          />
+          <Button
+            icon="pi pi-angle-double-left"
+            :disabled="!members.length"
+            aria-label="Remove all listed nodes from the category"
+            title="Remove all"
+            data-test="remove-all"
+            @click="removeAll"
+          />
+        </div>
+
+        <div class="list-col">
+          <div class="list-title">In this category ({{ members.length }})</div>
+          <Listbox
+            v-model="selectedMembers"
+            :options="members"
+            optionLabel="label"
+            multiple
+            filter
+            :filterFields="['label']"
+            filterPlaceholder="Search nodes in this category"
+            listStyle="height: 320px"
+            :virtualScrollerOptions="{ itemSize: 34 }"
+            data-test="member-listbox"
+          >
+            <template #option="{ option }">
+              <span class="node-label">{{ option.label }}</span>
+              <span v-if="option.requisitioned" class="req-tag">(requisitioned)</span>
+            </template>
+          </Listbox>
+        </div>
+      </div>
+    </template>
+
+    <template #footer>
+      <Button text label="Close" data-test="close-button" @click="emit('update:visible', false)" />
+      <Button
+        label="Save"
+        :disabled="loading || loadError || saving || !dirty"
+        data-test="save-button"
+        @click="save"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import Listbox from 'primevue/listbox'
+
+import useSnackbar from '@/composables/useSnackbar'
+import API from '@/services'
+import { CategoryNode } from '@/services/categoryAdminService'
+
+const props = defineProps<{
+  visible: boolean
+  categoryName: string
+}>()
+
+const emit = defineEmits(['update:visible'])
+
+const { showSnackBar } = useSnackbar()
+
+const available = ref<CategoryNode[]>([])
+const members = ref<CategoryNode[]>([])
+const selectedAvailable = ref<CategoryNode[]>([])
+const selectedMembers = ref<CategoryNode[]>([])
+const originalMemberIds = ref<Set<number>>(new Set())
+const loading = ref(true)
+const loadError = ref(false)
+const saving = ref(false)
+// bumped on every load(); a stale in-flight load compares unequal and bails out
+// so a slow category-A fetch can't seat its baseline while B is showing
+let loadToken = 0
+
+const byLabel = (a: CategoryNode, b: CategoryNode) => a.label.localeCompare(b.label)
+
+const memberIds = computed(() => new Set(members.value.map((n) => n.id)))
+const dirty = computed(() => {
+  if (memberIds.value.size !== originalMemberIds.value.size) {
+    return true
+  }
+  for (const id of memberIds.value) {
+    if (!originalMemberIds.value.has(id)) {
+      return true
+    }
+  }
+  return false
+})
+
+const hasRequisitioned = computed(() =>
+  available.value.some((n) => n.requisitioned) || members.value.some((n) => n.requisitioned))
+
+const addSelected = () => {
+  const moving = new Set(selectedAvailable.value.map((n) => n.id))
+  members.value = [...members.value, ...selectedAvailable.value].sort(byLabel)
+  available.value = available.value.filter((n) => !moving.has(n.id))
+  selectedAvailable.value = []
+}
+
+const removeSelected = () => {
+  const moving = new Set(selectedMembers.value.map((n) => n.id))
+  available.value = [...available.value, ...selectedMembers.value].sort(byLabel)
+  members.value = members.value.filter((n) => !moving.has(n.id))
+  selectedMembers.value = []
+}
+
+const addAll = () => {
+  members.value = [...members.value, ...available.value].sort(byLabel)
+  available.value = []
+  selectedAvailable.value = []
+}
+
+const removeAll = () => {
+  available.value = [...available.value, ...members.value].sort(byLabel)
+  members.value = []
+  selectedMembers.value = []
+}
+
+const load = async () => {
+  const token = ++loadToken
+  const category = props.categoryName
+  loading.value = true
+  loadError.value = false
+  // clear immediately so the previous category's rows don't flash on reopen
+  available.value = []
+  members.value = []
+  selectedAvailable.value = []
+  selectedMembers.value = []
+  const [all, member] = await Promise.all([API.listAllNodes(), API.listCategoryNodes(category)])
+  // a newer load (or a category switch) superseded this one — discard its result
+  if (token !== loadToken || category !== props.categoryName) {
+    return
+  }
+  // a failed fetch must NOT look like an empty category — otherwise the diff on
+  // Save would try to remove every real member. Surface the error and disable Save.
+  if (all === null || member === null) {
+    available.value = []
+    members.value = []
+    originalMemberIds.value = new Set()
+    loadError.value = true
+    loading.value = false
+    return
+  }
+  const memberSet = new Set(member.map((n) => n.id))
+  originalMemberIds.value = memberSet
+  // seat the members list from the membership fetch itself (not the intersection
+  // with all-nodes) so the Save baseline always matches what's displayed — a node
+  // returned as a member but missing from all-nodes can't arm a phantom removal
+  members.value = member.slice().sort(byLabel)
+  available.value = all.filter((n) => !memberSet.has(n.id)).sort(byLabel)
+  loading.value = false
+}
+
+watch(
+  () => props.visible,
+  (isVisible) => {
+    if (isVisible && props.categoryName) {
+      load()
+    }
+  }
+)
+
+const save = async () => {
+  saving.value = true
+  try {
+    const now = memberIds.value
+    const toAdd = [...now].filter((id) => !originalMemberIds.value.has(id))
+    const toRemove = [...originalMemberIds.value].filter((id) => !now.has(id))
+    const results = await Promise.all([
+      ...toAdd.map((id) => API.addNodeToCategory(props.categoryName, id)),
+      ...toRemove.map((id) => API.removeNodeFromCategory(props.categoryName, id))
+    ])
+    if (results.every(Boolean)) {
+      showSnackBar({ msg: `Category '${props.categoryName}' membership updated.` })
+      emit('update:visible', false)
+    } else {
+      // some calls failed; re-sync from the server so the view is accurate
+      showSnackBar({ msg: 'Some membership changes failed; the list has been refreshed.', error: true })
+      await load()
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.hint {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.875rem;
+  color: var(--p-text-muted-color);
+}
+
+.warn {
+  margin: 0 0 0.75rem 0;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  border-radius: 4px;
+  background: var(--p-yellow-50, #fffbeb);
+  border: 1px solid var(--p-yellow-200, #fde68a);
+  color: var(--p-yellow-800, #854d0e);
+}
+
+.node-label {
+  margin-right: 0.4rem;
+}
+
+.req-tag {
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  font-style: italic;
+}
+
+.loading {
+  padding: 2rem;
+  text-align: center;
+  color: var(--p-text-muted-color);
+}
+
+.dual-list {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  .list-col {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .list-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  .list-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+</style>

--- a/ui/src/containers/ManageCategories.vue
+++ b/ui/src/containers/ManageCategories.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+  <div class="manage-categories-container">
+    <h1 class="page-title">Surveillance Categories</h1>
+    <CategoriesHelpPanel />
+    <CategoriesTable />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import CategoriesHelpPanel from '@/components/ManageCategories/CategoriesHelpPanel.vue'
+import CategoriesTable from '@/components/ManageCategories/CategoriesTable.vue'
+import { useMenuStore } from '@/stores/menuStore'
+import { useCategoryAdminStore } from '@/stores/categoryAdminStore'
+import { BreadCrumb } from '@/types'
+
+const menuStore = useMenuStore()
+const store = useCategoryAdminStore()
+
+const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
+
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Surveillance Categories', to: '#', position: 'last' }
+  ]
+})
+
+onMounted(async () => {
+  await store.getCategories()
+})
+</script>
+
+<style lang="scss" scoped>
+.manage-categories-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 2px 2rem 2px;
+}
+
+.page-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+</style>

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -121,6 +121,24 @@ const router = createRouter({
       }
     },
     {
+      path: '/admin/surveillance-categories',
+      name: 'Surveillance Categories',
+      component: () => import('@/containers/ManageCategories.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'Must be admin to manage surveillance categories.' })
+            router.push(from.path)
+          }
+        }
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
+      }
+    },
+    {
       path: '/configuration',
       name: 'Configuration',
       component: () => import('@/containers/ProvisionDConfig.vue'),

--- a/ui/src/services/categoryAdminService.ts
+++ b/ui/src/services/categoryAdminService.ts
@@ -1,0 +1,212 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import useSnackbar from '@/composables/useSnackbar'
+import useSpinner from '@/composables/useSpinner'
+import { rest, v2 } from './axiosInstances'
+
+// PrimeVue Manage Surveillance Categories (NMS-20131). Reuses existing REST —
+// no backend change: category CRUD via the v1 /rest/categories service, and
+// node membership via its granular /rest/categories/{name}/nodes/{nodeId}
+// sub-resource. Member nodes are read from the v2 node search (the only place
+// that resolves category membership: `_s=category.name==NAME`; the bare
+// ?category= param does NOT filter).
+
+export interface AdminCategory {
+  id?: number
+  name: string
+  description?: string | null
+  authorizedGroups?: string[]
+}
+
+export interface CategoryNode {
+  id: number
+  label: string
+  // set when the node comes from a requisition — category changes on such nodes
+  // are overwritten on the next provisiond synchronization
+  requisitioned?: boolean
+}
+
+const { showSnackBar } = useSnackbar()
+const { startSpinner, stopSpinner } = useSpinner()
+const endpoint = '/categories'
+
+// Only surface a server detail if it looks like a short, plain message — a 500
+// often returns a servlet HTML error page, which must not be shown verbatim.
+const errorMessage = (err: any, fallback: string): string => {
+  const detail = err?.response?.data
+  if (typeof detail === 'string') {
+    const trimmed = detail.trim()
+    if (trimmed && trimmed.length <= 200 && !/[<>]/.test(trimmed)) return trimmed
+  }
+  return fallback
+}
+
+const listCategories = async (): Promise<AdminCategory[] | null> => {
+  try {
+    startSpinner()
+    const resp = await rest.get(endpoint)
+    if (resp.status === 204) {
+      return []
+    }
+    const raw = resp.data?.category ?? []
+    return Array.isArray(raw) ? raw : [raw]
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load surveillance categories.' })
+    return null
+  } finally {
+    stopSpinner()
+  }
+}
+
+const createCategory = async (category: AdminCategory): Promise<string | null> => {
+  try {
+    startSpinner()
+    await rest.post(endpoint, category)
+    showSnackBar({ msg: `Category '${category.name}' created.` })
+    return null
+  } catch (err: any) {
+    const msg = errorMessage(err, `Failed to create category '${category.name}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
+  } finally {
+    stopSpinner()
+  }
+}
+
+// v1 category update is form-urlencoded bean-property update (used for the
+// description; name is the immutable id).
+const updateCategoryDescription = async (name: string, description: string): Promise<string | null> => {
+  try {
+    startSpinner()
+    const body = new URLSearchParams()
+    body.set('description', description)
+    await rest.put(`${endpoint}/${encodeURIComponent(name)}`, body, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    })
+    showSnackBar({ msg: `Category '${name}' updated.` })
+    return null
+  } catch (err: any) {
+    const msg = errorMessage(err, `Failed to update category '${name}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
+  } finally {
+    stopSpinner()
+  }
+}
+
+const deleteCategory = async (name: string): Promise<string | null> => {
+  try {
+    startSpinner()
+    await rest.delete(`${endpoint}/${encodeURIComponent(name)}`)
+    showSnackBar({ msg: `Category '${name}' deleted.` })
+    return null
+  } catch (err: any) {
+    // already gone — the desired end-state holds, so treat it as success
+    if (err?.response?.status === 404) {
+      showSnackBar({ msg: `Category '${name}' deleted.` })
+      return null
+    }
+    const msg = errorMessage(err, `Failed to delete category '${name}'.`)
+    showSnackBar({ msg, error: true })
+    return msg
+  } finally {
+    stopSpinner()
+  }
+}
+
+// all nodes (id + label) as the candidate pool for the assignment picker
+// null (not []) on failure so the caller can tell a failed fetch from an empty
+// result — otherwise a transient error looks like "zero nodes" and can arm a
+// destructive membership diff
+const listAllNodes = async (): Promise<CategoryNode[] | null> => {
+  try {
+    const resp = await v2.get('/nodes?limit=0&orderBy=label')
+    const raw = resp.data?.node ?? []
+    return (Array.isArray(raw) ? raw : [raw]).map(toCategoryNode)
+  } catch (_err) {
+    showSnackBar({ msg: 'Failed to load nodes.' })
+    return null
+  }
+}
+
+const toCategoryNode = (n: any): CategoryNode => ({
+  id: Number(n.id),
+  label: n.label ?? `Node ${n.id}`,
+  requisitioned: !!n.foreignSource
+})
+
+// FIQL treats these as operators/grouping; a category name containing one can't
+// be used in a category.name==NAME selector, so refuse rather than issue a
+// malformed query that could return the wrong members (and arm a bad diff).
+const FIQL_UNSAFE = /[;,()=<>!~]/
+
+// nodes currently in a category — resolved via the node search property that
+// actually filters by membership. null (not []) on failure — see listAllNodes.
+const listCategoryNodes = async (name: string): Promise<CategoryNode[] | null> => {
+  if (FIQL_UNSAFE.test(name)) {
+    showSnackBar({ msg: `Category '${name}' has a name that can't be searched safely; rename it to manage its nodes.`, error: true })
+    return null
+  }
+  try {
+    const resp = await v2.get(`/nodes?limit=0&_s=${encodeURIComponent(`category.name==${name}`)}`)
+    if (resp.status === 204) {
+      return []
+    }
+    const raw = resp.data?.node ?? []
+    return (Array.isArray(raw) ? raw : [raw]).map(toCategoryNode)
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to load nodes for category '${name}'.` })
+    return null
+  }
+}
+
+const addNodeToCategory = async (name: string, nodeId: number): Promise<boolean> => {
+  try {
+    await rest.put(`${endpoint}/${encodeURIComponent(name)}/nodes/${nodeId}`)
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to add node to '${name}'.`, error: true })
+    return false
+  }
+}
+
+const removeNodeFromCategory = async (name: string, nodeId: number): Promise<boolean> => {
+  try {
+    await rest.delete(`${endpoint}/${encodeURIComponent(name)}/nodes/${nodeId}`)
+    return true
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to remove node from '${name}'.`, error: true })
+    return false
+  }
+}
+
+export {
+  addNodeToCategory,
+  createCategory,
+  deleteCategory,
+  listAllNodes,
+  listCategories,
+  listCategoryNodes,
+  removeNodeFromCategory,
+  updateCategoryDescription
+}

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -29,6 +29,16 @@ import {
   getNodeAvailabilityPercentage
 } from './nodeService'
 import { getCategories } from './categoryService'
+import {
+  addNodeToCategory,
+  createCategory,
+  deleteCategory,
+  listAllNodes,
+  listCategories,
+  listCategoryNodes,
+  removeNodeFromCategory,
+  updateCategoryDescription
+} from './categoryAdminService'
 import { getMonitoringLocations } from './monitoringLocationService'
 import { getServiceTypes } from './serviceTypes'
 import { getProvisionDService, putProvisionDService } from './configurationService'
@@ -92,6 +102,14 @@ export default {
   getNodeSnmpInterfaces,
   getNodeAvailabilityPercentage,
   getCategories,
+  addNodeToCategory,
+  createCategory,
+  deleteCategory,
+  listAllNodes,
+  listCategories,
+  listCategoryNodes,
+  removeNodeFromCategory,
+  updateCategoryDescription,
   getMonitoringLocations,
   getLog,
   getLogs,

--- a/ui/src/stores/categoryAdminStore.ts
+++ b/ui/src/stores/categoryAdminStore.ts
@@ -1,0 +1,67 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import API from '@/services'
+import { AdminCategory } from '@/services/categoryAdminService'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useCategoryAdminStore = defineStore('categoryAdminStore', () => {
+  const categories = ref([] as AdminCategory[])
+  const loadError = ref(false)
+
+  const getCategories = async () => {
+    const result = await API.listCategories()
+    if (result !== null) {
+      categories.value = result
+      loadError.value = false
+    } else {
+      loadError.value = true
+    }
+  }
+
+  const createCategory = async (category: AdminCategory) => {
+    const error = await API.createCategory(category)
+    if (error === null) {
+      await getCategories()
+    }
+    return error
+  }
+
+  const updateCategoryDescription = async (name: string, description: string) => {
+    const error = await API.updateCategoryDescription(name, description)
+    if (error === null) {
+      await getCategories()
+    }
+    return error
+  }
+
+  const deleteCategory = async (name: string) => {
+    const error = await API.deleteCategory(name)
+    if (error === null) {
+      await getCategories()
+    }
+    return error
+  }
+
+  return { categories, loadError, getCategories, createCategory, updateCategoryDescription, deleteCategory }
+})

--- a/ui/tests/components/ManageCategories/CategoriesTable.test.ts
+++ b/ui/tests/components/ManageCategories/CategoriesTable.test.ts
@@ -1,0 +1,44 @@
+import CategoriesTable from '@/components/ManageCategories/CategoriesTable.vue'
+import { useCategoryAdminStore } from '@/stores/categoryAdminStore'
+import { createTestingPinia } from '@pinia/testing'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mountTable = () => {
+  const wrapper = mount(CategoriesTable, {
+    global: {
+      plugins: [PrimeVue, createTestingPinia({ createSpy: vi.fn, stubActions: true })],
+      stubs: {
+        CategoryEditorDialog: true, CategoryNodesDialog: true, OnmsConfirmationDialog: true,
+        TableCard: { template: '<div><slot /></div>' }
+      }
+    }
+  })
+  return { wrapper, store: useCategoryAdminStore() }
+}
+
+describe('CategoriesTable.vue', () => {
+  let ctx: ReturnType<typeof mountTable>
+
+  beforeEach(() => {
+    ctx = mountTable()
+  })
+
+  it('renders column headers even when there are no categories', async () => {
+    ctx.store.categories = []
+    await ctx.wrapper.vm.$nextTick()
+    const headers = ctx.wrapper.findAll('th').map((th) => th.text().trim()).filter(Boolean)
+    expect(headers).toContain('Name')
+    expect(headers).toContain('Description')
+    expect(ctx.wrapper.find('[data-test="empty-list"]').exists()).toBe(true)
+  })
+
+  it('renders a row per category with the action buttons', async () => {
+    ctx.store.categories = [{ name: 'Routers', description: 'core' }] as any
+    await ctx.wrapper.vm.$nextTick()
+    expect(ctx.wrapper.find('[data-test="manage-nodes-button"]').exists()).toBe(true)
+    expect(ctx.wrapper.find('[data-test="edit-category-button"]').exists()).toBe(true)
+    expect(ctx.wrapper.find('[data-test="delete-category-button"]').exists()).toBe(true)
+  })
+})

--- a/ui/tests/components/ManageCategories/CategoryNodesDialog.test.ts
+++ b/ui/tests/components/ManageCategories/CategoryNodesDialog.test.ts
@@ -1,0 +1,149 @@
+import CategoryNodesDialog from '@/components/ManageCategories/CategoryNodesDialog.vue'
+import API from '@/services'
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/services', () => ({
+  default: {
+    listAllNodes: vi.fn(),
+    listCategoryNodes: vi.fn(),
+    addNodeToCategory: vi.fn(),
+    removeNodeFromCategory: vi.fn()
+  }
+}))
+
+const DialogStub = {
+  name: 'Dialog',
+  props: ['visible', 'header', 'modal'],
+  template: '<div v-if="visible"><slot /><slot name="footer" /></div>'
+}
+// stub Listbox so we can read its options and drive its selection directly
+const ListboxStub = {
+  name: 'Listbox',
+  props: ['modelValue', 'options'],
+  emits: ['update:modelValue'],
+  template: '<div class="listbox-stub" />'
+}
+
+describe('CategoryNodesDialog.vue', () => {
+  let wrapper: VueWrapper<any>
+
+  const mountDialog = async () => {
+    wrapper = mount(CategoryNodesDialog, {
+      props: { visible: false, categoryName: 'Routers' },
+      global: { plugins: [PrimeVue], stubs: { Dialog: DialogStub, Listbox: ListboxStub } }
+    })
+    await wrapper.setProps({ visible: true })
+    await flushPromises()
+  }
+
+  // [0] = available listbox, [1] = member listbox
+  const listboxes = () => wrapper.findAllComponents(ListboxStub)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(API.listAllNodes).mockResolvedValue([
+      { id: 1, label: 'node-a' }, { id: 2, label: 'node-b' }, { id: 3, label: 'node-c' }
+    ])
+    vi.mocked(API.listCategoryNodes).mockResolvedValue([{ id: 1, label: 'node-a' }])
+    vi.mocked(API.addNodeToCategory).mockResolvedValue(true)
+    vi.mocked(API.removeNodeFromCategory).mockResolvedValue(true)
+  })
+
+  it('splits nodes into available and member lists', async () => {
+    await mountDialog()
+    const [available, member] = listboxes()
+    expect((member.props('options') as any[]).map((n) => n.id)).toEqual([1])
+    expect((available.props('options') as any[]).map((n) => n.id).sort()).toEqual([2, 3])
+  })
+
+  it('applies only the diff (adds newly moved members, removes dropped ones)', async () => {
+    await mountDialog()
+    let [available, member] = listboxes()
+    // select node 2 in available and add it
+    available.vm.$emit('update:modelValue', [{ id: 2, label: 'node-b' }])
+    await flushPromises()
+    await wrapper.find('[data-test="add-selected"]').trigger('click')
+    await flushPromises()
+    // select node 1 in members and remove it
+    ;[available, member] = listboxes()
+    member.vm.$emit('update:modelValue', [{ id: 1, label: 'node-a' }])
+    await flushPromises()
+    await wrapper.find('[data-test="remove-selected"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('[data-test="save-button"]').trigger('click')
+    await flushPromises()
+    expect(API.addNodeToCategory).toHaveBeenCalledWith('Routers', 2)
+    expect(API.removeNodeFromCategory).toHaveBeenCalledWith('Routers', 1)
+    expect(API.addNodeToCategory).toHaveBeenCalledTimes(1)
+    expect(API.removeNodeFromCategory).toHaveBeenCalledTimes(1)
+  })
+
+  it('save is disabled when nothing changed', async () => {
+    await mountDialog()
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('add-all moves every available node into the category', async () => {
+    await mountDialog()
+    await wrapper.find('[data-test="add-all"]').trigger('click')
+    await flushPromises()
+    const [available, member] = listboxes()
+    expect((available.props('options') as any[]).length).toBe(0)
+    expect((member.props('options') as any[]).map((n) => n.id).sort()).toEqual([1, 2, 3])
+  })
+
+  it('shows an error and disables Save when the member fetch fails (never arms a destructive diff)', async () => {
+    vi.mocked(API.listCategoryNodes).mockResolvedValue(null as any)
+    await mountDialog()
+    expect(wrapper.find('[data-test="nodes-load-error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('shows an error and disables Save when the all-nodes fetch fails', async () => {
+    vi.mocked(API.listAllNodes).mockResolvedValue(null as any)
+    await mountDialog()
+    expect(wrapper.find('[data-test="nodes-load-error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('does not arm a removal when a member id is missing from the all-nodes list (TOCTOU)', async () => {
+    // node 9 is a member but was NOT returned by listAllNodes (added/skewed between the two fetches)
+    vi.mocked(API.listAllNodes).mockResolvedValue([{ id: 1, label: 'node-a' }, { id: 2, label: 'node-b' }])
+    vi.mocked(API.listCategoryNodes).mockResolvedValue([{ id: 9, label: 'node-i' }])
+    await mountDialog()
+    // clean on open: Save disabled, and the member appears in the members list
+    expect(wrapper.find('[data-test="save-button"]').attributes('disabled')).toBeDefined()
+    const [, member] = listboxes()
+    expect((member.props('options') as any[]).map((n) => n.id)).toContain(9)
+  })
+
+  it('warns when requisitioned nodes are present', async () => {
+    vi.mocked(API.listAllNodes).mockResolvedValue([{ id: 1, label: 'node-a', requisitioned: true }])
+    vi.mocked(API.listCategoryNodes).mockResolvedValue([])
+    await mountDialog()
+    expect(wrapper.find('[data-test="requisitioned-warning"]').exists()).toBe(true)
+  })
+})
+
+describe('CategoryNodesDialog.vue — real Listbox (filter must actually render)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(API.listAllNodes).mockResolvedValue([{ id: 1, label: 'node-a' }, { id: 2, label: 'node-b' }])
+    vi.mocked(API.listCategoryNodes).mockResolvedValue([])
+  })
+
+  it('renders a real filter/search input on each list (regression: PickList filterBy did nothing in v4)', async () => {
+    const wrapper = mount(CategoryNodesDialog, {
+      props: { visible: false, categoryName: 'Routers' },
+      global: { plugins: [PrimeVue], stubs: { Dialog: DialogStub } }
+    })
+    await wrapper.setProps({ visible: true })
+    await flushPromises()
+    // PrimeVue Listbox renders its filter as an input inside .p-listbox-filter-container
+    const filters = wrapper.findAll('.p-listbox-filter, input[data-pc-name="pcfilter"], .p-listbox-filter-container input')
+    expect(filters.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/ui/tests/services/categoryAdminService.test.ts
+++ b/ui/tests/services/categoryAdminService.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AxiosError, AxiosHeaders } from 'axios'
+import {
+  deleteCategory, listCategories, listAllNodes, listCategoryNodes
+} from '@/services/categoryAdminService'
+import { rest, v2 } from '@/services/axiosInstances'
+
+vi.mock('@/services/axiosInstances', () => ({
+  rest: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+  v2: { get: vi.fn() }
+}))
+vi.mock('@/composables/useSnackbar', () => ({ default: () => ({ showSnackBar: vi.fn() }) }))
+vi.mock('@/composables/useSpinner', () => ({ default: () => ({ startSpinner: vi.fn(), stopSpinner: vi.fn() }) }))
+
+const http = (status: number, data: any = '') => {
+  const e = new AxiosError('x')
+  e.response = { status, data, statusText: '', headers: {}, config: { headers: new AxiosHeaders() } }
+  return e
+}
+
+describe('categoryAdminService', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => vi.restoreAllMocks())
+
+  describe('listCategories', () => {
+    it('returns [] on 204 and normalizes a single object to an array', async () => {
+      vi.mocked(rest.get).mockResolvedValueOnce({ status: 204, data: '' } as any)
+      expect(await listCategories()).toEqual([])
+      vi.mocked(rest.get).mockResolvedValueOnce({ status: 200, data: { category: { name: 'Routers' } } } as any)
+      expect(await listCategories()).toEqual([{ name: 'Routers' }])
+    })
+    it('returns null (not []) on failure so the store can flag a load error', async () => {
+      vi.mocked(rest.get).mockRejectedValueOnce(http(500))
+      expect(await listCategories()).toBeNull()
+    })
+  })
+
+  describe('deleteCategory', () => {
+    it('treats a 404 (already gone) as success', async () => {
+      vi.mocked(rest.delete).mockRejectedValueOnce(http(404))
+      expect(await deleteCategory('gone')).toBeNull()
+    })
+    it('does not surface an HTML error page verbatim', async () => {
+      vi.mocked(rest.delete).mockRejectedValueOnce(http(500, '<html>Internal Server Error</html>'))
+      const msg = await deleteCategory('Routers')
+      expect(msg).not.toContain('<html>')
+      expect(msg).toContain('Routers')
+    })
+  })
+
+  describe('node fetches (the invariant the destructive-diff guard rests on)', () => {
+    it('listAllNodes returns null on failure, and marks requisitioned nodes', async () => {
+      vi.mocked(v2.get).mockRejectedValueOnce(http(500))
+      expect(await listAllNodes()).toBeNull()
+
+      vi.mocked(v2.get).mockResolvedValueOnce({ data: { node: [
+        { id: '1', label: 'auto', foreignSource: null },
+        { id: '2', label: 'req', foreignSource: 'Provisiond' }
+      ] } } as any)
+      const nodes = await listAllNodes()
+      expect(nodes).toEqual([
+        { id: 1, label: 'auto', requisitioned: false },
+        { id: 2, label: 'req', requisitioned: true }
+      ])
+    })
+
+    it('listCategoryNodes returns null on failure', async () => {
+      vi.mocked(v2.get).mockRejectedValueOnce(http(500))
+      expect(await listCategoryNodes('Routers')).toBeNull()
+    })
+
+    it('refuses a FIQL-unsafe category name instead of issuing a malformed query', async () => {
+      const result = await listCategoryNodes('net,core')
+      expect(result).toBeNull()
+      expect(v2.get).not.toHaveBeenCalled()
+    })
+
+    it('builds a category.name== selector for a safe name', async () => {
+      vi.mocked(v2.get).mockResolvedValueOnce({ status: 200, data: { node: [] } } as any)
+      await listCategoryNodes('Routers')
+      expect(vi.mocked(v2.get).mock.calls[0][0]).toContain('category.name%3D%3DRouters')
+    })
+  })
+})

--- a/ui/tests/stores/categoryAdminStore.test.ts
+++ b/ui/tests/stores/categoryAdminStore.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCategoryAdminStore } from '@/stores/categoryAdminStore'
+import API from '@/services'
+
+vi.mock('@/services', () => ({
+  default: {
+    listCategories: vi.fn(),
+    createCategory: vi.fn(),
+    updateCategoryDescription: vi.fn(),
+    deleteCategory: vi.fn()
+  }
+}))
+
+const cat = (name: string) => ({ id: 1, name, description: '', authorizedGroups: [] })
+
+describe('useCategoryAdminStore', () => {
+  let store: ReturnType<typeof useCategoryAdminStore>
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useCategoryAdminStore()
+    vi.clearAllMocks()
+  })
+
+  it('starts empty', () => {
+    expect(store.categories).toEqual([])
+  })
+
+  it('getCategories loads on success and preserves on failure', async () => {
+    vi.mocked(API.listCategories).mockResolvedValue([cat('Routers')])
+    await store.getCategories()
+    expect(store.categories).toEqual([cat('Routers')])
+    expect(store.loadError).toBe(false)
+    vi.mocked(API.listCategories).mockResolvedValue(null)
+    await store.getCategories()
+    expect(store.categories).toEqual([cat('Routers')])
+    expect(store.loadError).toBe(true)
+  })
+
+  it('createCategory refreshes on success, not on failure', async () => {
+    vi.mocked(API.createCategory).mockResolvedValue(null)
+    vi.mocked(API.listCategories).mockResolvedValue([cat('A')])
+    expect(await store.createCategory(cat('A'))).toBeNull()
+    expect(API.listCategories).toHaveBeenCalledTimes(1)
+    vi.clearAllMocks()
+    vi.mocked(API.createCategory).mockResolvedValue('exists')
+    expect(await store.createCategory(cat('A'))).toBe('exists')
+    expect(API.listCategories).not.toHaveBeenCalled()
+  })
+
+  it('updateCategoryDescription passes name+description and refreshes', async () => {
+    vi.mocked(API.updateCategoryDescription).mockResolvedValue(null)
+    vi.mocked(API.listCategories).mockResolvedValue([cat('A')])
+    await store.updateCategoryDescription('A', 'new desc')
+    expect(API.updateCategoryDescription).toHaveBeenCalledWith('A', 'new desc')
+  })
+
+  it('deleteCategory refreshes on success', async () => {
+    vi.mocked(API.deleteCategory).mockResolvedValue(null)
+    vi.mocked(API.listCategories).mockResolvedValue([])
+    await store.deleteCategory('A')
+    expect(store.categories).toEqual([])
+  })
+})


### PR DESCRIPTION
Migrates the Manage Surveillance Categories admin page to a PrimeVue /ui screen. Reuses the existing `/rest/categories` CRUD and the granular node-membership endpoints unchanged — no backend change.

- The menu entry is repointed; `MenuHeaderIT` is updated to assert the new page.
- Node assignment is a server-paged, searchable node table (reusing the Node List's `nodeService`, so it scales to large inventories) with a per-row membership toggle applied immediately.
- Requisitioned nodes are locked by default behind an opt-in override, with a warning that a provisioning sync overwrites their categories.
- Category create/edit and description update are supported; delete shows a generic "may break references" warning (no surveillance-views.xml cross-check — that would require a backend endpoint that does not exist today).
- Category names block URL- and FIQL-unsafe characters (client-side).
- Empty, error, and loading states are handled throughout.
- Component, service, store, and container tests are added.
