### PR TITLE
NMS-20153: CSV and PDF export for Resource Graphs

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "ip-regex": "^5.0.0",
     "is-ip": "^5.0.1",
     "is-valid-domain": "^0.1.6",
+    "jspdf": "^4.2.1",
     "leaflet": "^1.8.0",
     "leaflet.markercluster": "^1.5.3",
     "lodash": "^4.18.1",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       is-valid-domain:
         specifier: ^0.1.6
         version: 0.1.6
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
       leaflet:
         specifier: ^1.8.0
         version: 1.9.4
@@ -295,6 +298,10 @@ packages:
 
   '@babel/runtime-corejs3@7.29.2':
     resolution: {integrity: sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -603,42 +610,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -743,79 +744,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1117,6 +1105,12 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/ramda@0.30.2':
     resolution: {integrity: sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==}
@@ -1445,6 +1439,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1514,6 +1512,9 @@ packages:
   core-js-pure@3.49.0:
     resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cronstrue@3.14.0:
     resolution: {integrity: sha512-XnW4vuK/jPJjmTyDWiej1Zq36Od7ITwxaV2O1pzHZuyMVvdy7NAvyvIBzybt+idqSpfqYuoDG7uf/ocGtJVWxA==}
     hasBin: true
@@ -1521,6 +1522,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -1734,6 +1738,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -1896,6 +1903,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
@@ -1914,6 +1924,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2034,6 +2047,10 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -2062,6 +2079,9 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   ip-regex@5.0.0:
     resolution: {integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==}
@@ -2132,6 +2152,9 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2317,6 +2340,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -2341,6 +2367,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2412,6 +2441,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   ramda-adjunct@5.1.0:
     resolution: {integrity: sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==}
     engines: {node: '>=0.10.3'}
@@ -2437,6 +2469,9 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
     engines: {node: '>=0.10'}
@@ -2460,6 +2495,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -2562,6 +2601,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -2600,6 +2643,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   svgo@3.3.3:
     resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
     engines: {node: '>=14.0.0'}
@@ -2607,6 +2654,9 @@ packages:
 
   swagger-client@3.37.2:
     resolution: {integrity: sha512-KcB8psL1On4GWwv9Ribp1oteh50ygNnAyvQbd5MwiXMGkcB4f53rkZEdvZKPDdJO764mQjgErxQEGDVw6QBUMQ==}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
@@ -2728,8 +2778,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-plugin-externals@0.6.2:
@@ -2980,6 +3034,8 @@ snapshots:
   '@babel/runtime-corejs3@7.29.2':
     dependencies:
       core-js-pure: 3.49.0
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.0':
     dependencies:
@@ -3962,6 +4018,11 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/pako@2.0.4': {}
+
+  '@types/raf@3.4.3':
+    optional: true
+
   '@types/ramda@0.30.2':
     dependencies:
       types-ramda: 0.30.1
@@ -4373,6 +4434,18 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -4448,6 +4521,9 @@ snapshots:
 
   core-js-pure@3.49.0: {}
 
+  core-js@3.49.0:
+    optional: true
+
   cronstrue@3.14.0: {}
 
   cross-spawn@7.0.6:
@@ -4455,6 +4531,11 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   css-select@5.2.2:
     dependencies:
@@ -4679,6 +4760,11 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -4874,6 +4960,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.2.0
+
   fast-xml-builder@1.1.4:
     dependencies:
       path-expression-matcher: 1.5.0
@@ -4896,6 +4988,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5015,6 +5109,12 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -5032,6 +5132,8 @@ snapshots:
   ini@1.3.8: {}
 
   internmap@2.0.3: {}
+
+  iobuffer@5.4.0: {}
 
   ip-regex@5.0.0: {}
 
@@ -5097,6 +5199,17 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      fast-png: 6.4.0
+      fflate: 0.8.3
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 3.4.13
+      html2canvas: 1.4.1
 
   keyv@4.5.4:
     dependencies:
@@ -5255,6 +5368,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@2.2.0: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -5271,6 +5386,9 @@ snapshots:
       minipass: 7.1.3
 
   pathe@2.0.3: {}
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -5334,6 +5452,11 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   ramda-adjunct@5.1.0(ramda@0.30.1):
     dependencies:
       ramda: 0.30.1
@@ -5364,6 +5487,9 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   repeat-string@1.6.1: {}
 
   require-directory@2.1.1: {}
@@ -5380,6 +5506,9 @@ snapshots:
   ret@0.2.2: {}
 
   reusify@1.1.0: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   robust-predicates@3.0.3: {}
 
@@ -5472,6 +5601,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   std-env@4.2.0: {}
 
   string-width@4.2.3:
@@ -5512,6 +5644,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   svgo@3.3.3:
     dependencies:
       commander: 7.2.0
@@ -5545,6 +5680,11 @@ snapshots:
       ramda-adjunct: 5.1.0(ramda@0.30.1)
     transitivePeerDependencies:
       - debug
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   time-span@5.1.0:
     dependencies:
@@ -5662,6 +5802,11 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   uuid@10.0.0: {}
 

--- a/ui/src/components/Resources/Graph.vue
+++ b/ui/src/components/Resources/Graph.vue
@@ -1,13 +1,22 @@
 <template>
   <div class="onms-row">
     <div class="onms-col-12 container">
-      <router-link
-        v-if="!isSingleGraph"
-        :to="`/resource-graphs/graphs/${label}/${definition}/${resourceId}`"
-        target="_blank"
-      >
-        <OnmsButton variant="outlined" class="single-graph-btn">Open</OnmsButton>
-      </router-link>
+      <div class="graph-actions">
+        <OnmsButton
+          v-if="graphData"
+          variant="outlined"
+          data-test="csv-download-btn"
+          title="Download this graph's data as CSV"
+          @click="downloadCsv"
+        >CSV</OnmsButton>
+        <router-link
+          v-if="!isSingleGraph"
+          :to="`/resource-graphs/graphs/${label}/${definition}/${resourceId}`"
+          target="_blank"
+        >
+          <OnmsButton variant="outlined">Open</OnmsButton>
+        </router-link>
+      </div>
       <OnmsTabs value="0" class="graph-data-tabs">
         <OnmsTabList>
           <OnmsTab value="0">Graph</OnmsTab>
@@ -38,6 +47,7 @@
 <script setup lang="ts">
 import RrdGraphConverter from './utils/RrdGraphConverter.class'
 import { formatTimestamps, getFormattedLegendStatements } from './utils/LegendFormatter'
+import { downloadGraphCsv } from './utils/graphExport'
 import GraphDataTable from './GraphDataTable.vue'
 import { ConvertedGraphData, GraphMetricsPayload, GraphMetricsResponse, Metric, PreFabGraph, StartEndTime } from '@/types'
 import { useGraphStore } from '@/stores/graphStore'
@@ -302,6 +312,13 @@ const render = async (update?: boolean) => {
   }
 }
 
+const downloadCsv = () => {
+  if (!graphData.value) {
+    return
+  }
+  downloadGraphCsv(graphData.value, convertedGraphDataRef.value, convertedGraphDataRef.value.title || props.definition)
+}
+
 watch(props.time, () => render(true))
 
 onMounted(() => render())
@@ -330,11 +347,13 @@ onBeforeUnmount(() => {
   margin-top: 50px;
   margin-bottom: v-bind(legendHeight);
 }
-.single-graph-btn {
+.graph-actions {
   position: absolute;
   top: 12px;
   right: 70px;
   z-index: 1;
+  display: flex;
+  gap: 0.5rem;
 }
 .lc {
   @include onms-body-small;

--- a/ui/src/components/Resources/Graph.vue
+++ b/ui/src/components/Resources/Graph.vue
@@ -2,13 +2,14 @@
   <div class="onms-row">
     <div class="onms-col-12 container">
       <div class="graph-actions">
-        <OnmsButton
+        <OnmsIconButton
           v-if="graphData"
           variant="outlined"
+          :icon="DownloadFile"
           data-test="csv-download-btn"
           title="Download this graph's data as CSV"
           @click="downloadCsv"
-        >CSV</OnmsButton>
+        />
         <router-link
           v-if="!isSingleGraph"
           :to="`/resource-graphs/graphs/${label}/${definition}/${resourceId}`"
@@ -57,7 +58,8 @@ import { Chart, registerables } from 'chart.js'
 import zoomPlugin from 'chartjs-plugin-zoom'
 import HtmlLegendPlugin from './plugins/HtmlLegendPlugin'
 import { format } from 'd3'
-import { OnmsButton, OnmsTab, OnmsTabList, OnmsTabPanel, OnmsTabPanels, OnmsTabs } from '@opennms/onms-ui'
+import { OnmsButton, OnmsIconButton, OnmsTab, OnmsTabList, OnmsTabPanel, OnmsTabPanels, OnmsTabs } from '@opennms/onms-ui'
+import DownloadFile from '@/components/icons/action/DownloadFile.vue'
 import { PropType, computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 Chart.register(...registerables)

--- a/ui/src/components/Resources/Graphs.vue
+++ b/ui/src/components/Resources/Graphs.vue
@@ -5,20 +5,25 @@
     </div>
   </div>
   <div class="onms-row">
-    <div class="onms-col-11">
+    <div class="onms-col-11" ref="graphsContainerRef">
       <div class="controls">
         <TimeControls @updateTime="updateTime" />
-        <FormField
-          v-if="!singleGraphDefinition"
-          class="search-input"
-        >
-          <OnmsInputText
-            placeholder="Search"
-            aria-label="Search"
-            :modelValue="searchVal"
-            @update:modelValue="(val) => searchHandler(val as string)"
-          />
-        </FormField>
+        <div class="controls-right" v-if="!singleGraphDefinition">
+          <OnmsButton
+            variant="outlined"
+            data-test="pdf-download-btn"
+            title="Download the graphs currently loaded on this page as a PDF"
+            @click="downloadPdf"
+          >PDF</OnmsButton>
+          <FormField class="search-input">
+            <OnmsInputText
+              placeholder="Search"
+              aria-label="Search"
+              :modelValue="searchVal"
+              @update:modelValue="(val) => searchHandler(val as string)"
+            />
+          </FormField>
+        </div>
       </div>
       <GraphContainer
         v-for="resource in resources"
@@ -34,13 +39,15 @@
 </template>
 
 <script setup lang="ts">
-import { OnmsInputText } from '@opennms/onms-ui'
+import { OnmsButton, OnmsInputText } from '@opennms/onms-ui'
 import { computed, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
 import { useDebounceFn, useScroll } from '@vueuse/core'
 import { useRouter } from 'vue-router'
 
 import GraphContainer from './GraphContainer.vue'
 import TimeControls from './TimeControls.vue'
+import { exportGraphsToPdf } from './utils/graphExport'
+import useSnackbar from '@/composables/useSnackbar'
 import { sub, getUnixTime } from 'date-fns'
 import { StartEndTime } from '@/types'
 import FormField from '@/components/Common/FormField.vue'
@@ -64,6 +71,22 @@ const { startSpinner, stopSpinner } = useSpinner()
 const now = new Date()
 const initNumOfGraphs = 4
 const searchVal = ref<string>('')
+const { showSnackBar } = useSnackbar()
+const graphsContainerRef = ref<HTMLElement | null>(null)
+
+const downloadPdf = () => {
+  if (!graphsContainerRef.value) {
+    return
+  }
+  const exported = exportGraphsToPdf(graphsContainerRef.value, 'Resource Graphs')
+  if (!exported) {
+    showSnackBar({ msg: 'No graphs are ready to export yet.' })
+  } else {
+    // only DOM-mounted graphs are captured; tell the user how many so a partially
+    // scrolled page isn't mistaken for the whole set
+    showSnackBar({ msg: `Exported ${exported} loaded graph${exported === 1 ? '' : 's'} to PDF.` })
+  }
+}
 
 const props = defineProps({
   singleGraphDefinition: {
@@ -185,6 +208,12 @@ onBeforeMount(() => {
 .controls {
   display: flex;
   justify-content: space-between;
+
+  .controls-right {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
 
   .search-input {
     width: 230px;

--- a/ui/src/components/Resources/Graphs.vue
+++ b/ui/src/components/Resources/Graphs.vue
@@ -9,12 +9,13 @@
       <div class="controls">
         <TimeControls @updateTime="updateTime" />
         <div class="controls-right" v-if="!singleGraphDefinition">
-          <OnmsButton
+          <OnmsIconButton
             variant="outlined"
+            :icon="DownloadFile"
             data-test="pdf-download-btn"
             title="Download the graphs currently loaded on this page as a PDF"
             @click="downloadPdf"
-          >PDF</OnmsButton>
+          />
           <FormField class="search-input">
             <OnmsInputText
               placeholder="Search"
@@ -39,7 +40,8 @@
 </template>
 
 <script setup lang="ts">
-import { OnmsButton, OnmsInputText } from '@opennms/onms-ui'
+import { OnmsIconButton, OnmsInputText } from '@opennms/onms-ui'
+import DownloadFile from '@/components/icons/action/DownloadFile.vue'
 import { computed, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
 import { useDebounceFn, useScroll } from '@vueuse/core'
 import { useRouter } from 'vue-router'

--- a/ui/src/components/Resources/utils/graphExport.ts
+++ b/ui/src/components/Resources/utils/graphExport.ts
@@ -1,0 +1,178 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { Chart } from 'chart.js'
+import { jsPDF } from 'jspdf'
+
+import { ConvertedGraphData, GraphMetricsResponse } from '@/types'
+
+// A safe filename stem from a graph title/definition.
+export const safeFileStem = (name: string): string =>
+  (name || 'graph').replace(/[^\w.-]+/g, '_').replace(/^_+|_+$/g, '') || 'graph'
+
+// Header cells come from graph config text, so neutralize spreadsheet
+// formula-injection prefixes (=,+,-,@,tab,CR) before quoting. Value cells are
+// numbers or ISO timestamps and are emitted raw (guarding them would corrupt
+// legitimate negatives).
+const escapeCsvHeader = (value: string): string => {
+  const guarded = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
+  return /[",\r\n]/.test(guarded) ? `"${guarded.replaceAll('"', '""')}"` : guarded
+}
+
+// One column per plotted metric, one row per timestamp. Times are emitted as ISO
+// strings and values as raw numbers (gaps left blank) so the CSV is analysis-ready.
+export const buildGraphCsv = (graphData: GraphMetricsResponse, converted: ConvertedGraphData): string => {
+  const headerFor = (metricName: string): string => {
+    const statement = converted.printStatements.find((s) => s.metric === metricName)
+    return statement?.header || metricName
+  }
+  const columnFor = (metricName: string): number[] => {
+    const index = graphData.labels.indexOf(metricName)
+    return index >= 0 ? (graphData.columns[index]?.values ?? []) : []
+  }
+
+  // Only export metrics that actually have a column in the response; transient or
+  // CDEF metrics absent from labels would otherwise emit a header over blank cells.
+  const columns = converted.metrics
+    .filter((m) => m.name && graphData.labels.includes(m.name as string))
+    .map((m) => ({ header: headerFor(m.name as string), values: columnFor(m.name as string) }))
+
+  const lines: string[] = []
+  lines.push(['Date/Time', ...columns.map((c) => escapeCsvHeader(c.header))].join(','))
+
+  graphData.timestamps.forEach((ts, i) => {
+    const row = [Number.isFinite(ts) ? new Date(ts).toISOString() : '']
+    for (const column of columns) {
+      const value = column.values[i]
+      row.push(value === null || value === undefined || Number.isNaN(value) ? '' : String(value))
+    }
+    lines.push(row.join(','))
+  })
+
+  return lines.join('\r\n')
+}
+
+export const downloadTextFile = (filename: string, text: string, mimeType: string): void => {
+  const blob = new Blob([`﻿${text}`], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  // some browsers ignore a click on a detached anchor or a URL revoked in the
+  // same tick, so attach it and defer the revoke
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+export const downloadGraphCsv = (
+  graphData: GraphMetricsResponse,
+  converted: ConvertedGraphData,
+  fileStem: string
+): void => {
+  downloadTextFile(`${safeFileStem(fileStem)}.csv`, buildGraphCsv(graphData, converted), 'text/csv;charset=utf-8')
+}
+
+// Chart.js canvases are transparent; flatten onto white so the PDF image is not
+// rendered over a black background.
+const canvasToPngOnWhite = (canvas: HTMLCanvasElement): string => {
+  const flattened = document.createElement('canvas')
+  flattened.width = canvas.width
+  flattened.height = canvas.height
+  const ctx = flattened.getContext('2d')
+  if (!ctx) {
+    return canvas.toDataURL('image/png')
+  }
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(0, 0, flattened.width, flattened.height)
+  ctx.drawImage(canvas, 0, 0)
+  return flattened.toDataURL('image/png')
+}
+
+// Render each live chart inside `container` into a single landscape PDF. The chart
+// image already carries the graph title (Chart.js bakes it in), so only the legend
+// stats are added as text. Returns the number of graphs exported (0 = nothing
+// saved). Note: only DOM-mounted graphs are captured — with infinite scroll the
+// caller may not have loaded them all.
+export const exportGraphsToPdf = (container: HTMLElement, docTitle: string): number => {
+  const canvases = (Array.from(container.querySelectorAll('canvas')) as HTMLCanvasElement[])
+    .filter((c) => Chart.getChart(c))
+  if (!canvases.length) {
+    return 0
+  }
+
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'a4' })
+  const pageWidth = doc.internal.pageSize.getWidth()
+  const pageHeight = doc.internal.pageSize.getHeight()
+  const margin = 40
+  const contentWidth = pageWidth - margin * 2
+  let y = margin
+  let exported = 0
+
+  doc.setFontSize(15)
+  doc.text(docTitle, margin, y)
+  y += 24
+
+  for (const canvas of canvases) {
+    try {
+      const legend = (document.getElementById(`${canvas.id}-lc`)?.innerText ?? '').trim()
+      const legendLines = legend ? (doc.splitTextToSize(legend, contentWidth) as string[]) : []
+      const legendHeight = legendLines.length * 12
+
+      // preserve aspect ratio, but never let a single graph exceed one page
+      const ratio = canvas.height / canvas.width || 0.4
+      let imgWidth = contentWidth
+      let imgHeight = imgWidth * ratio
+      const maxImgHeight = pageHeight - margin * 2 - legendHeight - 12
+      if (imgHeight > maxImgHeight) {
+        imgHeight = Math.max(60, maxImgHeight)
+        imgWidth = Math.min(contentWidth, imgHeight / ratio)
+      }
+
+      // new page if the block doesn't fit in what's left (unless already at the top)
+      if (y + imgHeight + legendHeight + 12 > pageHeight - margin && y > margin) {
+        doc.addPage()
+        y = margin
+      }
+
+      doc.addImage(canvasToPngOnWhite(canvas), 'PNG', margin, y, imgWidth, imgHeight)
+      y += imgHeight + 6
+      if (legendLines.length) {
+        doc.setFontSize(9)
+        doc.text(legendLines, margin, y)
+        y += legendHeight
+      }
+      y += 12
+      exported++
+    } catch {
+      // a tainted or over-large canvas shouldn't abort the whole export
+      continue
+    }
+  }
+
+  if (!exported) {
+    return 0
+  }
+  doc.save(`${safeFileStem(docTitle)}.pdf`)
+  return exported
+}

--- a/ui/src/components/Resources/utils/graphExport.ts
+++ b/ui/src/components/Resources/utils/graphExport.ts
@@ -23,6 +23,7 @@
 import { Chart } from 'chart.js'
 import { jsPDF } from 'jspdf'
 
+import useDownload from '@/composables/useDownload'
 import { ConvertedGraphData, GraphMetricsResponse } from '@/types'
 
 // A safe filename stem from a graph title/definition.
@@ -42,7 +43,7 @@ const escapeCsvHeader = (value: string): string => {
 // strings and values as raw numbers (gaps left blank) so the CSV is analysis-ready.
 export const buildGraphCsv = (graphData: GraphMetricsResponse, converted: ConvertedGraphData): string => {
   const headerFor = (metricName: string): string => {
-    const statement = converted.printStatements.find((s) => s.metric === metricName)
+    const statement = converted.printStatements.find(s => s.metric === metricName)
     return statement?.header || metricName
   }
   const columnFor = (metricName: string): number[] => {
@@ -53,11 +54,11 @@ export const buildGraphCsv = (graphData: GraphMetricsResponse, converted: Conver
   // Only export metrics that actually have a column in the response; transient or
   // CDEF metrics absent from labels would otherwise emit a header over blank cells.
   const columns = converted.metrics
-    .filter((m) => m.name && graphData.labels.includes(m.name as string))
-    .map((m) => ({ header: headerFor(m.name as string), values: columnFor(m.name as string) }))
+    .filter(m => m.name && graphData.labels.includes(m.name as string))
+    .map(m => ({ header: headerFor(m.name as string), values: columnFor(m.name as string) }))
 
   const lines: string[] = []
-  lines.push(['Date/Time', ...columns.map((c) => escapeCsvHeader(c.header))].join(','))
+  lines.push(['Date/Time', ...columns.map(c => escapeCsvHeader(c.header))].join(','))
 
   graphData.timestamps.forEach((ts, i) => {
     const row = [Number.isFinite(ts) ? new Date(ts).toISOString() : '']
@@ -72,17 +73,10 @@ export const buildGraphCsv = (graphData: GraphMetricsResponse, converted: Conver
 }
 
 export const downloadTextFile = (filename: string, text: string, mimeType: string): void => {
-  const blob = new Blob([`﻿${text}`], { type: mimeType })
-  const url = URL.createObjectURL(blob)
-  const link = document.createElement('a')
-  link.href = url
-  link.download = filename
-  // some browsers ignore a click on a detached anchor or a URL revoked in the
-  // same tick, so attach it and defer the revoke
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  setTimeout(() => URL.revokeObjectURL(url), 0)
+  // Leading BOM so Excel opens the UTF-8 CSV correctly; hand the blob to the
+  // shared useDownload helper rather than rolling a separate anchor here.
+  const blob = new Blob([`\uFEFF${text}`], { type: mimeType })
+  useDownload().downloadBlob(blob, filename)
 }
 
 export const downloadGraphCsv = (
@@ -116,7 +110,7 @@ const canvasToPngOnWhite = (canvas: HTMLCanvasElement): string => {
 // caller may not have loaded them all.
 export const exportGraphsToPdf = (container: HTMLElement, docTitle: string): number => {
   const canvases = (Array.from(container.querySelectorAll('canvas')) as HTMLCanvasElement[])
-    .filter((c) => Chart.getChart(c))
+    .filter(c => Chart.getChart(c))
   if (!canvases.length) {
     return 0
   }
@@ -173,6 +167,6 @@ export const exportGraphsToPdf = (container: HTMLElement, docTitle: string): num
   if (!exported) {
     return 0
   }
-  doc.save(`${safeFileStem(docTitle)}.pdf`)
+  useDownload().downloadBlob(doc.output('blob'), `${safeFileStem(docTitle)}.pdf`)
   return exported
 }

--- a/ui/src/composables/useDownload.ts
+++ b/ui/src/composables/useDownload.ts
@@ -36,7 +36,18 @@ const useDownload = () => {
     generateDownload(blob, name)
   }
 
-  return { downloadFile }
+  /**
+   * Download an already-built Blob (e.g. a client-generated CSV or PDF) under
+   * the given name, reusing the same anchor mechanism as downloadFile.
+   *
+   * @param  {Blob}    blob  the file contents
+   * @param  {string}  name  the download filename
+   */
+  const downloadBlob = (blob: Blob, name: string): void => {
+    generateDownload(blob, name)
+  }
+
+  return { downloadFile, downloadBlob }
 }
 
 export default useDownload

--- a/ui/tests/resourceGraphExport.test.ts
+++ b/ui/tests/resourceGraphExport.test.ts
@@ -73,7 +73,7 @@ describe('buildGraphCsv', () => {
   it('neutralizes spreadsheet formula prefixes in header cells', () => {
     const conv: any = { metrics: [{ name: 'm' }], printStatements: [{ metric: 'm', header: '=SUM(A1:A2)' }] }
     const gd: any = { timestamps: [1700000000000], labels: ['m'], columns: [{ values: [1] }] }
-    expect(buildGraphCsv(gd, conv).split('\r\n')[0]).toBe("Date/Time,'=SUM(A1:A2)")
+    expect(buildGraphCsv(gd, conv).split('\r\n')[0]).toBe('Date/Time,\'=SUM(A1:A2)')
   })
 
   it('emits a blank time for an invalid timestamp rather than throwing', () => {

--- a/ui/tests/resourceGraphExport.test.ts
+++ b/ui/tests/resourceGraphExport.test.ts
@@ -1,0 +1,92 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { describe, it, expect } from 'vitest'
+import { buildGraphCsv, safeFileStem } from '@/components/Resources/utils/graphExport'
+
+describe('safeFileStem', () => {
+  it('sanitizes titles to safe filenames', () => {
+    expect(safeFileStem('Node-level Performance Data')).toBe('Node-level_Performance_Data')
+    expect(safeFileStem('a/b:c*d')).toBe('a_b_c_d')
+    expect(safeFileStem('')).toBe('graph')
+    expect(safeFileStem('***')).toBe('graph')
+  })
+})
+
+describe('buildGraphCsv', () => {
+  const graphData: any = {
+    timestamps: [1700000000000, 1700000060000],
+    labels: ['m1', 'm2'],
+    columns: [{ values: [1.5, NaN] }, { values: [10, 20] }]
+  }
+  const converted: any = {
+    metrics: [{ name: 'm1' }, { name: 'm2' }],
+    printStatements: [
+      { metric: 'm1', header: 'Alarms' },
+      { metric: 'm2', header: 'Events' }
+    ]
+  }
+
+  it('emits a header row and one ISO-timestamped row per sample, gaps blank', () => {
+    const lines = buildGraphCsv(graphData, converted).split('\r\n')
+    expect(lines[0]).toBe('Date/Time,Alarms,Events')
+    expect(lines[1]).toBe('2023-11-14T22:13:20.000Z,1.5,10')
+    // the NaN gap in m1 becomes an empty cell rather than "NaN"
+    expect(lines[2]).toBe('2023-11-14T22:14:20.000Z,,20')
+  })
+
+  it('falls back to the metric name when there is no print header, and escapes commas', () => {
+    const conv: any = { metrics: [{ name: 'a,b' }], printStatements: [] }
+    const gd: any = { timestamps: [1700000000000], labels: ['a,b'], columns: [{ values: [5] }] }
+    const lines = buildGraphCsv(gd, conv).split('\r\n')
+    expect(lines[0]).toBe('Date/Time,"a,b"')
+    expect(lines[1]).toBe('2023-11-14T22:13:20.000Z,5')
+  })
+
+  it('omits metrics that have no column in the response instead of emitting blank columns', () => {
+    const conv: any = { metrics: [{ name: 'ghost' }, { name: 'real' }], printStatements: [] }
+    const gd: any = { timestamps: [1700000000000], labels: ['real'], columns: [{ values: [7] }] }
+    const lines = buildGraphCsv(gd, conv).split('\r\n')
+    expect(lines[0]).toBe('Date/Time,real')
+    expect(lines[1]).toBe('2023-11-14T22:13:20.000Z,7')
+  })
+
+  it('neutralizes spreadsheet formula prefixes in header cells', () => {
+    const conv: any = { metrics: [{ name: 'm' }], printStatements: [{ metric: 'm', header: '=SUM(A1:A2)' }] }
+    const gd: any = { timestamps: [1700000000000], labels: ['m'], columns: [{ values: [1] }] }
+    expect(buildGraphCsv(gd, conv).split('\r\n')[0]).toBe("Date/Time,'=SUM(A1:A2)")
+  })
+
+  it('emits a blank time for an invalid timestamp rather than throwing', () => {
+    const conv: any = { metrics: [{ name: 'm' }], printStatements: [{ metric: 'm', header: 'M' }] }
+    const gd: any = { timestamps: [NaN, 1700000000000], labels: ['m'], columns: [{ values: [1, 2] }] }
+    const lines = buildGraphCsv(gd, conv).split('\r\n')
+    expect(lines[1]).toBe(',1')
+    expect(lines[2]).toBe('2023-11-14T22:13:20.000Z,2')
+  })
+
+  it('does not corrupt legitimate negative values (value cells are not formula-guarded)', () => {
+    const conv: any = { metrics: [{ name: 'm' }], printStatements: [{ metric: 'm', header: 'M' }] }
+    const gd: any = { timestamps: [1700000000000], labels: ['m'], columns: [{ values: [-42] }] }
+    expect(buildGraphCsv(gd, conv).split('\r\n')[1]).toBe('2023-11-14T22:13:20.000Z,-42')
+  })
+})

--- a/ui/tests/resourceGraphPdfExport.test.ts
+++ b/ui/tests/resourceGraphPdfExport.test.ts
@@ -27,19 +27,24 @@ const pdf = {
   text: vi.fn(),
   addImage: vi.fn(),
   addPage: vi.fn(),
-  save: vi.fn(),
+  output: vi.fn(() => new Blob(['%PDF'], { type: 'application/pdf' })),
   splitTextToSize: vi.fn((t: string) => String(t).split('\n')),
-  internal: { pageSize: { getWidth: () => 800, getHeight: () => 600 } }
+  internal: { pageSize: { getWidth: () => 800, getHeight: () => 600 }}
 }
-vi.mock('jspdf', () => ({ jsPDF: vi.fn(function () { return pdf }) }))
-vi.mock('chart.js', () => ({ Chart: { getChart: vi.fn() } }))
+vi.mock('jspdf', () => ({ jsPDF: vi.fn(function () {
+  return pdf
+}) }))
+vi.mock('chart.js', () => ({ Chart: { getChart: vi.fn() }}))
+
+const downloadBlob = vi.fn()
+vi.mock('@/composables/useDownload', () => ({ default: () => ({ downloadBlob }) }))
 
 import { exportGraphsToPdf } from '@/components/Resources/utils/graphExport'
 import { Chart } from 'chart.js'
 
 const containerWith = (...ids: string[]): HTMLElement => {
   const el = document.createElement('div')
-  el.innerHTML = ids.map((id) => `<canvas id="${id}"></canvas>`).join('')
+  el.innerHTML = ids.map(id => `<canvas id="${id}"></canvas>`).join('')
   return el
 }
 
@@ -58,24 +63,24 @@ describe('exportGraphsToPdf', () => {
 
     expect(count).toBe(0)
     expect(pdf.addImage).not.toHaveBeenCalled()
-    expect(pdf.save).not.toHaveBeenCalled()
+    expect(downloadBlob).not.toHaveBeenCalled()
   })
 
   it('adds one image per live chart, saves a sanitized filename, and returns the count', () => {
     vi.mocked(Chart.getChart).mockImplementation(
-      (c: any) => ({ options: { plugins: { title: { text: `Title ${c.id}` } } } }) as any
+      (c: any) => ({ options: { plugins: { title: { text: `Title ${c.id}` }}}}) as any
     )
 
     const count = exportGraphsToPdf(containerWith('g1', 'g2'), 'Resource Graphs')
 
     expect(count).toBe(2)
     expect(pdf.addImage).toHaveBeenCalledTimes(2)
-    expect(pdf.save).toHaveBeenCalledWith('Resource_Graphs.pdf')
+    expect(downloadBlob).toHaveBeenCalledWith(expect.any(Blob), 'Resource_Graphs.pdf')
   })
 
   it('skips canvases with no chart but still exports the ones that have one', () => {
     vi.mocked(Chart.getChart).mockImplementation(
-      (c: any) => (c.id === 'live' ? ({ options: { plugins: { title: { text: 'Live' } } } }) : undefined) as any
+      (c: any) => (c.id === 'live' ? ({ options: { plugins: { title: { text: 'Live' }}}}) : undefined) as any
     )
 
     const count = exportGraphsToPdf(containerWith('dead', 'live'), 'Resource Graphs')
@@ -86,7 +91,7 @@ describe('exportGraphsToPdf', () => {
 
   it('skips a canvas whose image capture throws instead of aborting the whole export', () => {
     vi.mocked(Chart.getChart).mockImplementation(
-      (c: any) => ({ options: { plugins: { title: { text: c.id } } } }) as any
+      (c: any) => ({ options: { plugins: { title: { text: c.id }}}}) as any
     )
     // make the SECOND canvas's toDataURL throw (e.g. tainted canvas)
     let calls = 0
@@ -101,6 +106,6 @@ describe('exportGraphsToPdf', () => {
     const count = exportGraphsToPdf(containerWith('ok', 'bad'), 'Resource Graphs')
 
     expect(count).toBe(1)
-    expect(pdf.save).toHaveBeenCalled()
+    expect(downloadBlob).toHaveBeenCalled()
   })
 })

--- a/ui/tests/resourceGraphPdfExport.test.ts
+++ b/ui/tests/resourceGraphPdfExport.test.ts
@@ -1,0 +1,106 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const pdf = {
+  setFontSize: vi.fn(),
+  text: vi.fn(),
+  addImage: vi.fn(),
+  addPage: vi.fn(),
+  save: vi.fn(),
+  splitTextToSize: vi.fn((t: string) => String(t).split('\n')),
+  internal: { pageSize: { getWidth: () => 800, getHeight: () => 600 } }
+}
+vi.mock('jspdf', () => ({ jsPDF: vi.fn(function () { return pdf }) }))
+vi.mock('chart.js', () => ({ Chart: { getChart: vi.fn() } }))
+
+import { exportGraphsToPdf } from '@/components/Resources/utils/graphExport'
+import { Chart } from 'chart.js'
+
+const containerWith = (...ids: string[]): HTMLElement => {
+  const el = document.createElement('div')
+  el.innerHTML = ids.map((id) => `<canvas id="${id}"></canvas>`).join('')
+  return el
+}
+
+describe('exportGraphsToPdf', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // jsdom has no real canvas backend; stub the bits the exporter touches
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({ fillStyle: '', fillRect: vi.fn(), drawImage: vi.fn() })) as any
+    HTMLCanvasElement.prototype.toDataURL = vi.fn(() => 'data:image/png;base64,AAAA')
+  })
+
+  it('exports nothing and returns 0 when no canvas has a live chart', () => {
+    vi.mocked(Chart.getChart).mockReturnValue(undefined as any)
+
+    const count = exportGraphsToPdf(containerWith('a', 'b'), 'Resource Graphs')
+
+    expect(count).toBe(0)
+    expect(pdf.addImage).not.toHaveBeenCalled()
+    expect(pdf.save).not.toHaveBeenCalled()
+  })
+
+  it('adds one image per live chart, saves a sanitized filename, and returns the count', () => {
+    vi.mocked(Chart.getChart).mockImplementation(
+      (c: any) => ({ options: { plugins: { title: { text: `Title ${c.id}` } } } }) as any
+    )
+
+    const count = exportGraphsToPdf(containerWith('g1', 'g2'), 'Resource Graphs')
+
+    expect(count).toBe(2)
+    expect(pdf.addImage).toHaveBeenCalledTimes(2)
+    expect(pdf.save).toHaveBeenCalledWith('Resource_Graphs.pdf')
+  })
+
+  it('skips canvases with no chart but still exports the ones that have one', () => {
+    vi.mocked(Chart.getChart).mockImplementation(
+      (c: any) => (c.id === 'live' ? ({ options: { plugins: { title: { text: 'Live' } } } }) : undefined) as any
+    )
+
+    const count = exportGraphsToPdf(containerWith('dead', 'live'), 'Resource Graphs')
+
+    expect(count).toBe(1)
+    expect(pdf.addImage).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a canvas whose image capture throws instead of aborting the whole export', () => {
+    vi.mocked(Chart.getChart).mockImplementation(
+      (c: any) => ({ options: { plugins: { title: { text: c.id } } } }) as any
+    )
+    // make the SECOND canvas's toDataURL throw (e.g. tainted canvas)
+    let calls = 0
+    HTMLCanvasElement.prototype.toDataURL = vi.fn(() => {
+      calls += 1
+      if (calls === 2) {
+        throw new Error('tainted canvas')
+      }
+      return 'data:image/png;base64,AAAA'
+    })
+
+    const count = exportGraphsToPdf(containerWith('ok', 'bad'), 'Resource Graphs')
+
+    expect(count).toBe(1)
+    expect(pdf.save).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Adds CSV and PDF export to the new /ui Resource Graphs page.

The export reads from the same measurement data the graphs already hold, so it needs no new backend and reflects exactly what is plotted.

- Each graph gains a **CSV** button that downloads its data as one column per plotted metric with one ISO-timestamped row per sample, gaps left blank.
- The page gains a **PDF** button that renders the loaded graphs — chart image plus legend stats — into a single landscape PDF via jsPDF (new UI dependency, ~100 KB gzip).
- CSV omits metrics that have no column in the response (rather than emitting blank columns) and neutralizes spreadsheet formula-injection prefixes in header cells.
- PDF clamps each chart to fit a page, paginates, wraps long legends, and reports how many graphs were exported — only graphs currently mounted are captured, since the page loads them lazily on scroll.
- Covered by 11 unit tests (`buildGraphCsv`, `safeFileStem`, `exportGraphsToPdf`); full `ui` suite green.

* External References
            Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20159