### PR TITLE
NMS-20159: Run pnpm lint in CI for UI builds

### DIFF
--- a/.circleci/main/jobs/build/build-ui.yml
+++ b/.circleci/main/jobs/build/build-ui.yml
@@ -6,4 +6,4 @@ jobs:
       - run:
           name: Build
           command: |
-            cd ui && pnpm install && pnpm build:all && pnpm test
+            cd ui && pnpm install && pnpm lint && pnpm build:all && pnpm test


### PR DESCRIPTION
Enforce running the linter in CI builds for `/ui`.

This is particularly important to enforce the ban on direct PrimeVue (or other) imports and to enforce some basic formatting rules.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20159
