### PR TITLE
NMS-20164: Lock OSGi resolved dependencies to the root pom versions

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -104,6 +104,46 @@
               </artifactItems>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-jaxrs-feature</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.eclipsesource.jaxrs</groupId>
+                  <artifactId>features</artifactId>
+                  <version>${osgiJaxRsVersion}</version>
+                  <classifier>features</classifier>
+                  <type>xml</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/downloaded-features</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-newts-feature</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.opennms.newts</groupId>
+                  <artifactId>newts-karaf</artifactId>
+                  <version>${newtsVersion}</version>
+                  <classifier>features</classifier>
+                  <type>xml</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/downloaded-features</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -155,6 +195,70 @@
                 <replacement>
                   <token>com\.fasterxml\.jackson\.([a-z]+)/([a-zA-Z0-9._-]+)/2\.[0-9]+[0-9.]*</token>
                   <value>com.fasterxml.jackson.$1/$2/${jackson2Version}</value>
+                </replacement>
+              </replacements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>exec-jaxrs</id>
+            <phase>package</phase>
+            <goals>
+              <goal>replace</goal>
+            </goals>
+            <configuration>
+              <file>${project.build.directory}/downloaded-features/features-${osgiJaxRsVersion}-features.xml</file>
+              <replacements>
+                <!-- Lock Jackson to our version -->
+                <replacement>
+                  <token>com\.fasterxml\.jackson\.([a-z]+)/([a-zA-Z0-9._-]+)/2\.[0-9]+[0-9.]*</token>
+                  <value>com.fasterxml.jackson.$1/$2/${jackson2Version}</value>
+                </replacement>
+                <!-- keep the "jackson" feature version and its consumers in step with the bundles above -->
+                <replacement>
+                  <token>name="jackson" version="2\.9\.8"</token>
+                  <value>name="jackson" version="${jackson2Version}"</value>
+                </replacement>
+                <replacement>
+                  <token><![CDATA[<feature version="2\.9\.8">jackson</feature>]]></token>
+                  <value><![CDATA[<feature version="${jackson2Version}">jackson</feature>]]></value>
+                </replacement>
+              </replacements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>exec-newts</id>
+            <phase>package</phase>
+            <goals>
+              <goal>replace</goal>
+            </goals>
+            <configuration>
+              <file>${project.build.directory}/downloaded-features/newts-karaf-${newtsVersion}-features.xml</file>
+              <replacements>
+                <!-- Lock Jackson to our version, feature label included -->
+                <replacement>
+                  <token>com\.fasterxml\.jackson\.([a-z]+)/([a-zA-Z0-9._-]+)/2\.[0-9]+[0-9.]*</token>
+                  <value>com.fasterxml.jackson.$1/$2/${jackson2Version}</value>
+                </replacement>
+                <replacement>
+                  <token>(name="fastxml-jackson"[^>]*version=)"2\.5\.4"</token>
+                  <value>$1"${jackson2Version}"</value>
+                </replacement>
+                <!-- Lock Netty to our version. The feature label stays 4.0.56.Final on purpose:
+                     nothing references it by version, and renaming it would collide with our own
+                     netty/${netty4Version} feature. -->
+                <replacement>
+                  <token>io\.netty/([a-zA-Z0-9._-]+)/4\.0\.56\.Final</token>
+                  <value>io.netty/$1/${netty4Version}</value>
+                </replacement>
+                <!-- Lock Guava to our version (Newts 1.5.7 imports [18.0,26)) -->
+                <replacement>
+                  <token>com\.google\.guava/guava/18\.0</token>
+                  <value>com.google.guava/guava/${guavaVersion}</value>
+                </replacement>
+                <!-- Lock the Cassandra driver to our version; label left alone as above -->
+                <replacement>
+                  <token>com\.datastax\.cassandra/cassandra-driver-core/3\.5\.0</token>
+                  <value>com.datastax.cassandra/cassandra-driver-core/${cassandraVersion}</value>
                 </replacement>
               </replacements>
             </configuration>
@@ -213,6 +317,16 @@
                   <type>xml</type>
                   <classifier>camel</classifier>
                 </artifact>
+                <artifact>
+                  <file>${project.build.directory}/downloaded-features/features-${osgiJaxRsVersion}-features.xml</file>
+                  <type>xml</type>
+                  <classifier>jaxrs</classifier>
+                </artifact>
+                <artifact>
+                  <file>${project.build.directory}/downloaded-features/newts-karaf-${newtsVersion}-features.xml</file>
+                  <type>xml</type>
+                  <classifier>newts</classifier>
+                </artifact>
               </artifacts>
             </configuration>
           </execution>
@@ -236,13 +350,14 @@
                       <descriptors>
                           <descriptor>mvn:org.apache.karaf.features/framework/${karafVersion}/xml/features</descriptor>
                           <descriptor>mvn:org.apache.karaf.features/standard/${karafVersion}/xml/features</descriptor>
-                          <descriptor>mvn:org.opennms.newts/newts-karaf/${newtsVersion}/xml/features</descriptor>
+                          <descriptor>file:${project.build.directory}/downloaded-features/newts-karaf-${newtsVersion}-features.xml</descriptor>
                           <descriptor>file:${project.build.directory}/classes/features.xml</descriptor>
                           <descriptor>file:${project.build.directory}/classes/features-core.xml</descriptor>
                           <descriptor>file:${project.build.directory}/classes/features-experimental.xml</descriptor>
                           <descriptor>file:${project.build.directory}/classes/features-minion.xml</descriptor>
                           <descriptor>file:${project.build.directory}/classes/features-sentinel.xml</descriptor>
                           <descriptor>file:${project.build.directory}/downloaded-features/apache-camel-${camelVersion}-features.xml</descriptor>
+                          <descriptor>file:${project.build.directory}/downloaded-features/features-${osgiJaxRsVersion}-features.xml</descriptor>
                           <descriptor>file:${project.build.directory}/classes/karaf-extensions.xml</descriptor>
                           <descriptor>file:${project.build.directory}/classes/spring-legacy.xml</descriptor>
                       </descriptors>

--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -135,6 +135,27 @@
                   <token>org.apache.geronimo.specs/geronimo-jms_2.0_spec/1.0-alpha-2</token>
                   <value>javax.jms/javax.jms-api/${jmsApiVersion}</value>
                 </replacement>
+                <!-- Netty moved the kqueue classes out of the native artifact after 4.1.22,
+                     so point at the classes artifact. Must precede the generic rule below. -->
+                <replacement>
+                  <token>io\.netty/netty-transport-native-kqueue/4\.1\.22\.Final</token>
+                  <value>io.netty/netty-transport-classes-kqueue/${netty4Version}</value>
+                </replacement>
+                <!-- Lock Netty to our version -->
+                <replacement>
+                  <token>io\.netty/([a-zA-Z0-9._-]+)/4\.1\.22\.Final</token>
+                  <value>io.netty/$1/${netty4Version}</value>
+                </replacement>
+                <!-- upstream Camel typo: the property is never interpolated -->
+                <replacement>
+                  <token>com\.fasterxml\.jackson\.core/jackson-databind/\$\{jackson2-databind-ersion\}</token>
+                  <value>com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</value>
+                </replacement>
+                <!-- Lock Jackson to our version -->
+                <replacement>
+                  <token>com\.fasterxml\.jackson\.([a-z]+)/([a-zA-Z0-9._-]+)/2\.[0-9]+[0-9.]*</token>
+                  <value>com.fasterxml.jackson.$1/$2/${jackson2Version}</value>
+                </replacement>
               </replacements>
             </configuration>
           </execution>

--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -10,7 +10,8 @@
     <repository>mvn:${project.groupId}/${project.artifactId}/${project.version}/xml/features</repository>
 
     <!-- Newts Features -->
-    <repository>mvn:org.opennms.newts/newts-karaf/${newtsVersion}/xml/features</repository>
+    <!-- our repackaged copy, with Jackson/Netty/Guava/driver locked to ours -->
+    <repository>mvn:${project.groupId}/${project.artifactId}/${project.version}/xml/newts</repository>
 
     <!-- ActiveMQ service features -->
     <repository>mvn:org.apache.karaf.features/enterprise/${karafVersion}/xml/features</repository>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -7,10 +7,12 @@
     <repository>mvn:org.ops4j.pax.jdbc/pax-jdbc-features/1.0.1/xml/features</repository>
     <repository>mvn:org.apache.activemq/activemq-karaf/${activemqVersion}/xml/features</repository>
     <repository>mvn:org.opennms.integration.api/karaf-features/${opennmsApiVersion}/xml</repository>
-    <repository>mvn:com.eclipsesource.jaxrs/features/${osgiJaxRsVersion}/xml/features</repository>
+    <!-- our repackaged copy, with Jackson locked to ours -->
+    <repository>mvn:${project.groupId}/${project.artifactId}/${project.version}/xml/jaxrs</repository>
     <repository>mvn:org.apache.karaf.features/enterprise/${karafVersion}/xml/features</repository>
     <!-- Newts Features -->
-    <repository>mvn:org.opennms.newts/newts-karaf/${newtsVersion}/xml/features</repository>
+    <!-- our repackaged copy, with Jackson/Netty/Guava/driver locked to ours -->
+    <repository>mvn:${project.groupId}/${project.artifactId}/${project.version}/xml/newts</repository>
     <feature name="opennms-camel-amqp" version="${project.version}" description="OpenNMS :: Features :: AMQP :: Camel Wrapper">
         <!-- start this early so camel-amqp doesn't use its old version -->
         <bundle start-level="60">mvn:io.netty/netty-common/${netty4Version}</bundle>

--- a/features/sentinel/repository/pom.xml
+++ b/features/sentinel/repository/pom.xml
@@ -31,7 +31,7 @@
                                 <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/camel</descriptor>
                                 <descriptor>mvn:org.apache.karaf.features/standard/${karafVersion}/xml/features</descriptor>
                                 <!-- Add OpenNMS features -->
-                                <descriptor>mvn:org.opennms.newts/newts-karaf/${newtsVersion}/xml/features</descriptor>
+                                <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/newts</descriptor>
                                 <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/features</descriptor>
                                 <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions</repository>
                                 <!-- Add Sentinel features -->


### PR DESCRIPTION
Lock netty and jackson-databind to the versions specified in the root pom, so OSGi resolution doesn't pull in older, vulnerable versions.  Make a similar fix with Newts 1.5.7, so it won't pull in older transient dependencies either. 

Updating the actual package versions looked hugely invasive.  This should get everything on consistent versions of these dependencies, matching what's defined in pom.xml.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20164
* https://opennms.atlassian.net/browse/SUPPORT-3278