### PR TITLE
NMS-20029: forward the #option slot in OnmsAutoComplete

### DIFF
--- a/ui/packages/onms-ui/src/components/OnmsAutoComplete.vue
+++ b/ui/packages/onms-ui/src/components/OnmsAutoComplete.vue
@@ -28,6 +28,15 @@
     >
       <slot name="footer" />
     </template>
+    <template
+      v-if="$slots.option"
+      #option="slotProps"
+    >
+      <slot
+        name="option"
+        v-bind="slotProps"
+      />
+    </template>
   </AutoComplete>
 </template>
 

--- a/ui/tests/onms-ui/OnmsAutoComplete.test.ts
+++ b/ui/tests/onms-ui/OnmsAutoComplete.test.ts
@@ -57,4 +57,13 @@ describe('OnmsAutoComplete', () => {
     })
     expect(wrapper.findComponent({ name: 'AutoComplete' }).vm.$slots.empty).toBeTruthy()
   })
+
+  it('forwards the option slot for custom suggestion rendering', () => {
+    const wrapper = mount(OnmsAutoComplete, {
+      props: { suggestions: [{ label: 'node1' }] },
+      slots: { option: '<div data-test="opt">custom</div>' },
+      global: globalPlugins
+    })
+    expect(wrapper.findComponent({ name: 'AutoComplete' }).vm.$slots.option).toBeTruthy()
+  })
 })


### PR DESCRIPTION
Fixes a seam-wrapper gap: OnmsAutoComplete forwarded only `#empty` and `#footer`, so migrating a type-ahead from PrimeVue AutoComplete to the wrapper silently dropped any custom `#option` template and fell back to the bare `optionLabel`.

- Forward PrimeVue AutoComplete's `#option` slot (with its slot props) alongside `#empty`/`#footer`.
- Add a unit test asserting the `#option` slot reaches the inner AutoComplete.
- No consumer on develop currently relies on `#option`, so this is additive with no behavior change to existing usages; it unblocks rich suggestion rendering (e.g. a UEI plus its event label).