### PR TITLE
NMS-20165: announce beanshell support deprecated

### DIFF
--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -149,3 +149,9 @@ The underlying configuration file (`etc/ksc-performance-reports.xml`), the REST 
 
 NOTE: Update any of your own documentation, runbooks, training material, or UI automation that refers to *KSC Reports* by name — including tests that match on the old menu label or the *KSC Report* search category — to use *Graph Collections*.
 
+=== BeanShell integration deprecated
+
+The last release of the BeanShell interpreter was in 2016.
+As such, we are deprecating support for BeanShell and will remove it in Horizon 37.
+Groovy support remains available everywhere BeanShell was implemented.
+


### PR DESCRIPTION
Mark BeanShell support as deprecated in the 36 release notes / whatsnew

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20165
