### PR TITLE
NMS-20168: Update Netty to 4.2.16.Final

### DIFF
--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -296,6 +296,8 @@ org.jolokia.authMode=jaas
     <feature name="netty" version="${netty4Version}" description="Netty">
         <feature>bouncycastle</feature>
         <bundle dependency="true">mvn:io.netty/netty-buffer/${netty4Version}</bundle>
+        <!-- netty 4.2 moved the codec base classes out of netty-codec into netty-codec-base -->
+        <bundle dependency="true">mvn:io.netty/netty-codec-base/${netty4Version}</bundle>
         <bundle dependency="true">mvn:io.netty/netty-codec/${netty4Version}</bundle>
         <bundle dependency="true">mvn:io.netty/netty-codec-dns/${netty4Version}</bundle>
         <bundle dependency="true">mvn:io.netty/netty-common/${netty4Version}</bundle>

--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -24,6 +24,8 @@
     </feature>
 
     <feature name="sentinel-jms" description="Sentinel :: Core :: JMS" version="${project.version}">
+        <!-- camel-netty4 reaches io.netty.handler.codec via the netty feature, which is where netty-codec-base lives -->
+        <feature prerequisite="true" version="${netty4Version}">netty</feature>
         <feature prerequisite="true">opennms-distributed-core-jms</feature>
         <feature>opennms-core-ipc-sink-camel-server</feature>
         <!-- Sink Client -->
@@ -32,6 +34,7 @@
     </feature>
 
     <feature name="sentinel-kafka" description="Sentinel :: Core :: Kafka" version="${project.version}">
+        <feature prerequisite="true" version="${netty4Version}">netty</feature>
         <feature>sentinel-core</feature>
         <!-- Sink Client-->
         <feature>opennms-core-ipc-sink-kafka</feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -20,6 +20,9 @@
         <bundle start-level="60">mvn:io.netty/netty-transport/${netty4Version}</bundle>
         <bundle start-level="60">mvn:io.netty/netty-handler/${netty4Version}</bundle>
         <bundle start-level="60">mvn:io.netty/netty-codec/${netty4Version}</bundle>
+        <!-- netty 4.2 split the base and compression codecs out of netty-codec; netty-codec-http needs both -->
+        <bundle start-level="60">mvn:io.netty/netty-codec-base/${netty4Version}</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-codec-compression/${netty4Version}</bundle>
         <bundle start-level="60">mvn:io.netty/netty-codec-http/${netty4Version}</bundle>
         <bundle start-level="60">mvn:io.netty/netty-transport-classes-epoll/${netty4Version}</bundle>
         <bundle start-level="60">mvn:io.netty/netty-transport-native-epoll/${netty4Version}</bundle>
@@ -326,6 +329,9 @@
         <bundle dependency="true">mvn:io.netty/netty-transport-classes-epoll/${netty4Version}</bundle>
         <feature>camel-netty4</feature>
         <feature>opennms-core</feature>
+        <!-- XmlFrameDecoderFactory needs the XML codec, which netty 4.2 no longer pulls in via netty-codec -->
+        <bundle dependency="true">mvn:com.fasterxml/aalto-xml/${aaltoXmlVersion}</bundle>
+        <bundle dependency="true">mvn:io.netty/netty-codec-xml/${netty4Version}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.camel/${project.version}</bundle>
     </feature>
     <feature name="opennms-core-daemon" version="${project.version}" description="OpenNMS :: Core :: Daemon">
@@ -1654,6 +1660,7 @@
         <bundle>mvn:io.netty/netty-transport/${netty4Version}</bundle>
         <bundle>mvn:io.netty/netty-handler/${netty4Version}</bundle>
         <bundle>mvn:io.netty/netty-codec/${netty4Version}</bundle>
+        <bundle>mvn:io.netty/netty-codec-base/${netty4Version}</bundle>
         <bundle>mvn:io.netty/netty-codec-dns/${netty4Version}</bundle>
         <bundle>mvn:io.netty/netty-resolver-dns/${netty4Version}</bundle>
         <bundle>mvn:io.netty/netty-transport-classes-epoll/${netty4Version}</bundle>

--- a/container/karaf/src/main/filtered-resources/etc/overrides.properties
+++ b/container/karaf/src/main/filtered-resources/etc/overrides.properties
@@ -83,6 +83,9 @@ mvn:io.netty/netty-buffer/${netty4Version}
 mvn:io.netty/netty-transport/${netty4Version}
 mvn:io.netty/netty-handler/${netty4Version}
 mvn:io.netty/netty-codec/${netty4Version}
+mvn:io.netty/netty-codec-base/${netty4Version}
+mvn:io.netty/netty-codec-compression/${netty4Version}
+mvn:io.netty/netty-codec-xml/${netty4Version}
 mvn:io.netty/netty-codec-http/${netty4Version}
 mvn:io.netty/netty-transport-classes-epoll/${netty4Version}
 mvn:io.netty/netty-transport-native-epoll/${netty4Version}

--- a/container/shared/src/main/filtered-resources/etc/overrides.properties
+++ b/container/shared/src/main/filtered-resources/etc/overrides.properties
@@ -81,8 +81,10 @@ mvn:io.netty/netty-common/${netty4Version}
 mvn:io.netty/netty-buffer/${netty4Version}
 mvn:io.netty/netty-transport/${netty4Version}
 mvn:io.netty/netty-handler/${netty4Version}
-mvn:io.netty/netty-transport/${netty4Version}
 mvn:io.netty/netty-codec/${netty4Version}
+mvn:io.netty/netty-codec-base/${netty4Version}
+mvn:io.netty/netty-codec-compression/${netty4Version}
+mvn:io.netty/netty-codec-xml/${netty4Version}
 mvn:io.netty/netty-codec-http/${netty4Version}
 mvn:io.netty/netty-transport-classes-epoll/${netty4Version}
 mvn:io.netty/netty-transport-native-epoll/${netty4Version}

--- a/pom.xml
+++ b/pom.xml
@@ -1604,6 +1604,7 @@
     <hawtio.version>2.17.5</hawtio.version>
 
     <!-- dependency versions -->
+    <aaltoXmlVersion>1.3.3</aaltoXmlVersion>
     <antVersion>1.10.13</antVersion>
     <args4jVersion>2.33</args4jVersion>
     <asmVersion>9.7</asmVersion>
@@ -1782,7 +1783,7 @@
     <minaVersion>2.2.3</minaVersion>
     <mockitoVersion>3.12.4</mockitoVersion>
     <netty3Version>3.10.6.Final</netty3Version>
-    <netty4Version>4.1.100.Final</netty4Version>
+    <netty4Version>4.2.16.Final</netty4Version>
     <newtsVersion>1.5.7</newtsVersion>
     <paxCdiVersion>1.1.4</paxCdiVersion>
     <paxExamVersion>4.13.5</paxExamVersion>
@@ -4942,6 +4943,11 @@
         <version>1.9.22.noko2</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml</groupId>
+        <artifactId>aalto-xml</artifactId>
+        <version>${aaltoXmlVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>${netty4Version}</version>
@@ -4949,6 +4955,21 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
+        <version>${netty4Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-base</artifactId>
+        <version>${netty4Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-compression</artifactId>
+        <version>${netty4Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-xml</artifactId>
         <version>${netty4Version}</version>
       </dependency>
       <dependency>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -64,7 +64,7 @@
     <seleniarm.version>4.6.0-20221104</seleniarm.version>
     <slf4jVersion>2.0.7</slf4jVersion>
     <testcontainers.version>1.19.7</testcontainers.version>
-    <netty4Version>4.1.99.Final</netty4Version>
+    <netty4Version>4.2.16.Final</netty4Version>
     <jna.version>5.8.0</jna.version>
     <okhttpVersion>3.10.0</okhttpVersion>
     <test.fork.count>0</test.fork.count>


### PR DESCRIPTION
Raises netty4Version to close the netty advisories still open against Meridian 2023 after NMS-20164.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20168
* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20164