### PR TITLE
NMS-20167: Sidemenu flicker, expand/collapse hotkey

### DIFF
--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -17,6 +17,7 @@
     </button>
 
     <TieredMenu
+      ref="tieredMenuRef"
       :model="topPanels as never"
       class="onms-side-menu__menu"
       breakpoint="0px"
@@ -100,9 +101,18 @@ const topPanels = computed<OnmsMenuItem[]>(() => {
   return createPrimeMenuModel(allMenus, mainMenu.value.baseHref, getIcon, onPerformLogout)
 })
 
+const tieredMenuRef = ref<any>(null)
+
 const togglePinned = () => {
   isPinned.value = !isPinned.value
   menuStore.setSideMenuExpanded(isPinned.value)
+
+  // Close any open flyout. Clicking the toggle button already does this via
+  // TieredMenu's outside-click listener; this makes the keyboard shortcut
+  // behave the same — otherwise the flyout would be repositioned mid-way
+  // through the rail's 0.1s width transition and end up with a stale left
+  // offset once the transition finishes.
+  tieredMenuRef.value?.hide?.()
 }
 
 // Global shortcut: Ctrl+\ toggles the rail expand/collapse, so the menu can be
@@ -112,18 +122,27 @@ const togglePinned = () => {
 // e.code (physical key) so it works regardless of keyboard layout; the other
 // modifiers are excluded so a larger chord doesn't also trigger it.
 const onGlobalKeydown = (e: KeyboardEvent) => {
-  if (e.code === 'Backslash' && e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.repeat) {
-    e.preventDefault()
-    togglePinned()
+  if (e.code !== 'Backslash' || !e.ctrlKey || e.shiftKey || e.altKey || e.metaKey || e.repeat) {
+    return
   }
+
+  // Don't steal the shortcut while the user is typing in an editable element.
+  const target = e.target as HTMLElement | null
+
+  if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT' || target.isContentEditable)) {
+    return
+  }
+
+  e.preventDefault()
+  togglePinned()
 }
 
 // Push the main content aside when the rail is pinned (persisted) expanded.
-// The COLLAPSED/base left offset is
-// owned by each host's stylesheet (JSP #content, SPA .app-layout) so the two
-// contexts can differ; when not pinned we clear the inline padding-left so that
-// base applies. This keeps the collapsed gap "guaranteed" (JS never clobbers
-// it) while still widening the push when the rail is pinned open.
+// The COLLAPSED/base left offset is owned by each host's stylesheet (JSP
+// #content, SPA .app-layout) so the two contexts can differ; when not pinned we
+// clear the inline padding-left so that base applies. This keeps the collapsed
+// gap "guaranteed" (JS never clobbers it) while still widening the push when
+// the rail is pinned open.
 const getPushedElement = (): HTMLElement | null => {
   try {
     return document.querySelector<HTMLElement>(props.pushedSelector)

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -8,7 +8,7 @@
     <button
       type="button"
       class="onms-side-menu__toggle"
-      v-onms-tooltip="{ value: isPinned ? 'Collapse menu' : 'Expand menu', showDelay: 300 }"
+      v-onms-tooltip="{ value: isPinned ? 'Collapse menu (Ctrl+\\)' : 'Expand menu (Ctrl+\\)', showDelay: 300 }"
       :aria-label="isPinned ? 'Collapse menu' : 'Expand menu'"
       :aria-expanded="isPinned"
       @click="togglePinned"
@@ -103,6 +103,19 @@ const topPanels = computed<OnmsMenuItem[]>(() => {
 const togglePinned = () => {
   isPinned.value = !isPinned.value
   menuStore.setSideMenuExpanded(isPinned.value)
+}
+
+// Global shortcut: Ctrl+\ toggles the rail expand/collapse, so the menu can be
+// pinned/unpinned without first tabbing to the toggle button. Ctrl+\ is free of
+// browser-shortcut conflicts in all major browsers (unlike e.g. Ctrl+Shift+M:
+// Firefox responsive design mode, Chrome/Edge profile switcher). Matched on
+// e.code (physical key) so it works regardless of keyboard layout; the other
+// modifiers are excluded so a larger chord doesn't also trigger it.
+const onGlobalKeydown = (e: KeyboardEvent) => {
+  if (e.code === 'Backslash' && e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.repeat) {
+    e.preventDefault()
+    togglePinned()
+  }
 }
 
 // Push the main content aside when the rail is pinned (persisted) expanded.
@@ -203,6 +216,8 @@ const scheduleFlyoutPosition = () => {
 onMounted(() => {
   applyPush()
 
+  window.addEventListener('keydown', onGlobalKeydown)
+
   const nav = navRef.value
 
   if (nav) {
@@ -234,6 +249,7 @@ onBeforeUnmount(() => {
   }
 
   window.removeEventListener('resize', scheduleFlyoutPosition)
+  window.removeEventListener('keydown', onGlobalKeydown)
 })
 </script>
 

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -3,14 +3,12 @@
     ref="navRef"
     id="opennms-sidemenu-vue-container"
     class="onms-side-menu"
-    :class="{ 'onms-side-menu--open': isOpen }"
-    @mouseenter="onRailEnter"
-    @mouseleave="onRailLeave"
+    :class="{ 'onms-side-menu--open': isPinned }"
   >
     <button
       type="button"
       class="onms-side-menu__toggle"
-      :title="isPinned ? 'Collapse menu' : 'Expand menu'"
+      v-onms-tooltip="{ value: isPinned ? 'Collapse menu' : 'Expand menu', showDelay: 300 }"
       :aria-label="isPinned ? 'Collapse menu' : 'Expand menu'"
       :aria-expanded="isPinned"
       @click="togglePinned"
@@ -19,7 +17,6 @@
     </button>
 
     <TieredMenu
-      ref="tieredMenuRef"
       :model="topPanels as never"
       class="onms-side-menu__menu"
       breakpoint="0px"
@@ -28,6 +25,7 @@
         <a
           class="onms-side-menu__link"
           v-bind="props.action"
+          v-onms-tooltip="{ value: item.label, disabled: isPinned || !item.topLevel, showDelay: 300 }"
           :href="item.url || undefined"
           :target="item.target || undefined"
         >
@@ -45,7 +43,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
-// eslint-disable-next-line no-restricted-imports -- deliberately unwrapped: SideMenu drives TieredMenu internals (dirty flag, DOM queries); revisit when the side menu is redesigned (NMS-20081)
+// eslint-disable-next-line no-restricted-imports -- deliberately unwrapped: SideMenu drives TieredMenu internals (DOM queries in positionFlyouts); revisit when the side menu is redesigned (NMS-20081)
 import TieredMenu from 'primevue/tieredmenu'
 import { OnmsIcon, OnmsMenuItem } from '@opennms/onms-ui'
 import ChevronLeft from '@/components/icons/navigation/ChevronLeft.vue'
@@ -77,37 +75,11 @@ const { getIcon } = useMenuIcons()
 const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 const plugins = computed<Plugin[]>(() => pluginStore.plugins)
 
-// isPinned is the persisted expanded/collapsed state (toggle button).
-// isHovering expands the rail transiently (open-on-hover) without persisting.
+// isPinned is the persisted expanded/collapsed state (toggle button). The rail
+// no longer expands on hover (NMS-20167): submenus follow PrimeVue TieredMenu's
+// default interaction — click to open, hover-to-switch only after that first
+// click — and TieredMenu's own outside-click listener closes any open flyout.
 const isPinned = ref<boolean>(menuStore.sideMenuExpanded() ?? false)
-const isHovering = ref<boolean>(false)
-const isOpen = computed<boolean>(() => isPinned.value || isHovering.value)
-
-const tieredMenuRef = ref<any>(null)
-
-const onRailEnter = () => {
-  isHovering.value = true
-
-  // PrimeVue's TieredMenu only opens submenus on hover once it is "dirty"
-  // (after an initial click / keyboard interaction). Enable that flag on entry
-  // so the rail behaves as open-on-hover from the first interaction, matching
-  // the previous FeatherSidenav. Guarded so it degrades to click-to-open if the
-  // internal flag ever changes.
-  if (tieredMenuRef.value) {
-    tieredMenuRef.value.dirty = true
-  }
-}
-
-const onRailLeave = () => {
-  isHovering.value = false
-
-  // The flyout submenus are position:fixed (see positionFlyouts) so they are
-  // visually detached from the rail. When the pointer leaves the rail+flyout,
-  // close any open flyout via TieredMenu's hide() (clears activeItemPath) so it
-  // doesn't linger orphaned after the rail collapses. hide() also resets the
-  // internal `dirty` flag, which onRailEnter re-enables on the next hover.
-  tieredMenuRef.value?.hide?.()
-}
 
 const onPerformLogout = async () => {
   await performLogout()
@@ -133,9 +105,8 @@ const togglePinned = () => {
   menuStore.setSideMenuExpanded(isPinned.value)
 }
 
-// Push the main content aside for the pinned (persisted) expanded rail only;
-// hover-expansion overlays the content instead of pushing it, to avoid
-// reflowing the whole page on every hover. The COLLAPSED/base left offset is
+// Push the main content aside when the rail is pinned (persisted) expanded.
+// The COLLAPSED/base left offset is
 // owned by each host's stylesheet (JSP #content, SPA .app-layout) so the two
 // contexts can differ; when not pinned we clear the inline padding-left so that
 // base applies. This keeps the collapsed gap "guaranteed" (JS never clobbers

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -44,7 +44,11 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
-// eslint-disable-next-line no-restricted-imports -- deliberately unwrapped: SideMenu drives TieredMenu internals (DOM queries in positionFlyouts); revisit when the side menu is redesigned (NMS-20081)
+// We are using PrimeVue TieredMenu directly here, rather than wrapping it in an OnmsUI component.
+// We are reaching into TieredMenu internals (DOM queries in positionFlyouts, hide() in togglePinned),
+// and also not using this anywhere else in the app, so we don't want to add a new OnmsUI component for it.
+// If we ever need to use TieredMenu elsewhere, we can wrap it in an OnmsUI component at that time.
+// eslint-disable-next-line no-restricted-imports
 import TieredMenu from 'primevue/tieredmenu'
 import { OnmsIcon, OnmsMenuItem } from '@opennms/onms-ui'
 import ChevronLeft from '@/components/icons/navigation/ChevronLeft.vue'

--- a/ui/src/components/Menu/utils.ts
+++ b/ui/src/components/Menu/utils.ts
@@ -180,7 +180,10 @@ const createPrimeTopItem = (
   const item: PrimeMenuItem = {
     key: `${TOP_MENU_ID_PREFIX}${topMenuItem.id ?? topMenuItem.name ?? ''}`,
     label: topMenuItem.name ?? undefined,
-    iconComponent: createMenuIcon(topMenuItem, getIcon)
+    iconComponent: createMenuIcon(topMenuItem, getIcon),
+    // Marks root items so the side menu can show label tooltips for them while
+    // the rail is collapsed (submenu items keep their visible labels).
+    topLevel: true
   }
 
   const children = topMenuItem.items ?? []

--- a/ui/tests/components/Menu/utils.test.ts
+++ b/ui/tests/components/Menu/utils.test.ts
@@ -70,6 +70,8 @@ describe('Menu utils', () => {
       expect(inventory.key).toBe('opennms-menu-id-inventoryMenu')
       expect(inventory.label).toBe('Inventory')
       expect(inventory.iconComponent).toBeDefined()
+      // topLevel marks root items for collapsed-rail tooltips; child items don't get it
+      expect(inventory.topLevel).toBe(true)
 
       const inventoryItems = childItems(inventory)
       expect(inventoryItems).toHaveLength(3)
@@ -80,6 +82,7 @@ describe('Menu utils', () => {
         target: '_self'
       })
       expect(inventoryItems[0].iconComponent).toBeUndefined()
+      expect(inventoryItems[0].topLevel).toBeUndefined()
       expect(inventoryItems[1]).toMatchObject({
         key: 'legacyNodes',
         label: 'Nodes (Legacy)',


### PR DESCRIPTION
The side menu was triggering menu item flyouts on mouseover. In particular, when the menu was collapsed, mouseover would expand the menu, then open the flyout menus. This made the menu "flicker" and seem unstable and unwieldy.

This fix removes that. The behavior is now that you need to click on an item (when either expanded or collapsed) in order to trigger menu flyout on mouseover. Note, this is now actually the native PrimeVue behavior. We were overriding it to mimic some behavior in Feather.

Added tooltips to the collapsed icons and expand/collapse button.

Added `Ctrl-\` (`Ctrl-Backslash`) hotkey to toggle menu expansion. Note that this is disabled if user is in an input/edit field.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20167
