### PR TITLE
NMS-20175: Node List UI Fixes - less default columns, indentation

### DIFF
--- a/ui/src/components/Nodes/AssetFilterPanel.vue
+++ b/ui/src/components/Nodes/AssetFilterPanel.vue
@@ -77,7 +77,7 @@ import Add from '@/components/icons/action/Add.vue'
 import DeleteIcon from '@/components/icons/action/Delete.vue'
 import FormField from '@/components/Common/FormField.vue'
 import { ALL_ASSET_COLUMN_OPTIONS, ASSET_COLUMN_OPTIONS, getAssetColumnLabel } from '@/components/Nodes/hooks/queryStringParser'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 
 interface GridItem {
   column: string
@@ -95,7 +95,7 @@ const assetOptions = computed<AssetOption[]>(() =>
   (featuredOnly.value ? ASSET_COLUMN_OPTIONS : ALL_ASSET_COLUMN_OPTIONS).map(o => ({ title: o.label, value: o.value }))
 )
 
-const nodeStructureStore = useNodeStructureStore()
+const nodeListStore = useNodeListStore()
 const assetValue = ref('')
 const currentSelection = ref<AssetOption | undefined>(undefined)
 const gridItems = ref<GridItem[]>([])
@@ -124,11 +124,11 @@ const applyToStore = () => {
   const assetFilters = gridItems.value
     .filter(i => i.value.trim())
     .map(i => ({ column: i.column, value: i.value.trim() }))
-  nodeStructureStore.setFilterWithAssetFilters(assetFilters)
+  nodeListStore.setFilterWithAssetFilters(assetFilters)
 }
 
 const resetFromStore = () => {
-  const filters = nodeStructureStore.queryFilter.assetFilters ?? []
+  const filters = nodeListStore.queryFilter.assetFilters ?? []
   gridItems.value = filters.map(f => ({
     column: f.column,
     label: getAssetColumnLabel(f.column),

--- a/ui/src/components/Nodes/ColumnSelectionDrawer.vue
+++ b/ui/src/components/Nodes/ColumnSelectionDrawer.vue
@@ -50,7 +50,7 @@
           @click="addColumn"
         >Add Column</OnmsButton>
         <OnmsButton variant="outlined" @click="resetColumns">Reset Columns</OnmsButton>
-        <OnmsButton variant="outlined" @click="nodeStructureStore.columnsDrawerState.visible = false">Close</OnmsButton>
+        <OnmsButton variant="outlined" @click="nodeListStore.columnsDrawerState.visible = false">Close</OnmsButton>
       </div>
     </div>
   </OnmsDrawer>
@@ -64,19 +64,19 @@ import Cancel from '@/components/icons/navigation/Cancel.vue'
 import Draggable from 'vuedraggable'
 import { OnmsButton, OnmsDrawer, OnmsIconButton, OnmsSelect } from '@opennms/onms-ui'
 import { saveNodePreferences } from '@/services/localStorageService'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { NodeColumnSelectionItem } from '@/types'
 import { defaultColumns } from './utils'
 
-const nodeStructureStore = useNodeStructureStore()
+const nodeListStore = useNodeListStore()
 const columns = ref<NodeColumnSelectionItem[]>(defaultColumns)
 const selectedColumns = ref<{ name: string; value: string }[]>([])
 
 const drawerVisible = computed({
-  get: () => nodeStructureStore.columnsDrawerState.visible,
+  get: () => nodeListStore.columnsDrawerState.visible,
   set: (val: boolean) => {
     if (!val) {
-      nodeStructureStore.columnsDrawerState.visible = false
+      nodeListStore.columnsDrawerState.visible = false
     }
   }
 })
@@ -118,7 +118,7 @@ const customizeTable = async () => {
   // only `col.value` (the id) and never `col.name` — trusting `col.name` here
   // persisted an empty label for any re-added/changed column, which rendered as
   // a header with no text. The id is always correct, so derive the label from it.
-  nodeStructureStore.columns = selectedColumns.value
+  nodeListStore.columns = selectedColumns.value
     .filter(col => col.value)
     .map((col, index) => ({
       id: col.value as string,
@@ -127,19 +127,19 @@ const customizeTable = async () => {
       order: index
     }))
 
-  const nodePrefs = await nodeStructureStore.getNodePreferences()
+  const nodePrefs = await nodeListStore.getNodePreferences()
   saveNodePreferences(nodePrefs)
-  nodeStructureStore.columnsDrawerState.visible = false
+  nodeListStore.columnsDrawerState.visible = false
 }
 
 const resetColumns = async () => {
-  nodeStructureStore.columns = [...defaultColumns]
-  const nodePrefs = await nodeStructureStore.getNodePreferences()
+  nodeListStore.columns = [...defaultColumns]
+  const nodePrefs = await nodeListStore.getNodePreferences()
   saveNodePreferences(nodePrefs)
-  nodeStructureStore.columnsDrawerState.visible = false
+  nodeListStore.columnsDrawerState.visible = false
 }
 
-watch(() => nodeStructureStore.columns, (newColumns) => {
+watch(() => nodeListStore.columns, (newColumns) => {
   initializeSelectedColumns(newColumns)
 }, { immediate: true, deep: true })
 </script>

--- a/ui/src/components/Nodes/ExtendedSearchPanel.vue
+++ b/ui/src/components/Nodes/ExtendedSearchPanel.vue
@@ -69,7 +69,7 @@ import { OnmsButton, OnmsColumn, OnmsIcon, OnmsIconButton, OnmsInputText, OnmsSe
 import Add from '@/components/icons/action/Add.vue'
 import DeleteIcon from '@/components/icons/action/Delete.vue'
 import FormField from '@/components/Common/FormField.vue'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { useNodeQuery } from '@/components/Nodes/hooks/useNodeQuery'
 import { NodeQueryExtendedSearchParams } from '@/types'
 
@@ -108,7 +108,7 @@ const foreignSourceKeys = ['foreignSource', 'foreignId', 'foreignSourceId']
 const snmpKeys = ['snmpIfAlias', 'snmpIfDescription', 'snmpIfIndex', 'snmpIfName', 'snmpIfType']
 const sysKeys = ['sysContact', 'sysDescription', 'sysLocation', 'sysName', 'sysObjectId']
 
-const nodeStructureStore = useNodeStructureStore()
+const nodeListStore = useNodeListStore()
 const searchTerm = ref('')
 const currentSelection = ref<SearchOption | undefined>(undefined)
 const gridItems = ref<GridItem[]>([])
@@ -156,11 +156,11 @@ const applyToStore = () => {
       Object.assign(ext.sysParams, { [item.key]: item.value })
     }
   }
-  nodeStructureStore.setExtendedSearchParams(ext)
+  nodeListStore.setExtendedSearchParams(ext)
 }
 
 const resetFromStore = () => {
-  const values = getExtendedSearchValues(nodeStructureStore.queryFilter.extendedSearch)
+  const values = getExtendedSearchValues(nodeListStore.queryFilter.extendedSearch)
   gridItems.value = values.map(v => ({ key: v.key, label: v.name, value: v.value }))
   searchTerm.value = ''
   currentSelection.value = undefined

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -161,20 +161,20 @@
         </div>
       </div>
       <div class="onms-row">
-        <div class="onms-col-12 toggle-row" data-test="with-assets">
-          <label for="with-assets">Nodes with asset info only</label>
-          <OnmsToggleSwitch
-            v-model="selectedFilters.nodesWithAssets"
-            inputId="with-assets"
-          />
-        </div>
-      </div>
-      <div class="onms-row">
         <div class="onms-col-12 toggle-row" data-test="with-outages">
           <label for="with-outages">Nodes with current outages</label>
           <OnmsToggleSwitch
             v-model="selectedFilters.nodesWithOutages"
             inputId="with-outages"
+          />
+        </div>
+      </div>
+      <div class="onms-row">
+        <div class="onms-col-12 toggle-row" data-test="with-assets">
+          <label for="with-assets">Nodes with asset info only</label>
+          <OnmsToggleSwitch
+            v-model="selectedFilters.nodesWithAssets"
+            inputId="with-assets"
           />
         </div>
       </div>
@@ -243,11 +243,11 @@
             <p><strong>Down nodes only</strong></p>
             <p>Limits results to nodes with a down aggregate status, i.e. nodes that have at least one active monitored service currently in outage.</p>
             <br />
-            <p><strong>Nodes with asset info only</strong></p>
-            <p>Limits results to nodes that have at least one non-empty asset-record field.</p>
-            <br />
             <p><strong>Nodes with current outages</strong></p>
             <p>Limits results to nodes that have one or more services currently in outage.</p>
+            <br />
+            <p><strong>Nodes with asset info only</strong></p>
+            <p>Limits results to nodes that have at least one non-empty asset-record field.</p>
             <br />
             <p><strong>Asset Fields</strong></p>
             <p>Filter by one or more node asset-record fields (such as Building, Region, or Rack). Choose an asset field, enter a value, and click Add. Each added field is an exact match, and multiple asset fields are intersected (a node must match all of them).</p>

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -277,7 +277,7 @@
         </OnmsButton>
         <OnmsButton
           variant="outlined"
-          @click="nodeStructureStore.closeInstancesDrawerModal()"
+          @click="nodeListStore.closeInstancesDrawerModal()"
         >
           Close
         </OnmsButton>
@@ -298,7 +298,7 @@ import InfoIcon from '@/components/icons/action/Info.vue'
 import FormField from '@/components/Common/FormField.vue'
 import ExtendedSearchPanel from './ExtendedSearchPanel.vue'
 import AssetFilterPanel from './AssetFilterPanel.vue'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 
 interface DrawerErrors {
   ipAddress?: string
@@ -311,7 +311,7 @@ const isMessageDialogVisible = ref(false)
 const errors = ref<DrawerErrors>({})
 const isApplyDisabled = ref(false)
 
-const nodeStructureStore = useNodeStructureStore()
+const nodeListStore = useNodeListStore()
 const extendedSearchPanelRef = ref<ExtendedSearchPanelInstance | null>(null)
 const assetFilterPanelRef = ref<AssetFilterPanelInstance | null>(null)
 const showSecondCategories = ref(false)
@@ -330,10 +330,10 @@ const selectedFilters = reactive({
 })
 
 const drawerVisible = computed({
-  get: () => nodeStructureStore.drawerState.visible,
+  get: () => nodeListStore.drawerState.visible,
   set: (val: boolean) => {
     if (!val) {
-      nodeStructureStore.closeInstancesDrawerModal()
+      nodeListStore.closeInstancesDrawerModal()
     }
   }
 })
@@ -341,14 +341,14 @@ const drawerVisible = computed({
 // Full option lists for each MultiSelect (the same lists the old @search
 // handlers filtered over). MultiSelect performs its own client-side filtering.
 const categoryOptions = computed<IAutocompleteItemType[]>(() => {
-  const categoriesArray = Array.isArray(nodeStructureStore.categories)
-    ? nodeStructureStore.categories
+  const categoriesArray = Array.isArray(nodeListStore.categories)
+    ? nodeListStore.categories
     : []
   return categoriesArray.map(c => ({ _text: c.name, _value: c.id } as IAutocompleteItemType))
 })
 
 const locationOptions = computed<IAutocompleteItemType[]>(() =>
-  nodeStructureStore.monitoringLocations.map(location => ({
+  nodeListStore.monitoringLocations.map(location => ({
     _text: location.name,
     _value: location.name,
     name: location.name
@@ -356,7 +356,7 @@ const locationOptions = computed<IAutocompleteItemType[]>(() =>
 )
 
 const serviceOptions = computed<IAutocompleteItemType[]>(() =>
-  nodeStructureStore.allServiceTypes.map(s => ({ _value: s.id, _text: s.name } as IAutocompleteItemType))
+  nodeListStore.allServiceTypes.map(s => ({ _value: s.id, _text: s.name } as IAutocompleteItemType))
 )
 
 const flowOptions = computed<IAutocompleteItemType[]>(() => [
@@ -389,24 +389,24 @@ watchEffect(() => {
 })
 
 const applySelectedFilters = () => {
-  nodeStructureStore.updateSelectedCategories(selectedFilters.categories)
-  nodeStructureStore.updateSelectedCategories2(showSecondCategories.value ? selectedFilters.categories2 : [])
-  nodeStructureStore.updateSelectedFlows(selectedFilters.flows)
-  nodeStructureStore.updateSelectedMonitoringLocations(selectedFilters.locations)
-  nodeStructureStore.updateSelectedServices(selectedFilters.services)
-  nodeStructureStore.setFilterWithIpAddress(selectedFilters.ipAddress)
-  nodeStructureStore.setFilterWithMacAddress(selectedFilters.macAddress)
-  nodeStructureStore.setFilterWithDownAggregateStatus(selectedFilters.nodesWithDownAggregateStatus)
-  nodeStructureStore.setFilterWithNodesWithAssets(selectedFilters.nodesWithAssets)
-  nodeStructureStore.setFilterWithNodesWithOutages(selectedFilters.nodesWithOutages)
-  nodeStructureStore.setFilterWithTopology(selectedFilters.topology)
+  nodeListStore.updateSelectedCategories(selectedFilters.categories)
+  nodeListStore.updateSelectedCategories2(showSecondCategories.value ? selectedFilters.categories2 : [])
+  nodeListStore.updateSelectedFlows(selectedFilters.flows)
+  nodeListStore.updateSelectedMonitoringLocations(selectedFilters.locations)
+  nodeListStore.updateSelectedServices(selectedFilters.services)
+  nodeListStore.setFilterWithIpAddress(selectedFilters.ipAddress)
+  nodeListStore.setFilterWithMacAddress(selectedFilters.macAddress)
+  nodeListStore.setFilterWithDownAggregateStatus(selectedFilters.nodesWithDownAggregateStatus)
+  nodeListStore.setFilterWithNodesWithAssets(selectedFilters.nodesWithAssets)
+  nodeListStore.setFilterWithNodesWithOutages(selectedFilters.nodesWithOutages)
+  nodeListStore.setFilterWithTopology(selectedFilters.topology)
   assetFilterPanelRef.value?.applyToStore()
   extendedSearchPanelRef.value?.applyToStore()
-  nodeStructureStore.closeInstancesDrawerModal()
+  nodeListStore.closeInstancesDrawerModal()
 }
 
 const clearDrawerFilters = async () => {
-  await nodeStructureStore.clearAllFiltersAndSelections()
+  await nodeListStore.clearAllFiltersAndSelections()
   selectedFilters.categories = []
   selectedFilters.categories2 = []
   selectedFilters.flows = []
@@ -423,20 +423,20 @@ const clearDrawerFilters = async () => {
   extendedSearchPanelRef.value?.resetFromStore()
 }
 
-watch(() => nodeStructureStore.drawerState.visible, (visible) => {
+watch(() => nodeListStore.drawerState.visible, (visible) => {
   if (visible) {
-    selectedFilters.categories = [...nodeStructureStore.selectedCategories]
-    selectedFilters.categories2 = [...nodeStructureStore.selectedCategories2]
-    showSecondCategories.value = nodeStructureStore.selectedCategories2.length > 0
-    selectedFilters.flows = [...nodeStructureStore.selectedFlows]
-    selectedFilters.locations = [...nodeStructureStore.selectedMonitoringLocations]
-    selectedFilters.services = [...nodeStructureStore.selectedServices]
-    selectedFilters.ipAddress = nodeStructureStore.queryFilter.ipAddress ?? ''
-    selectedFilters.macAddress = nodeStructureStore.queryFilter.macAddress ?? ''
-    selectedFilters.topology = nodeStructureStore.queryFilter.topology ?? ''
-    selectedFilters.nodesWithDownAggregateStatus = nodeStructureStore.queryFilter.nodesWithDownAggregateStatus ?? false
-    selectedFilters.nodesWithAssets = nodeStructureStore.queryFilter.nodesWithAssets ?? false
-    selectedFilters.nodesWithOutages = nodeStructureStore.queryFilter.nodesWithOutages ?? false
+    selectedFilters.categories = [...nodeListStore.selectedCategories]
+    selectedFilters.categories2 = [...nodeListStore.selectedCategories2]
+    showSecondCategories.value = nodeListStore.selectedCategories2.length > 0
+    selectedFilters.flows = [...nodeListStore.selectedFlows]
+    selectedFilters.locations = [...nodeListStore.selectedMonitoringLocations]
+    selectedFilters.services = [...nodeListStore.selectedServices]
+    selectedFilters.ipAddress = nodeListStore.queryFilter.ipAddress ?? ''
+    selectedFilters.macAddress = nodeListStore.queryFilter.macAddress ?? ''
+    selectedFilters.topology = nodeListStore.queryFilter.topology ?? ''
+    selectedFilters.nodesWithDownAggregateStatus = nodeListStore.queryFilter.nodesWithDownAggregateStatus ?? false
+    selectedFilters.nodesWithAssets = nodeListStore.queryFilter.nodesWithAssets ?? false
+    selectedFilters.nodesWithOutages = nodeListStore.queryFilter.nodesWithOutages ?? false
     assetFilterPanelRef.value?.resetFromStore()
     extendedSearchPanelRef.value?.resetFromStore()
   }

--- a/ui/src/components/Nodes/NodeInterfacesPanel.vue
+++ b/ui/src/components/Nodes/NodeInterfacesPanel.vue
@@ -27,7 +27,7 @@
 import { PropType, computed } from 'vue'
 import { useMenuStore } from '@/stores/menuStore'
 import { useNodeStore } from '@/stores/nodeStore'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { Node } from '@/types'
 import { getInterfaceListMode, getInterfaceRowsForNode } from './hooks/useInterfaceListing'
 
@@ -40,10 +40,10 @@ const props = defineProps({
 
 const menuStore = useMenuStore()
 const nodeStore = useNodeStore()
-const nodeStructureStore = useNodeStructureStore()
+const nodeListStore = useNodeListStore()
 
 const rows = computed(() => {
-  const mode = getInterfaceListMode(nodeStructureStore.queryFilter)
+  const mode = getInterfaceListMode(nodeListStore.queryFilter)
   const ipInterfaces = nodeStore.nodeToIpInterfaceMap.get(props.node.id) ?? []
   const snmpInterfaces = nodeStore.nodeToSnmpInterfaceMap.get(props.node.id) ?? []
   const baseHref = menuStore.mainMenu.baseHref

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -177,7 +177,7 @@
         >
           <OnmsColumn
             v-if="nodeStructureStore.showInterfaces"
-            style="width: 3rem"
+            style="width: var(--expander-col-width)"
           >
             <template #body="{ data }">
               <OnmsIconButton
@@ -252,7 +252,15 @@
             />
           </template>
           <template #expansion="{ data }">
-            <NodeInterfacesPanel :node="data" />
+            <!-- The expansion cell spans the full table width; offset by the expander column's
+                 width so the interface list left-aligns with the first data column's content,
+                 whichever column the user has placed there. -->
+            <div
+              class="interface-expansion"
+              data-test="interface-expansion"
+            >
+              <NodeInterfacesPanel :node="data" />
+            </div>
           </template>
         </OnmsTable>
         <div
@@ -864,6 +872,13 @@ defineExpose({ onSort, onPage, removeItem, isRowExpandable, isRowExpanded, toggl
 
 .node-table {
   margin-top: 1rem;
+  // Single source of truth for the expander column width, shared by the expander
+  // OnmsColumn's inline style and the expansion row's alignment offset below.
+  --expander-col-width: 3rem;
+}
+
+.interface-expansion {
+  margin-left: var(--expander-col-width);
 }
 
 .card {

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -131,16 +131,16 @@
               @remove="nodeListStore.removeDownAggregateStatus()"
             />
             <OnmsChip
-              v-if="nodeListStore.queryFilter.nodesWithAssets"
-              label="Nodes with asset info"
-              removable
-              @remove="nodeListStore.removeNodesWithAssets()"
-            />
-            <OnmsChip
               v-if="nodeListStore.queryFilter.nodesWithOutages"
               label="Nodes with current outages"
               removable
               @remove="nodeListStore.removeNodesWithOutages()"
+            />
+            <OnmsChip
+              v-if="nodeListStore.queryFilter.nodesWithAssets"
+              label="Nodes with asset info"
+              removable
+              @remove="nodeListStore.removeNodesWithAssets()"
             />
             <OnmsChip
               v-for="assetFilter in (nodeListStore.queryFilter.assetFilters ?? [])"

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -11,19 +11,19 @@
           <OnmsButton
             label="Customize Columns"
             data-test="customize-columns-button"
-            @click="nodeStructureStore.openColumnsDrawerModal()"
+            @click="nodeListStore.openColumnsDrawerModal()"
           />
           <OnmsButton
-            :label="nodeStructureStore.showInterfaces ? 'Hide interfaces' : 'Show interfaces'"
+            :label="nodeListStore.showInterfaces ? 'Hide interfaces' : 'Show interfaces'"
             variant="outlined"
             data-test="show-interfaces-button"
-            @click="nodeStructureStore.setShowInterfaces(!nodeStructureStore.showInterfaces)"
+            @click="nodeListStore.setShowInterfaces(!nodeListStore.showInterfaces)"
           />
           <OnmsButton
             label="Clear Filters"
             variant="outlined"
             data-test="clear-filters-button"
-            @click="nodeStructureStore.clearAllFiltersAndSelections()"
+            @click="nodeListStore.clearAllFiltersAndSelections()"
           />
         </div>
       </div>
@@ -59,41 +59,41 @@
                 title="Advanced Filters"
                 data-test="advanced-filters-button"
                 :icon="FilterAlt"
-                @click="nodeStructureStore.openInstancesDrawerModal()"
+                @click="nodeListStore.openInstancesDrawerModal()"
               />
             </div>
           </div>
           <div class="chip-container">
             <OnmsChip
-              v-for="cat in nodeStructureStore.selectedCategories"
+              v-for="cat in nodeListStore.selectedCategories"
               :key="`cat-${cat._value}`"
               :label="`Category: ${cat._text}`"
               removable
               @remove="removeItem(cat, FilterTypeEnum.Category)"
             />
             <OnmsChip
-              v-for="cat in nodeStructureStore.selectedCategories2"
+              v-for="cat in nodeListStore.selectedCategories2"
               :key="`cat2-${cat._value}`"
               :label="`Category (2): ${cat._text}`"
               removable
               @remove="removeItem(cat, FilterTypeEnum.Category2)"
             />
             <OnmsChip
-              v-for="flow in nodeStructureStore.selectedFlows"
+              v-for="flow in nodeListStore.selectedFlows"
               :key="`flow-${flow._value}`"
               :label="`Flows: ${flow._text}`"
               removable
               @remove="removeItem(flow, FilterTypeEnum.Flow)"
             />
             <OnmsChip
-              v-for="loc in nodeStructureStore.queryFilter.selectedMonitoringLocations"
+              v-for="loc in nodeListStore.queryFilter.selectedMonitoringLocations"
               :key="loc.name"
               :label="`Location: ${loc.name}`"
               removable
               @remove="removeItem(loc, FilterTypeEnum.MonitoringLocation)"
             />
             <OnmsChip
-              v-for="svc in nodeStructureStore.selectedServices"
+              v-for="svc in nodeListStore.selectedServices"
               :key="`svc-${svc._value}`"
               :label="`Service: ${svc._text}`"
               removable
@@ -107,47 +107,47 @@
               @remove="removeExtendedSearchItem(value)"
             />
             <OnmsChip
-              v-if="nodeStructureStore.queryFilter.ipAddress"
-              :label="`IP Pattern: ${nodeStructureStore.queryFilter.ipAddress}`"
+              v-if="nodeListStore.queryFilter.ipAddress"
+              :label="`IP Pattern: ${nodeListStore.queryFilter.ipAddress}`"
               removable
-              @remove="nodeStructureStore.removeIpAddress()"
+              @remove="nodeListStore.removeIpAddress()"
             />
             <OnmsChip
-              v-if="nodeStructureStore.queryFilter.macAddress"
-              :label="`MAC Address: ${nodeStructureStore.queryFilter.macAddress}`"
+              v-if="nodeListStore.queryFilter.macAddress"
+              :label="`MAC Address: ${nodeListStore.queryFilter.macAddress}`"
               removable
-              @remove="nodeStructureStore.removeMacAddress()"
+              @remove="nodeListStore.removeMacAddress()"
             />
             <OnmsChip
               v-if="hasTopologySearch"
               :label="`Topology: ${topologyTerm}`"
               removable
-              @remove="nodeStructureStore.removeTopology()"
+              @remove="nodeListStore.removeTopology()"
             />
             <OnmsChip
-              v-if="nodeStructureStore.queryFilter.nodesWithDownAggregateStatus"
+              v-if="nodeListStore.queryFilter.nodesWithDownAggregateStatus"
               label="Down nodes only"
               removable
-              @remove="nodeStructureStore.removeDownAggregateStatus()"
+              @remove="nodeListStore.removeDownAggregateStatus()"
             />
             <OnmsChip
-              v-if="nodeStructureStore.queryFilter.nodesWithAssets"
+              v-if="nodeListStore.queryFilter.nodesWithAssets"
               label="Nodes with asset info"
               removable
-              @remove="nodeStructureStore.removeNodesWithAssets()"
+              @remove="nodeListStore.removeNodesWithAssets()"
             />
             <OnmsChip
-              v-if="nodeStructureStore.queryFilter.nodesWithOutages"
+              v-if="nodeListStore.queryFilter.nodesWithOutages"
               label="Nodes with current outages"
               removable
-              @remove="nodeStructureStore.removeNodesWithOutages()"
+              @remove="nodeListStore.removeNodesWithOutages()"
             />
             <OnmsChip
-              v-for="assetFilter in (nodeStructureStore.queryFilter.assetFilters ?? [])"
+              v-for="assetFilter in (nodeListStore.queryFilter.assetFilters ?? [])"
               :key="assetFilter.column"
               :label="`Asset: ${getAssetColumnLabel(assetFilter.column)}: ${assetFilter.value}`"
               removable
-              @remove="nodeStructureStore.removeAssetFilter(assetFilter.column)"
+              @remove="nodeListStore.removeAssetFilter(assetFilter.column)"
             />
           </div>
         </div>
@@ -176,7 +176,7 @@
           @sort="onSort"
         >
           <OnmsColumn
-            v-if="nodeStructureStore.showInterfaces"
+            v-if="nodeListStore.showInterfaces"
             style="width: var(--expander-col-width)"
           >
             <template #body="{ data }">
@@ -264,7 +264,7 @@
           </template>
         </OnmsTable>
         <div
-          v-if="nodeStructureStore.showInterfaces"
+          v-if="nodeListStore.showInterfaces"
           class="interfaces-footer"
           data-test="interfaces-footer"
         >
@@ -309,7 +309,7 @@
 import useSnackbar from '@/composables/useSnackbar'
 import { useMenuStore } from '@/stores/menuStore'
 import { useNodeStore } from '@/stores/nodeStore'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import {
   ExtendedSearchValue,
   FilterTypeEnum,
@@ -360,17 +360,17 @@ import EmptyList from '../Common/EmptyList.vue'
 import FormField from '../Common/FormField.vue'
 
 const menuStore = useMenuStore()
-const nodeStructureStore = useNodeStructureStore()
+const nodeListStore = useNodeListStore()
 const nodeStore = useNodeStore()
 const { showSnackBar } = useSnackbar()
 const { generateBlob, generateDownload, getExportData } = useNodeExport()
-const { buildUpdatedNodeStructureQueryParameters, getExtendedSearchValues } = useNodeQuery()
+const { buildUpdatedNodeListQueryParameters, getExtendedSearchValues } = useNodeQuery()
 const isHelpMessageDialogVisible = ref(false)
 
 const sortField = ref('label')
 const sortOrder = ref(1) // 1 = ascending, -1 = descending
 
-const currentSearch = ref(nodeStructureStore.queryFilter.searchTerm || '')
+const currentSearch = ref(nodeListStore.queryFilter.searchTerm || '')
 const nodes = computed(() => nodeStore.nodes)
 const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 
@@ -385,7 +385,7 @@ const pageSize = ref(nodeStore.nodeQueryParameters.limit || 50)
 const first = computed(() => (pageNumber.value - 1) * pageSize.value)
 
 const orderedSelectedColumns = computed<NodeColumnSelectionItem[]>(() =>
-  nodeStructureStore.columns
+  nodeListStore.columns
     .filter(col => col.selected)
     .sort((a, b) => a.order - b.order)
 )
@@ -429,14 +429,14 @@ const updatePageSize = (size: number) => {
 }
 
 const searchFilterHandler: UpdateModelFunction = (val = '') => {
-  if (val !== nodeStructureStore.queryFilter.searchTerm) {
-    nodeStructureStore.setSearchTerm(val)
+  if (val !== nodeListStore.queryFilter.searchTerm) {
+    nodeListStore.setSearchTerm(val)
   }
 }
 
 const onDownload = async (format: string) => {
-  const updatedParams = buildUpdatedNodeStructureQueryParameters(queryParameters.value, nodeStructureStore.queryFilter)
-  const data = await getExportData(format, updatedParams, nodeStructureStore.columns)
+  const updatedParams = buildUpdatedNodeListQueryParameters(queryParameters.value, nodeListStore.queryFilter)
+  const data = await getExportData(format, updatedParams, nodeListStore.columns)
 
   if (!data) {
     showSnackBar({
@@ -478,12 +478,12 @@ const onNodeLinkClick = (nodeId: number | string) => {
 }
 
 const extendedSearchValues = computed(() => {
-  return getExtendedSearchValues(nodeStructureStore.queryFilter.extendedSearch)
+  return getExtendedSearchValues(nodeListStore.queryFilter.extendedSearch)
 })
 
 // ── "Show interfaces" mode (legacy ?listInterfaces=true parity) ────────────────
 
-const interfaceListMode = computed(() => getInterfaceListMode(nodeStructureStore.queryFilter))
+const interfaceListMode = computed(() => getInterfaceListMode(nodeListStore.queryFilter))
 
 const pageNodeIds = computed(() => nodes.value.map(n => n.id))
 
@@ -599,29 +599,29 @@ const buildSnmpNarrowing = (mode: InterfaceListMode): string | undefined => {
 }
 
 const hasTopologySearch = computed(() => {
-  return !!nodeStructureStore.queryFilter.topology?.length
+  return !!nodeListStore.queryFilter.topology?.length
 })
 
 const topologyTerm = computed(() => {
-  return nodeStructureStore.queryFilter.topology ?? ''
+  return nodeListStore.queryFilter.topology ?? ''
 })
 
 const removeItem = (item: IAutocompleteItemType, type: FilterTypeEnum) => {
   switch (type) {
     case FilterTypeEnum.Category:
-      nodeStructureStore.removeCategory(item)
+      nodeListStore.removeCategory(item)
       break
     case FilterTypeEnum.Category2:
-      nodeStructureStore.removeCategory2(item)
+      nodeListStore.removeCategory2(item)
       break
     case FilterTypeEnum.Flow:
-      nodeStructureStore.removeFlow(item)
+      nodeListStore.removeFlow(item)
       break
     case FilterTypeEnum.MonitoringLocation:
-      nodeStructureStore.removeMonitoringLocation(item)
+      nodeListStore.removeMonitoringLocation(item)
       break
     case FilterTypeEnum.MonitoredService:
-      nodeStructureStore.removeService(item)
+      nodeListStore.removeService(item)
       break
     default:
       console.warn(`Unknown filter type: ${type}`)
@@ -629,7 +629,7 @@ const removeItem = (item: IAutocompleteItemType, type: FilterTypeEnum) => {
 }
 
 const removeExtendedSearchItem = (item: ExtendedSearchValue) => {
-  nodeStructureStore.removeExtendedSearch(item)
+  nodeListStore.removeExtendedSearch(item)
 }
 
 const updateQuery = (options?: { orderBy?: string, order?: SORT }) => {
@@ -645,7 +645,7 @@ const updateQuery = (options?: { orderBy?: string, order?: SORT }) => {
       }
       : nodeStore.nodeQueryParameters
 
-  const updatedParams = buildUpdatedNodeStructureQueryParameters(queryParamsToUse, nodeStructureStore.queryFilter)
+  const updatedParams = buildUpdatedNodeListQueryParameters(queryParamsToUse, nodeListStore.queryFilter)
   queryParameters.value = updatedParams
 
   nodeStore.getNodes(updatedParams, true)
@@ -655,9 +655,9 @@ const emptyListContent = {
   msg: 'No results found.'
 }
 
-watch([() => nodeStructureStore.queryFilter], () => {
-  if (nodeStructureStore.queryFilter.searchTerm !== currentSearch.value) {
-    currentSearch.value = nodeStructureStore.queryFilter.searchTerm
+watch([() => nodeListStore.queryFilter], () => {
+  if (nodeListStore.queryFilter.searchTerm !== currentSearch.value) {
+    currentSearch.value = nodeListStore.queryFilter.searchTerm
   }
 
   updateQuery()
@@ -670,7 +670,7 @@ watch([() => nodeStructureStore.queryFilter], () => {
 // Harmless — and correct — to re-run on every one of these, since it's just a snapshot of "which
 // rows are on the current page".
 watch(
-  [nodes, () => nodeStructureStore.showInterfaces, interfaceListMode],
+  [nodes, () => nodeListStore.showInterfaces, interfaceListMode],
   ([currentNodes, showInterfaces]) => {
     // Reset BOTH catch-up watchers' "already applied" flags on every input change here (new page,
     // toggle, or mode change): each such change starts a new generation whose eventual async map
@@ -722,7 +722,7 @@ watch(
 const lastSnmpFetchKey = ref<string | null>(null)
 
 watch(
-  [nodes, () => nodeStructureStore.showInterfaces],
+  [nodes, () => nodeListStore.showInterfaces],
   ([currentNodes, showInterfaces]) => {
     // Deliberately don't reset lastSnmpFetchKey when toggling off — re-toggling on with the exact
     // same nodes/mode should stay deduped rather than re-issuing an identical request.
@@ -782,7 +782,7 @@ let snmpCatchUpAppliedForKey: string | null = null
 watch(
   () => nodeStore.nodeToSnmpInterfaceMap,
   () => {
-    if (!nodeStructureStore.showInterfaces) {
+    if (!nodeListStore.showInterfaces) {
       return
     }
 
@@ -837,7 +837,7 @@ let ipCatchUpAppliedForKey: string | null = null
 watch(
   () => nodeStore.nodeToIpInterfaceMap,
   () => {
-    if (!nodeStructureStore.showInterfaces) {
+    if (!nodeListStore.showInterfaces) {
       return
     }
 

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -185,8 +185,8 @@ export const useNodeQuery = () => {
    * Build new QueryParameters based on existing QueryParameters (which contain e.g. limit, offset and similar),
    * combined with the given NodeQueryFilter.
    */
-  const buildUpdatedNodeStructureQueryParameters = (queryParameters: QueryParameters, filter: NodeQueryFilter) => {
-    const searchQuery = buildNodeStructureQuery(filter)
+  const buildUpdatedNodeListQueryParameters = (queryParameters: QueryParameters, filter: NodeQueryFilter) => {
+    const searchQuery = buildNodeListQuery(filter)
     const searchQueryParam: QueryParameters = { _s: searchQuery }
     const updatedParams = { ...queryParameters, ...searchQueryParam }
 
@@ -194,7 +194,7 @@ export const useNodeQuery = () => {
   }
 
   /**
-   * Query string search parameters tracked/accepted by the Node Structure page.
+   * Query string search parameters tracked/accepted by the Node List page.
    */
   const trackedNodeQueryStringProperties = new Set([
     'assetColumn',
@@ -343,7 +343,7 @@ export const useNodeQuery = () => {
     }
 
     // listInterfaces: not handled here — it's a display flag, not a filter, so it's applied directly
-    // in Nodes.vue (nodeStructureStore.setShowInterfaces) rather than folded into the NodeQueryFilter.
+    // in Nodes.vue (nodeListStore.setShowInterfaces) rather than folded into the NodeQueryFilter.
     // service=<id>: numeric service ID is not resolved here; PR 3 pages will send monitoredService=<name>.
     // NOTE nodeId: not handled here. Legacy `?nodeId=<n>` bookmarks are redirected to the node
     //   detail page (element/node.jsp?node={id}) before the query filter is ever built — see
@@ -356,7 +356,7 @@ export const useNodeQuery = () => {
   return {
     addIpAddressToQueryFilter,
     buildNodeQueryFilterFromQueryString,
-    buildUpdatedNodeStructureQueryParameters,
+    buildUpdatedNodeListQueryParameters,
     getDefaultNodeQueryFilter,
     getDefaultNodeQueryExtendedSearchParams,
     getDefaultNodeQueryForeignSourceParams,
@@ -370,7 +370,7 @@ export const useNodeQuery = () => {
 /**
  * Build a FIQL query for the Node Rest service from a NodeQueryFilter.
  */
-const buildNodeStructureQuery = (filter: NodeQueryFilter) => {
+const buildNodeListQuery = (filter: NodeQueryFilter) => {
   const searchTerm = sanitizeSearchTerm(filter.searchTerm)
   // don't sanitize IP address — allow users to enter commas and other FIQL characters, since buildIpAddressQuery will handle them appropriately
   // (commas are valid in iplike patterns, and users may naturally enter comma-separated lists of IPs or CIDRs)

--- a/ui/src/components/Nodes/utils.ts
+++ b/ui/src/components/Nodes/utils.ts
@@ -63,8 +63,8 @@ export const defaultColumns: NodeColumnSelectionItem[] = [
   { id: 'location', label: 'Monitoring Location', selected: true, order: 3 },
   { id: 'foreignSource', label: 'Foreign Source', selected: true, order: 4 },
   { id: 'foreignId', label: 'Foreign ID', selected: true, order: 5 },
-  { id: 'sysContact', label: 'Sys Contact', selected: true, order: 6 },
-  { id: 'sysLocation', label: 'Sys Location', selected: true, order: 7 },
-  { id: 'sysDescription', label: 'Sys Description', selected: true, order: 8 },
-  { id: 'flows', label: 'Flows', selected: true, order: 9 }
+  { id: 'sysContact', label: 'Sys Contact', selected: false, order: 6 },
+  { id: 'sysLocation', label: 'Sys Location', selected: false, order: 7 },
+  { id: 'sysDescription', label: 'Sys Description', selected: false, order: 8 },
+  { id: 'flows', label: 'Flows', selected: false, order: 9 }
 ]

--- a/ui/src/containers/Nodes.vue
+++ b/ui/src/containers/Nodes.vue
@@ -21,12 +21,12 @@ import { buildNodeDetailUrl, parseNodeIdQueryParam, useNodeQuery } from '@/compo
 import NodesTable from '@/components/Nodes/NodesTable.vue'
 import { loadNodePreferences, saveNodeQueryFilter } from '@/services/localStorageService'
 import { useMenuStore } from '@/stores/menuStore'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { BreadCrumb, NodePreferences } from '@/types'
 import { LocationQuery, useRoute, useRouter } from 'vue-router'
 
 const menuStore = useMenuStore()
-const nodeStructureStore = useNodeStructureStore()
+const nodeListStore = useNodeListStore()
 const { buildNodeQueryFilterFromQueryString, queryStringHasTrackedValues } = useNodeQuery()
 
 const route = useRoute()
@@ -88,9 +88,9 @@ watch(
 const applyQueryFilter = (query: LocationQuery, prefs: NodePreferences | null) => {
   const nodeFilter = buildNodeQueryFilterFromQueryString(
     query,
-    nodeStructureStore.categories,
-    nodeStructureStore.monitoringLocations,
-    nodeStructureStore.allServiceTypes
+    nodeListStore.categories,
+    nodeListStore.monitoringLocations,
+    nodeListStore.allServiceTypes
   )
   const newPrefs = {
     nodeColumns: prefs?.nodeColumns || [],
@@ -100,15 +100,15 @@ const applyQueryFilter = (query: LocationQuery, prefs: NodePreferences | null) =
   // listInterfaces is a display flag (legacy ?listInterfaces=true), not part of the filter —
   // applied directly on the store here rather than persisted via NodePreferences.
   if (String(query.listInterfaces).toLowerCase() === 'true') {
-    nodeStructureStore.setShowInterfaces(true)
+    nodeListStore.setShowInterfaces(true)
   }
 
-  nodeStructureStore.setFromNodePreferences(newPrefs)
+  nodeListStore.setFromNodePreferences(newPrefs)
 }
 
 const handleQuery = (prefs: NodePreferences | null) => {
   if (queryStringHasTrackedValues(route.query)) {
-    if (!nodeStructureStore.categoriesLoaded || !nodeStructureStore.monitoringLocationsLoaded || !nodeStructureStore.serviceTypesLoaded) {
+    if (!nodeListStore.categoriesLoaded || !nodeListStore.monitoringLocationsLoaded || !nodeListStore.serviceTypesLoaded) {
       // Lists not finished loading yet — save and defer.
       pendingRouteQuery.value = { ...route.query }
     } else {
@@ -126,7 +126,7 @@ const handleQuery = (prefs: NodePreferences | null) => {
 // and Nodes.vue mounting with query params already in the URL.
 // Note: lists may be empty (e.g. no categories configured) — loaded flags handle this correctly.
 watch(
-  [() => nodeStructureStore.categoriesLoaded, () => nodeStructureStore.monitoringLocationsLoaded, () => nodeStructureStore.serviceTypesLoaded],
+  [() => nodeListStore.categoriesLoaded, () => nodeListStore.monitoringLocationsLoaded, () => nodeListStore.serviceTypesLoaded],
   ([catsLoaded, locsLoaded, svcTypesLoaded]) => {
     if (pendingRouteQuery.value && catsLoaded && locsLoaded && svcTypesLoaded) {
       applyQueryFilter(pendingRouteQuery.value, loadNodePreferences())
@@ -138,7 +138,7 @@ watch(
 let saveFilterTimeout: number | undefined
 
 watch(
-  () => nodeStructureStore.queryFilter,
+  () => nodeListStore.queryFilter,
   (filter) => {
     if (saveFilterTimeout !== undefined) {
       clearTimeout(saveFilterTimeout)
@@ -157,7 +157,7 @@ onMounted(() => {
     return
   }
   if (prefs) {
-    nodeStructureStore.setFromNodePreferences(prefs)
+    nodeListStore.setFromNodePreferences(prefs)
   }
 })
 

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -39,13 +39,13 @@ import { useInfoStore } from '@/stores/infoStore'
 import { usePluginStore } from '@/stores/pluginStore'
 import { useMenuStore } from '@/stores/menuStore'
 import { useMonitoringSystemStore } from '@/stores/monitoringSystemStore'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 
 const authStore = useAuthStore()
 const infoStore = useInfoStore()
 const menuStore = useMenuStore()
 const monitoringSystemStore = useMonitoringSystemStore()
-const nodeStructureStore = useNodeStructureStore()
+const nodeListStore = useNodeListStore()
 const pluginStore = usePluginStore()
 
 onMounted(() => {
@@ -55,9 +55,9 @@ onMounted(() => {
   menuStore.getNotificationSummary()
   menuStore.loadSideMenuExpanded()
   monitoringSystemStore.getMainMonitoringSystem()
-  nodeStructureStore.getCategories()
-  nodeStructureStore.getMonitoringLocations()
-  nodeStructureStore.getServiceTypes()
+  nodeListStore.getCategories()
+  nodeListStore.getMonitoringLocations()
+  nodeListStore.getServiceTypes()
   pluginStore.getPlugins()
 })
 </script>

--- a/ui/src/stores/nodeListStore.ts
+++ b/ui/src/stores/nodeListStore.ts
@@ -55,7 +55,7 @@ const getDefaultDrawerState = (): DrawerState => {
   }
 }
 
-export const useNodeStructureStore = defineStore('nodeStructureStore', () => {
+export const useNodeListStore = defineStore('nodeListStore', () => {
   const categories = ref<Category[]>([])
   const categoryCount = computed(() => categories.value.length)
   const categoriesLoaded = ref(false)

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -618,7 +618,7 @@ export interface AssetFilter {
   value: string
 }
 
-/** All components of a node structure query */
+/** All components of a node list query */
 export interface NodeQueryFilter {
   searchTerm: string
   categoryMode: SetOperator

--- a/ui/tests/components/Nodes/AssetFilterPanel.test.ts
+++ b/ui/tests/components/Nodes/AssetFilterPanel.test.ts
@@ -1,7 +1,7 @@
 // ui/tests/components/Nodes/AssetFilterPanel.test.ts
 import AssetFilterPanel from '@/components/Nodes/AssetFilterPanel.vue'
 import { ALL_ASSET_COLUMN_OPTIONS, ASSET_COLUMN_OPTIONS } from '@/components/Nodes/hooks/queryStringParser'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
@@ -13,7 +13,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 describe('AssetFilterPanel.vue', () => {
-  let store: ReturnType<typeof useNodeStructureStore>
+  let store: ReturnType<typeof useNodeListStore>
 
   const mountPanel = () =>
     mount(AssetFilterPanel, {
@@ -28,7 +28,7 @@ describe('AssetFilterPanel.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     setActivePinia(createTestingPinia({ createSpy: vi.fn, stubActions: false }))
-    store = useNodeStructureStore()
+    store = useNodeListStore()
     store.setFilterWithAssetFilters = vi.fn()
     store.queryFilter = {
       ...store.queryFilter,
@@ -114,7 +114,7 @@ describe('AssetFilterPanel.vue', () => {
 
   // ── resetFromStore ─────────────────────────────────────────────────────────
 
-  it('resetFromStore() seeds grid rows from nodeStructureStore.queryFilter.assetFilters', async () => {
+  it('resetFromStore() seeds grid rows from nodeListStore.queryFilter.assetFilters', async () => {
     const wrapper = mountPanel()
 
     store.queryFilter = {

--- a/ui/tests/components/Nodes/ColumnSelectionDrawer.test.ts
+++ b/ui/tests/components/Nodes/ColumnSelectionDrawer.test.ts
@@ -21,7 +21,7 @@
 ///
 
 import ColumnSelectionDrawer from '@/components/Nodes/ColumnSelectionDrawer.vue'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { defaultColumns } from '@/components/Nodes/utils'
 import { createTestingPinia } from '@pinia/testing'
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
@@ -59,7 +59,7 @@ vi.mock('@/components/Nodes/hooks/useNodeQuery', () => {
   })
   return {
     useNodeQuery: () => ({
-      buildUpdatedNodeStructureQueryParameters: vi.fn().mockImplementation(params => params),
+      buildUpdatedNodeListQueryParameters: vi.fn().mockImplementation(params => params),
       getExtendedSearchValues: vi.fn().mockReturnValue([]),
       getDefaultNodeQueryFilter: makeDefaultFilter,
       getDefaultNodeQueryForeignSourceParams: () => ({ foreignId: '', foreignSource: '', foreignSourceId: '' }),
@@ -105,12 +105,12 @@ const mountDrawer = () =>
 
 describe('ColumnSelectionDrawer.vue', () => {
   let wrapper: VueWrapper<any>
-  let store: ReturnType<typeof useNodeStructureStore>
+  let store: ReturnType<typeof useNodeListStore>
 
   beforeEach(async () => {
     vi.clearAllMocks()
     wrapper = mountDrawer()
-    store = useNodeStructureStore()
+    store = useNodeListStore()
 
     // Seed the store with two selected columns so the drawer has rows to display.
     store.columns = defaultColumns.map(c => ({ ...c }))

--- a/ui/tests/components/Nodes/ExtendedSearchPanel.test.ts
+++ b/ui/tests/components/Nodes/ExtendedSearchPanel.test.ts
@@ -1,6 +1,6 @@
 // ui/tests/components/Nodes/ExtendedSearchPanel.test.ts
 import ExtendedSearchPanel from '@/components/Nodes/ExtendedSearchPanel.vue'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 describe('ExtendedSearchPanel.vue', () => {
-  let store: ReturnType<typeof useNodeStructureStore>
+  let store: ReturnType<typeof useNodeListStore>
 
   const mountPanel = () =>
     mount(ExtendedSearchPanel, {
@@ -27,7 +27,7 @@ describe('ExtendedSearchPanel.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     setActivePinia(createTestingPinia({ createSpy: vi.fn, stubActions: false }))
-    store = useNodeStructureStore()
+    store = useNodeListStore()
     store.setExtendedSearchParams = vi.fn()
     store.queryFilter = {
       ...store.queryFilter,
@@ -159,7 +159,7 @@ describe('ExtendedSearchPanel.vue', () => {
 
   // ── resetFromStore ─────────────────────────────────────────────────────────
 
-  it('resetFromStore() seeds grid rows from nodeStructureStore.queryFilter.extendedSearch', async () => {
+  it('resetFromStore() seeds grid rows from nodeListStore.queryFilter.extendedSearch', async () => {
     const wrapper = mountPanel()
 
     // Simulate a store with a pre-existing foreignSource param

--- a/ui/tests/components/Nodes/NodeAdvancedFiltersDrawer.test.ts
+++ b/ui/tests/components/Nodes/NodeAdvancedFiltersDrawer.test.ts
@@ -21,7 +21,7 @@
 ///
 
 import NodeAdvancedFiltersDrawer from '@/components/Nodes/NodeAdvancedFiltersDrawer.vue'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { createTestingPinia } from '@pinia/testing'
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
@@ -54,7 +54,7 @@ vi.mock('@/components/Nodes/hooks/useNodeQuery', () => {
   })
   return {
     useNodeQuery: () => ({
-      buildUpdatedNodeStructureQueryParameters: vi.fn().mockImplementation(params => params),
+      buildUpdatedNodeListQueryParameters: vi.fn().mockImplementation(params => params),
       getExtendedSearchValues: vi.fn().mockReturnValue([]),
       getDefaultNodeQueryFilter: makeDefaultFilter,
       getDefaultNodeQueryForeignSourceParams: () => ({ foreignId: '', foreignSource: '', foreignSourceId: '' }),
@@ -110,7 +110,7 @@ const ExtendedSearchPanelStub = {
 
 // ── Mount helper ───────────────────────────────────────────────────────────────
 
-const seedStore = (store: ReturnType<typeof useNodeStructureStore>) => {
+const seedStore = (store: ReturnType<typeof useNodeListStore>) => {
   store.categories = [
     { id: 1, name: 'Routers', authorizedGroups: [] },
     { id: 2, name: 'Switches', authorizedGroups: [] }
@@ -143,12 +143,12 @@ const mountDrawer = () =>
 
 describe('NodeAdvancedFiltersDrawer.vue', () => {
   let wrapper: VueWrapper<any>
-  let store: ReturnType<typeof useNodeStructureStore>
+  let store: ReturnType<typeof useNodeListStore>
 
   beforeEach(async () => {
     vi.clearAllMocks()
     wrapper = mountDrawer()
-    store = useNodeStructureStore()
+    store = useNodeListStore()
     seedStore(store)
     store.drawerState = { visible: true } as any
     await nextTick()

--- a/ui/tests/components/Nodes/NodeInterfacesPanel.test.ts
+++ b/ui/tests/components/Nodes/NodeInterfacesPanel.test.ts
@@ -2,7 +2,7 @@
 import NodeInterfacesPanel from '@/components/Nodes/NodeInterfacesPanel.vue'
 import { useMenuStore } from '@/stores/menuStore'
 import { useNodeStore } from '@/stores/nodeStore'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
@@ -19,7 +19,7 @@ const mountPanel = (node: any = { id: '1' }) => {
     wrapper,
     menuStore: useMenuStore(),
     nodeStore: useNodeStore(),
-    structure: useNodeStructureStore()
+    structure: useNodeListStore()
   }
 }
 

--- a/ui/tests/components/Nodes/NodesTable.test.ts
+++ b/ui/tests/components/Nodes/NodesTable.test.ts
@@ -992,8 +992,12 @@ describe('NodesTable.vue', () => {
   // ── Flows sort fix ───────────────────────────────────────────────────────────
 
   describe('flows column sorting', () => {
-    it('the Flows column is not sortable', () => {
+    it('the Flows column is not sortable', async () => {
       const wrapper = mountTable()
+      // Flows is no longer in the default column selection (NMS-20175) — select it explicitly.
+      const structure = useNodeStructureStore()
+      structure.columns = structure.columns.map(c => (c.id === 'flows' ? { ...c, selected: true } : c))
+      await nextTick()
       const flowsColumn = wrapper.findAllComponents(Column).find(c => c.props('header') === 'Flows')
       expect(flowsColumn).toBeDefined()
       expect(flowsColumn!.props('sortable')).toBe(false)

--- a/ui/tests/components/Nodes/NodesTable.test.ts
+++ b/ui/tests/components/Nodes/NodesTable.test.ts
@@ -2,7 +2,7 @@
 import NodesTable from '@/components/Nodes/NodesTable.vue'
 import { useMenuStore } from '@/stores/menuStore'
 import { useNodeStore } from '@/stores/nodeStore'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { FilterTypeEnum } from '@/types'
 import { defaultColumns } from '@/components/Nodes/utils'
 import { SORT } from '@/types'
@@ -45,7 +45,7 @@ vi.mock('@/components/Nodes/hooks/useNodeExport', () => ({
 
 vi.mock('@/components/Nodes/hooks/useNodeQuery', async () => {
   // Real (unmocked) module — delegated to below for sanitizeSearchTerm and for
-  // buildUpdatedNodeStructureQueryParameters, so tests that write a searchTerm directly into the
+  // buildUpdatedNodeListQueryParameters, so tests that write a searchTerm directly into the
   // store can assert on the ACTUAL request shape (e.g. that a term with FIQL-special characters
   // really does get double-encoded end-to-end), rather than a naive passthrough stub.
   const actual = await vi.importActual<typeof import('@/components/Nodes/hooks/useNodeQuery')>(
@@ -75,7 +75,7 @@ vi.mock('@/components/Nodes/hooks/useNodeQuery', async () => {
   })
   return {
     useNodeQuery: () => ({
-      buildUpdatedNodeStructureQueryParameters: actual.useNodeQuery().buildUpdatedNodeStructureQueryParameters,
+      buildUpdatedNodeListQueryParameters: actual.useNodeQuery().buildUpdatedNodeListQueryParameters,
       getExtendedSearchValues: vi.fn().mockReturnValue([]),
       getDefaultNodeQueryFilter: makeDefaultFilter,
       getDefaultNodeQueryForeignSourceParams: () => ({ foreignId: '', foreignSource: '', foreignSourceId: '' }),
@@ -117,7 +117,7 @@ const mountTable = () =>
 
 describe('NodesTable.vue', () => {
   let nodeStore: ReturnType<typeof useNodeStore>
-  let structure: ReturnType<typeof useNodeStructureStore>
+  let structure: ReturnType<typeof useNodeListStore>
 
   beforeEach(async () => {
     vi.clearAllMocks()
@@ -126,7 +126,7 @@ describe('NodesTable.vue', () => {
     const wrapper = mountTable()
 
     nodeStore = useNodeStore()
-    structure = useNodeStructureStore()
+    structure = useNodeListStore()
     const menuStore = useMenuStore()
 
     // Seed stores
@@ -223,7 +223,7 @@ describe('NodesTable.vue', () => {
   it('removing a category chip calls the store', () => {
     // Seed a category before mounting so the chip renders
     const wrapper = mountTable()
-    const str = useNodeStructureStore()
+    const str = useNodeListStore()
     str.removeCategory = vi.fn()
     ;(wrapper.vm as any).removeItem({ _text: 'Routers', _value: '1' }, FilterTypeEnum.Category)
     expect(str.removeCategory).toHaveBeenCalled()
@@ -243,7 +243,7 @@ describe('NodesTable.vue', () => {
 
     it('renders a leading expander column once showInterfaces is on', async () => {
       const wrapper = mountTable()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       structure.setShowInterfaces(true)
       await nextTick()
 
@@ -253,9 +253,9 @@ describe('NodesTable.vue', () => {
       expect(headers.length).toBe(selectedCount + 2)
     })
 
-    it('toggle button flips nodeStructureStore.showInterfaces and updates its label', async () => {
+    it('toggle button flips nodeListStore.showInterfaces and updates its label', async () => {
       const wrapper = mountTable()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       expect(structure.showInterfaces).toBe(false)
 
       const toggleBtn = wrapper.findAllComponents(Button).find(b => b.attributes('data-test') === 'show-interfaces-button')
@@ -270,7 +270,7 @@ describe('NodesTable.vue', () => {
     it('expands only rows with expandable interface content when showInterfaces turns on, and collapses all when turned off', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.nodes = [{ id: '1' }, { id: '2' }, { id: '3' }] as any
       ns.nodeToIpInterfaceMap = new Map([
@@ -299,7 +299,7 @@ describe('NodesTable.vue', () => {
     it('renders the footer with node/interface counts only when showInterfaces is on', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.nodes = [{ id: '1' }] as any
       ns.totalCount = 1
@@ -319,7 +319,7 @@ describe('NodesTable.vue', () => {
     it('pluralizes node/interface counts when greater than one', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.nodes = [{ id: '1' }, { id: '2' }] as any
       ns.totalCount = 5
@@ -343,7 +343,7 @@ describe('NodesTable.vue', () => {
     it('default mode: caret renders only for a node with more than one IP interface', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.nodes = [{ id: '1', label: 'two-ips' }, { id: '2', label: 'one-ip' }, { id: '3', label: 'no-ips' }] as any
       ns.nodeToIpInterfaceMap = new Map([
@@ -370,7 +370,7 @@ describe('NodesTable.vue', () => {
     it('maclike mode: caret renders for a node with a single matching SNMP interface (>= 1 threshold)', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
@@ -400,7 +400,7 @@ describe('NodesTable.vue', () => {
       // exercise the race the auto-expand watcher and the async fetch create.
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
 
@@ -441,7 +441,7 @@ describe('NodesTable.vue', () => {
     it('does not force a manually-collapsed row back open when the SNMP map is replaced again for the same fetch generation', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       const snmpMap = () => new Map([
         ['1', [{ id: 5, ifIndex: 2, physAddr: 'aabbccddeeff', collectFlag: 'N', ifName: 'eth0', ifDescr: null }]]
@@ -480,7 +480,7 @@ describe('NodesTable.vue', () => {
     it('clicking the caret expands the row and clicking again collapses it, reflected in aria-expanded', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.nodes = [{ id: '1', label: 'node-1' }] as any
       ns.nodeToIpInterfaceMap = new Map([
@@ -528,7 +528,7 @@ describe('NodesTable.vue', () => {
     it('auto-expands a qualifying row once the IP batch resolves AFTER nodes changes, and leaves 0/1-interface rows collapsed', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       // Reproduces real production ordering: nodes arrives first (e.g. a page change) while
       // nodeToIpInterfaceMap is still whatever the PREVIOUS page left behind — here, empty — and
@@ -566,7 +566,7 @@ describe('NodesTable.vue', () => {
     it('does not force a manually-collapsed row back open when the IP map is replaced again for the same page (generation)', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       const ipMap = () => new Map([
         ['1', [
@@ -603,7 +603,7 @@ describe('NodesTable.vue', () => {
     it('applies catch-up again for a new page (new node ids reset the generation key)', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.nodes = [{ id: '1', label: 'two-ips' }] as any
       await nextTick()
@@ -644,7 +644,7 @@ describe('NodesTable.vue', () => {
     it('does not double-handle the IP batch in maclike mode (qualification stays governed by the SNMP map)', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
@@ -686,7 +686,7 @@ describe('NodesTable.vue', () => {
     it('applies IP catch-up again when a page recurs after an intervening page with no qualifying rows (A -> B -> A)', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.nodes = [{ id: '1', label: 'page-a' }] as any
       await nextTick()
@@ -739,7 +739,7 @@ describe('NodesTable.vue', () => {
     it('applies IP catch-up again after a default -> maclike -> default mode round-trip on the same page', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
@@ -789,7 +789,7 @@ describe('NodesTable.vue', () => {
     it('applies SNMP catch-up again after a maclike -> default -> maclike mode round-trip on the same page', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
@@ -841,7 +841,7 @@ describe('NodesTable.vue', () => {
     it('does not fetch snmp interfaces in default mode', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
 
@@ -858,7 +858,7 @@ describe('NodesTable.vue', () => {
     it('fetches snmp interfaces narrowed to physAddr in maclike mode, normalizing the mac', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
 
@@ -877,7 +877,7 @@ describe('NodesTable.vue', () => {
     it('narrows using the fully-normalized MAC (dots/spaces stripped too, not just : and -)', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
 
@@ -899,7 +899,7 @@ describe('NodesTable.vue', () => {
     it('fetches snmp interfaces narrowed to the snmpParm attribute in snmpParm mode', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
 
@@ -918,7 +918,7 @@ describe('NodesTable.vue', () => {
     it('omits the attribute narrowing when the snmpParm value contains SQL wildcards (% or _)', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
 
@@ -947,7 +947,7 @@ describe('NodesTable.vue', () => {
     ])('omits the attribute narrowing when the snmpParm value contains %s', async (_title, value) => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
 
@@ -966,7 +966,7 @@ describe('NodesTable.vue', () => {
     it('does not re-fetch when nodes/mode/narrowing are unchanged (dedupe)', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getSnmpInterfacesForNodes = vi.fn().mockResolvedValue(undefined)
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
 
@@ -995,7 +995,7 @@ describe('NodesTable.vue', () => {
     it('the Flows column is not sortable', async () => {
       const wrapper = mountTable()
       // Flows is no longer in the default column selection (NMS-20175) — select it explicitly.
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       structure.columns = structure.columns.map(c => (c.id === 'flows' ? { ...c, selected: true } : c))
       await nextTick()
       const flowsColumn = wrapper.findAllComponents(Column).find(c => c.props('header') === 'Flows')
@@ -1018,7 +1018,7 @@ describe('NodesTable.vue', () => {
     it('typing a term with a former blocklist character (%) searches immediately, with no error UI', async () => {
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
       ;(ns.getNodes as any).mockClear()
 
@@ -1040,7 +1040,7 @@ describe('NodesTable.vue', () => {
       ['a close paren', 'bad)term']
     ])('searches a term containing %s (R&D-sw1 / Core (bldg 3) style labels are now valid input)', async (_title, value) => {
       const wrapper = mountTable()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       const input = wrapper.find('input[data-test="search-input"]')
       await input.setValue(value)
@@ -1052,7 +1052,7 @@ describe('NodesTable.vue', () => {
 
     it('allows a term containing only an asterisk wildcard', async () => {
       const wrapper = mountTable()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
 
       const input = wrapper.find('input[data-test="search-input"]')
       await input.setValue('*serv*')
@@ -1064,14 +1064,14 @@ describe('NodesTable.vue', () => {
 
     it('a searchTerm written directly into the store (URL nodename param / restored preferences) flows through unchanged, no error UI', async () => {
       // Reproduces the programmatic-injection paths that never go through searchFilterHandler:
-      // nodeStructureStore.setFromNodePreferences writes queryFilter.searchTerm straight from
+      // nodeListStore.setFromNodePreferences writes queryFilter.searchTerm straight from
       // either the URL `nodename` param (parseNodeLabel, via Nodes.vue's applyQueryFilter) or a
       // restored localStorage preference — both land here as a raw store mutation. Mutating
       // queryFilter directly, as done elsewhere in this file (e.g. the macAddress tests above),
       // exercises exactly that path without depending on setFromNodePreferences' other side effects.
       const wrapper = mountTable()
       const ns = useNodeStore()
-      const structure = useNodeStructureStore()
+      const structure = useNodeListStore()
       ns.getNodes = vi.fn().mockResolvedValue(undefined)
       ;(ns.getNodes as any).mockClear()
 
@@ -1107,7 +1107,7 @@ describe('NodesTable.vue', () => {
   describe('Outages chip', () => {
     it('renders "Nodes with current outages" (matching the drawer + help text) when the filter is set, and remove calls the store', async () => {
       const wrapper = mountTable()
-      const structureStore = useNodeStructureStore()
+      const structureStore = useNodeListStore()
       structureStore.queryFilter = {
         ...structureStore.queryFilter,
         nodesWithOutages: true
@@ -1135,7 +1135,7 @@ describe('NodesTable.vue', () => {
   describe('Asset filter chips', () => {
     it('shows a proper title (not the raw key) for a non-curated asset column', async () => {
       const wrapper = mountTable()
-      const structureStore = useNodeStructureStore()
+      const structureStore = useNodeListStore()
       structureStore.queryFilter = {
         ...structureStore.queryFilter,
         assetFilters: [{ column: 'city', value: 'Pittsboro' }]

--- a/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
+++ b/ui/tests/components/Nodes/hooks/useNodeQuery.test.ts
@@ -29,7 +29,7 @@ import { MainMenu } from '@/types/mainMenu'
 
 const {
   buildNodeQueryFilterFromQueryString,
-  buildUpdatedNodeStructureQueryParameters,
+  buildUpdatedNodeListQueryParameters,
   getDefaultNodeQueryFilter,
   getDefaultNodeQuerySnmpParams,
   queryStringHasTrackedValues
@@ -404,7 +404,7 @@ describe('Nodes useNodeQuery test', () => {
     })
   })
 
-  describe('test buildUpdatedNodeStructureQueryParameters', () => {
+  describe('test buildUpdatedNodeListQueryParameters', () => {
     test.each([
       [
         'empty filter, _s is the node.type!=D guard alone',
@@ -440,15 +440,15 @@ describe('Nodes useNodeQuery test', () => {
         }
       ]
     ]) (
-      'buildUpdatedNodeStructureQueryParameters: %s',
+      'buildUpdatedNodeListQueryParameters: %s',
       (title, queryParams, filter, expectedParams) => {
-        const updatedParams = buildUpdatedNodeStructureQueryParameters(queryParams, filter)
+        const updatedParams = buildUpdatedNodeListQueryParameters(queryParams, filter)
         expect(updatedParams).toEqual(expectedParams)
       }
     )
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: sysParams match type', () => {
+  describe('buildUpdatedNodeListQueryParameters: sysParams match type', () => {
     test('sysMatchType Contains uses wildcards', () => {
       const filter = getDefaultNodeQueryFilter()
       filter.extendedSearch.sysParams = {
@@ -459,7 +459,7 @@ describe('Nodes useNodeQuery test', () => {
         sysObjectId: '',
         sysMatchType: MatchType.Contains
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(node.sysDescription==*Linux*);node.type!=D')
     })
 
@@ -473,7 +473,7 @@ describe('Nodes useNodeQuery test', () => {
         sysObjectId: '',
         sysMatchType: MatchType.Equals
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(node.sysDescription==Linux);node.type!=D')
     })
 
@@ -486,12 +486,12 @@ describe('Nodes useNodeQuery test', () => {
         sysName: '',
         sysObjectId: ''
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(node.sysDescription==*Linux*);node.type!=D')
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: snmpParams match type', () => {
+  describe('buildUpdatedNodeListQueryParameters: snmpParams match type', () => {
     test('snmpMatchType Contains uses wildcards on string fields', () => {
       const filter = getDefaultNodeQueryFilter()
       filter.extendedSearch.snmpParams = {
@@ -502,7 +502,7 @@ describe('Nodes useNodeQuery test', () => {
         snmpIfType: '',
         snmpMatchType: MatchType.Contains
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(snmpInterface.ifAlias==*Uplink*);node.type!=D')
     })
 
@@ -516,7 +516,7 @@ describe('Nodes useNodeQuery test', () => {
         snmpIfType: '',
         snmpMatchType: MatchType.Equals
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(snmpInterface.ifAlias==Uplink);node.type!=D')
     })
 
@@ -529,16 +529,16 @@ describe('Nodes useNodeQuery test', () => {
         snmpIfName: '',
         snmpIfType: ''
       } as any
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(snmpInterface.ifAlias==Uplink);node.type!=D')
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: physAddr', () => {
+  describe('buildUpdatedNodeListQueryParameters: physAddr', () => {
     test('physAddr generates snmpInterface.physAddr wildcard FIQL query', () => {
       const filter = getDefaultNodeQueryFilter()
       filter.extendedSearch.snmpParams = { ...getDefaultNodeQuerySnmpParams(), physAddr: 'aabbccddeeff' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(snmpInterface.physAddr==*aabbccddeeff*);node.type!=D')
     })
 
@@ -553,47 +553,47 @@ describe('Nodes useNodeQuery test', () => {
         snmpMatchType: MatchType.Equals,
         physAddr: 'aabbcc'
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(snmpInterface.ifAlias==Uplink;snmpInterface.physAddr==*aabbcc*);node.type!=D')
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: macAddress / maclike', () => {
+  describe('buildUpdatedNodeListQueryParameters: macAddress / maclike', () => {
     test('emits maclike== for a MAC with colons (stripped, lowercase)', () => {
       const filter = { ...getDefaultNodeQueryFilter(), macAddress: 'AA:BB:CC:DD:EE:FF' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(maclike==aabbccddeeff);node.type!=D')
     })
 
     test('emits maclike== for a MAC with dashes', () => {
       const filter = { ...getDefaultNodeQueryFilter(), macAddress: 'AA-BB-CC-DD-EE-FF' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(maclike==aabbccddeeff);node.type!=D')
     })
 
     test('emits maclike== for a partial MAC (manufacturer prefix)', () => {
       const filter = { ...getDefaultNodeQueryFilter(), macAddress: 'AA:BB:CC' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(maclike==aabbcc);node.type!=D')
     })
 
     test('omits maclike query when macAddress is empty', () => {
       const filter = { ...getDefaultNodeQueryFilter(), macAddress: '' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('maclike==')
     })
 
     test('omits maclike query when macAddress is only separators', () => {
       const filter = { ...getDefaultNodeQueryFilter(), macAddress: '::--' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('maclike==')
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: searchTerm-as-IP union', () => {
+  describe('buildUpdatedNodeListQueryParameters: searchTerm-as-IP union', () => {
     test('a searchTerm that looks like an IP, with no explicit ipAddress filter, unions label and ipInterface.ipAddress inside the node.type guard', () => {
       const filter = { ...getDefaultNodeQueryFilter(), searchTerm: '192.168.1.1' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       // Exact shape (not toContain): buildSearchQuery wraps the label term in wildcards, the union
       // (',') is spliced in ahead of the closing node.type!=D guard, and the whole thing stays
       // inside the guard's mandatory parens so the OR branch can't escape it.
@@ -601,7 +601,7 @@ describe('Nodes useNodeQuery test', () => {
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: search term double-encoding (NMS-20125 PR review)', () => {
+  describe('buildUpdatedNodeListQueryParameters: search term double-encoding (NMS-20125 PR review)', () => {
     // The search box no longer blocks # % & ( ) — instead, buildSearchQuery double-encodes the
     // search term (minus '*', the FIQL wildcard) so it survives the two URL-decodes on the way to
     // the backend (the servlet container's decode of the unencoded query string, then CXF's
@@ -616,13 +616,13 @@ describe('Nodes useNodeQuery test', () => {
       [')', 'has)paren', 'label==*has%2529paren*']
     ])('double-encodes a term containing %s', (_char, searchTerm, expectedLabelClause) => {
       const filter = { ...getDefaultNodeQueryFilter(), searchTerm }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe(`(${expectedLabelClause});node.type!=D`)
     })
 
     test('a mixed term with a legitimate label character combination (R&D-sw1) double-encodes just the ampersand', () => {
       const filter = { ...getDefaultNodeQueryFilter(), searchTerm: 'R&D-sw1' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(label==*R%2526D-sw1*);node.type!=D')
     })
 
@@ -632,59 +632,59 @@ describe('Nodes useNodeQuery test', () => {
         searchTerm: 'bad%term',
         nodesWithDownAggregateStatus: true
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(label==*bad%2525term*;nodesWithDownAggregateStatus==true);node.type!=D')
     })
 
     test('a valid searchTerm containing only *, letters, digits, dots, dashes and spaces still searches (spaces double-encode too)', () => {
       const filter = { ...getDefaultNodeQueryFilter(), searchTerm: '*node-1 A.b*' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(label==*node-1%2520A.b*);node.type!=D')
     })
 
     test('keeps * raw as the wildcard while double-encoding the surrounding text', () => {
       const filter = { ...getDefaultNodeQueryFilter(), searchTerm: 'ser*ice' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(label==*ser*ice*);node.type!=D')
     })
 
     test('preserves consecutive stars (empty segments) unchanged', () => {
       const filter = { ...getDefaultNodeQueryFilter(), searchTerm: 'a**b' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(label==*a**b*);node.type!=D')
     })
 
     test('a term that is only stars stays as-is (no extra wrapping stars added)', () => {
       const filter = { ...getDefaultNodeQueryFilter(), searchTerm: '**' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(label==**);node.type!=D')
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: nodesWithDownAggregateStatus', () => {
+  describe('buildUpdatedNodeListQueryParameters: nodesWithDownAggregateStatus', () => {
     test('emits nodesWithDownAggregateStatus==true when set', () => {
       const filter = { ...getDefaultNodeQueryFilter(), nodesWithDownAggregateStatus: true }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(nodesWithDownAggregateStatus==true);node.type!=D')
     })
 
     test('omits the down filter when false', () => {
       const filter = { ...getDefaultNodeQueryFilter(), nodesWithDownAggregateStatus: false }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('nodesWithDownAggregateStatus')
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: nodesWithAssets', () => {
+  describe('buildUpdatedNodeListQueryParameters: nodesWithAssets', () => {
     test('emits nodesWithAssets==true when set', () => {
       const filter = { ...getDefaultNodeQueryFilter(), nodesWithAssets: true }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(nodesWithAssets==true);node.type!=D')
     })
 
     test('omits the filter when false', () => {
       const filter = { ...getDefaultNodeQueryFilter(), nodesWithAssets: false }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('nodesWithAssets')
     })
 
@@ -696,16 +696,16 @@ describe('Nodes useNodeQuery test', () => {
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: nodesWithOutages', () => {
+  describe('buildUpdatedNodeListQueryParameters: nodesWithOutages', () => {
     test('emits nodesWithOutages==true when set', () => {
       const filter = { ...getDefaultNodeQueryFilter(), nodesWithOutages: true }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(nodesWithOutages==true);node.type!=D')
     })
 
     test('omits the filter when false', () => {
       const filter = { ...getDefaultNodeQueryFilter(), nodesWithOutages: false }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('nodesWithOutages')
     })
 
@@ -718,15 +718,15 @@ describe('Nodes useNodeQuery test', () => {
 
     test('combines with another filter using a semicolon', () => {
       const filter = { ...getDefaultNodeQueryFilter(), nodesWithAssets: true, nodesWithOutages: true }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(nodesWithAssets==true;nodesWithOutages==true);node.type!=D')
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: asset filters', () => {
+  describe('buildUpdatedNodeListQueryParameters: asset filters', () => {
     test('emits assetRecord.<col>== for a single allowed column', () => {
       const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'building', value: 'HQ' }] }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(assetRecord.building==HQ);node.type!=D')
     })
 
@@ -735,25 +735,25 @@ describe('Nodes useNodeQuery test', () => {
         ...getDefaultNodeQueryFilter(),
         assetFilters: [{ column: 'building', value: 'HQ' }, { column: 'region', value: 'East' }]
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(assetRecord.building==HQ;assetRecord.region==East);node.type!=D')
     })
 
     test('emits assetRecord.geolocation.<field>== for a geolocation-backed column', () => {
       const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'city', value: 'Pittsburgh' }] }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(assetRecord.geolocation.city==Pittsburgh);node.type!=D')
     })
 
     test('omits disallowed (unknown) columns', () => {
       const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'bogusColumn', value: 'Whatever' }] }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('assetRecord')
     })
 
     test('omits entries with an empty value', () => {
       const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'building', value: '' }] }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s ?? '').not.toContain('assetRecord')
     })
 
@@ -763,7 +763,7 @@ describe('Nodes useNodeQuery test', () => {
         assetFilters: [{ column: 'building', value: 'HQ' }],
         nodesWithDownAggregateStatus: true
       }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toContain('assetRecord.building==HQ')
       expect(params._s).toContain('nodesWithDownAggregateStatus==true')
       expect(params._s).toContain(';')
@@ -783,14 +783,14 @@ describe('Nodes useNodeQuery test', () => {
       ['mixed', 'Bldg 1, Floor (2)', '(assetRecord.building==Bldg%25201%252C%2520Floor%2520%25282%2529);node.type!=D']
     ])('double-encodes a value with %s', (title, value, expected) => {
       const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'building', value }] }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe(expected)
     })
 
     test('round-trips back to the original value after two URL-decodes', () => {
       const value = 'Bldg 1, Floor (2) & A;B 50%'
       const filter = { ...getDefaultNodeQueryFilter(), assetFilters: [{ column: 'building', value }] }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       // params._s is now wrapped as `(assetRecord.building==<encoded>);node.type!=D`
       const match = (params._s as string).match(/assetRecord\.building==([^)]*)\)/)
       const encoded = match ? match[1] : ''
@@ -834,88 +834,88 @@ describe('Nodes useNodeQuery test', () => {
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: selectedServices', () => {
+  describe('buildUpdatedNodeListQueryParameters: selectedServices', () => {
     test('single selectedService generates serviceType.name FIQL query', () => {
       const filter = getDefaultNodeQueryFilter()
       filter.selectedServices = ['HTTP']
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('(serviceType.name==HTTP);node.type!=D')
     })
 
     test('two selectedServices generates OR FIQL query', () => {
       const filter = getDefaultNodeQueryFilter()
       filter.selectedServices = ['HTTP', 'HTTPS']
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('((serviceType.name==HTTP,serviceType.name==HTTPS));node.type!=D')
     })
 
     test('empty selectedServices still emits the node.type!=D guard', () => {
       const filter = getDefaultNodeQueryFilter()
       filter.selectedServices = []
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 10 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 10 }, filter)
       expect(params._s).toBe('node.type!=D')
     })
   })
 
-  describe('buildUpdatedNodeStructureQueryParameters: ipAddress / iplike', () => {
+  describe('buildUpdatedNodeListQueryParameters: ipAddress / iplike', () => {
     test('emits ipInterface.ipAddress== for an exact IP', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '192.168.1.100' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s).toContain('ipInterface.ipAddress==192.168.1.100')
       expect(params._s).not.toContain('iplike==')
     })
 
     test('emits iplike== for a wildcard pattern', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '192.168.1.*' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s).toContain('iplike==192.168.1.*')
       expect(params._s).not.toContain('ipInterface.ipAddress==')
     })
 
     test('omits IP query when ipAddress is empty', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s ?? '').not.toContain('ipInterface.ipAddress==')
       expect(params._s ?? '').not.toContain('iplike==')
     })
 
     test('emits iplike== for a range-only pattern (no wildcard)', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '10.0.0.1-255' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s).toContain('iplike==10.0.0.1-255')
       expect(params._s).not.toContain('ipInterface.ipAddress==')
     })
 
     test('emits iplike== with double-encoded commas for a comma-list pattern', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '192.168.1,2.*' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s).toContain('iplike==192.168.1%252C2.*')
       expect(params._s).not.toContain('ipInterface.ipAddress==')
     })
 
     test('normalizes spaces around commas before encoding', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '192.168.1, 2, 3-255.*' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s).toContain('iplike==192.168.1%252C2%252C3-255.*')
     })
 
     test('omits IP query when ipAddress is not a valid IP or iplike pattern', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: 'notanip' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s ?? '').not.toContain('ipInterface.ipAddress==')
       expect(params._s ?? '').not.toContain('iplike==')
     })
 
     test('emits iplike== for an IPv6 wildcard pattern', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: '2001:db8:*:*:*:*:*:*' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s).toContain('iplike==2001:db8:*:*:*:*:*:*')
       expect(params._s).not.toContain('ipInterface.ipAddress==')
     })
 
     test('emits ipInterface.ipAddress== for an exact IPv6 address', () => {
       const filter = { ...getDefaultNodeQueryFilter(), ipAddress: 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329' }
-      const params = buildUpdatedNodeStructureQueryParameters({ limit: 25, offset: 0 }, filter)
+      const params = buildUpdatedNodeListQueryParameters({ limit: 25, offset: 0 }, filter)
       expect(params._s).toContain('ipInterface.ipAddress==FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
       expect(params._s).not.toContain('iplike==')
     })

--- a/ui/tests/containers/Nodes.test.ts
+++ b/ui/tests/containers/Nodes.test.ts
@@ -1,12 +1,12 @@
 // ui/tests/containers/Nodes.test.ts
 //
-// NOTE: originally this file only covered the listInterfaces=true -> nodeStructureStore.setShowInterfaces
+// NOTE: originally this file only covered the listInterfaces=true -> nodeListStore.setShowInterfaces
 // wiring added for NMS-20125 (Task 4). It has since been extended (Task 6) with coverage for the
 // legacy `?nodeId=<n>` bookmark redirect. Please extend this file further rather than creating a
 // second one.
 import Nodes from '@/containers/Nodes.vue'
 import { useMenuStore } from '@/stores/menuStore'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { createTestingPinia } from '@pinia/testing'
 import { flushPromises, mount } from '@vue/test-utils'
 import { setActivePinia } from 'pinia'
@@ -40,7 +40,7 @@ describe('Nodes.vue container', () => {
     const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
     setActivePinia(pinia)
 
-    const structure = useNodeStructureStore()
+    const structure = useNodeListStore()
     // Skip the deferred-query path: pretend categories/locations/service-types are already loaded.
     structure.categoriesLoaded = true
     structure.monitoringLocationsLoaded = true

--- a/ui/tests/stores/nodeListStore.test.ts
+++ b/ui/tests/stores/nodeListStore.test.ts
@@ -22,7 +22,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { useNodeStructureStore } from '@/stores/nodeStructureStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { defaultColumns } from '@/components/Nodes/utils'
 import API from '@/services'
 import { SetOperator } from '@/types'
@@ -36,12 +36,12 @@ vi.mock('@/services', () => ({
   }
 }))
 
-describe('useNodeStructureStore', () => {
-  let store: ReturnType<typeof useNodeStructureStore>
+describe('useNodeListStore', () => {
+  let store: ReturnType<typeof useNodeListStore>
 
   beforeEach(() => {
     setActivePinia(createPinia())
-    store = useNodeStructureStore()
+    store = useNodeListStore()
     vi.clearAllMocks()
   })
 
@@ -651,21 +651,21 @@ describe('useNodeStructureStore', () => {
 
   describe('service types', () => {
     it('loads service types on init', async () => {
-      const store = useNodeStructureStore()
+      const store = useNodeListStore()
       vi.mocked(API.getServiceTypes).mockResolvedValue([{ id: 1, name: 'HTTP' }, { id: 8, name: 'HTTPS' }])
       await store.getServiceTypes()
       expect(store.allServiceTypes).toEqual([{ id: 1, name: 'HTTP' }, { id: 8, name: 'HTTPS' }])
     })
 
     it('updateSelectedServices updates selectedServices and queryFilter', () => {
-      const store = useNodeStructureStore()
+      const store = useNodeListStore()
       store.updateSelectedServices([{ _value: 8, _text: 'HTTPS' }])
       expect(store.selectedServices).toEqual([{ _value: 8, _text: 'HTTPS' }])
       expect(store.queryFilter.selectedServices).toEqual(['HTTPS'])
     })
 
     it('removeService removes from selectedServices and queryFilter', () => {
-      const store = useNodeStructureStore()
+      const store = useNodeListStore()
       store.updateSelectedServices([{ _value: 1, _text: 'HTTP' }, { _value: 8, _text: 'HTTPS' }])
       store.removeService({ _value: 8, _text: 'HTTPS' })
       expect(store.selectedServices).toEqual([{ _value: 1, _text: 'HTTP' }])
@@ -673,7 +673,7 @@ describe('useNodeStructureStore', () => {
     })
 
     it('clearAllFiltersAndSelections clears selectedServices', async () => {
-      const store = useNodeStructureStore()
+      const store = useNodeListStore()
       store.updateSelectedServices([{ _value: 8, _text: 'HTTPS' }])
       await store.clearAllFiltersAndSelections()
       expect(store.selectedServices).toEqual([])
@@ -681,7 +681,7 @@ describe('useNodeStructureStore', () => {
     })
 
     it('setFromNodePreferences restores selectedServices after getServiceTypes', async () => {
-      const store = useNodeStructureStore()
+      const store = useNodeListStore()
       vi.mocked(API.getServiceTypes).mockResolvedValue([
         { id: 1, name: 'HTTP' },
         { id: 8, name: 'HTTPS' }


### PR DESCRIPTION
## NMS-20175: Node List page UI fixes

Follow-up UI fixes for the Vue Node List page (NMS-20125):

- Trimmed default columns to Node Label, IP Address, Monitoring Location, Foreign Source, Foreign ID — Sys Contact/Location/Description and Flows are still available via Customize Columns, just no longer default, so headers aren't cramped. 

- Existing saved column preferences are unaffected.

- Expanded interface rows now align with the first data column instead of the far left of the row

-  Renamed the legacy "Node Structure" internals to "Node List" (useNodeListStore, buildNodeListQuery, etc.) — pure mechanical rename, no behavior change.

- Reodered the outages toggles in Advanced Node Filters, put the 2 outage-related ones together, with "Node with asset info only" afterwards

### Deferred until later

- Sorting by IP interface remains intentionally disabled: analysis (attached to the Jira) showed the v2 join-based ordering breaks pagination (row fan-out) and text-column IP ordering is lexicographic; a proper management-IP sort needs a derived property + index and is deferred.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20175
