### PR TITLE
NMS-20176: Reorder Resource Graphs menu items

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -199,14 +199,14 @@
         {
           "id": "resourceGraphs",
           "name": "Resource Graphs",
-          "url": "ui/index.html#/resource-graphs",
+          "url": "graph/index.jsp",
           "locationMatch": "performance",
           "roles": null
         },
         {
-          "id": "resourceGraphsOld",
-          "name": "Resource Graphs (Legacy)",
-          "url": "graph/index.jsp",
+          "id": "resourceGraphsPreview",
+          "name": "Resource Graphs (Preview)",
+          "url": "ui/index.html#/resource-graphs",
           "locationMatch": "performance",
           "roles": null
         }

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -199,14 +199,14 @@
         {
           "id": "resourceGraphs",
           "name": "Resource Graphs",
-          "url": "ui/index.html#/resource-graphs",
+          "url": "graph/index.jsp",
           "locationMatch": "performance",
           "roles": null
         },
         {
-          "id": "resourceGraphsOld",
-          "name": "Resource Graphs (Legacy)",
-          "url": "graph/index.jsp",
+          "id": "resourceGraphsPreview",
+          "name": "Resource Graphs (Preview)",
+          "url": "ui/index.html#/resource-graphs",
           "locationMatch": "performance",
           "roles": null
         }

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -122,6 +122,9 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         // Metrics Menu
         clickMenuItem("Metrics (Resource Graphs)", "Resource Graphs");
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Network Performance Data']")));
+
+        clickMenuItem("Metrics (Resource Graphs)", "Resource Graphs (Preview)");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//a[@class='router-link-active router-link-exact-active'][contains(text()[normalize-space()], 'Resource Graphs')]")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='main-content']//li[contains(text()[normalize-space()], 'Resources')]")));
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -121,12 +121,13 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         frontPage();
 
         // Metrics Menu
+        // JSP Resource Graphs page
         clickMenuItem("Metrics (Resource Graphs)", "Resource Graphs");
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Network Performance Data']")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Resource Graphs')]")));
 
+        // Vue Resource Graphs page
         clickMenuItem("Metrics (Resource Graphs)", "Resource Graphs (Preview)");
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//a[@class='router-link-active router-link-exact-active'][contains(text()[normalize-space()], 'Resource Graphs')]")));
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='main-content']//li[contains(text()[normalize-space()], 'Resources')]")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='app']//div[contains(@class, 'search-field')]//label[contains(text()[normalize-space()], 'Search/Filter Resources')]")));
 
         // Distributed Monitoring
         clickMenuItem("Distributed Monitoring", "Manage Minions");


### PR DESCRIPTION
NMS-20176: Reorder Resource Graphs menu items. 

Since the Vue UI page doesn't quite have the full functionality of the legacy JSP page, put the JSP page first, as "Resource Graphs"; and Vue page 2nd, as "Resource Graphs (Preview)".

**NOTE:** This just moves/renames the menu items, it does *not* address all the issues needed to replace the JSP resource graphs, that will be handled separately.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20176
