### PR TITLE
NMS-20199: Pin Netty 4.1 for the modules that embed Cassandra

### DIFF
--- a/features/distributed/kv-store/blob/blob-itests/pom.xml
+++ b/features/distributed/kv-store/blob/blob-itests/pom.xml
@@ -9,6 +9,10 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.opennms.features.distributed.kv-store.blob.itests</artifactId>
+    <properties>
+        <!-- cassandra-unit runs Cassandra 3.11 in-process, and it cannot serve requests on Netty 4.2 -->
+        <netty4Version>4.1.132.Final</netty4Version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.opennms.features.distributed</groupId>

--- a/features/newts-repository-converter/pom.xml
+++ b/features/newts-repository-converter/pom.xml
@@ -12,6 +12,8 @@
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- cassandra-unit runs Cassandra 3.11 in-process, and it cannot serve requests on Netty 4.2 -->
+    <netty4Version>4.1.132.Final</netty4Version>
   </properties>
   <dependencies>
     <dependency>

--- a/features/newts/pom.xml
+++ b/features/newts/pom.xml
@@ -10,6 +10,10 @@
   <artifactId>org.opennms.features.newts</artifactId>
   <name>OpenNMS :: Features :: Newts</name>
   <packaging>bundle</packaging>
+  <properties>
+    <!-- cassandra-unit runs Cassandra 3.11 in-process, and it cannot serve requests on Netty 4.2 -->
+    <netty4Version>4.1.132.Final</netty4Version>
+  </properties>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
cassandra-unit starts Cassandra 3.11 inside the test JVM, and that server cannot serve requests on Netty 4.2: it accepts the connection, never answers, and the client times out. NMS-20168 moved this branch to 4.2.16 and broke NewtsPersisterIT, NewtsConverterIT and CassandraBlobStoreIT.

Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20199

