### PR TITLE
Docs: Fix argument element order in notification command examples

### DIFF
--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/scripting.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/scripting.adoc
@@ -75,7 +75,10 @@ These selected a BSF engine class, which has no JSR-223 equivalent; they are ign
 | A `Map<String, String>` the script uses to report its outcome (see below).
 
 | bsf_notif_strategy
-| The strategy instance; scripts can call `bsf_notif_strategy.log(level, format, args...)`.
+| The strategy instance.
+Groovy scripts can call `bsf_notif_strategy.log(level, format, args...)`.
+That method is declared with variable arguments, which the BeanShell engine does not resolve, so under BeanShell the call fails with `Method log( ... ) not found` and the notification is marked failed.
+The `logger` variable works under both engines and is the safer choice.
 
 | logger
 | An SLF4J logger.

--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/scripting.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/scripting.adoc
@@ -18,8 +18,8 @@ Add a command to `notificationCommands.xml`:
   <execute>org.opennms.netmgt.notifd.BSFNotificationStrategy</execute>
   <comment>run a script to deliver notifications</comment>
   <argument streamed="false">
-    <switch>file-name</switch>
     <substitution>/opt/opennms/etc/scripts/notify.bsh</substitution>
+    <switch>file-name</switch>
   </argument>
   <argument streamed="false">
     <switch>-tm</switch>

--- a/docs/modules/operation/pages/deep-dive/notifications/strategies/webhook.adoc
+++ b/docs/modules/operation/pages/deep-dive/notifications/strategies/webhook.adoc
@@ -112,12 +112,12 @@ For more information, see the https://api.slack.com/messaging/webhooks[Slack API
   <execute>org.opennms.netmgt.notifd.WebhookNotificationStrategy</execute>
   <comment>Send a notice to a Slack channel</comment>
   <argument streamed="false">
-    <switch>-url</switch>
     <substitution>https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX</substitution>
+    <switch>-url</switch>
   </argument>
   <argument streamed="false">
-    <switch>-body</switch>
     <substitution>{"text": "*${subject}*\n${textMessage}"}</substitution>
+    <switch>-body</switch>
   </argument>
   <argument streamed="false">
     <switch>-subject</switch>
@@ -143,12 +143,12 @@ For more information, see the https://docs.mattermost.com/developer/webhooks-inc
   <execute>org.opennms.netmgt.notifd.WebhookNotificationStrategy</execute>
   <comment>Send a notice to a Mattermost channel</comment>
   <argument streamed="false">
-    <switch>-url</switch>
     <substitution>https://mattermost.example.org/hooks/bf980352b5f7232efe721dbf0626bee1</substitution>
+    <switch>-url</switch>
   </argument>
   <argument streamed="false">
-    <switch>-body</switch>
     <substitution>{"username": "opennms", "text": "**${subject}**\n${textMessage}"}</substitution>
+    <switch>-body</switch>
   </argument>
   <argument streamed="false">
     <switch>-subject</switch>
@@ -174,12 +174,12 @@ For more information, see the https://learn.microsoft.com/en-us/power-automate/[
   <execute>org.opennms.netmgt.notifd.WebhookNotificationStrategy</execute>
   <comment>Send a notice to a Microsoft Teams channel</comment>
   <argument streamed="false">
-    <switch>-url</switch>
     <substitution>https://prod-00.westus.logic.azure.com:443/workflows/00000000/triggers/manual/paths/invoke?...</substitution>
+    <switch>-url</switch>
   </argument>
   <argument streamed="false">
-    <switch>-body</switch>
     <substitution>{"type": "message", "attachments": [{"contentType": "application/vnd.microsoft.card.adaptive", "content": {"type": "AdaptiveCard", "$schema": "http://adaptivecards.io/schemas/adaptive-card.json", "version": "1.4", "body": [{"type": "TextBlock", "weight": "Bolder", "text": "${subject}"}, {"type": "TextBlock", "wrap": true, "text": "${textMessage}"}]}}]}</substitution>
+    <switch>-body</switch>
   </argument>
   <argument streamed="false">
     <switch>-subject</switch>
@@ -206,12 +206,12 @@ For more information, see the https://discord.com/developers/docs/resources/webh
   <execute>org.opennms.netmgt.notifd.WebhookNotificationStrategy</execute>
   <comment>Send a notice to a Discord channel</comment>
   <argument streamed="false">
-    <switch>-url</switch>
     <substitution>https://discord.com/api/webhooks/000000000000000000/XXXXXXXXXXXXXXXXXXXXXXXX</substitution>
+    <switch>-url</switch>
   </argument>
   <argument streamed="false">
-    <switch>-body</switch>
     <substitution>{"username": "OpenNMS", "content": "**${subject}**\n${textMessage}"}</substitution>
+    <switch>-body</switch>
   </argument>
   <argument streamed="false">
     <switch>-subject</switch>
@@ -236,19 +236,19 @@ This example posts to an internal service with a bearer token and treats the not
   <execute>org.opennms.netmgt.notifd.WebhookNotificationStrategy</execute>
   <comment>Raise an incident through an internal API</comment>
   <argument streamed="false">
-    <switch>-url</switch>
     <substitution>https://incidents.example.org/api/v1/incidents</substitution>
+    <switch>-url</switch>
   </argument>
   <argument streamed="false">
     <switch>-header-Authorization</switch>
   </argument>
   <argument streamed="false">
-    <switch>-success-match</switch>
     <substitution>"accepted"\s*:\s*true</substitution>
+    <switch>-success-match</switch>
   </argument>
   <argument streamed="false">
-    <switch>-body</switch>
     <substitution>{"title": "${subject}", "detail": "${textMessage}", "node": "${nodeid}", "source": "opennms"}</substitution>
+    <switch>-body</switch>
   </argument>
   <argument streamed="false">
     <switch>-subject</switch>


### PR DESCRIPTION
The XML examples put `<switch> before <substitution> inside <argument>`, but notificationCommands.xsd declares the sequence as substitution then switch.

scripting.adoc carried the same inversion before the webhook page existed (not my fault!!!) so I fixed it too.

This doc update brought to you by the letters X, S, and D... and assisted by Anthropic Claude Opus 5.
