### PR TITLE
NMS-20201: Make top menubar more responsive at narrow window widths

### DIFF
--- a/ui/src/components/Menu/Menubar.vue
+++ b/ui/src/components/Menu/Menubar.vue
@@ -29,11 +29,12 @@
 
       <span
         class="date-icon-wrapper"
-        v-onms-tooltip="`${formattedTime} ${formattedDate}`"
-        tabindex="0"
-        :aria-label="`${formattedTime} ${formattedDate}`"
+        v-onms-tooltip="dateTimeLabel"
       >
-        <OnmsIcon :icon="CalendarIcon" />
+        <OnmsIcon
+          :icon="CalendarIcon"
+          :title="dateTimeLabel"
+        />
       </span>
 
        <span title="Toggle Light/Dark Mode">
@@ -93,6 +94,11 @@ const displayAddNodeButton = computed(() => (mainMenu?.value.displayAddNodeButto
 
 const formattedDate = computed<string>(() => mainMenu.value?.formattedDate ?? '')
 const formattedTime = computed<string>(() => mainMenu.value?.formattedTime ?? '')
+
+// Empty (falsy) until the menu data loads, which keeps the tooltip unbound —
+// PrimeVue's string-form tooltip does not trim whitespace-only values and
+// would otherwise show an empty box.
+const dateTimeLabel = computed<string>(() => [formattedTime.value, formattedDate.value].filter(Boolean).join(' '))
 
 useOutsideClick(outsideClick.value, () => {
   resetMenuItems()
@@ -232,11 +238,14 @@ onUnmounted(() => {
 }
 
 // The logo is a wide wordmark SVG (viewBox 624x69). Size by height and let
-// width follow; override the SVG's own max-width so it isn't clamped/distorted.
+// width follow. The max-width is a guard for rebranded logos substituted via
+// VITE_APP_LOGO_NAME: since the left column refuses to shrink below the logo,
+// an unbounded ultra-wide asset would crowd out the rest of the bar. An SVG
+// wider than the cap letterboxes (scales down) rather than distorts.
 .onms-menubar__logo {
   height: 1.75rem;
   width: auto;
-  max-width: none;
+  max-width: 18rem;
 }
 
 // Notification-status colors stay on their light-mode values so the indicator
@@ -289,6 +298,7 @@ onUnmounted(() => {
   flex-direction: column;
   font-family: var(--onms-header-font-family);
   font-size: 0.875rem;
+  margin-left: 1em;
   margin-right: 1em;
   // Keep time/date each on one line; without this the text word-wraps and
   // spills out of the fixed-height bar when the right column is squeezed.
@@ -321,14 +331,8 @@ onUnmounted(() => {
     display: inline-flex;
     align-items: center;
     font-size: 24px;
+    margin-left: 1em;
     margin-right: 1em;
-    outline: none;
-
-    &:focus-visible {
-      outline: 2px solid var(--onms-primary);
-      outline-offset: 2px;
-      border-radius: 4px;
-    }
   }
 }
 </style>

--- a/ui/src/components/Menu/Menubar.vue
+++ b/ui/src/components/Menu/Menubar.vue
@@ -28,8 +28,9 @@
       </div>
 
       <span
+        v-if="dateTimeLabel"
         class="date-icon-wrapper"
-        v-onms-tooltip="dateTimeLabel"
+        v-onms-tooltip.bottom="dateTimeLabel"
       >
         <OnmsIcon
           :icon="CalendarIcon"
@@ -95,9 +96,11 @@ const displayAddNodeButton = computed(() => (mainMenu?.value.displayAddNodeButto
 const formattedDate = computed<string>(() => mainMenu.value?.formattedDate ?? '')
 const formattedTime = computed<string>(() => mainMenu.value?.formattedTime ?? '')
 
-// Empty (falsy) until the menu data loads, which keeps the tooltip unbound —
-// PrimeVue's string-form tooltip does not trim whitespace-only values and
-// would otherwise show an empty box.
+// Empty until the menu data loads. The calendar icon is v-if'd on this:
+// PrimeVue's tooltip captures the configured z-index only when the directive
+// mounts with a non-empty value (an empty value both binds a blank tooltip
+// and falls back to z-index ~1000, behind this fixed header's 1030), so the
+// element must not mount until the label is ready.
 const dateTimeLabel = computed<string>(() => [formattedTime.value, formattedDate.value].filter(Boolean).join(' '))
 
 useOutsideClick(outsideClick.value, () => {

--- a/ui/src/components/Menu/Menubar.vue
+++ b/ui/src/components/Menu/Menubar.vue
@@ -27,6 +27,15 @@
         <div class="date-formatted-date">{{ formattedDate }}</div>
       </div>
 
+      <span
+        class="date-icon-wrapper"
+        v-onms-tooltip="`${formattedTime} ${formattedDate}`"
+        tabindex="0"
+        :aria-label="`${formattedTime} ${formattedDate}`"
+      >
+        <OnmsIcon :icon="CalendarIcon" />
+      </span>
+
        <span title="Toggle Light/Dark Mode">
         <OnmsIcon
             :icon="LightDarkMode"
@@ -61,6 +70,7 @@ import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
 import { useOutsideClick } from '@/composables/useOutsideClick'
 import { OnmsIcon, OnmsButton } from '@opennms/onms-ui'
 import LightDarkMode from '@/components/icons/action/LightDarkMode.vue'
+import CalendarIcon from '@/components/icons/action/Calendar.vue'
 
 // see vite.config.ts, resolve.alias for the actual logo file that is imported
 import IconLogo from './src/assets/ProductLogo.vue'
@@ -193,11 +203,13 @@ onUnmounted(() => {
   color: var(--onms-state-text-color-on-surface-dark);
 }
 
+// No `min-width: 0` here: the flex-item default of `min-width: auto` keeps
+// this column from collapsing below the logo's intrinsic width, so the
+// (rigid) center column can never paint over the logo (NMS-20201).
 .onms-menubar__left {
   flex: 1 1 0;
   display: flex;
   align-items: center;
-  min-width: 0;
 }
 
 .onms-menubar__center {
@@ -278,6 +290,9 @@ onUnmounted(() => {
   font-family: var(--onms-header-font-family);
   font-size: 0.875rem;
   margin-right: 1em;
+  // Keep time/date each on one line; without this the text word-wraps and
+  // spills out of the fixed-height bar when the right column is squeezed.
+  white-space: nowrap;
 
   .date-formatted-date {
     display: flex;
@@ -288,6 +303,32 @@ onUnmounted(() => {
     display: flex;
     justify-content: right;
     font-weight: 800;
+  }
+}
+
+// Compact date representation: below 1024px the two-line date text is
+// replaced by a calendar icon whose tooltip carries the full date/time.
+.date-icon-wrapper {
+  display: none;
+}
+
+@media (max-width: 1023.98px) {
+  .date-wrapper {
+    display: none;
+  }
+
+  .date-icon-wrapper {
+    display: inline-flex;
+    align-items: center;
+    font-size: 24px;
+    margin-right: 1em;
+    outline: none;
+
+    &:focus-visible {
+      outline: 2px solid var(--onms-primary);
+      outline-offset: 2px;
+      border-radius: 4px;
+    }
   }
 }
 </style>

--- a/ui/src/components/Menu/Search.vue
+++ b/ui/src/components/Menu/Search.vue
@@ -279,7 +279,9 @@ const onKeyDown = async (event: KeyboardEvent) => {
 <style lang="scss" scoped>
 .onms-search-control-wrapper {
   position: relative;
-  min-width: 30em;
+  // Fluid width: 24em on wide viewports, shrinking down to a 12em floor so
+  // the menubar degrades gracefully as the window narrows (NMS-20201).
+  min-width: clamp(12em, 28vw, 24em);
 }
 
 .search-results-dropdown {
@@ -287,6 +289,8 @@ const onKeyDown = async (event: KeyboardEvent) => {
   top: 100%;
   left: 0;
   width: 100%;
+  // Keep results readable even when the input has shrunk to its floor width.
+  min-width: 24em;
   background: var(--p-content-background);
   color: var(--p-text-muted-color);
   border: 1px solid var(--p-content-border-color);

--- a/ui/src/components/Menu/Search.vue
+++ b/ui/src/components/Menu/Search.vue
@@ -279,15 +279,20 @@ const onKeyDown = async (event: KeyboardEvent) => {
 <style lang="scss" scoped>
 .onms-search-control-wrapper {
   position: relative;
-  // Fluid width: 24em on wide viewports, shrinking down to a 12em floor so
+  // Fluid width: 24em on wide viewports, shrinking down to a 10em floor so
   // the menubar degrades gracefully as the window narrows (NMS-20201).
-  min-width: clamp(12em, 28vw, 24em);
+  min-width: clamp(10em, 28vw, 24em);
 }
 
 .search-results-dropdown {
   position: absolute;
   top: 100%;
-  left: 0;
+  // Anchor to the input's right edge: when min-width exceeds the input's
+  // width the dropdown grows leftward (over the logo area, still on-screen)
+  // instead of rightward past the viewport edge, where the fixed header
+  // provides no scrollbar to reach it.
+  left: auto;
+  right: 0;
   width: 100%;
   // Keep results readable even when the input has shrunk to its floor width.
   min-width: 24em;


### PR DESCRIPTION
Make the top menubar more responsive when width narrows.

This does the following:

- Keeps OpenNMS logo from being painted over by the Search box
- Makes Search box smaller for smaller screen widths
- For smaller widths, changes the Date to a Calendar icon with a tooltip

Specifically:

- 1440px: search at its 24em cap, full two-line date display
- 1100px: search shrinks fluidly, date text intact on single lines
- 1024px: date swaps to the calendar icon; hover shows a tooltip with the date text
- For lower widths, the menu bar (notification / self-service icons) will overflow off the right edge instead of overlapping 

Note: the search box width is now `clamp(10em, 28vw, 24em)`, so this intentionally changes wide/desktop viewports too — the previous fixed `30em` (480px) minimum is capped at `24em` (384px) at every width, not just narrow ones.

### Narrow width, Search box shrinks, Calendar icon for date, icons overflow

<img width="671" height="225" alt="menu-at-670px" src="https://github.com/user-attachments/assets/8fcb8db3-d33a-4545-b7fa-2fde2bb8e04d" />


### Narrow width showing date tooltip

<img width="690" height="300" alt="menubar-690-tooltip" src="https://github.com/user-attachments/assets/99332dcd-de3c-42ad-82a2-f196fd7804ec" />



### Narrow width showing narrower search box, but search results still wider

<img width="690" height="300" alt="menubar-690-search" src="https://github.com/user-attachments/assets/e0692f0c-faed-4c72-bf0a-cee03bf4e19a" />



### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20201
