### PR TITLE
NMS-19979: clear data collection alarms after a restart or collectd reload

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -156,7 +156,10 @@ public class CollectableService implements ReadyRunnable {
         m_persisterFactory = persisterFactory;
 
         m_nodeId = iface.getNode().getId().intValue();
-        m_status = CollectionStatus.SUCCEEDED;
+        // Start out with no opinion rather than assuming success, so the first successful collection is a
+        // transition and emits the event that clears an alarm left over from a previous scheduling
+        // generation. A restart and a collectd reload both discard and rebuild every CollectableService.
+        m_status = CollectionStatus.UNKNOWN;
 
         m_updates = new CollectorUpdates();
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectableServiceTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectableServiceTest.java
@@ -61,6 +61,8 @@ import org.opennms.netmgt.collection.support.builder.NodeLevelResource;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.ResourceStorageDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.rrd.RrdRepository;
@@ -69,6 +71,7 @@ import org.opennms.netmgt.rrd.jrobin.JRobinRrdStrategy;
 import org.opennms.netmgt.scheduler.Scheduler;
 import org.opennms.netmgt.snmp.InetAddrUtils;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
+import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.FileAnticipator;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -243,6 +246,45 @@ public class CollectableServiceTest {
         createCollectableService(paramsMap);
 
         verify(thresholdingService, times(1)).createSession(anyInt(), any(), any(), any());
+    }
+
+    /**
+     * A CollectableService starts with no known status, so the first successful collection is a transition
+     * and emits dataCollectionSucceeded. That is what clears a dataCollectionFailed alarm raised before a
+     * restart or a collectd reload, both of which rebuild every CollectableService. See NMS-19979.
+     */
+    @Test
+    public void sendsSucceededEventOnFirstSuccessfulCollection() throws CollectionInitializationException, CollectionException, IOException {
+        EventIpcManager eventIpcManager = mock(EventIpcManager.class);
+        EventIpcManagerFactory.setIpcManager(eventIpcManager);
+
+        createCollectableService();
+        when(spec.collect(any())).thenReturn(null);
+
+        service.run();
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventIpcManager, times(1)).sendNow(eventCaptor.capture());
+        assertEquals(EventConstants.DATA_COLLECTION_SUCCEEDED_EVENT_UEI, eventCaptor.getValue().getUei());
+    }
+
+    /**
+     * Only the transition emits, so a service that keeps collecting successfully stays quiet after the
+     * first pass rather than sending an event per collection cycle.
+     */
+    @Test
+    public void sendsNoFurtherEventWhileCollectionKeepsSucceeding() throws CollectionInitializationException, CollectionException, IOException {
+        EventIpcManager eventIpcManager = mock(EventIpcManager.class);
+        EventIpcManagerFactory.setIpcManager(eventIpcManager);
+
+        createCollectableService();
+        when(spec.collect(any())).thenReturn(null);
+
+        service.run();
+        service.run();
+        service.run();
+
+        verify(eventIpcManager, times(1)).sendNow(any(Event.class));
     }
 
     private void createCollectableService() throws CollectionInitializationException, IOException {

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdIT.java
@@ -88,6 +88,7 @@ import org.opennms.netmgt.scheduler.Scheduler;
 import org.opennms.netmgt.scheduler.mock.MockScheduler;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
+import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -336,6 +337,9 @@ public class CollectdIT {
 
         verify(m_eventIpcManager, times(1)).addEventListener(eq(m_collectd), (Collection<String>)isA(Collection.class));
         verify(m_eventIpcManager, times(1)).removeEventListener(m_collectd);
+        // This test actually collects, and the first success transitions out of UNKNOWN and emits
+        // dataCollectionSucceeded. Account for it here so tearDown's verifyNoMoreInteractions passes.
+        verify(m_eventIpcManager, times(1)).sendNow(isA(Event.class));
     }
 
     /**

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/ThresholdIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/ThresholdIT.java
@@ -204,6 +204,10 @@ public class ThresholdIT implements TemporaryDatabaseAware<MockDatabase> {
 
         EventAnticipator eventAnticipator = mockEventIpcManager.getEventAnticipator();
 
+        // Each scheduling generation starts out UNKNOWN, so its first successful collection emits this
+        // once. Anticipate before the service is scheduled below, or the collection can beat us to it.
+        anticipateDataCollectionSucceeded(eventAnticipator);
+
         // Let's send a nodeGainedService event
         EventBuilder bldr = new EventBuilder(EventConstants.NODE_GAINED_SERVICE_EVENT_UEI, "Test");
         bldr.setNodeid(1);
@@ -273,6 +277,9 @@ public class ThresholdIT implements TemporaryDatabaseAware<MockDatabase> {
 
         eventAnticipator.reset();
 
+        // The category change above rescheduled the service, so a fresh generation reports success again.
+        anticipateDataCollectionSucceeded(eventAnticipator);
+
         // Again, Assert 2 collections are performed and that Threshold is no longer triggered
         collector.resetLatch(2);
         if (!collector.getLatch().await(30, TimeUnit.SECONDS)) {
@@ -282,6 +289,14 @@ public class ThresholdIT implements TemporaryDatabaseAware<MockDatabase> {
 
         // Stop collectd gracefully so we don't keep trying to collect during the tear down
         collectd.stop();
+    }
+
+    private static void anticipateDataCollectionSucceeded(EventAnticipator eventAnticipator) {
+        EventBuilder bldr = new EventBuilder(EventConstants.DATA_COLLECTION_SUCCEEDED_EVENT_UEI, "OpenNMS.Collectd");
+        bldr.setNodeid(1);
+        bldr.setInterface(addr("192.168.1.1"));
+        bldr.setService("Mock");
+        eventAnticipator.anticipateEvent(bldr.getEvent());
     }
 
     private void initThreshdFactories(String threshd, String thresholds) throws Exception {


### PR DESCRIPTION
My attempt at a fix for the collectd reload bug. A dataCollectionFailed alarm never clears if collection recovers across an OpenNMS restart or a collectd configuration reload.

CollectableService keeps the last collection status in memory and updateStatus() only emits an event on a transition. That status was seeded to SUCCEEDED, and both a restart and rebuildScheduler() discard and rebuild every CollectableService, so the recovery is no longer a transition, no dataCollectionSucceeded is sent, and the alarm is orphaned. Seed it to UNKNOWN instead.
 
 - The first collection after a restart or reload always transitions: a success emits dataCollectionSucceeded and clears the orphaned alarm, a failure emits dataCollectionFailed as before.
 - Costs one extra event per collected service per restart or reload, not one per collection cycle.
 - An unmatched dataCollectionSucceeded creates a Normal severity alarm of its own, which the default alarmd cleanUp rule deletes after five minutes.
 - The default reduction key is node scoped (%uei%:%dpname%:%nodeid%), so any one service recovering clears the node's alarm.

Tests: two cases in CollectableServiceTest, one for the transition on first success and one confirming later successful cycles stay quiet.
  
Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19979
