### PR TITLE
NMS-20203: Kafka sink consumer manager tracks unstarted consumers, leaking live ones on reload

### DIFF
--- a/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/HeartbeatSinkIT.java
+++ b/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/HeartbeatSinkIT.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.awaitility.core.ConditionFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -176,27 +177,34 @@ public class HeartbeatSinkIT {
             }
         };
 
-        // Other tests in this class share the group, so wait for it to drain first
-        await().atMost(30, SECONDS).until(this::countConsumerGroupMembers, equalTo(0));
-
-        try {
-            consumerManager.registerConsumer(heartbeatConsumer);
-            await().atMost(30, SECONDS).until(this::countConsumerGroupMembers, equalTo(numConsumerThreads));
-        } finally {
-            consumerManager.unregisterConsumer(heartbeatConsumer);
-        }
-
-        await().atMost(30, SECONDS).until(this::countConsumerGroupMembers, equalTo(0));
-    }
-
-    private int countConsumerGroupMembers() throws Exception {
         final Properties adminConfig = new Properties();
         adminConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer.getKafkaConnectString());
-        final String groupId = SystemInfoUtils.getInstanceId();
+
         try (AdminClient admin = AdminClient.create(adminConfig)) {
-            return admin.describeConsumerGroups(Collections.singleton(groupId))
-                    .describedGroups().get(groupId).get().members().size();
+            // describeConsumerGroups fails until the broker has a coordinator for the group, which
+            // it may not have yet on a freshly started server
+            final ConditionFactory groupMembership = await().atMost(30, SECONDS)
+                    .pollInterval(1, SECONDS)
+                    .ignoreExceptions();
+
+            // Other tests in this class share the group, so wait for it to drain first
+            groupMembership.until(() -> countConsumerGroupMembers(admin), equalTo(0));
+
+            try {
+                consumerManager.registerConsumer(heartbeatConsumer);
+                groupMembership.until(() -> countConsumerGroupMembers(admin), equalTo(numConsumerThreads));
+            } finally {
+                consumerManager.unregisterConsumer(heartbeatConsumer);
+            }
+
+            groupMembership.until(() -> countConsumerGroupMembers(admin), equalTo(0));
         }
+    }
+
+    private int countConsumerGroupMembers(final AdminClient admin) throws Exception {
+        final String groupId = SystemInfoUtils.getInstanceId();
+        return admin.describeConsumerGroups(Collections.singleton(groupId))
+                .describedGroups().get(groupId).get().members().size();
     }
 
     @Test(timeout=60000)

--- a/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/HeartbeatSinkIT.java
+++ b/core/ipc/sink/kafka/itests/src/test/java/org/opennms/core/ipc/sink/kafka/itests/HeartbeatSinkIT.java
@@ -30,12 +30,16 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.Hashtable;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,6 +57,7 @@ import org.opennms.core.ipc.sink.kafka.itests.heartbeat.HeartbeatModule;
 import org.opennms.core.ipc.sink.kafka.server.KafkaMessageConsumerManager;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.kafka.JUnitKafkaServer;
+import org.opennms.core.utils.SystemInfoUtils;
 import org.opennms.distributed.core.api.MinionIdentity;
 import org.opennms.distributed.core.api.SystemType;
 import org.opennms.test.JUnitConfigurationEnvironment;
@@ -146,6 +151,51 @@ public class HeartbeatSinkIT {
             await().atMost(1, MINUTES).until(() -> heartbeatCount.get(), equalTo(2));
         } finally {
             consumerManager.unregisterConsumer(heartbeatConsumer);
+        }
+    }
+
+    @Test(timeout=180000)
+    public void consumersLeaveTheGroupWhenUnregistered() throws Exception {
+        final int numConsumerThreads = 3;
+        final HeartbeatModule module = new HeartbeatModule() {
+            @Override
+            public int getNumConsumerThreads() {
+                return numConsumerThreads;
+            }
+        };
+
+        final MessageConsumer<Heartbeat,Heartbeat> heartbeatConsumer = new MessageConsumer<Heartbeat,Heartbeat>() {
+            @Override
+            public SinkModule<Heartbeat,Heartbeat> getModule() {
+                return module;
+            }
+
+            @Override
+            public void handleMessage(final Heartbeat heartbeat) {
+                // pass
+            }
+        };
+
+        // Other tests in this class share the group, so wait for it to drain first
+        await().atMost(30, SECONDS).until(this::countConsumerGroupMembers, equalTo(0));
+
+        try {
+            consumerManager.registerConsumer(heartbeatConsumer);
+            await().atMost(30, SECONDS).until(this::countConsumerGroupMembers, equalTo(numConsumerThreads));
+        } finally {
+            consumerManager.unregisterConsumer(heartbeatConsumer);
+        }
+
+        await().atMost(30, SECONDS).until(this::countConsumerGroupMembers, equalTo(0));
+    }
+
+    private int countConsumerGroupMembers() throws Exception {
+        final Properties adminConfig = new Properties();
+        adminConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer.getKafkaConnectString());
+        final String groupId = SystemInfoUtils.getInstanceId();
+        try (AdminClient admin = AdminClient.create(adminConfig)) {
+            return admin.describeConsumerGroups(Collections.singleton(groupId))
+                    .describedGroups().get(groupId).get().members().size();
         }
     }
 

--- a/core/ipc/sink/kafka/server/src/main/java/org/opennms/core/ipc/sink/kafka/server/KafkaMessageConsumerManager.java
+++ b/core/ipc/sink/kafka/server/src/main/java/org/opennms/core/ipc/sink/kafka/server/KafkaMessageConsumerManager.java
@@ -267,7 +267,7 @@ public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager 
             for (int i = 0; i < numConsumerThreads; i++) {
                 final KafkaConsumerRunner consumerRunner = new KafkaConsumerRunner(module);
                 executor.execute(consumerRunner);
-                consumerRunners.add(new KafkaConsumerRunner(module));
+                consumerRunners.add(consumerRunner);
             }
 
             consumerRunnersByModule.put(module, consumerRunners);

--- a/core/ipc/sink/kafka/server/src/main/java/org/opennms/core/ipc/sink/kafka/server/KafkaMessageConsumerManager.java
+++ b/core/ipc/sink/kafka/server/src/main/java/org/opennms/core/ipc/sink/kafka/server/KafkaMessageConsumerManager.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -86,6 +87,8 @@ import io.opentracing.util.GlobalTracer;
 
 public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager implements InitializingBean {
     private static final Duration CONSUMER_POLL_DURATION = Duration.ofMillis(100);
+
+    private static final long SHUTDOWN_TIMEOUT_MS = 30000;
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaMessageConsumerManager.class);
 
@@ -307,7 +310,26 @@ public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager 
     }
 
     public void shutdown() {
+        // The runners only leave their poll loop via shutdown(); executor.shutdown() on its own
+        // does not interrupt them, so wake them before waiting on the executor.
+        for (List<KafkaConsumerRunner> consumerRunners : consumerRunnersByModule.values()) {
+            for (KafkaConsumerRunner consumerRunner : consumerRunners) {
+                consumerRunner.shutdown();
+            }
+        }
+        consumerRunnersByModule.clear();
+
         executor.shutdown();
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                LOG.warn("Sink consumers did not stop within {}ms. Interrupting them.", SHUTDOWN_TIMEOUT_MS);
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+
         if (jmxReporter != null) {
             jmxReporter.close();
         }

--- a/core/ipc/sink/kafka/server/src/main/java/org/opennms/core/ipc/sink/kafka/server/KafkaMessageConsumerManager.java
+++ b/core/ipc/sink/kafka/server/src/main/java/org/opennms/core/ipc/sink/kafka/server/KafkaMessageConsumerManager.java
@@ -90,6 +90,9 @@ public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager 
 
     private static final long SHUTDOWN_TIMEOUT_MS = 30000;
 
+    // Starting a consumer is quick, so this only has to cover a task that is already in flight
+    private static final long STARTUP_SHUTDOWN_TIMEOUT_MS = 5000;
+
     private static final Logger LOG = LoggerFactory.getLogger(KafkaMessageConsumerManager.class);
 
     private final Map<SinkModule<?, Message>, List<KafkaConsumerRunner>> consumerRunnersByModule = new ConcurrentHashMap<>();
@@ -310,6 +313,14 @@ public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager 
     }
 
     public void shutdown() {
+        // Drain the starter threads first: startConsumingForModule() otherwise races us and can
+        // register consumers that nothing is left to stop.
+        final ExecutorService startupExecutor = getStartupExecutor();
+        if (startupExecutor != null) {
+            startupExecutor.shutdown();
+            awaitTermination(startupExecutor, STARTUP_SHUTDOWN_TIMEOUT_MS, "Sink consumer starters");
+        }
+
         // The runners only leave their poll loop via shutdown(); executor.shutdown() on its own
         // does not interrupt them, so wake them before waiting on the executor.
         for (List<KafkaConsumerRunner> consumerRunners : consumerRunnersByModule.values()) {
@@ -320,21 +331,22 @@ public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager 
         consumerRunnersByModule.clear();
 
         executor.shutdown();
-        try {
-            if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                LOG.warn("Sink consumers did not stop within {}ms. Interrupting them.", SHUTDOWN_TIMEOUT_MS);
-                executor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            executor.shutdownNow();
-            Thread.currentThread().interrupt();
-        }
+        awaitTermination(executor, SHUTDOWN_TIMEOUT_MS, "Sink consumers");
 
         if (jmxReporter != null) {
             jmxReporter.close();
         }
-        if(getStartupExecutor() != null) {
-            getStartupExecutor().shutdown();
+    }
+
+    private static void awaitTermination(ExecutorService executorService, long timeoutMs, String description) {
+        try {
+            if (!executorService.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+                LOG.warn("{} did not stop within {}ms. Interrupting them.", description, timeoutMs);
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 


### PR DESCRIPTION
Found what I think is a pretty minor bug.

KafkaMessageConsumerManager.startConsumingForModule() added a second, never-started KafkaConsumerRunner to its tracking list instead of the one it started, so stopConsumingForModule() shut down inert objects while the live consumers kept running.

- Orphaned consumers keep their Kafka group partitions but dispatch against a SinkModule key that is no longer registered, so AbstractMessageConsumerManager.dispatch() drops the record while auto-commit advances the offset. Telemetryd and Sentinel adapter reloads lose telemetry in proportion to the partitions those consumers hold, compounding per reload.
- The unstarted duplicates never subscribe, so throughput was unaffected, but each held 2 file descriptors and 6 JMX MBeans that the MBean registration kept alive through GC.
- shutdown() used executor.shutdown(), which never ended the poll loops; it now stops the runners first, then bounds the wait with a shutdownNow() fallback.
- New IT asserts the consumer group drains to zero members after unregistering. It times out against the unfixed code.

Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20203
