### PR TITLE
NMS-20205: Bump Apache CXF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1650,7 +1650,7 @@
     <cronParserCoreVersion>3.5</cronParserCoreVersion>
     <c3p0Version>0.9.5.5</c3p0Version>
     <curatorVersion>5.6.0</curatorVersion>
-    <cxfVersion>3.6.3</cxfVersion>
+    <cxfVersion>3.6.12</cxfVersion>
     <cxfXjcVersion>3.3.2</cxfXjcVersion>
     <dhcp4javaVersion>1.1.0</dhcp4javaVersion>
     <serviceMixDnsjavaVersion>3.5.3_1</serviceMixDnsjavaVersion>


### PR DESCRIPTION
### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20205
 * https://opennms.atlassian.net/browse/SUPPORT-3283
 * https://nvd.nist.gov/vuln/detail/CVE-2026-49875
 * https://nvd.nist.gov/vuln/detail/CVE-2026-50645
 * https://nvd.nist.gov/vuln/detail/CVE-2026-54225
 * https://nvd.nist.gov/vuln/detail/CVE-2026-64958

