### PR TITLE
NMS-20206: Fix XXE in XML collector

### DIFF
--- a/docs/modules/reference/pages/performance-data-collection/collectors/xml.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/xml.adoc
@@ -135,6 +135,13 @@ Configure the system proxy settings via <<operation:deep-dive/admin/configuratio
 | n/a
 |===
 
+[NOTE]
+====
+The XSLT stylesheet must be self-contained.
+Because the collected XML can come from an untrusted endpoint, the transformer blocks all external references to prevent XML External Entity (XXE) and server-side request forgery attacks: `xsl:include`, `xsl:import`, the `document()` function, and external DTDs referenced by the collected XML are not resolved.
+Secure processing is also enabled, which disables XSLT extension functions (for example, EXSLT or `java:` extensions).
+====
+
 === HTTP headers
 
 If the endpoint being collected requires additional headers, you can add them as part of the `<request>` object.

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
@@ -496,7 +496,6 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         is = applyXsltTransformation(request, is);
         DocumentBuilderFactory factory = newSecureDocumentBuilderFactory();
         factory.setIgnoringComments(true);
-        factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         StringWriter writer = new StringWriter();
         IOUtils.copy(is, writer, StandardCharsets.UTF_8);
@@ -557,10 +556,7 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         // Block XXE: forbid external entities/DTDs. Not disallow-doctype-decl, since
         // pre-parse-html produces a benign <!DOCTYPE html>.
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        disableExternalEntities(factory::setFeature);
         factory.setXIncludeAware(false);
         factory.setNamespaceAware(true);
         return factory;
@@ -572,11 +568,29 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
     private static XMLReader newSecureXmlReader() throws Exception {
         SAXParserFactory spf = SAXParserFactory.newInstance();
         spf.setNamespaceAware(true);
-        spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        disableExternalEntities(spf::setFeature);
         return spf.newSAXParser().getXMLReader();
+    }
+
+    @FunctionalInterface
+    private interface FeatureSetter {
+        void setFeature(String name, boolean value) throws Exception;
+    }
+
+    /**
+     * Applies the XXE hardening features shared by the DOM and SAX parsers.
+     * external-general/parameter-entities are SAX-standard and required; load-external-dtd is
+     * Xerces-specific and set best-effort so a non-Xerces provider does not fail parsing outright.
+     */
+    private static void disableExternalEntities(FeatureSetter parser) throws Exception {
+        parser.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        parser.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        parser.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        try {
+            parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        } catch (Exception e) {
+            LOG.debug("XML parser does not support the load-external-dtd feature; skipping");
+        }
     }
 
     /**

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
@@ -53,17 +53,15 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -102,6 +100,8 @@ import org.springframework.beans.BeanWrapperImpl;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
 
 /**
  * The Abstract Class XML Collection Handler.
@@ -494,14 +494,7 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
     protected Document getXmlDocument(InputStream is, Request request) throws Exception {
         is = preProcessHtml(request, is);
         is = applyXsltTransformation(request, is);
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        // Block XXE: forbid external entities/DTDs. Not disallow-doctype-decl, since
-        // pre-parse-html produces a benign <!DOCTYPE html>.
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        factory.setXIncludeAware(false);
+        DocumentBuilderFactory factory = newSecureDocumentBuilderFactory();
         factory.setIgnoringComments(true);
         factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
@@ -536,23 +529,17 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         File xsltFile = new File(xsltFilename);
         if (!xsltFile.exists())
             return is;
+        // The collected source XML is untrusted, so block XXE/SSRF: deny external URI
+        // resolution (xsl:import/include and document()) and parse with an entity-hardened reader.
         TransformerFactory factory = TransformerFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        // Best-effort; Xalan rejects these. The SAXSource readers below are the real guard.
-        try {
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        } catch (IllegalArgumentException e) {
-            LOG.debug("TransformerFactory {} does not support {}; skipping", factory.getClass().getName(), XMLConstants.ACCESS_EXTERNAL_DTD);
-        }
-        try {
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-        } catch (IllegalArgumentException e) {
-            LOG.debug("TransformerFactory {} does not support {}; skipping", factory.getClass().getName(), XMLConstants.ACCESS_EXTERNAL_STYLESHEET);
-        }
-        // Parse the stylesheet and the (attacker-controlled) source with hardened readers so
-        // XXE is blocked even when the factory (e.g. Xalan) ignores the attributes above.
+        final URIResolver denyExternal = (href, base) -> {
+            throw new TransformerException("External resource resolution disabled for collector XSLT: " + href);
+        };
+        factory.setURIResolver(denyExternal);
         Source xslt = new SAXSource(newSecureXmlReader(), new InputSource(xsltFile.toURI().toString()));
         Transformer transformer = factory.newTransformer(xslt);
+        transformer.setURIResolver(denyExternal);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
             Source source = new SAXSource(newSecureXmlReader(), new InputSource(is));
@@ -561,6 +548,22 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         } finally {
             IOUtils.closeQuietly(is);
         }
+    }
+
+    /**
+     * Builds a namespace-aware DocumentBuilderFactory with external entity/DTD resolution disabled (XXE-safe).
+     */
+    private static DocumentBuilderFactory newSecureDocumentBuilderFactory() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        // Block XXE: forbid external entities/DTDs. Not disallow-doctype-decl, since
+        // pre-parse-html produces a benign <!DOCTYPE html>.
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setXIncludeAware(false);
+        factory.setNamespaceAware(true);
+        return factory;
     }
 
     /**

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
@@ -46,6 +46,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -489,6 +490,18 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         is = preProcessHtml(request, is);
         is = applyXsltTransformation(request, is);
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        // Harden against XXE: the parsed content comes from a collected (potentially
+        // attacker-controlled) source. We do not use disallow-doctype-decl here because the
+        // pre-parse-html feature legitimately produces documents with a <!DOCTYPE html>;
+        // instead we forbid resolving any external entities/DTDs, which blocks both the
+        // in-band (external general entity) and out-of-band (external parameter entity /
+        // external DTD) XXE vectors while still allowing benign, entity-free DOCTYPEs.
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
         factory.setIgnoringComments(true);
         factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
@@ -524,6 +537,11 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         if (!xsltFile.exists())
             return is;
         TransformerFactory factory = TransformerFactory.newInstance();
+        // Harden against XXE/SSRF: the input being transformed is collected (potentially
+        // attacker-controlled) content, so forbid resolution of external DTDs/stylesheets.
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Source xslt = new StreamSource(xsltFile);
         Transformer transformer = factory.newTransformer(xslt);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
@@ -51,6 +51,7 @@ import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.ErrorListener;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -536,9 +537,28 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
             throw new TransformerException("External resource resolution disabled for collector XSLT: " + href);
         };
         factory.setURIResolver(denyExternal);
+        // The default listener only logs to stderr and continues on error; fail the collection instead.
+        final ErrorListener failLoudly = new ErrorListener() {
+            @Override
+            public void warning(TransformerException e) {
+                LOG.warn("XSLT transform warning: {}", e.getMessage());
+            }
+            @Override
+            public void error(TransformerException e) throws TransformerException {
+                LOG.error("XSLT transform error, failing collection: {}", e.getMessage());
+                throw e;
+            }
+            @Override
+            public void fatalError(TransformerException e) throws TransformerException {
+                LOG.error("XSLT transform fatal error, failing collection: {}", e.getMessage());
+                throw e;
+            }
+        };
+        factory.setErrorListener(failLoudly);
         Source xslt = new SAXSource(newSecureXmlReader(), new InputSource(xsltFile.toURI().toString()));
         Transformer transformer = factory.newTransformer(xslt);
         transformer.setURIResolver(denyExternal);
+        transformer.setErrorListener(failLoudly);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
             Source source = new SAXSource(newSecureXmlReader(), new InputSource(is));

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
@@ -490,18 +490,13 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         is = preProcessHtml(request, is);
         is = applyXsltTransformation(request, is);
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        // Harden against XXE: the parsed content comes from a collected (potentially
-        // attacker-controlled) source. We do not use disallow-doctype-decl here because the
-        // pre-parse-html feature legitimately produces documents with a <!DOCTYPE html>;
-        // instead we forbid resolving any external entities/DTDs, which blocks both the
-        // in-band (external general entity) and out-of-band (external parameter entity /
-        // external DTD) XXE vectors while still allowing benign, entity-free DOCTYPEs.
+        // Block XXE: forbid external entities/DTDs. Not disallow-doctype-decl, since
+        // pre-parse-html produces a benign <!DOCTYPE html>.
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         factory.setXIncludeAware(false);
-        factory.setExpandEntityReferences(false);
         factory.setIgnoringComments(true);
         factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
@@ -537,11 +532,19 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         if (!xsltFile.exists())
             return is;
         TransformerFactory factory = TransformerFactory.newInstance();
-        // Harden against XXE/SSRF: the input being transformed is collected (potentially
-        // attacker-controlled) content, so forbid resolution of external DTDs/stylesheets.
+        // Block XXE/SSRF via external DTDs/stylesheets. Best-effort: some factories
+        // (e.g. Xalan) reject these attributes with IllegalArgumentException.
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        } catch (IllegalArgumentException e) {
+            LOG.debug("TransformerFactory {} does not support {}; skipping", factory.getClass().getName(), XMLConstants.ACCESS_EXTERNAL_DTD);
+        }
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (IllegalArgumentException e) {
+            LOG.debug("TransformerFactory {} does not support {}; skipping", factory.getClass().getName(), XMLConstants.ACCESS_EXTERNAL_STYLESHEET);
+        }
         Source xslt = new StreamSource(xsltFile);
         Transformer transformer = factory.newTransformer(xslt);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
@@ -50,15 +50,20 @@ import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -532,9 +537,8 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         if (!xsltFile.exists())
             return is;
         TransformerFactory factory = TransformerFactory.newInstance();
-        // Block XXE/SSRF via external DTDs/stylesheets. Best-effort: some factories
-        // (e.g. Xalan) reject these attributes with IllegalArgumentException.
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        // Best-effort; Xalan rejects these. The SAXSource readers below are the real guard.
         try {
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         } catch (IllegalArgumentException e) {
@@ -545,15 +549,31 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         } catch (IllegalArgumentException e) {
             LOG.debug("TransformerFactory {} does not support {}; skipping", factory.getClass().getName(), XMLConstants.ACCESS_EXTERNAL_STYLESHEET);
         }
-        Source xslt = new StreamSource(xsltFile);
+        // Parse the stylesheet and the (attacker-controlled) source with hardened readers so
+        // XXE is blocked even when the factory (e.g. Xalan) ignores the attributes above.
+        Source xslt = new SAXSource(newSecureXmlReader(), new InputSource(xsltFile.toURI().toString()));
         Transformer transformer = factory.newTransformer(xslt);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
-            transformer.transform(new StreamSource(is), new StreamResult(baos));
+            Source source = new SAXSource(newSecureXmlReader(), new InputSource(is));
+            transformer.transform(source, new StreamResult(baos));
             return new ByteArrayInputStream(baos.toByteArray());
         } finally {
             IOUtils.closeQuietly(is);
         }
+    }
+
+    /**
+     * Builds a namespace-aware XMLReader with external entity/DTD resolution disabled (XXE-safe).
+     */
+    private static XMLReader newSecureXmlReader() throws Exception {
+        SAXParserFactory spf = SAXParserFactory.newInstance();
+        spf.setNamespaceAware(true);
+        spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        return spf.newSAXParser().getXMLReader();
     }
 
     /**

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
@@ -229,6 +229,41 @@ public class AbstractXmlCollectionHandlerTest {
         }
     }
 
+    /** NMS-20206: XSLT document() on a URI from collected data must not read files / issue requests. */
+    @Test
+    public void testXsltDocumentFunctionIsBlocked() throws Exception {
+        final File secret = File.createTempFile("nms20206-doc", ".xml");
+        secret.deleteOnExit();
+        Files.write(secret.toPath(), "<r>DOC_SECRET_SENTINEL</r>".getBytes(StandardCharsets.UTF_8));
+
+        // Stylesheet resolves document() using a URI taken from the (attacker-controlled) source.
+        final File xslt = File.createTempFile("nms20206-doc", ".xsl");
+        xslt.deleteOnExit();
+        Files.write(xslt.toPath(), (
+                "<?xml version=\"1.0\"?>\n" +
+                "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n" +
+                "  <xsl:template match=\"/\">\n" +
+                "    <stats><val><xsl:value-of select=\"document(/stats/uri)\"/></val></stats>\n" +
+                "  </xsl:template>\n" +
+                "</xsl:stylesheet>").getBytes(StandardCharsets.UTF_8));
+
+        final String source = "<stats><uri>" + secret.toURI() + "</uri></stats>";
+
+        final Request request = new Request();
+        request.addParameter("xslt-source-file", xslt.getAbsolutePath());
+
+        final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
+        try {
+            final Document doc = handler.getXmlDocument(
+                    new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), request);
+            final String text = doc.getElementsByTagName("val").item(0).getTextContent();
+            Assert.assertFalse("document() resolved a source URI - SSRF/file-read not blocked (leaked: " + text + ")",
+                    text.contains("DOC_SECRET_SENTINEL"));
+        } catch (Exception expected) {
+            // A rejecting URIResolver aborting the transform is equally safe.
+        }
+    }
+
     /** NMS-20206: the XXE hardening must not break collection of normal, entity-free XML. */
     @Test
     public void testWellFormedXmlStillParses() throws Exception {

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
@@ -45,6 +46,7 @@ import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.protocols.xml.config.Request;
 import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
 /**
  * The Test Class for AbstractXmlCollectionHandler.
@@ -97,7 +99,7 @@ public class AbstractXmlCollectionHandlerTest {
             final String text = doc.getElementsByTagName("val").item(0).getTextContent();
             Assert.assertFalse("External entity was resolved - XXE not blocked (leaked: " + text + ")",
                     text.contains("TOP_SECRET_SENTINEL"));
-        } catch (Exception expected) {
+        } catch (SAXException | TransformerException expected) {
             // Rejecting the entity outright is equally safe.
         }
     }
@@ -133,7 +135,7 @@ public class AbstractXmlCollectionHandlerTest {
             final String text = doc.getElementsByTagName("val").item(0).getTextContent();
             Assert.assertFalse("External DTD was fetched - OOB XXE not blocked (leaked: " + text + ")",
                     text.contains("OOB_SECRET_SENTINEL"));
-        } catch (Exception expected) {
+        } catch (SAXException | TransformerException expected) {
             // Rejecting the undefined entity (because the external DTD was not loaded) is safe.
         }
     }
@@ -224,7 +226,7 @@ public class AbstractXmlCollectionHandlerTest {
             final String text = doc.getElementsByTagName("val").item(0).getTextContent();
             Assert.assertFalse("Source entity resolved during XSLT - XXE not blocked (leaked: " + text + ")",
                     text.contains("XSLT_SRC_SENTINEL"));
-        } catch (Exception expected) {
+        } catch (SAXException | TransformerException expected) {
             // Rejecting the entity outright is equally safe.
         }
     }
@@ -259,7 +261,7 @@ public class AbstractXmlCollectionHandlerTest {
             final String text = doc.getElementsByTagName("val").item(0).getTextContent();
             Assert.assertFalse("document() resolved a source URI - SSRF/file-read not blocked (leaked: " + text + ")",
                     text.contains("DOC_SECRET_SENTINEL"));
-        } catch (Exception expected) {
+        } catch (SAXException | TransformerException expected) {
             // A rejecting URIResolver aborting the transform is equally safe.
         }
     }

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
@@ -191,11 +191,45 @@ public class AbstractXmlCollectionHandlerTest {
         Assert.assertEquals("xslt-ran", doc.getElementsByTagName("val").item(0).getTextContent());
     }
 
-    /**
-     * NMS-20206: the XXE hardening must not break collection of normal, entity-free XML.
-     *
-     * @throws Exception the exception
-     */
+    /** NMS-20206: XXE in the collected source must be blocked during XSLT too (Xalan ignores ACCESS_EXTERNAL_*). */
+    @Test
+    public void testXsltSourceExternalEntityIsNotResolved() throws Exception {
+        final File secret = File.createTempFile("nms20206-xslt-src", ".txt");
+        secret.deleteOnExit();
+        Files.write(secret.toPath(), "XSLT_SRC_SENTINEL".getBytes(StandardCharsets.UTF_8));
+
+        // Copy-through stylesheet: a resolved source entity would surface in the output.
+        final File xslt = File.createTempFile("nms20206-xslt-src", ".xsl");
+        xslt.deleteOnExit();
+        Files.write(xslt.toPath(), (
+                "<?xml version=\"1.0\"?>\n" +
+                "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n" +
+                "  <xsl:template match=\"/\">\n" +
+                "    <stats><val><xsl:value-of select=\"/stats/val\"/></val></stats>\n" +
+                "  </xsl:template>\n" +
+                "</xsl:stylesheet>").getBytes(StandardCharsets.UTF_8));
+
+        final String malicious =
+                "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE stats [ <!ENTITY xxe SYSTEM \"" + secret.toURI() + "\"> ]>\n" +
+                "<stats><val>&xxe;</val></stats>";
+
+        final Request request = new Request();
+        request.addParameter("xslt-source-file", xslt.getAbsolutePath());
+
+        final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
+        try {
+            final Document doc = handler.getXmlDocument(
+                    new ByteArrayInputStream(malicious.getBytes(StandardCharsets.UTF_8)), request);
+            final String text = doc.getElementsByTagName("val").item(0).getTextContent();
+            Assert.assertFalse("Source entity resolved during XSLT - XXE not blocked (leaked: " + text + ")",
+                    text.contains("XSLT_SRC_SENTINEL"));
+        } catch (Exception expected) {
+            // Rejecting the entity outright is equally safe.
+        }
+    }
+
+    /** NMS-20206: the XXE hardening must not break collection of normal, entity-free XML. */
     @Test
     public void testWellFormedXmlStillParses() throws Exception {
         final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
@@ -28,6 +28,10 @@
 
 package org.opennms.protocols.xml.collector;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,6 +39,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
+import org.w3c.dom.Document;
 
 /**
  * The Test Class for AbstractXmlCollectionHandler.
@@ -67,6 +72,100 @@ public class AbstractXmlCollectionHandlerTest {
         String jsonContent = "{'test':{'key':'value','key2':0}}";
         String json = AbstractXmlCollectionHandler.parseString("Content", jsonContent, node, "127.0.0.1", 300, parameters);
         Assert.assertEquals(jsonContent, json);
+    }
+
+    /**
+     * NMS-20206: collected XML can be attacker-controlled. An external general entity that
+     * points at a local file (the in-band XXE file-read vector) must never be resolved into
+     * the parsed document. We assert the secret file content never reaches the DOM (the
+     * parser may instead reject the reference outright - either outcome is safe).
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testInBandExternalEntityIsNotResolved() throws Exception {
+        final File secret = File.createTempFile("nms20206-secret", ".txt");
+        secret.deleteOnExit();
+        Files.write(secret.toPath(), "TOP_SECRET_SENTINEL".getBytes(StandardCharsets.UTF_8));
+
+        final String malicious =
+                "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE stats [ <!ENTITY xxe SYSTEM \"" + secret.toURI() + "\"> ]>\n" +
+                "<stats><val>&xxe;</val></stats>";
+        final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
+        try {
+            final Document doc = handler.getXmlDocument(
+                    new ByteArrayInputStream(malicious.getBytes(StandardCharsets.UTF_8)), null);
+            final String text = doc.getElementsByTagName("val").item(0).getTextContent();
+            Assert.assertFalse("External entity was resolved - XXE not blocked (leaked: " + text + ")",
+                    text.contains("TOP_SECRET_SENTINEL"));
+        } catch (Exception expected) {
+            // The parser rejecting the disabled external entity is equally acceptable.
+        }
+    }
+
+    /**
+     * NMS-20206: the out-of-band vector uses an external parameter entity that pulls an
+     * external DTD. With external-parameter-entities and load-external-dtd disabled, the
+     * local file referenced through the parameter entity must not be read into the document.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testOutOfBandParameterEntityIsNotResolved() throws Exception {
+        final File secret = File.createTempFile("nms20206-oob", ".txt");
+        secret.deleteOnExit();
+        Files.write(secret.toPath(), "OOB_SECRET_SENTINEL".getBytes(StandardCharsets.UTF_8));
+
+        final String malicious =
+                "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE stats [\n" +
+                "  <!ENTITY % file SYSTEM \"" + secret.toURI() + "\">\n" +
+                "  <!ENTITY % eval \"<!ENTITY exfil '%file;'>\">\n" +
+                "  %eval;\n" +
+                "]>\n" +
+                "<stats><val>&exfil;</val></stats>";
+        final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
+        try {
+            final Document doc = handler.getXmlDocument(
+                    new ByteArrayInputStream(malicious.getBytes(StandardCharsets.UTF_8)), null);
+            final String text = doc.getElementsByTagName("val").item(0).getTextContent();
+            Assert.assertFalse("Parameter entity was resolved - OOB XXE not blocked (leaked: " + text + ")",
+                    text.contains("OOB_SECRET_SENTINEL"));
+        } catch (Exception expected) {
+            // Rejecting the disabled parameter entity is equally acceptable.
+        }
+    }
+
+    /**
+     * NMS-20206: the hardening must not use disallow-doctype-decl, because the pre-parse-html
+     * feature legitimately produces documents that begin with a benign, entity-free DOCTYPE
+     * (e.g. &lt;!DOCTYPE html&gt;). Such documents must still parse.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testBenignDoctypeStillParses() throws Exception {
+        final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
+        final String withDoctype = "<!DOCTYPE html>\n<stats><val>ok</val></stats>";
+        final Document doc = handler.getXmlDocument(
+                new ByteArrayInputStream(withDoctype.getBytes(StandardCharsets.UTF_8)), null);
+        Assert.assertNotNull(doc);
+        Assert.assertEquals("ok", doc.getElementsByTagName("val").item(0).getTextContent());
+    }
+
+    /**
+     * NMS-20206: the XXE hardening must not break collection of normal, entity-free XML.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testWellFormedXmlStillParses() throws Exception {
+        final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
+        final String ok = "<stats><val>ok</val></stats>";
+        final Document doc = handler.getXmlDocument(new ByteArrayInputStream(ok.getBytes(StandardCharsets.UTF_8)), null);
+        Assert.assertNotNull(doc);
+        Assert.assertEquals("ok", doc.getElementsByTagName("val").item(0).getTextContent());
     }
 
 }

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
@@ -35,10 +35,15 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.protocols.xml.config.Request;
 import org.w3c.dom.Document;
 
 /**
@@ -74,14 +79,7 @@ public class AbstractXmlCollectionHandlerTest {
         Assert.assertEquals(jsonContent, json);
     }
 
-    /**
-     * NMS-20206: collected XML can be attacker-controlled. An external general entity that
-     * points at a local file (the in-band XXE file-read vector) must never be resolved into
-     * the parsed document. We assert the secret file content never reaches the DOM (the
-     * parser may instead reject the reference outright - either outcome is safe).
-     *
-     * @throws Exception the exception
-     */
+    /** NMS-20206: in-band XXE - an external general entity must not read a local file into the DOM. */
     @Test
     public void testInBandExternalEntityIsNotResolved() throws Exception {
         final File secret = File.createTempFile("nms20206-secret", ".txt");
@@ -100,29 +98,32 @@ public class AbstractXmlCollectionHandlerTest {
             Assert.assertFalse("External entity was resolved - XXE not blocked (leaked: " + text + ")",
                     text.contains("TOP_SECRET_SENTINEL"));
         } catch (Exception expected) {
-            // The parser rejecting the disabled external entity is equally acceptable.
+            // Rejecting the entity outright is equally safe.
         }
     }
 
-    /**
-     * NMS-20206: the out-of-band vector uses an external parameter entity that pulls an
-     * external DTD. With external-parameter-entities and load-external-dtd disabled, the
-     * local file referenced through the parameter entity must not be read into the document.
-     *
-     * @throws Exception the exception
-     */
+    /** NMS-20206: out-of-band XXE - an external parameter entity / external DTD must not be fetched. */
     @Test
     public void testOutOfBandParameterEntityIsNotResolved() throws Exception {
         final File secret = File.createTempFile("nms20206-oob", ".txt");
         secret.deleteOnExit();
         Files.write(secret.toPath(), "OOB_SECRET_SENTINEL".getBytes(StandardCharsets.UTF_8));
 
+        // The nested parameter-entity trick is only well-formed in an EXTERNAL DTD, which is
+        // exactly what the real attack fetches. An unhardened parser loads this and expands
+        // &exfil; to the file contents; the hardening must prevent the external DTD load.
+        final File dtd = File.createTempFile("nms20206-oob", ".dtd");
+        dtd.deleteOnExit();
+        Files.write(dtd.toPath(), (
+                "<!ENTITY % file SYSTEM \"" + secret.toURI() + "\">\n" +
+                "<!ENTITY % eval \"<!ENTITY exfil '%file;'>\">\n" +
+                "%eval;\n").getBytes(StandardCharsets.UTF_8));
+
         final String malicious =
                 "<?xml version=\"1.0\"?>\n" +
                 "<!DOCTYPE stats [\n" +
-                "  <!ENTITY % file SYSTEM \"" + secret.toURI() + "\">\n" +
-                "  <!ENTITY % eval \"<!ENTITY exfil '%file;'>\">\n" +
-                "  %eval;\n" +
+                "  <!ENTITY % dtd SYSTEM \"" + dtd.toURI() + "\">\n" +
+                "  %dtd;\n" +
                 "]>\n" +
                 "<stats><val>&exfil;</val></stats>";
         final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
@@ -130,20 +131,14 @@ public class AbstractXmlCollectionHandlerTest {
             final Document doc = handler.getXmlDocument(
                     new ByteArrayInputStream(malicious.getBytes(StandardCharsets.UTF_8)), null);
             final String text = doc.getElementsByTagName("val").item(0).getTextContent();
-            Assert.assertFalse("Parameter entity was resolved - OOB XXE not blocked (leaked: " + text + ")",
+            Assert.assertFalse("External DTD was fetched - OOB XXE not blocked (leaked: " + text + ")",
                     text.contains("OOB_SECRET_SENTINEL"));
         } catch (Exception expected) {
-            // Rejecting the disabled parameter entity is equally acceptable.
+            // Rejecting the undefined entity (because the external DTD was not loaded) is safe.
         }
     }
 
-    /**
-     * NMS-20206: the hardening must not use disallow-doctype-decl, because the pre-parse-html
-     * feature legitimately produces documents that begin with a benign, entity-free DOCTYPE
-     * (e.g. &lt;!DOCTYPE html&gt;). Such documents must still parse.
-     *
-     * @throws Exception the exception
-     */
+    /** NMS-20206: a benign DOCTYPE (e.g. pre-parse-html's &lt;!DOCTYPE html&gt;) must still parse. */
     @Test
     public void testBenignDoctypeStillParses() throws Exception {
         final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
@@ -152,6 +147,48 @@ public class AbstractXmlCollectionHandlerTest {
                 new ByteArrayInputStream(withDoctype.getBytes(StandardCharsets.UTF_8)), null);
         Assert.assertNotNull(doc);
         Assert.assertEquals("ok", doc.getElementsByTagName("val").item(0).getTextContent());
+    }
+
+    /** NMS-20206: internal entities must still expand (read via XPath string(), as collection does). */
+    @Test
+    public void testInternalEntityIsExpanded() throws Exception {
+        final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
+        final String xml =
+                "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE stats [ <!ENTITY ver \"1.2.3\"> ]>\n" +
+                "<stats><val>v&ver;</val></stats>";
+        final Document doc = handler.getXmlDocument(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), null);
+        final XPath xpath = XPathFactory.newInstance().newXPath();
+        final String value = (String) xpath.evaluate("string(/stats/val)", doc, XPathConstants.STRING);
+        Assert.assertEquals("v1.2.3", value);
+    }
+
+    /** NMS-20206: XSLT collection must still work (TransformerFactory hardening is best-effort). */
+    @Test
+    public void testXsltTransformationStillWorks() throws Exception {
+        // Stylesheet rewrites <val> to a fixed marker, so the assertion fails if the
+        // transform is skipped (rather than a no-op identity transform that proves nothing).
+        final File xslt = File.createTempFile("nms20206-xslt", ".xsl");
+        xslt.deleteOnExit();
+        final String stylesheet =
+                "<?xml version=\"1.0\"?>\n" +
+                "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n" +
+                "  <xsl:template match=\"/\">\n" +
+                "    <stats><val>xslt-ran</val></stats>\n" +
+                "  </xsl:template>\n" +
+                "</xsl:stylesheet>";
+        Files.write(xslt.toPath(), stylesheet.getBytes(StandardCharsets.UTF_8));
+
+        final Request request = new Request();
+        request.addParameter("xslt-source-file", xslt.getAbsolutePath());
+
+        final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
+        final String xml = "<stats><val>raw</val></stats>";
+        final Document doc = handler.getXmlDocument(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), request);
+        Assert.assertNotNull(doc);
+        Assert.assertEquals("xslt-ran", doc.getElementsByTagName("val").item(0).getTextContent());
     }
 
     /**

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
@@ -256,13 +256,11 @@ public class AbstractXmlCollectionHandlerTest {
 
         final DefaultXmlCollectionHandler handler = new DefaultXmlCollectionHandler();
         try {
-            final Document doc = handler.getXmlDocument(
-                    new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), request);
-            final String text = doc.getElementsByTagName("val").item(0).getTextContent();
-            Assert.assertFalse("document() resolved a source URI - SSRF/file-read not blocked (leaked: " + text + ")",
-                    text.contains("DOC_SECRET_SENTINEL"));
+            handler.getXmlDocument(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), request);
+            Assert.fail("Expected the blocked document() reference to fail the collection loudly");
         } catch (SAXException | TransformerException expected) {
-            // A rejecting URIResolver aborting the transform is equally safe.
+            // Fail-loud: the ErrorListener rethrows the denied reference instead of letting the
+            // transform continue with silent, corrupt output.
         }
     }
 


### PR DESCRIPTION
Disable external entity/DTD resolution in AbstractXmlCollectionHandler's DocumentBuilderFactory and TransformerFactory so collected XML cannot read local files or trigger out-of-band requests.
Adds regression tests.



### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20206

