### PR TITLE
NMS-20208: Replace adhoc graphs workflow

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -212,7 +212,7 @@
         },
         {
           "id": "adhocGraphs",
-          "name": "Ad-Hoc Graphs",
+          "name": "Custom Performance Graphs (Preview)",
           "url": "ui/index.html#/adhoc-graphs",
           "locationMatch": "performance",
           "roles": null

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -209,6 +209,13 @@
           "url": "ui/index.html#/resource-graphs",
           "locationMatch": "performance",
           "roles": null
+        },
+        {
+          "id": "adhocGraphs",
+          "name": "Ad-Hoc Graphs",
+          "url": "ui/index.html#/adhoc-graphs",
+          "locationMatch": "performance",
+          "roles": null
         }
       ]
     },

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -212,7 +212,7 @@
         },
         {
           "id": "adhocGraphs",
-          "name": "Ad-Hoc Graphs",
+          "name": "Custom Performance Graphs (Preview)",
           "url": "ui/index.html#/adhoc-graphs",
           "locationMatch": "performance",
           "roles": null

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -209,6 +209,13 @@
           "url": "ui/index.html#/resource-graphs",
           "locationMatch": "performance",
           "roles": null
+        },
+        {
+          "id": "adhocGraphs",
+          "name": "Ad-Hoc Graphs",
+          "url": "ui/index.html#/adhoc-graphs",
+          "locationMatch": "performance",
+          "roles": null
         }
       ]
     },

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -129,6 +129,11 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         clickMenuItem("Metrics (Resource Graphs)", "Resource Graphs (Preview)");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='app']//div[contains(@class, 'search-field')]//label[contains(text()[normalize-space()], 'Search/Filter Resources')]")));
 
+        // Vue Custom Performance Graphs page
+        clickMenuItem("Metrics (Resource Graphs)", "Custom Performance Graphs (Preview)");
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='Custom Performance Graphs']")));
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//h2[text()='Custom Performance Graphs']")));
+
         // Distributed Monitoring
         clickMenuItem("Distributed Monitoring", "Manage Minions");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Manage Minions')]")));

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "ip-regex": "^5.0.0",
     "is-ip": "^5.0.1",
     "is-valid-domain": "^0.1.6",
+    "jspdf": "^4.2.1",
     "leaflet": "^1.8.0",
     "leaflet.markercluster": "^1.5.3",
     "lodash": "^4.18.1",

--- a/ui/packages/onms-ui/src/components/OnmsListbox.vue
+++ b/ui/packages/onms-ui/src/components/OnmsListbox.vue
@@ -2,13 +2,38 @@
   <Listbox
     :modelValue="modelValue"
     :options="options"
+    :optionLabel="optionLabel"
+    :optionValue="optionValue"
+    :optionDisabled="optionDisabled"
+    :optionGroupLabel="optionGroupLabel"
+    :optionGroupChildren="optionGroupChildren"
+    :dataKey="dataKey"
+    :multiple="multiple"
+    :metaKeySelection="metaKeySelection"
+    :checkmark="checkmark"
     :filter="filter"
     :filterPlaceholder="filterPlaceholder"
+    :filterFields="filterFields"
     :listStyle="listStyle"
+    :scrollHeight="scrollHeight"
+    :virtualScrollerOptions="virtualScrollerOptions"
+    :emptyMessage="emptyMessage"
+    :emptyFilterMessage="emptyFilterMessage"
+    :disabled="disabled"
     :pt="unsafePt as never"
     @update:modelValue="emit('update:modelValue', $event)"
     @change="emit('change', $event.value)"
-  />
+  >
+    <template
+      v-if="$slots.option"
+      #option="slotProps"
+    >
+      <slot
+        name="option"
+        v-bind="slotProps"
+      />
+    </template>
+  </Listbox>
 </template>
 
 <script setup lang="ts">
@@ -17,24 +42,63 @@ import Listbox from 'primevue/listbox'
 // Seam wrapper (NMS-20081) around PrimeVue Listbox. `change` fires with the
 // selected value only (the seam does not expose PrimeVue's event object),
 // matching the OnmsAutoComplete `optionSelect` precedent.
+//
+// `multiple` selection deliberately ships with `metaKeySelection` defaulting to
+// false: in a multi-select picker plain clicking must toggle, and requiring
+// ctrl/cmd (PrimeVue's own default) is the behaviour users report as broken.
 withDefaults(defineProps<{
   modelValue?: unknown
   options?: unknown[]
+  optionLabel?: string
+  optionValue?: string
+  optionDisabled?: string
+  optionGroupLabel?: string
+  optionGroupChildren?: string
+  dataKey?: string
+  multiple?: boolean
+  metaKeySelection?: boolean
+  checkmark?: boolean
   filter?: boolean
   filterPlaceholder?: string
+  filterFields?: string[]
   listStyle?: string
+  scrollHeight?: string
+  /** Windowing for long option lists; requires a fixed `itemSize` (px). */
+  virtualScrollerOptions?: { itemSize: number, [key: string]: unknown }
+  emptyMessage?: string
+  emptyFilterMessage?: string
+  disabled?: boolean
   unsafePt?: unknown
 }>(), {
   modelValue: undefined,
   options: () => [],
+  optionLabel: undefined,
+  optionValue: undefined,
+  optionDisabled: undefined,
+  optionGroupLabel: undefined,
+  optionGroupChildren: undefined,
+  dataKey: undefined,
+  multiple: false,
+  metaKeySelection: false,
+  checkmark: false,
   filter: false,
   filterPlaceholder: undefined,
+  filterFields: undefined,
   listStyle: undefined,
+  scrollHeight: undefined,
+  virtualScrollerOptions: undefined,
+  emptyMessage: undefined,
+  emptyFilterMessage: undefined,
+  disabled: false,
   unsafePt: undefined
 })
 
 const emit = defineEmits<{
   'update:modelValue': [value: unknown]
   change: [value: unknown]
+}>()
+
+defineSlots<{
+  option?: (props: { option: unknown, index: number, selected: boolean }) => unknown
 }>()
 </script>

--- a/ui/packages/onms-ui/src/components/OnmsListbox.vue
+++ b/ui/packages/onms-ui/src/components/OnmsListbox.vue
@@ -3,22 +3,15 @@
     :modelValue="modelValue"
     :options="options"
     :optionLabel="optionLabel"
-    :optionValue="optionValue"
-    :optionDisabled="optionDisabled"
-    :optionGroupLabel="optionGroupLabel"
-    :optionGroupChildren="optionGroupChildren"
     :dataKey="dataKey"
     :multiple="multiple"
-    :metaKeySelection="metaKeySelection"
     :checkmark="checkmark"
     :filter="filter"
     :filterPlaceholder="filterPlaceholder"
-    :filterFields="filterFields"
     :listStyle="listStyle"
     :scrollHeight="scrollHeight"
     :virtualScrollerOptions="virtualScrollerOptions"
     :emptyMessage="emptyMessage"
-    :emptyFilterMessage="emptyFilterMessage"
     :disabled="disabled"
     :pt="unsafePt as never"
     @update:modelValue="emit('update:modelValue', $event)"
@@ -43,52 +36,41 @@ import Listbox from 'primevue/listbox'
 // selected value only (the seam does not expose PrimeVue's event object),
 // matching the OnmsAutoComplete `optionSelect` precedent.
 //
-// `multiple` selection deliberately ships with `metaKeySelection` defaulting to
-// false: in a multi-select picker plain clicking must toggle, and requiring
-// ctrl/cmd (PrimeVue's own default) is the behaviour users report as broken.
+// The declared surface is kept close to what the app uses. PrimeVue's Listbox has
+// more (option grouping, its own filter fields, metaKeySelection); those are left
+// out until something needs them. `emptyMessage` and `disabled` are the exceptions
+// — general enough that any listbox may want them, so they are exposed up front
+// rather than waiting for the first consumer.
 withDefaults(defineProps<{
   modelValue?: unknown
   options?: unknown[]
   optionLabel?: string
-  optionValue?: string
-  optionDisabled?: string
-  optionGroupLabel?: string
-  optionGroupChildren?: string
   dataKey?: string
   multiple?: boolean
-  metaKeySelection?: boolean
   checkmark?: boolean
   filter?: boolean
   filterPlaceholder?: string
-  filterFields?: string[]
   listStyle?: string
   scrollHeight?: string
   /** Windowing for long option lists; requires a fixed `itemSize` (px). */
   virtualScrollerOptions?: { itemSize: number, [key: string]: unknown }
+  /** Shown in place of the list when there are no options. */
   emptyMessage?: string
-  emptyFilterMessage?: string
   disabled?: boolean
   unsafePt?: unknown
 }>(), {
   modelValue: undefined,
   options: () => [],
   optionLabel: undefined,
-  optionValue: undefined,
-  optionDisabled: undefined,
-  optionGroupLabel: undefined,
-  optionGroupChildren: undefined,
   dataKey: undefined,
   multiple: false,
-  metaKeySelection: false,
   checkmark: false,
   filter: false,
   filterPlaceholder: undefined,
-  filterFields: undefined,
   listStyle: undefined,
   scrollHeight: undefined,
   virtualScrollerOptions: undefined,
   emptyMessage: undefined,
-  emptyFilterMessage: undefined,
   disabled: false,
   unsafePt: undefined
 })

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       is-valid-domain:
         specifier: ^0.1.6
         version: 0.1.6
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
       leaflet:
         specifier: ^1.8.0
         version: 1.9.4
@@ -291,6 +294,10 @@ packages:
 
   '@babel/runtime-corejs3@7.29.2':
     resolution: {integrity: sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -1114,6 +1121,12 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
+
   '@types/ramda@0.30.2':
     resolution: {integrity: sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==}
 
@@ -1477,6 +1490,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1546,6 +1563,9 @@ packages:
   core-js-pure@3.49.0:
     resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
 
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
+
   cronstrue@3.14.0:
     resolution: {integrity: sha512-XnW4vuK/jPJjmTyDWiej1Zq36Od7ITwxaV2O1pzHZuyMVvdy7NAvyvIBzybt+idqSpfqYuoDG7uf/ocGtJVWxA==}
     hasBin: true
@@ -1553,6 +1573,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -1763,6 +1786,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -1918,6 +1944,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
 
@@ -1936,6 +1965,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2054,6 +2086,10 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -2086,6 +2122,9 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   ip-regex@5.0.0:
     resolution: {integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==}
@@ -2158,6 +2197,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2335,6 +2377,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -2359,6 +2404,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2426,6 +2474,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   ramda-adjunct@5.1.0:
     resolution: {integrity: sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==}
     engines: {node: '>=0.10.3'}
@@ -2451,6 +2502,9 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
     engines: {node: '>=0.10'}
@@ -2474,6 +2528,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -2577,6 +2635,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -2615,6 +2677,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   svgo@3.3.4:
     resolution: {integrity: sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==}
     engines: {node: '>=14.0.0'}
@@ -2622,6 +2688,9 @@ packages:
 
   swagger-client@3.37.2:
     resolution: {integrity: sha512-KcB8psL1On4GWwv9Ribp1oteh50ygNnAyvQbd5MwiXMGkcB4f53rkZEdvZKPDdJO764mQjgErxQEGDVw6QBUMQ==}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
@@ -2743,6 +2812,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   vite-svg-loader@4.0.0:
     resolution: {integrity: sha512-0MMf1yzzSYlV4MGePsLVAOqXsbF5IVxbn4EEzqRnWxTQl8BJg/cfwIzfQNmNQxZp5XXwd4kyRKF1LytuHZTnqA==}
@@ -3000,6 +3072,8 @@ snapshots:
   '@babel/runtime-corejs3@7.29.2':
     dependencies:
       core-js-pure: 3.49.0
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.0':
     dependencies:
@@ -3983,6 +4057,11 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/pako@2.0.4': {}
+
+  '@types/raf@3.4.3':
+    optional: true
+
   '@types/ramda@0.30.2':
     dependencies:
       types-ramda: 0.30.1
@@ -4448,6 +4527,18 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/raf': 3.4.3
+      core-js: 3.50.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -4523,6 +4614,9 @@ snapshots:
 
   core-js-pure@3.49.0: {}
 
+  core-js@3.50.0:
+    optional: true
+
   cronstrue@3.14.0: {}
 
   cross-spawn@7.0.6:
@@ -4530,6 +4624,11 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   css-select@5.2.2:
     dependencies:
@@ -4752,6 +4851,11 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -4943,6 +5047,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.2.0
+
   fast-xml-builder@1.3.0:
     dependencies:
       path-expression-matcher: 1.6.2
@@ -4968,6 +5078,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5087,6 +5199,12 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -5111,6 +5229,8 @@ snapshots:
   ini@1.3.8: {}
 
   internmap@2.0.3: {}
+
+  iobuffer@5.4.0: {}
 
   ip-regex@5.0.0: {}
 
@@ -5176,6 +5296,17 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      fast-png: 6.4.0
+      fflate: 0.8.3
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.50.0
+      dompurify: 3.4.13
+      html2canvas: 1.4.1
 
   keyv@4.5.4:
     dependencies:
@@ -5328,6 +5459,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@2.2.0: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -5344,6 +5477,9 @@ snapshots:
       minipass: 7.1.3
 
   pathe@2.0.3: {}
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -5401,6 +5537,11 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   ramda-adjunct@5.1.0(ramda@0.30.1):
     dependencies:
       ramda: 0.30.1
@@ -5432,6 +5573,9 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   repeat-string@1.6.1: {}
 
   require-directory@2.1.1: {}
@@ -5448,6 +5592,9 @@ snapshots:
   ret@0.2.2: {}
 
   reusify@1.1.0: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   robust-predicates@3.0.3: {}
 
@@ -5546,6 +5693,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   std-env@4.2.0: {}
 
   string-width@4.2.3:
@@ -5588,6 +5738,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   svgo@3.3.4:
     dependencies:
       commander: 7.2.0
@@ -5622,6 +5775,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   time-span@5.1.0:
     dependencies:
@@ -5739,6 +5897,11 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   vite-svg-loader@4.0.0:
     dependencies:

--- a/ui/src/components/AdhocGraphs/AdhocChart.vue
+++ b/ui/src/components/AdhocGraphs/AdhocChart.vue
@@ -1,0 +1,441 @@
+<template>
+  <div
+    class="adhoc-chart"
+    :class="{ 'is-expanded': expanded }"
+  >
+    <OnmsTabs
+      value="graph"
+      class="chart-tabs"
+    >
+      <OnmsTabList>
+        <OnmsTab value="graph">Graph</OnmsTab>
+        <OnmsTab value="data">Data</OnmsTab>
+      </OnmsTabList>
+      <OnmsTabPanels>
+        <OnmsTabPanel value="graph">
+          <div
+            ref="chartAreaRef"
+            class="chart-area"
+          >
+            <div
+              v-if="loading"
+              class="chart-status"
+              data-test="chart-loading"
+            >
+              <OnmsSpinner />
+            </div>
+            <p
+              v-else-if="error"
+              class="chart-status chart-error"
+              role="alert"
+              data-test="chart-error"
+            >{{ error }}</p>
+            <p
+              v-else-if="!plotted.length"
+              class="chart-status chart-empty"
+              data-test="chart-empty"
+            >
+              Select one or more datasources to graph.
+            </p>
+            <p
+              v-else-if="!measurements"
+              class="chart-status chart-empty"
+              data-test="chart-unrun"
+            >
+              Choose a time range or select Refresh to draw the graph.
+            </p>
+            <p
+              v-else-if="noDataInRange"
+              class="chart-status chart-empty"
+              data-test="chart-no-data"
+            >
+              No data was collected for this selection over the chosen range.
+            </p>
+
+            <!-- The canvas stays mounted across states so Chart.js keeps its context;
+                 the status messages above simply cover it. -->
+            <div
+              class="canvas-wrapper"
+              :class="{ 'is-hidden': !showCanvas }"
+            >
+              <canvas
+                :id="canvasId"
+                data-test="chart-canvas"
+              ></canvas>
+            </div>
+          </div>
+          <div
+            class="chart-legend"
+            :id="`${canvasId}-lc`"
+          ></div>
+        </OnmsTabPanel>
+
+        <OnmsTabPanel value="data">
+          <GraphDataTable
+            v-if="measurements && plotted.length"
+            :id="canvasId"
+            :graphData="tableData"
+            :convertedGraphData="convertedGraphData"
+          />
+          <p
+            v-else
+            class="chart-status chart-empty"
+          >Nothing to tabulate yet.</p>
+        </OnmsTabPanel>
+      </OnmsTabPanels>
+    </OnmsTabs>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  OnmsSpinner,
+  OnmsTab,
+  OnmsTabList,
+  OnmsTabPanel,
+  OnmsTabPanels,
+  OnmsTabs
+} from '@opennms/onms-ui'
+import { Chart, ChartDataset, ChartOptions, registerables } from 'chart.js'
+import zoomPlugin from 'chartjs-plugin-zoom'
+import { format as d3Format } from 'd3'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+import GraphDataTable from '@/components/Resources/GraphDataTable.vue'
+import HtmlLegendPlugin from '@/components/Resources/plugins/HtmlLegendPlugin'
+import { formatTimestamps } from '@/components/Resources/utils/LegendFormatter'
+import { GraphMetricsResponse, StartEndTime } from '@/types'
+import { AdhocExpression, AdhocGraphConfig, AdhocSeries } from '@/types/adhocGraph'
+import { useAppStore } from '@/stores/appStore'
+import { chartInk, seriesColor, strokeWidthFor } from './utils/adhocColors'
+import { plottedSeries, toConvertedGraphData } from './utils/adhocQuery'
+
+Chart.register(...registerables)
+Chart.register(zoomPlugin)
+
+const props = defineProps<{
+  config: AdhocGraphConfig
+  measurements: GraphMetricsResponse | null
+  time: StartEndTime
+  loading: boolean
+  error: string
+  /** Let the plot fill the available height instead of its default band. */
+  expanded?: boolean
+}>()
+
+/** Stable id — this page hosts exactly one ad-hoc chart. */
+const canvasId = 'adhoc-graph'
+
+const appStore = useAppStore()
+const chartAreaRef = ref<HTMLElement | null>(null)
+let chart: Chart | null = null
+
+const yAxisFormatter = d3Format('.3s')
+
+const plotted = computed<(AdhocSeries | AdhocExpression)[]>(() => plottedSeries(props.config))
+
+const convertedGraphData = computed(() => toConvertedGraphData(props.config))
+
+/** Column values for a label, or an empty array when the server returned no such column. */
+const columnFor = (label: string): number[] => {
+  const index = props.measurements?.labels.indexOf(label) ?? -1
+  return index >= 0 ? (props.measurements?.columns[index]?.values ?? []) : []
+}
+
+const noDataInRange = computed<boolean>(() => {
+  if (!props.measurements || !plotted.value.length) {
+    return false
+  }
+
+  // `relaxed: true` means a missing or empty source comes back as a column of NaN
+  // rather than as an error, so "nothing collected" has to be detected here.
+  return plotted.value.every(item =>
+    columnFor(item.label).every(value => value === null || value === undefined || Number.isNaN(value)))
+})
+
+const showCanvas = computed<boolean>(() =>
+  !props.loading && !props.error && Boolean(props.measurements) && plotted.value.length > 0 && !noDataInRange.value)
+
+const EMPTY_MEASUREMENTS = {
+  columns: [] as unknown as GraphMetricsResponse['columns'],
+  labels: [],
+  timestamps: [],
+  formattedTimestamps: [],
+  formattedLabels: []
+} as unknown as GraphMetricsResponse
+
+/** A timestamp-formatted copy; formatTimestamps mutates, so never hand it the prop. */
+const tableData = computed<GraphMetricsResponse>(() => {
+  if (!props.measurements) {
+    return EMPTY_MEASUREMENTS
+  }
+
+  return formatTimestamps({ ...props.measurements, formattedTimestamps: [] }, props.time.format)
+})
+
+const isStacked = computed<boolean>(() =>
+  props.config.stacked || props.config.series.some(entry => entry.style === 'stack'))
+
+/**
+ * Translucent companion to a series colour, for area/stack fills. Overlapping
+ * opaque fills hide each other; 22% alpha keeps every band readable while the
+ * 2px stroke still carries the line itself.
+ */
+const fillColor = (color: string): string => `${color}38`
+
+/**
+ * Every configured series in a stable order, whether plotted or not. Both the
+ * colour slot and the dash pattern are looked up here rather than by position in
+ * the plotted list, so hiding one series never repaints the survivors.
+ */
+const slotIndexOf = computed<Map<string, number>>(() => new Map(
+  [...props.config.series, ...props.config.expressions].map((item, index) => [item.label, index])
+))
+
+const buildDatasets = (): ChartDataset<'line'>[] =>
+  plotted.value.map((item, index) => {
+    const slot = slotIndexOf.value.get(item.label) ?? index
+    const color = item.color || seriesColor(slot, appStore.theme)
+    const filled = item.style === 'area' || item.style === 'stack'
+
+    return {
+      label: item.label,
+      data: columnFor(item.label),
+      borderColor: color,
+      backgroundColor: filled ? fillColor(color) : color,
+      // Weight comes from the chosen style (LINE1/2/3) and nothing else.
+      borderWidth: strokeWidthFor(item.style),
+      fill: filled ? 'origin' : false,
+      // No smoothing: a curve through sampled counters invents values that were
+      // never collected.
+      tension: 0,
+      spanGaps: false,
+      pointRadius: 0,
+      pointHoverRadius: 5,
+      hitRadius: 8,
+      order: plotted.value.length - index
+    }
+  })
+
+const buildOptions = (): ChartOptions<'line'> => {
+  const ink = chartInk()
+
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    // Index mode with intersect off gives the whole-column readout users expect
+    // when comparing series, without having to land exactly on a point.
+    interaction: {
+      mode: 'index',
+      intersect: false
+    },
+    plugins: {
+      htmlLegend: { containerID: `${canvasId}-lc` },
+      legend: { display: false },
+      title: {
+        display: Boolean(props.config.title),
+        text: props.config.title,
+        color: ink.text
+      },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value = context.parsed.y
+            return `${context.dataset.label}: ${Number.isFinite(value) ? yAxisFormatter(value) : 'N/A'}`
+          }
+        }
+      },
+      zoom: {
+        zoom: {
+          wheel: { enabled: true },
+          pinch: { enabled: true },
+          mode: 'x'
+        },
+        pan: { enabled: true, mode: 'x' }
+      }
+    },
+    scales: {
+      x: {
+        ticks: { maxTicksLimit: 12, color: ink.muted },
+        grid: { color: ink.grid }
+      },
+      y: {
+        stacked: isStacked.value,
+        title: {
+          display: Boolean(props.config.verticalLabel),
+          text: props.config.verticalLabel,
+          color: ink.muted
+        },
+        ticks: {
+          maxTicksLimit: 8,
+          color: ink.muted,
+          callback: value => yAxisFormatter(value as number)
+        },
+        grid: { color: ink.grid }
+      }
+    }
+  } as ChartOptions<'line'>
+}
+
+const render = () => {
+  const canvas = document.getElementById(canvasId) as HTMLCanvasElement | null
+
+  if (!canvas || !showCanvas.value) {
+    return
+  }
+
+  const data = {
+    labels: tableData.value.formattedTimestamps,
+    datasets: buildDatasets()
+  }
+
+  if (chart) {
+    chart.data = data
+    chart.options = buildOptions()
+    chart.update()
+    return
+  }
+
+  // Chart.js refuses a canvas another chart still owns ("Canvas is already in
+  // use"); a stale instance can survive a navigation away and back.
+  Chart.getChart(canvas)?.destroy()
+  chart = new Chart(canvas, {
+    type: 'line',
+    data,
+    options: buildOptions(),
+    plugins: [HtmlLegendPlugin]
+  })
+}
+
+const destroyChart = () => {
+  chart?.destroy()
+  chart = null
+}
+
+watch(
+  () => [props.measurements, props.config, appStore.theme, showCanvas.value],
+  () => {
+    if (showCanvas.value) {
+      render()
+    } else {
+      // Drop the chart when there is nothing to show so the legend and canvas do
+      // not keep displaying the previous selection's series.
+      destroyChart()
+    }
+  },
+  { deep: true, flush: 'post' }
+)
+
+/** Reset zoom/pan when the range changes — a stale zoom window hides the new data. */
+watch(() => [props.time.startTime, props.time.endTime], () => chart?.resetZoom())
+
+const exportTarget = (): HTMLElement | null => chartAreaRef.value
+
+defineExpose({ exportTarget })
+
+onMounted(render)
+onBeforeUnmount(destroyChart)
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/onms-typography';
+
+.adhoc-chart {
+  width: 100%;
+}
+
+.chart-area {
+  position: relative;
+  height: 420px;
+}
+
+/**
+ * Expanded: fill the height the parent hands down instead of guessing at it.
+ *
+ * A viewport-relative height cannot work here — the chart sits inside a card that
+ * already starts below the masthead, under breadcrumbs, a heading and a toolbar —
+ * so any calc(100vh - x) either overflows or wastes space. Flex measures the real
+ * leftover instead. Chart.js is responsive with maintainAspectRatio off, so the
+ * canvas simply follows its container.
+ *
+ * The chain has to be unbroken from this root down to .chart-area, which is why
+ * PrimeVue's own tab panels are reached with :deep(). `min-height: 0` on each link
+ * is what lets a flex child actually shrink below its content size.
+ */
+.adhoc-chart.is-expanded {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+
+  .chart-tabs {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  :deep(.p-tabpanels) {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  :deep(.p-tabpanel) {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .chart-area {
+    flex: 1;
+    height: auto;
+    // Below this the plot stops being readable; the legend gives up space first.
+    min-height: 10rem;
+  }
+
+  // A graph with a dozen series has a tall legend. Cap it and let it scroll so it
+  // can never push the plot off the bottom of the card.
+  .chart-legend {
+    flex: 0 0 auto;
+    max-height: 7rem;
+    overflow-y: auto;
+  }
+}
+
+.canvas-wrapper {
+  height: 100%;
+
+  &.is-hidden {
+    visibility: hidden;
+  }
+}
+
+.chart-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 1rem;
+  text-align: center;
+}
+
+.chart-empty {
+  color: var(--p-text-muted-color);
+}
+
+.chart-error {
+  color: var(--p-red-500);
+}
+
+.chart-legend {
+  @include onms-body-small;
+  margin-top: 0.5rem;
+}
+</style>

--- a/ui/src/components/AdhocGraphs/AdhocChart.vue
+++ b/ui/src/components/AdhocGraphs/AdhocChart.vue
@@ -177,7 +177,7 @@ const isStacked = computed<boolean>(() =>
   props.config.stacked || props.config.series.some(entry => entry.style === 'stack'))
 
 /**
- * Translucent companion to a series colour, for area/stack fills. Overlapping
+ * Translucent companion to a series color, for area/stack fills. Overlapping
  * opaque fills hide each other; 22% alpha keeps every band readable while the
  * 2px stroke still carries the line itself.
  */
@@ -185,7 +185,7 @@ const fillColor = (color: string): string => `${color}38`
 
 /**
  * Every configured series in a stable order, whether plotted or not. Both the
- * colour slot and the dash pattern are looked up here rather than by position in
+ * color slot and the dash pattern are looked up here rather than by position in
  * the plotted list, so hiding one series never repaints the survivors.
  */
 const slotIndexOf = computed<Map<string, number>>(() => new Map(

--- a/ui/src/components/AdhocGraphs/AdhocChartToolbar.vue
+++ b/ui/src/components/AdhocGraphs/AdhocChartToolbar.vue
@@ -1,0 +1,226 @@
+<template>
+  <div class="chart-toolbar">
+    <div class="toolbar-row">
+      <TimeControls @updateTime="(value: StartEndTime) => emit('updateTime', value)" />
+
+      <div class="toolbar-actions">
+        <OnmsButton
+          variant="outlined"
+          :disabled="!canQuery"
+          :loading="loading"
+          data-test="toolbar-refresh"
+          @click="emit('refresh')"
+        >Refresh</OnmsButton>
+        <OnmsIconButton
+          variant="outlined"
+          :icon="DownloadFile"
+          title="Download this graph's data as CSV"
+          :disabled="!hasData"
+          data-test="toolbar-csv"
+          @click="emit('exportCsv')"
+        />
+        <OnmsIconButton
+          variant="outlined"
+          :icon="PdfIcon"
+          title="Download this graph as a PDF"
+          :disabled="!hasData"
+          data-test="toolbar-pdf"
+          @click="emit('exportPdf')"
+        />
+        <OnmsIconButton
+          variant="outlined"
+          :icon="LinkIcon"
+          title="Copy a link to this graph"
+          :disabled="!canQuery"
+          data-test="toolbar-share"
+          @click="emit('share')"
+        />
+        <OnmsIconButton
+          v-if="!viewOnly"
+          variant="outlined"
+          :icon="CodeIcon"
+          title="Show this graph as an RRDtool graph definition"
+          :disabled="!canQuery"
+          data-test="toolbar-definition"
+          @click="emit('showDefinition')"
+        />
+        <OnmsIconButton
+          v-if="!viewOnly"
+          variant="outlined"
+          :icon="expanded ? FullscreenExitIcon : FullscreenIcon"
+          :title="expanded ? 'Show the selectors again' : 'Expand the graph, hiding the selectors'"
+          data-test="toolbar-expand"
+          @click="emit('toggleExpand')"
+        />
+        <OnmsIconButton
+          v-if="!viewOnly"
+          variant="outlined"
+          :icon="PopOutIcon"
+          title="Open this graph on its own, in a new tab"
+          :disabled="!canQuery"
+          data-test="toolbar-popout"
+          @click="emit('popOut')"
+        />
+        <OnmsButton
+          v-if="!viewOnly"
+          variant="ghost"
+          data-test="toolbar-clear"
+          @click="emit('clear')"
+        >Clear all</OnmsButton>
+      </div>
+    </div>
+
+    <div
+      v-if="!viewOnly && !expanded"
+      class="toolbar-row toolbar-fields"
+    >
+      <FormField
+        label="Graph title"
+        for="adhoc-title"
+        class="field-title"
+      >
+        <OnmsInputText
+          id="adhoc-title"
+          :modelValue="config.title"
+          placeholder="Untitled ad-hoc graph"
+          data-test="toolbar-title"
+          @update:modelValue="value => emit('update', { title: (value ?? '') as string })"
+        />
+      </FormField>
+
+      <FormField
+        label="Vertical label"
+        for="adhoc-vlabel"
+        class="field-vlabel"
+      >
+        <OnmsInputText
+          id="adhoc-vlabel"
+          :modelValue="config.verticalLabel"
+          placeholder="e.g. bits per second"
+          data-test="toolbar-vlabel"
+          @update:modelValue="value => emit('update', { verticalLabel: (value ?? '') as string })"
+        />
+      </FormField>
+
+      <FormField
+        label="Data points"
+        for="adhoc-resolution"
+        class="field-resolution"
+        hint="Samples across the range."
+      >
+        <OnmsInputNumber
+          inputId="adhoc-resolution"
+          :modelValue="config.resolution"
+          :min="10"
+          :max="MAX_RESOLUTION"
+          data-test="toolbar-resolution"
+          @update:modelValue="value => emit('update', { resolution: Number(value) || DEFAULT_RESOLUTION })"
+        />
+      </FormField>
+
+      <FormField
+        label="Stack series"
+        for="adhoc-stacked"
+        class="field-stacked"
+      >
+        <OnmsToggleSwitch
+          :modelValue="config.stacked"
+          inputId="adhoc-stacked"
+          data-test="toolbar-stacked"
+          @update:modelValue="value => emit('update', { stacked: value })"
+        />
+      </FormField>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { OnmsButton, OnmsIconButton, OnmsInputNumber, OnmsInputText, OnmsToggleSwitch } from '@opennms/onms-ui'
+
+import DownloadFile from '@/components/icons/action/DownloadFile.vue'
+import CodeIcon from '@/components/icons/action/Code.vue'
+import PopOutIcon from '@/components/icons/action/Expand.vue'
+import FullscreenIcon from '@/components/icons/navigation/Fullscreen.vue'
+import FullscreenExitIcon from '@/components/icons/navigation/FullscreenExit.vue'
+import LinkIcon from '@/components/icons/action/Link.vue'
+import PdfIcon from '@/components/icons/file/Pdf.vue'
+import FormField from '@/components/Common/FormField.vue'
+import TimeControls from '@/components/Resources/TimeControls.vue'
+import { StartEndTime } from '@/types'
+import { AdhocGraphConfig } from '@/types/adhocGraph'
+import { DEFAULT_RESOLUTION, MAX_RESOLUTION } from './utils/adhocQuery'
+
+withDefaults(defineProps<{
+  config: AdhocGraphConfig
+  canQuery: boolean
+  hasData: boolean
+  loading: boolean
+  /** True while the graph is filling the page with the selectors hidden. */
+  expanded?: boolean
+  /** Graph-only route: no editing controls, no expand/pop-out of its own. */
+  viewOnly?: boolean
+}>(), {
+  expanded: false,
+  viewOnly: false
+})
+
+const emit = defineEmits<{
+  update: [patch: Partial<AdhocGraphConfig>]
+  updateTime: [time: StartEndTime]
+  refresh: []
+  clear: []
+  toggleExpand: []
+  popOut: []
+  showDefinition: []
+  share: []
+  exportCsv: []
+  exportPdf: []
+}>()
+</script>
+
+<style scoped lang="scss">
+.chart-toolbar {
+  display: flex;
+  flex-direction: column;
+}
+
+.toolbar-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.toolbar-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.toolbar-fields {
+  justify-content: flex-start;
+  // flex-start, not flex-end: every field is a label above a control, so they line
+  // up at the top. Aligning to the bottom made a field whose hint wrapped onto a
+  // second line drag its neighbours down with it.
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+
+  .field-title {
+    flex: 1 1 18rem;
+  }
+
+  .field-vlabel {
+    flex: 1 1 14rem;
+  }
+
+  // Wide enough that the hint sits on one line at this font size.
+  .field-resolution {
+    flex: 0 0 13rem;
+  }
+
+  .field-stacked {
+    flex: 0 0 auto;
+  }
+}
+</style>

--- a/ui/src/components/AdhocGraphs/AdhocChartToolbar.vue
+++ b/ui/src/components/AdhocGraphs/AdhocChartToolbar.vue
@@ -1,20 +1,36 @@
 <template>
   <div class="chart-toolbar">
     <div class="toolbar-row">
-      <TimeControls @updateTime="(value: StartEndTime) => emit('updateTime', value)" />
+      <!--
+        A visible label: the range button shows only the current selection ("Last
+        day"), so without this there is nothing saying what it selects. Not wired up
+        with aria-labelledby, because TimeControls' fallthrough target is a plain
+        div and the attribute would be inert there — associating it properly means
+        changing the shared component, which Resource Graphs needs too.
+      -->
+      <div class="time-range">
+        <span class="time-range-label">Time Range:</span>
+        <TimeControls
+          data-test="toolbar-time-range"
+          @updateTime="(value: StartEndTime) => emit('updateTime', value)"
+        />
+      </div>
 
       <div class="toolbar-actions">
-        <OnmsButton
+        <OnmsIconButton
           variant="outlined"
-          :disabled="!canQuery"
-          :loading="loading"
+          :icon="RefreshIcon"
+          title="Refresh"
+          v-onms-tooltip="'Redraw the graph with the latest data'"
+          :disabled="!canQuery || loading"
           data-test="toolbar-refresh"
           @click="emit('refresh')"
-        >Refresh</OnmsButton>
+        />
         <OnmsIconButton
           variant="outlined"
           :icon="DownloadFile"
-          title="Download this graph's data as CSV"
+          title="Download the graph data as CSV"
+          v-onms-tooltip="'Download the graph data as CSV'"
           :disabled="!hasData"
           data-test="toolbar-csv"
           @click="emit('exportCsv')"
@@ -23,6 +39,7 @@
           variant="outlined"
           :icon="PdfIcon"
           title="Download this graph as a PDF"
+          v-onms-tooltip="'Download this graph as a PDF'"
           :disabled="!hasData"
           data-test="toolbar-pdf"
           @click="emit('exportPdf')"
@@ -31,6 +48,7 @@
           variant="outlined"
           :icon="LinkIcon"
           title="Copy a link to this graph"
+          v-onms-tooltip="'Copy a link to this graph'"
           :disabled="!canQuery"
           data-test="toolbar-share"
           @click="emit('share')"
@@ -40,6 +58,7 @@
           variant="outlined"
           :icon="CodeIcon"
           title="Show this graph as an RRDtool graph definition"
+          v-onms-tooltip="'Show this graph as an RRDtool graph definition'"
           :disabled="!canQuery"
           data-test="toolbar-definition"
           @click="emit('showDefinition')"
@@ -49,6 +68,7 @@
           variant="outlined"
           :icon="expanded ? FullscreenExitIcon : FullscreenIcon"
           :title="expanded ? 'Show the selectors again' : 'Expand the graph, hiding the selectors'"
+          v-onms-tooltip="expanded ? 'Show the selectors again' : 'Expand the graph, hiding the selectors'"
           data-test="toolbar-expand"
           @click="emit('toggleExpand')"
         />
@@ -57,16 +77,20 @@
           variant="outlined"
           :icon="PopOutIcon"
           title="Open this graph on its own, in a new tab"
+          v-onms-tooltip="'Open this graph on its own, in a new tab'"
           :disabled="!canQuery"
           data-test="toolbar-popout"
           @click="emit('popOut')"
         />
-        <OnmsButton
+        <OnmsIconButton
           v-if="!viewOnly"
-          variant="ghost"
+          variant="outlined"
+          :icon="CancelIcon"
+          title="Clear all"
+          v-onms-tooltip="'Clear every selection and start again'"
           data-test="toolbar-clear"
           @click="emit('clear')"
-        >Clear all</OnmsButton>
+        />
       </div>
     </div>
 
@@ -82,7 +106,7 @@
         <OnmsInputText
           id="adhoc-title"
           :modelValue="config.title"
-          placeholder="Untitled ad-hoc graph"
+          placeholder="Untitled custom performance graph"
           data-test="toolbar-title"
           @update:modelValue="value => emit('update', { title: (value ?? '') as string })"
         />
@@ -135,9 +159,11 @@
 </template>
 
 <script setup lang="ts">
-import { OnmsButton, OnmsIconButton, OnmsInputNumber, OnmsInputText, OnmsToggleSwitch } from '@opennms/onms-ui'
+import { OnmsIconButton, OnmsInputNumber, OnmsInputText, OnmsToggleSwitch } from '@opennms/onms-ui'
 
+import CancelIcon from '@/components/icons/action/Cancel.vue'
 import DownloadFile from '@/components/icons/action/DownloadFile.vue'
+import RefreshIcon from '@/components/icons/navigation/Refresh.vue'
 import CodeIcon from '@/components/icons/action/Code.vue'
 import PopOutIcon from '@/components/icons/action/Expand.vue'
 import FullscreenIcon from '@/components/icons/navigation/Fullscreen.vue'
@@ -196,6 +222,19 @@ const emit = defineEmits<{
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
+}
+
+// Every control on this row is now the same height, so the label sits beside the
+// range button rather than above it.
+.time-range {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  .time-range-label {
+    font-weight: 700;
+    white-space: nowrap;
+  }
 }
 
 .toolbar-fields {

--- a/ui/src/components/AdhocGraphs/AdhocChartToolbar.vue
+++ b/ui/src/components/AdhocGraphs/AdhocChartToolbar.vue
@@ -202,7 +202,7 @@ const emit = defineEmits<{
   justify-content: flex-start;
   // flex-start, not flex-end: every field is a label above a control, so they line
   // up at the top. Aligning to the bottom made a field whose hint wrapped onto a
-  // second line drag its neighbours down with it.
+  // second line drag its neighbors down with it.
   align-items: flex-start;
   margin-bottom: 0.75rem;
 

--- a/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
+++ b/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
@@ -199,7 +199,6 @@
 <script setup lang="ts">
 import { OnmsIconButton, OnmsMessageDialog, OnmsPanel } from '@opennms/onms-ui'
 import { onKeyStroke, useDebounceFn } from '@vueuse/core'
-import { getUnixTime, sub } from 'date-fns'
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -218,6 +217,7 @@ import { useAppStore } from '@/stores/appStore'
 import { useAdhocGraphStore } from '@/stores/adhocGraphStore'
 import { useMenuStore } from '@/stores/menuStore'
 import { BreadCrumb, StartEndTime } from '@/types'
+import { DEFAULT_RANGE, resolveRelativeRange } from '@/components/Resources/utils/timeRangeOptions'
 import {
   AdhocDatasourceOption,
   AdhocExpression,
@@ -299,12 +299,8 @@ const config = reactive<AdhocGraphConfig>({
   resolution: DEFAULT_RESOLUTION
 })
 
-const now = new Date()
-const time = reactive<StartEndTime>({
-  startTime: getUnixTime(sub(now, { hours: 24 })),
-  endTime: getUnixTime(now),
-  format: 'hours'
-})
+// Relative by default, so an unbookmarked page and a bookmarked one behave alike.
+const time = reactive<StartEndTime>(resolveRelativeRange(DEFAULT_RANGE))
 
 const breadcrumbs = computed<BreadCrumb[]>(() => (props.viewOnly ?
   [
@@ -403,6 +399,27 @@ const updateTime = (value: StartEndTime) => {
   time.startTime = value.startTime
   time.endTime = value.endTime
   time.format = value.format
+  // Deleted rather than left stale: a custom range carries no `range`, and keeping
+  // the previous one would make an absolute window silently start sliding.
+  if (value.range) {
+    time.range = value.range
+  } else {
+    delete time.range
+  }
+}
+
+/**
+ * Slide a relative window up to the present. A no-op for a custom range, which is
+ * absolute by definition.
+ */
+const refreshRelativeWindow = () => {
+  if (!time.range) {
+    return
+  }
+
+  const resolved = resolveRelativeRange(time.range)
+  time.startTime = resolved.startTime
+  time.endTime = resolved.endTime
 }
 
 const runQuery = () => {
@@ -410,6 +427,9 @@ const runQuery = () => {
     return
   }
 
+  // "Last hour" must mean the hour ending now, not the hour that ended whenever the
+  // range was chosen — which may have been a long time ago on a page left open.
+  refreshRelativeWindow()
   store.runQuery(buildMeasurementsPayload(config, time))
 }
 
@@ -595,7 +615,11 @@ onMounted(async () => {
 
   Object.assign(config, restored.config)
 
-  if (restored.time.startTime && restored.time.endTime) {
+  if (restored.time.range) {
+    // Resolved against the clock now, so the link shows current data however old
+    // the bookmark is.
+    updateTime(resolveRelativeRange(restored.time.range))
+  } else if (restored.time.startTime && restored.time.endTime) {
     updateTime(restored.time)
   }
 

--- a/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
+++ b/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
@@ -11,10 +11,10 @@
 
     <div class="onms-row">
       <div class="onms-col-12 page-heading">
-        <h1 class="headline3">{{ config.title || 'Ad-Hoc Graphs' }}</h1>
+        <h1 class="headline3">{{ config.title || 'Custom Performance Graphs' }}</h1>
         <OnmsIconButton
           v-if="!viewOnly"
-          title="Ad-Hoc Graphs Help"
+          title="Custom Performance Graphs Help"
           data-test="adhoc-info-icon"
           :icon="InfoIcon"
           @click="isHelpMessageDialogVisible = true"
@@ -177,7 +177,7 @@
       :relative="true"
       maxHeight="26em"
       maxWidth="50em"
-      title="Ad-Hoc Graphs"
+      title="Custom Performance Graphs"
       @close="isHelpMessageDialogVisible = false"
     >
       <template #content>
@@ -312,12 +312,12 @@ const time = reactive<StartEndTime>(resolveRelativeRange(DEFAULT_RANGE))
 const breadcrumbs = computed<BreadCrumb[]>(() => (props.viewOnly ?
   [
     { label: 'Home', to: menuStore.mainMenu.homeUrl, isAbsoluteLink: true },
-    { label: 'Ad-Hoc Graphs', to: ADHOC_ROUTE_PATH },
+    { label: 'Custom Performance Graphs', to: ADHOC_ROUTE_PATH },
     { label: 'Graph', to: '#', position: 'last' }
   ] :
   [
     { label: 'Home', to: menuStore.mainMenu.homeUrl, isAbsoluteLink: true },
-    { label: 'Ad-Hoc Graphs', to: '#', position: 'last' }
+    { label: 'Custom Performance Graphs', to: '#', position: 'last' }
   ]))
 
 const canQuery = computed<boolean>(() => configIsQueryable(config))
@@ -461,7 +461,7 @@ const exportCsv = () => {
 const exportPdf = () => {
   const target = chartRef.value?.exportTarget()
 
-  if (!target || !exportGraphsToPdf(target, config.title || 'Ad-Hoc Graph')) {
+  if (!target || !exportGraphsToPdf(target, config.title || 'Custom Performance Graph')) {
     showSnackBar({ msg: 'There is no rendered graph to export yet.' })
   }
 }

--- a/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
+++ b/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
@@ -1,0 +1,681 @@
+<template>
+  <div
+    class="adhoc-builder"
+    :class="{ 'is-expanded': chartIsExpanded }"
+  >
+    <div class="onms-row">
+      <div class="onms-col-12">
+        <BreadCrumbs :items="breadcrumbs" />
+      </div>
+    </div>
+
+    <div class="onms-row">
+      <div class="onms-col-12 page-heading">
+        <h1 class="headline3">{{ config.title || 'Ad-Hoc Graphs' }}</h1>
+        <OnmsIconButton
+          v-if="!viewOnly"
+          title="Ad-Hoc Graphs Help"
+          data-test="adhoc-info-icon"
+          :icon="InfoIcon"
+          @click="isHelpMessageDialogVisible = true"
+        />
+        <router-link
+          v-else
+          to="/adhoc-graphs"
+          class="builder-link"
+          data-test="adhoc-open-builder"
+        >Open in the builder</router-link>
+      </div>
+    </div>
+
+    <div
+      v-if="showBuilderChrome"
+      class="onms-row"
+    >
+      <div class="onms-col-4">
+        <SelectionColumn
+          title="Nodes"
+          dataTest="nodes"
+          serverFilter
+          dataKey="id"
+          optionLabel="label"
+          filterPlaceholder="Search nodes"
+          emptyMessage="No nodes match that search."
+          :options="store.nodeOptions"
+          :modelValue="store.selectedNodes"
+          :loading="store.nodesLoading"
+          :keyOf="option => (option as AdhocNodeOption).id"
+          :labelOf="option => (option as AdhocNodeOption).label"
+          :descriptionOf="describeNode"
+          @filter="searchNodes"
+          @update:modelValue="value => store.setSelectedNodes(value as AdhocNodeOption[])"
+        />
+      </div>
+      <div class="onms-col-4">
+        <SelectionColumn
+          title="Resources"
+          dataTest="resources"
+          dataKey="id"
+          optionLabel="label"
+          filterPlaceholder="Filter resources"
+          emptyMessage="Select a node to see its resources."
+          :options="store.resourceOptions"
+          :modelValue="store.selectedResources"
+          :loading="store.resourcesLoading"
+          :keyOf="option => (option as AdhocResourceOption).id"
+          :labelOf="option => (option as AdhocResourceOption).label"
+          :descriptionOf="describeResource"
+          @update:modelValue="value => store.setSelectedResources(value as AdhocResourceOption[])"
+        />
+      </div>
+      <div class="onms-col-4">
+        <SelectionColumn
+          title="Datasources"
+          dataTest="datasources"
+          dataKey="key"
+          optionLabel="attribute"
+          filterPlaceholder="Filter datasources"
+          emptyMessage="Select a resource to see its datasources."
+          :options="store.datasourceOptions"
+          :modelValue="store.selectedDatasources"
+          :loading="store.datasourcesLoading"
+          :keyOf="option => (option as AdhocDatasourceOption).key"
+          :labelOf="option => (option as AdhocDatasourceOption).attribute"
+          :descriptionOf="describeDatasource"
+          @update:modelValue="value => store.setSelectedDatasources(value as AdhocDatasourceOption[])"
+        />
+      </div>
+    </div>
+
+    <div
+      v-if="showBuilderChrome"
+      class="onms-row"
+    >
+      <div class="onms-col-12">
+        <OnmsPanel
+          :header="`Series (${config.series.length})`"
+          toggleable
+          :collapsed="seriesCollapsed"
+          class="builder-panel"
+          data-test="series-panel"
+          @update:collapsed="value => seriesCollapsed = value"
+        >
+          <SeriesTable
+            :series="config.series"
+            :expressions="config.expressions"
+            @update="updateSeries"
+            @remove="removeSeries"
+          />
+        </OnmsPanel>
+      </div>
+    </div>
+
+    <div
+      v-if="showBuilderChrome"
+      class="onms-row"
+    >
+      <div class="onms-col-12">
+        <OnmsPanel
+          :header="`Expressions (${config.expressions.length})`"
+          toggleable
+          :collapsed="expressionsCollapsed"
+          class="builder-panel"
+          data-test="expressions-panel"
+          @update:collapsed="value => expressionsCollapsed = value"
+        >
+          <ExpressionEditor
+            :series="config.series"
+            :expressions="config.expressions"
+            @add="addExpression"
+            @update="updateExpression"
+            @remove="removeExpression"
+          />
+        </OnmsPanel>
+      </div>
+    </div>
+
+    <div class="onms-row chart-row">
+      <div class="onms-col-12 chart-cell">
+        <AdhocChartToolbar
+          :config="config"
+          :canQuery="canQuery"
+          :hasData="Boolean(store.measurements)"
+          :loading="store.queryLoading"
+          :expanded="expanded"
+          :viewOnly="viewOnly"
+          @update="patch => Object.assign(config, patch)"
+          @updateTime="updateTime"
+          @refresh="runQuery"
+          @clear="clearAll"
+          @share="shareLink"
+          @toggleExpand="expanded = !expanded"
+          @popOut="popOut"
+          @showDefinition="isDefinitionDialogVisible = true"
+          @exportCsv="exportCsv"
+          @exportPdf="exportPdf"
+        />
+        <AdhocChart
+          ref="chartRef"
+          :config="config"
+          :measurements="store.measurements"
+          :time="time"
+          :loading="store.queryLoading"
+          :error="store.queryError"
+          :expanded="chartIsExpanded"
+        />
+      </div>
+    </div>
+
+    <RrdDefinitionDialog
+      :visible="isDefinitionDialogVisible"
+      :config="config"
+      @close="isDefinitionDialogVisible = false"
+    />
+
+    <OnmsMessageDialog
+      :visible="isHelpMessageDialogVisible"
+      :relative="true"
+      maxHeight="26em"
+      maxWidth="50em"
+      title="Ad-Hoc Graphs"
+      @close="isHelpMessageDialogVisible = false"
+    >
+      <template #content>
+        <div class="adhoc-help">
+          <p>Build a graph from any combination of datasources, across any number of nodes, without a pre-defined graph definition.</p>
+          <p>Pick nodes, then their resources, then the datasources you want to plot. Each selected datasource becomes a series you can label, recolour and restyle.</p>
+          <h3>Expressions</h3>
+          <p>Expressions are evaluated server-side with JEXL. Reference a source series by its label &mdash; for example <code>ifHCInOctets_eth0 * 8</code> to convert octets to bits &mdash; and the result is plotted as a series of its own.</p>
+          <p>Labels are JEXL identifiers, so they may contain only letters, digits and underscores, and must be unique across the graph.</p>
+          <p>Turn on <strong>Hide raw</strong> for a source to keep it out of the graph while still feeding an expression. It only takes effect when some expression actually references that source.</p>
+          <h3>Sharing</h3>
+          <p>The full selection, expressions, time range and render options live in the page URL, so a graph can be bookmarked or pasted to a colleague. Use the link button to copy it.</p>
+        </div>
+      </template>
+    </OnmsMessageDialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { OnmsIconButton, OnmsMessageDialog, OnmsPanel } from '@opennms/onms-ui'
+import { onKeyStroke, useDebounceFn } from '@vueuse/core'
+import { getUnixTime, sub } from 'date-fns'
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import AdhocChart from './AdhocChart.vue'
+import AdhocChartToolbar from './AdhocChartToolbar.vue'
+import ExpressionEditor from './ExpressionEditor.vue'
+import SelectionColumn from './SelectionColumn.vue'
+import RrdDefinitionDialog from './RrdDefinitionDialog.vue'
+import SeriesTable from './SeriesTable.vue'
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import InfoIcon from '@/components/icons/action/Info.vue'
+import { downloadGraphCsv, exportGraphsToPdf } from '@/components/Resources/utils/graphExport'
+import { copyToClipboard } from '@/composables/useClipboard'
+import useSnackbar from '@/composables/useSnackbar'
+import { useAppStore } from '@/stores/appStore'
+import { useAdhocGraphStore } from '@/stores/adhocGraphStore'
+import { useMenuStore } from '@/stores/menuStore'
+import { BreadCrumb, StartEndTime } from '@/types'
+import {
+  AdhocDatasourceOption,
+  AdhocExpression,
+  AdhocGraphConfig,
+  AdhocNodeOption,
+  AdhocResourceOption,
+  AdhocSeries
+} from '@/types/adhocGraph'
+import { ConsolidationFunctionType } from '@/types/timeSeries'
+import { restepColorForTheme, seriesColor } from './utils/adhocColors'
+import {
+  buildMeasurementsPayload,
+  configIsQueryable,
+  DEFAULT_RESOLUTION,
+  labelForDatasource,
+  querySignature,
+  toConvertedGraphData
+} from './utils/adhocQuery'
+import {
+  decodeAdhocState,
+  encodeAdhocState,
+  encodedQueryLength,
+  MAX_QUERY_LENGTH
+} from './utils/adhocUrlState'
+
+/** This component's own routes; also the last-resort fragment for a share link. */
+const ADHOC_ROUTE_PATH = '/adhoc-graphs'
+const ADHOC_VIEW_ROUTE_PATH = '/adhoc-graphs/view'
+
+const props = withDefaults(defineProps<{
+  /**
+   * Graph-only route (/adhoc-graphs/view). The page renders from the URL alone:
+   * no pickers, no editors, just the time controls, the plot and the exports.
+   */
+  viewOnly?: boolean
+}>(), {
+  viewOnly: false
+})
+
+const appStore = useAppStore()
+const menuStore = useMenuStore()
+const route = useRoute()
+const router = useRouter()
+const store = useAdhocGraphStore()
+const { showSnackBar } = useSnackbar()
+
+const chartRef = ref<InstanceType<typeof AdhocChart> | null>(null)
+// Series is the main event, so it opens; expressions are optional, so they stay
+// out of the way. Both are only INITIAL states — once the user toggles a panel,
+// nothing here reopens or recloses it behind their back.
+const seriesCollapsed = ref(false)
+const expressionsCollapsed = ref(true)
+const isHelpMessageDialogVisible = ref(false)
+const isDefinitionDialogVisible = ref(false)
+const expanded = ref(false)
+
+/** Pickers and editors are hidden while expanded, and absent entirely on the view route. */
+const showBuilderChrome = computed<boolean>(() => !props.viewOnly && !expanded.value)
+
+const chartIsExpanded = computed<boolean>(() => props.viewOnly || expanded.value)
+
+/** Guards the URL writer while hydrating, so restoring a link doesn't rewrite it. */
+let hydrating = false
+let expressionSeq = 0
+
+/**
+ * Set on teardown. The URL write and the query below are debounced, so both can
+ * still be pending when the user navigates away — and a late `router.replace`
+ * would stamp this page's query onto whatever route they moved to.
+ */
+let disposed = false
+
+const config = reactive<AdhocGraphConfig>({
+  series: [],
+  expressions: [],
+  title: '',
+  verticalLabel: '',
+  stacked: false,
+  resolution: DEFAULT_RESOLUTION
+})
+
+const now = new Date()
+const time = reactive<StartEndTime>({
+  startTime: getUnixTime(sub(now, { hours: 24 })),
+  endTime: getUnixTime(now),
+  format: 'hours'
+})
+
+const breadcrumbs = computed<BreadCrumb[]>(() => (props.viewOnly ?
+  [
+    { label: 'Home', to: menuStore.mainMenu.homeUrl, isAbsoluteLink: true },
+    { label: 'Ad-Hoc Graphs', to: ADHOC_ROUTE_PATH },
+    { label: 'Graph', to: '#', position: 'last' }
+  ] :
+  [
+    { label: 'Home', to: menuStore.mainMenu.homeUrl, isAbsoluteLink: true },
+    { label: 'Ad-Hoc Graphs', to: '#', position: 'last' }
+  ]))
+
+const canQuery = computed<boolean>(() => configIsQueryable(config))
+
+const describeNode = (option: unknown): string => `Node #${(option as AdhocNodeOption).id}`
+
+const describeResource = (option: unknown): string => {
+  const resource = option as AdhocResourceOption
+  return `${resource.nodeLabel} · ${resource.typeLabel}`
+}
+
+const describeDatasource = (option: unknown): string => {
+  const datasource = option as AdhocDatasourceOption
+  return `${datasource.nodeLabel} · ${datasource.resourceLabel}`
+}
+
+const searchNodes = useDebounceFn((term: string) => store.searchNodes(term), 350)
+
+/**
+ * Keep `config.series` in step with the datasource selection.
+ *
+ * Existing entries are carried over by key so a label, colour, style or aggregation
+ * the user set is never lost when an unrelated datasource is ticked or unticked —
+ * that regression is the whole reason this is a reconcile rather than a rebuild.
+ */
+const reconcileSeries = (datasources: AdhocDatasourceOption[]) => {
+  const existing = new Map(config.series.map(entry => [entry.key, entry]))
+  const taken = new Set<string>()
+  const next: AdhocSeries[] = []
+
+  for (const datasource of datasources) {
+    const previous = existing.get(datasource.key)
+
+    if (previous) {
+      taken.add(previous.label)
+      next.push(previous)
+      continue
+    }
+
+    const label = labelForDatasource(datasource, taken)
+    taken.add(label)
+    next.push({
+      key: datasource.key,
+      label,
+      resourceId: datasource.resourceId,
+      attribute: datasource.attribute,
+      aggregation: ConsolidationFunctionType.AVERAGE,
+      // Slot by final position, so an existing series keeps its colour when a new
+      // one is added — colour identifies the series, not its place in the list.
+      color: seriesColor(next.length + config.expressions.length, appStore.theme),
+      style: 'line',
+      hidden: false
+    })
+  }
+
+  config.series = next
+}
+
+const updateSeries = (key: string, patch: Partial<AdhocSeries>) => {
+  config.series = config.series.map(entry => (entry.key === key ? { ...entry, ...patch } : entry))
+}
+
+const removeSeries = (key: string) => {
+  store.setSelectedDatasources(store.selectedDatasources.filter(datasource => datasource.key !== key))
+}
+
+const addExpression = () => {
+  config.expressions = [...config.expressions, {
+    id: `expr-${++expressionSeq}`,
+    label: `expression_${config.expressions.length + 1}`,
+    value: '',
+    color: seriesColor(config.series.length + config.expressions.length, appStore.theme),
+    style: 'line'
+  }]
+}
+
+const updateExpression = (id: string, patch: Partial<AdhocExpression>) => {
+  config.expressions = config.expressions.map(entry => (entry.id === id ? { ...entry, ...patch } : entry))
+}
+
+const removeExpression = (id: string) => {
+  config.expressions = config.expressions.filter(entry => entry.id !== id)
+}
+
+const updateTime = (value: StartEndTime) => {
+  time.startTime = value.startTime
+  time.endTime = value.endTime
+  time.format = value.format
+}
+
+const runQuery = () => {
+  if (disposed || !canQuery.value) {
+    return
+  }
+
+  store.runQuery(buildMeasurementsPayload(config, time))
+}
+
+const clearAll = () => {
+  store.clearAll()
+  config.series = []
+  config.expressions = []
+  config.title = ''
+  config.verticalLabel = ''
+  config.stacked = false
+  config.resolution = DEFAULT_RESOLUTION
+}
+
+const exportCsv = () => {
+  if (!store.measurements) {
+    return
+  }
+
+  downloadGraphCsv(store.measurements, toConvertedGraphData(config), config.title || 'adhoc-graph')
+}
+
+const exportPdf = () => {
+  const target = chartRef.value?.exportTarget()
+
+  if (!target || !exportGraphsToPdf(target, config.title || 'Ad-Hoc Graph')) {
+    showSnackBar({ msg: 'There is no rendered graph to export yet.' })
+  }
+}
+
+/**
+ * The shareable link for the graph as it stands right now.
+ *
+ * Deliberately NOT `window.location.href`: the address bar is written by the
+ * debounced `syncUrl`, so for a few hundred milliseconds after any edit it still
+ * describes the previous state — long enough for "tweak something, hit copy" to
+ * hand out a link to the wrong graph. This rebuilds the query synchronously from
+ * the live config instead.
+ *
+ * Returns null when the selection is past the shareable size, which is the same
+ * point at which syncUrl gives up on the address bar.
+ */
+const buildShareUrl = (routePath?: string): string | null => {
+  const query = encodeAdhocState(config, time)
+
+  if (encodedQueryLength(query) > MAX_QUERY_LENGTH) {
+    return null
+  }
+
+  const params = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(query)) {
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      if (typeof entry === 'string') {
+        params.append(key, entry)
+      }
+    }
+  }
+
+  // Hash-history router: the route and its query both live inside the fragment,
+  // so take the real origin/pathname (which differ between a deployed instance
+  // and the dev server) and replace only the query part of the hash.
+  const { origin, pathname, hash } = window.location
+  // Prefer the live hash; fall back to the router's view, and finally to this
+  // component's own route — a link is never worth emitting with an empty or
+  // undefined fragment, which is what the first two produce before the first
+  // navigation settles.
+  const hashPath = routePath ?
+    `#${routePath}` :
+    hash.split('?')[0] || (route.path ? `#${route.path}` : `#${ADHOC_ROUTE_PATH}`)
+
+  return `${origin}${pathname}${hashPath}?${params.toString()}`
+}
+
+/**
+ * Open the current graph on its own, in a new tab.
+ *
+ * A real window rather than an in-app route change, so the builder stays put with
+ * its selection intact — the point of popping out is to park the graph on another
+ * screen while carrying on here. `noopener` because the new tab is untrusted with
+ * a handle back to this one.
+ */
+const popOut = () => {
+  const url = buildShareUrl(ADHOC_VIEW_ROUTE_PATH)
+
+  if (!url) {
+    showSnackBar({ msg: 'This graph has too many series to open in its own tab.', error: true })
+    return
+  }
+
+  const opened = window.open(url, '_blank', 'noopener')
+
+  if (!opened) {
+    showSnackBar({ msg: 'The browser blocked the new tab. Allow pop-ups for this site, or copy the link instead.', error: true })
+  }
+}
+
+const shareLink = async () => {
+  const url = buildShareUrl()
+
+  if (!url) {
+    showSnackBar({ msg: 'This graph has too many series to share as a link.', error: true })
+    return
+  }
+
+  // Called before any await so the click's transient user activation still stands.
+  const copied = copyToClipboard(url)
+
+  try {
+    await copied
+    showSnackBar({ msg: 'Link copied to the clipboard.' })
+  } catch (_err) {
+    // The browser can refuse outright (permissions policy, no activation). The
+    // address bar still holds a working link, so point at it rather than failing
+    // silently.
+    showSnackBar({ msg: 'Could not copy automatically — the link is in the address bar.', error: true })
+  }
+}
+
+/**
+ * Mirror the graph into the address bar so it can be bookmarked or pasted to a
+ * colleague. `replace` rather than `push`: every tweak would otherwise add a
+ * history entry and make Back unusable.
+ */
+const syncUrl = useDebounceFn(() => {
+  if (hydrating || disposed) {
+    return
+  }
+
+  const query = encodeAdhocState(config, time)
+
+  if (encodedQueryLength(query) > MAX_QUERY_LENGTH) {
+    // Past this size the link stops being pasteable and some proxies truncate it.
+    // The graph keeps working from in-memory state; only sharing is lost.
+    if (Object.keys(route.query).length) {
+      router.replace({ query: {}})
+    }
+    return
+  }
+
+  router.replace({ query: query as Record<string, string | string[]> })
+}, 400)
+
+const debouncedQuery = useDebounceFn(runQuery, 600)
+
+watch(() => store.selectedDatasources, value => reconcileSeries([...value]), { deep: true })
+
+// Only a change to what the server would return re-queries; style, colour and
+// title changes re-render from the data already in hand.
+watch(() => querySignature(config, time), () => {
+  syncUrl()
+  debouncedQuery()
+})
+
+// Non-query config still belongs in the URL.
+watch(() => [config.title, config.verticalLabel, config.stacked, config.series, config.expressions], syncUrl, { deep: true })
+
+// A shared link carries the colours of the theme it was built in; move any colour
+// still sitting on a palette slot to that slot's step for the current theme.
+watch(() => appStore.theme, (theme) => {
+  config.series = config.series.map(entry => ({ ...entry, color: restepColorForTheme(entry.color, theme) }))
+  config.expressions = config.expressions.map(entry => ({ ...entry, color: restepColorForTheme(entry.color, theme) }))
+})
+
+onKeyStroke('Escape', () => {
+  if (expanded.value) {
+    expanded.value = false
+  }
+})
+
+onBeforeUnmount(() => {
+  disposed = true
+})
+
+onMounted(async () => {
+  const restored = decodeAdhocState(route.query)
+
+  if (!restored?.config.series.length) {
+    store.searchNodes('')
+    return
+  }
+
+  hydrating = true
+
+  Object.assign(config, restored.config)
+
+  if (restored.time.startTime && restored.time.endTime) {
+    updateTime(restored.time)
+  }
+
+  // Fill in anything the link left out: colours are optional in the encoding, and
+  // an expression id is regenerated rather than carried.
+  config.series = config.series.map((entry, index) => ({
+    ...entry,
+    color: entry.color || seriesColor(index, appStore.theme)
+  }))
+  config.expressions = config.expressions.map((entry, index) => ({
+    ...entry,
+    id: `expr-${++expressionSeq}`,
+    color: entry.color || seriesColor(config.series.length + index, appStore.theme)
+  }))
+
+  // Walk the cascade backwards from the link's resource ids so all three panes
+  // show what is actually being plotted, then populate the node picker. The search
+  // runs after the restore, not before, so it can pin the restored nodes to the top
+  // rather than racing them.
+  // A link that carries expressions should show them; hiding them would make the
+  // graph look like it came from its sources alone.
+  expressionsCollapsed.value = config.expressions.length === 0
+
+  await store.restoreSelection(config.series.map(entry => ({
+    resourceId: entry.resourceId,
+    attribute: entry.attribute
+  })))
+
+  store.searchNodes('')
+
+  hydrating = false
+  runQuery()
+})
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/onms-typography';
+
+/**
+ * Normal mode scrolls as a whole. Expanded mode does not: the card is a fixed
+ * height, so the chart row takes whatever is left over after the breadcrumbs,
+ * heading and toolbar, and nothing spills past the bottom of the screen.
+ */
+.adhoc-builder {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+
+  &.is-expanded {
+    overflow: hidden;
+
+    .chart-row,
+    .chart-cell {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
+    }
+  }
+}
+
+.page-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  h1 {
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .builder-link {
+    color: var(--onms-clickable-normal);
+    white-space: nowrap;
+  }
+}
+
+.builder-panel {
+  width: 100%;
+}
+</style>

--- a/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
+++ b/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
@@ -9,9 +9,14 @@
       </div>
     </div>
 
-    <div class="onms-row">
-      <div class="onms-col-12 page-heading">
-        <h1 class="headline3">{{ config.title || 'Custom Performance Graphs' }}</h1>
+    <div class="header">
+      <div class="heading page-heading">
+        <!--
+          A fixed page title, not the graph's own title: the graph title is already
+          shown on the plot itself and is editable in the toolbar, and a heading
+          that changes with it stops naming the page you are on.
+        -->
+        <h2>Custom Performance Graphs</h2>
         <OnmsIconButton
           v-if="!viewOnly"
           title="Custom Performance Graphs Help"
@@ -702,12 +707,19 @@ onMounted(async () => {
   }
 }
 
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
 .page-heading {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 
-  h1 {
+  h2 {
     margin: 0;
     overflow-wrap: anywhere;
   }

--- a/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
+++ b/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
@@ -281,6 +281,13 @@ const chartIsExpanded = computed<boolean>(() => props.viewOnly || expanded.value
 
 /** Guards the URL writer while hydrating, so restoring a link doesn't rewrite it. */
 let hydrating = false
+
+/**
+ * Whether the user has already been told this graph outgrew its link. Latched so
+ * the debounced writer says it once per episode rather than on every keystroke,
+ * and re-arms if the graph shrinks back under the cap.
+ */
+let warnedUnshareable = false
 let expressionSeq = 0
 
 /**
@@ -562,13 +569,25 @@ const syncUrl = useDebounceFn(() => {
 
   if (encodedQueryLength(query) > MAX_QUERY_LENGTH) {
     // Past this size the link stops being pasteable and some proxies truncate it.
-    // The graph keeps working from in-memory state; only sharing is lost.
+    // The graph keeps working from in-memory state; only sharing is lost — so say
+    // so. Blanking the address bar silently meant a large graph quietly stopped
+    // being bookmarkable, and nothing revealed it until someone tried to copy.
     if (Object.keys(route.query).length) {
       router.replace({ query: {}})
     }
+
+    if (!warnedUnshareable) {
+      warnedUnshareable = true
+      showSnackBar({
+        msg: 'This graph now has too many series to keep in the page address — it still works, but the link no longer captures it.',
+        error: true
+      })
+    }
+
     return
   }
 
+  warnedUnshareable = false
   router.replace({ query: query as Record<string, string | string[]> })
 }, 400)
 

--- a/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
+++ b/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
@@ -183,7 +183,7 @@
       <template #content>
         <div class="adhoc-help">
           <p>Build a graph from any combination of datasources, across any number of nodes, without a pre-defined graph definition.</p>
-          <p>Pick nodes, then their resources, then the datasources you want to plot. Each selected datasource becomes a series you can label, recolour and restyle.</p>
+          <p>Pick nodes, then their resources, then the datasources you want to plot. Each selected datasource becomes a series you can label, recolor and restyle.</p>
           <h3>Expressions</h3>
           <p>Expressions are evaluated server-side with JEXL. Reference a source series by its label &mdash; for example <code>ifHCInOctets_eth0 * 8</code> to convert octets to bits &mdash; and the result is plotted as a series of its own.</p>
           <p>Labels are JEXL identifiers, so they may contain only letters, digits and underscores, and must be unique across the graph.</p>
@@ -332,7 +332,7 @@ const searchNodes = useDebounceFn((term: string) => store.searchNodes(term), 350
 /**
  * Keep `config.series` in step with the datasource selection.
  *
- * Existing entries are carried over by key so a label, colour, style or aggregation
+ * Existing entries are carried over by key so a label, color, style or aggregation
  * the user set is never lost when an unrelated datasource is ticked or unticked —
  * that regression is the whole reason this is a reconcile rather than a rebuild.
  */
@@ -358,8 +358,8 @@ const reconcileSeries = (datasources: AdhocDatasourceOption[]) => {
       resourceId: datasource.resourceId,
       attribute: datasource.attribute,
       aggregation: ConsolidationFunctionType.AVERAGE,
-      // Slot by final position, so an existing series keeps its colour when a new
-      // one is added — colour identifies the series, not its place in the list.
+      // Slot by final position, so an existing series keeps its color when a new
+      // one is added — color identifies the series, not its place in the list.
       color: seriesColor(next.length + config.expressions.length, appStore.theme),
       style: 'line',
       hidden: false
@@ -576,7 +576,7 @@ const debouncedQuery = useDebounceFn(runQuery, 600)
 
 watch(() => store.selectedDatasources, value => reconcileSeries([...value]), { deep: true })
 
-// Only a change to what the server would return re-queries; style, colour and
+// Only a change to what the server would return re-queries; style, color and
 // title changes re-render from the data already in hand.
 watch(() => querySignature(config, time), () => {
   syncUrl()
@@ -586,7 +586,7 @@ watch(() => querySignature(config, time), () => {
 // Non-query config still belongs in the URL.
 watch(() => [config.title, config.verticalLabel, config.stacked, config.series, config.expressions], syncUrl, { deep: true })
 
-// A shared link carries the colours of the theme it was built in; move any colour
+// A shared link carries the colors of the theme it was built in; move any color
 // still sitting on a palette slot to that slot's step for the current theme.
 watch(() => appStore.theme, (theme) => {
   config.series = config.series.map(entry => ({ ...entry, color: restepColorForTheme(entry.color, theme) }))
@@ -623,7 +623,7 @@ onMounted(async () => {
     updateTime(restored.time)
   }
 
-  // Fill in anything the link left out: colours are optional in the encoding, and
+  // Fill in anything the link left out: colors are optional in the encoding, and
   // an expression id is regenerated rather than carried.
   config.series = config.series.map((entry, index) => ({
     ...entry,

--- a/ui/src/components/AdhocGraphs/ExpressionEditor.vue
+++ b/ui/src/components/AdhocGraphs/ExpressionEditor.vue
@@ -32,7 +32,7 @@
       data-test="expression-table"
     >
       <OnmsColumn
-        header="Colour"
+        header="Color"
         style="width: 5rem"
       >
         <template #body="{ data }">
@@ -40,7 +40,7 @@
             type="color"
             class="color-swatch"
             :value="data.color"
-            :aria-label="`Colour for ${data.label}`"
+            :aria-label="`Color for ${data.label}`"
             :data-test="`expression-color-${data.id}`"
             @input="patch(data.id, { color: ($event.target as HTMLInputElement).value })"
           >

--- a/ui/src/components/AdhocGraphs/ExpressionEditor.vue
+++ b/ui/src/components/AdhocGraphs/ExpressionEditor.vue
@@ -1,0 +1,239 @@
+<template>
+  <div class="expression-editor">
+    <div
+      v-if="availableLabels.length"
+      class="label-tokens"
+    >
+      <span class="tokens-caption">Available labels:</span>
+      <OnmsChip
+        v-for="label in availableLabels"
+        :key="label"
+        :label="label"
+        class="token"
+        :title="`Insert ${label} into the expression being edited`"
+        data-test="expression-token"
+        @click="insertToken(label)"
+      />
+    </div>
+    <p
+      v-else
+      class="editor-empty"
+    >
+      Select some datasources first — an expression needs source labels to work with.
+    </p>
+
+    <OnmsTable
+      v-if="expressions.length"
+      :value="expressions"
+      dataKey="id"
+      size="small"
+      tableStyle="min-width: 50rem"
+      class="expression-table"
+      data-test="expression-table"
+    >
+      <OnmsColumn
+        header="Colour"
+        style="width: 5rem"
+      >
+        <template #body="{ data }">
+          <input
+            type="color"
+            class="color-swatch"
+            :value="data.color"
+            :aria-label="`Colour for ${data.label}`"
+            :data-test="`expression-color-${data.id}`"
+            @input="patch(data.id, { color: ($event.target as HTMLInputElement).value })"
+          >
+        </template>
+      </OnmsColumn>
+
+      <OnmsColumn
+        header="Name"
+        style="width: 14rem"
+      >
+        <template #body="{ data }">
+          <FormField
+            :for="`expression-name-${data.id}`"
+            :error="errorFor(data.id, 'label')"
+          >
+            <OnmsInputText
+              :id="`expression-name-${data.id}`"
+              :modelValue="data.label"
+              :invalid="Boolean(errorFor(data.id, 'label'))"
+              :data-test="`expression-name-${data.id}`"
+              @update:modelValue="value => patch(data.id, { label: (value ?? '') as string })"
+            />
+          </FormField>
+        </template>
+      </OnmsColumn>
+
+      <OnmsColumn header="Expression">
+        <template #body="{ data }">
+          <FormField
+            :for="`expression-value-${data.id}`"
+            :error="errorFor(data.id, 'value')"
+          >
+            <OnmsInputText
+              :id="`expression-value-${data.id}`"
+              :modelValue="data.value"
+              :invalid="Boolean(errorFor(data.id, 'value'))"
+              placeholder="e.g. ifHCInOctets_eth0 * 8"
+              :data-test="`expression-value-${data.id}`"
+              @update:modelValue="value => patch(data.id, { value: (value ?? '') as string })"
+              @focus="focusedId = data.id"
+            />
+          </FormField>
+        </template>
+      </OnmsColumn>
+
+      <OnmsColumn
+        header="Style"
+        style="width: 10rem"
+      >
+        <template #body="{ data }">
+          <OnmsSelect
+            :modelValue="data.style"
+            :options="styles"
+            :aria-label="`Style for ${data.label}`"
+            :data-test="`expression-style-${data.id}`"
+            @update:modelValue="value => patch(data.id, { style: value as AdhocSeriesStyle })"
+          />
+        </template>
+      </OnmsColumn>
+
+      <OnmsColumn
+        header="Actions"
+        style="width: 6rem"
+      >
+        <template #body="{ data }">
+          <OnmsIconButton
+            variant="text"
+            :icon="DeleteIcon"
+            :title="`Remove ${data.label}`"
+            :data-test="`expression-remove-${data.id}`"
+            @click="emit('remove', data.id)"
+          />
+        </template>
+      </OnmsColumn>
+    </OnmsTable>
+
+    <OnmsButton
+      variant="outlined"
+      :disabled="!availableLabels.length"
+      data-test="expression-add"
+      @click="emit('add')"
+    >Add expression</OnmsButton>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  OnmsButton,
+  OnmsChip,
+  OnmsColumn,
+  OnmsIconButton,
+  OnmsInputText,
+  OnmsSelect,
+  OnmsTable
+} from '@opennms/onms-ui'
+import { computed, ref } from 'vue'
+
+import DeleteIcon from '@/components/icons/action/Delete.vue'
+import FormField from '@/components/Common/FormField.vue'
+import { AdhocExpression, AdhocGraphConfig, AdhocSeries, AdhocSeriesStyle } from '@/types/adhocGraph'
+import { expressionIssues } from './utils/adhocQuery'
+
+const props = defineProps<{
+  series: AdhocSeries[]
+  expressions: AdhocExpression[]
+}>()
+
+const emit = defineEmits<{
+  add: []
+  update: [id: string, patch: Partial<AdhocExpression>]
+  remove: [id: string]
+}>()
+
+const styles: AdhocSeriesStyle[] = ['line', 'line2', 'line3', 'area', 'stack']
+
+/** The expression input that last had focus — where a clicked token is inserted. */
+const focusedId = ref('')
+
+const availableLabels = computed<string[]>(() => props.series.map(entry => entry.label).filter(Boolean))
+
+// Name and expression problems come from one shared validator so the toolbar's
+// "can this be queried" gate and these inline messages can never disagree.
+const issues = computed(() =>
+  expressionIssues({ series: props.series, expressions: props.expressions } as AdhocGraphConfig))
+
+const errorFor = (id: string, field: 'label' | 'value'): string | undefined => {
+  const issue = issues.value[id]
+  return issue?.field === field ? issue.message : undefined
+}
+
+const patch = (id: string, changes: Partial<AdhocExpression>) => emit('update', id, changes)
+
+/**
+ * Append a label to the expression that was last focused. Resource and attribute
+ * names are long and easy to mistype, and a typo silently becomes an unresolved
+ * JEXL variable, so clicking the token is the safer path.
+ */
+const insertToken = (label: string) => {
+  const target = props.expressions.find(expression => expression.id === focusedId.value) ??
+    props.expressions[props.expressions.length - 1]
+
+  if (!target) {
+    return
+  }
+
+  const separator = target.value && !/[\s(+\-*/,]$/.test(target.value) ? ' ' : ''
+  patch(target.id, { value: `${target.value}${separator}${label}` })
+}
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/onms-typography';
+
+.expression-editor {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.editor-empty {
+  @include onms-body-small;
+  margin: 0;
+  color: var(--p-text-muted-color);
+}
+
+.label-tokens {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+
+  .tokens-caption {
+    @include onms-body-small;
+    color: var(--p-text-muted-color);
+  }
+
+  .token {
+    cursor: pointer;
+  }
+}
+
+.expression-table {
+  width: 100%;
+}
+
+.color-swatch {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: var(--p-content-border-radius);
+  background: none;
+  cursor: pointer;
+}
+</style>

--- a/ui/src/components/AdhocGraphs/RrdDefinitionDialog.vue
+++ b/ui/src/components/AdhocGraphs/RrdDefinitionDialog.vue
@@ -1,0 +1,134 @@
+<template>
+  <OnmsDialog
+    :visible="visible"
+    header="Graph definition"
+    width="60rem"
+    @update:visible="value => !value && emit('close')"
+  >
+    <div
+      v-if="!definition"
+      class="definition-blocked"
+      data-test="rrd-definition-blocked"
+    >
+      <p class="blocked-reason">{{ reason }}</p>
+      <p class="blocked-help">
+        A prefab graph definition is a template bound to one resource: the
+        <code>{{ '{rrd1}' }}</code>&hellip;<code>{{ '{rrdN}' }}</code> placeholders are all
+        resolved against the resource the graph is rendered for. Ad-hoc graphs have no
+        such restriction, so only those drawing on a single resource can be expressed
+        this way.
+      </p>
+    </div>
+
+    <div
+      v-else
+      class="definition-body"
+    >
+      <p class="definition-intro">
+        Save this as a <code>.properties</code> file under
+        <code>$OPENNMS_HOME/etc/snmp-graph.properties.d/</code>, add
+        <code>{{ definition.reportName }}</code> to that file's <code>reports=</code> list,
+        and reload the graph definitions. It will then appear for every
+        <code>{{ definition.type }}</code> resource.
+      </p>
+      <pre
+        class="definition-text"
+        data-test="rrd-definition-text"
+      >{{ definition.properties }}</pre>
+      <p class="definition-note">
+        The time range is not part of a definition &mdash; the viewer chooses it.
+        Consolidation, colours, styles and expressions are carried over as-is.
+      </p>
+    </div>
+
+    <template #footer>
+      <OnmsButton
+        v-if="definition"
+        variant="outlined"
+        data-test="rrd-definition-copy"
+        @click="copy"
+      >Copy definition</OnmsButton>
+      <OnmsButton
+        variant="ghost"
+        data-test="rrd-definition-close"
+        @click="emit('close')"
+      >Close</OnmsButton>
+    </template>
+  </OnmsDialog>
+</template>
+
+<script setup lang="ts">
+import { OnmsButton, OnmsDialog } from '@opennms/onms-ui'
+import { computed } from 'vue'
+
+import { copyToClipboard } from '@/composables/useClipboard'
+import useSnackbar from '@/composables/useSnackbar'
+import { AdhocGraphConfig } from '@/types/adhocGraph'
+import {
+  buildRrdGraphDefinition,
+  isRrdGraphDefinition,
+  RrdGraphDefinition
+} from './utils/rrdGraphDefinition'
+
+const props = defineProps<{
+  visible: boolean
+  config: AdhocGraphConfig
+}>()
+
+const emit = defineEmits<{ close: [] }>()
+
+const { showSnackBar } = useSnackbar()
+
+const result = computed(() => buildRrdGraphDefinition(props.config))
+
+const definition = computed<RrdGraphDefinition | null>(() =>
+  (isRrdGraphDefinition(result.value) ? result.value : null))
+
+const reason = computed<string>(() =>
+  (isRrdGraphDefinition(result.value) ? '' : result.value.reason))
+
+const copy = async () => {
+  if (!definition.value) {
+    return
+  }
+
+  // Synchronously, while the click's user activation still stands.
+  const copied = copyToClipboard(definition.value.properties)
+
+  try {
+    await copied
+    showSnackBar({ msg: 'Graph definition copied to the clipboard.' })
+  } catch (_err) {
+    showSnackBar({ msg: 'Could not copy automatically — select the text and copy it.', error: true })
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/onms-typography';
+
+.definition-intro,
+.definition-note,
+.blocked-help {
+  @include onms-body-small;
+  color: var(--p-text-muted-color);
+}
+
+.blocked-reason {
+  color: var(--p-text-color);
+}
+
+.definition-text {
+  max-height: 26rem;
+  overflow: auto;
+  padding: 0.75rem;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: var(--p-content-border-radius);
+  background: var(--p-content-background);
+  font-family: monospace;
+  font-size: 0.8125rem;
+  // The command is one long value broken over continuation lines; keep those
+  // breaks and let anything wider scroll rather than wrap mid-token.
+  white-space: pre;
+}
+</style>

--- a/ui/src/components/AdhocGraphs/RrdDefinitionDialog.vue
+++ b/ui/src/components/AdhocGraphs/RrdDefinitionDialog.vue
@@ -25,11 +25,11 @@
       class="definition-body"
     >
       <p class="definition-intro">
-        Save this as a <code>.properties</code> file under
-        <code>$OPENNMS_HOME/etc/snmp-graph.properties.d/</code>, add
-        <code>{{ definition.reportName }}</code> to that file's <code>reports=</code> list,
-        and reload the graph definitions. It will then appear for every
-        <code>{{ definition.type }}</code> resource.
+        Save this as a new <code>.properties</code> file under
+        <code>$OPENNMS_HOME/etc/snmp-graph.properties.d/</code> and reload the graph
+        definitions &mdash; the <code>reports=</code> line is included, so it works as
+        it stands. It will then appear for every <code>{{ definition.type }}</code>
+        resource. To add it to an existing file instead, follow the note in the block.
       </p>
       <pre
         class="definition-text"

--- a/ui/src/components/AdhocGraphs/RrdDefinitionDialog.vue
+++ b/ui/src/components/AdhocGraphs/RrdDefinitionDialog.vue
@@ -37,7 +37,7 @@
       >{{ definition.properties }}</pre>
       <p class="definition-note">
         The time range is not part of a definition &mdash; the viewer chooses it.
-        Consolidation, colours, styles and expressions are carried over as-is.
+        Consolidation, colors, styles and expressions are carried over as-is.
       </p>
     </div>
 

--- a/ui/src/components/AdhocGraphs/RrdDefinitionDialog.vue
+++ b/ui/src/components/AdhocGraphs/RrdDefinitionDialog.vue
@@ -14,9 +14,9 @@
       <p class="blocked-help">
         A prefab graph definition is a template bound to one resource: the
         <code>{{ '{rrd1}' }}</code>&hellip;<code>{{ '{rrdN}' }}</code> placeholders are all
-        resolved against the resource the graph is rendered for. Ad-hoc graphs have no
-        such restriction, so only those drawing on a single resource can be expressed
-        this way.
+        resolved against the resource the graph is rendered for. Custom performance graphs
+        have no such restriction, so only those drawing on a single resource can be
+        expressed this way.
       </p>
     </div>
 
@@ -44,7 +44,7 @@
     <template #footer>
       <OnmsButton
         v-if="definition"
-        variant="outlined"
+        variant="filled"
         data-test="rrd-definition-copy"
         @click="copy"
       >Copy definition</OnmsButton>

--- a/ui/src/components/AdhocGraphs/SelectionColumn.vue
+++ b/ui/src/components/AdhocGraphs/SelectionColumn.vue
@@ -1,0 +1,234 @@
+<template>
+  <div class="selection-column">
+    <div class="column-header">
+      <span class="column-title">{{ title }}</span>
+      <span
+        class="column-count"
+        :data-test="`${dataTest}-count`"
+      >{{ countLabel }}</span>
+    </div>
+
+    <OnmsSearchInput
+      :modelValue="filterTerm"
+      :placeholder="filterPlaceholder"
+      :ariaLabel="`Filter ${title}`"
+      :dataTest="`${dataTest}-filter`"
+      @update:modelValue="onFilter"
+    />
+
+    <div class="column-actions">
+      <OnmsButton
+        variant="text"
+        :disabled="!visibleOptions.length"
+        :data-test="`${dataTest}-select-all`"
+        @click="selectAllVisible"
+      >Select all</OnmsButton>
+      <OnmsButton
+        variant="text"
+        :disabled="!modelValue.length"
+        :data-test="`${dataTest}-clear`"
+        @click="emit('update:modelValue', [])"
+      >Clear</OnmsButton>
+    </div>
+
+    <div
+      v-if="loading"
+      class="column-status"
+      :data-test="`${dataTest}-loading`"
+    >
+      <OnmsSpinner size="1.75rem" />
+    </div>
+    <p
+      v-else-if="!visibleOptions.length"
+      class="column-status column-empty"
+      :data-test="`${dataTest}-empty`"
+    >{{ emptyMessage }}</p>
+    <OnmsListbox
+      v-else
+      multiple
+      checkmark
+      :options="visibleOptions"
+      :modelValue="modelValue"
+      :dataKey="dataKey"
+      :optionLabel="optionLabel"
+      :scrollHeight="SCROLL_HEIGHT"
+      :virtualScrollerOptions="{ itemSize: ROW_HEIGHT }"
+      :aria-label="title"
+      :data-test="`${dataTest}-list`"
+      @update:modelValue="value => emit('update:modelValue', (value ?? []) as unknown[])"
+    >
+      <template #option="{ option }">
+        <span class="option-body">
+          <span class="option-primary">{{ labelOf(option) }}</span>
+          <span class="option-secondary">{{ describe(option) }}</span>
+        </span>
+      </template>
+    </OnmsListbox>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { OnmsButton, OnmsListbox, OnmsSearchInput, OnmsSpinner } from '@opennms/onms-ui'
+import { computed, ref } from 'vue'
+
+/**
+ * One filterable, multi-select column of the ad-hoc picker. Used three times over
+ * three different shapes, so options are opaque here and the parent supplies the
+ * key/label/description accessors.
+ *
+ * Filtering is either local (`serverFilter` false — the whole option set is already
+ * in memory) or delegated upward via the `filter` event, which is how the node
+ * column searches server-side instead of downloading every node.
+ *
+ * The list itself is `OnmsListbox` in multiple mode, windowed by its virtual
+ * scroller — a switch with 400 interfaces would otherwise put 400 rows in the DOM.
+ * The filter field stays a separate `OnmsSearchInput` rather than the listbox's own
+ * `filter` prop, both because it is the search control the rest of the app uses and
+ * because the node column's filter has to reach the server.
+ */
+interface Props {
+  title: string
+  dataTest: string
+  options: unknown[]
+  modelValue: unknown[]
+  /** Property holding each option's stable identity, for selection equality. */
+  dataKey: string
+  /** Property rendered as the primary line; also what the option slot echoes. */
+  optionLabel: string
+  keyOf: (option: unknown) => string
+  labelOf: (option: unknown) => string
+  descriptionOf?: (option: unknown) => string
+  loading?: boolean
+  emptyMessage?: string
+  filterPlaceholder?: string
+  serverFilter?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  descriptionOf: undefined,
+  loading: false,
+  emptyMessage: 'Nothing to show yet.',
+  filterPlaceholder: 'Filter',
+  serverFilter: false
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown[]]
+  filter: [term: string]
+}>()
+
+// Virtual scrolling needs a fixed row height, so every option renders the same
+// two-line block — which is why each column supplies a description even when it
+// is only echoing an id.
+const ROW_HEIGHT = 52
+const SCROLL_HEIGHT = '22rem'
+
+const filterTerm = ref('')
+
+/** Secondary line for an option; optional, so columns without one get ''. */
+const describe = (option: unknown): string => props.descriptionOf?.(option) ?? ''
+
+const matchesFilter = (option: unknown): boolean => {
+  const term = filterTerm.value.trim().toLowerCase()
+
+  if (!term) {
+    return true
+  }
+
+  return `${props.labelOf(option)} ${describe(option)}`.toLowerCase().includes(term)
+}
+
+const visibleOptions = computed<unknown[]>(() =>
+  (props.serverFilter ? props.options : props.options.filter(matchesFilter)))
+
+const selectedKeys = computed<Set<string>>(() => new Set(props.modelValue.map(props.keyOf)))
+
+const countLabel = computed<string>(() => `${props.modelValue.length} of ${props.options.length} selected`)
+
+const onFilter = (value: string | undefined) => {
+  filterTerm.value = value ?? ''
+
+  if (props.serverFilter) {
+    emit('filter', filterTerm.value)
+  }
+}
+
+/**
+ * Adds what is currently visible to the selection rather than replacing it, so
+ * "filter, select all, refine filter, select all" accumulates the way it reads.
+ */
+const selectAllVisible = () => {
+  const additions = visibleOptions.value.filter(option => !selectedKeys.value.has(props.keyOf(option)))
+  emit('update:modelValue', [...props.modelValue, ...additions])
+}
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/onms-typography';
+
+.selection-column {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: var(--p-content-border-radius);
+  padding: 0.75rem;
+  gap: 0.5rem;
+}
+
+.column-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+
+  .column-title {
+    @include onms-headline4();
+  }
+
+  .column-count {
+    @include onms-body-small;
+    color: var(--p-text-muted-color);
+    white-space: nowrap;
+  }
+}
+
+.column-actions {
+  display: flex;
+  gap: 0.25rem;
+  margin: -0.25rem 0;
+}
+
+.column-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 12rem;
+  margin: 0;
+  padding: 1rem;
+  text-align: center;
+}
+
+.column-empty {
+  color: var(--p-text-muted-color);
+}
+
+.option-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+
+  .option-primary,
+  .option-secondary {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .option-secondary {
+    @include onms-body-small;
+    color: var(--p-text-muted-color);
+  }
+}
+</style>

--- a/ui/src/components/AdhocGraphs/SelectionColumn.vue
+++ b/ui/src/components/AdhocGraphs/SelectionColumn.vue
@@ -18,13 +18,13 @@
 
     <div class="column-actions">
       <OnmsButton
-        variant="text"
+        variant="ghost"
         :disabled="!visibleOptions.length"
         :data-test="`${dataTest}-select-all`"
         @click="selectAllVisible"
       >Select all</OnmsButton>
       <OnmsButton
-        variant="text"
+        variant="ghost"
         :disabled="!modelValue.length"
         :data-test="`${dataTest}-clear`"
         @click="emit('update:modelValue', [])"

--- a/ui/src/components/AdhocGraphs/SeriesTable.vue
+++ b/ui/src/components/AdhocGraphs/SeriesTable.vue
@@ -1,0 +1,216 @@
+<template>
+  <OnmsTable
+    :value="series"
+    dataKey="key"
+    size="small"
+    stripedRows
+    tableStyle="min-width: 60rem"
+    data-test="series-grid"
+  >
+    <template #empty>
+      <p
+        class="series-empty"
+        data-test="series-empty"
+      >
+        Pick one or more datasources above and they will appear here, ready to label,
+        recolour and reference from an expression.
+      </p>
+    </template>
+
+    <OnmsColumn
+      header="Colour"
+      style="width: 5rem"
+    >
+      <template #body="{ data }">
+        <input
+          type="color"
+          class="color-swatch"
+          :value="data.color"
+          :aria-label="`Colour for ${data.label}`"
+          :data-test="`series-color-${data.key}`"
+          @input="patch(data.key, { color: ($event.target as HTMLInputElement).value })"
+        >
+      </template>
+    </OnmsColumn>
+
+    <OnmsColumn header="Label">
+      <template #body="{ data }">
+        <FormField
+          :for="`series-label-${data.key}`"
+          :error="labelErrors[data.key]"
+        >
+          <OnmsInputText
+            :id="`series-label-${data.key}`"
+            :modelValue="data.label"
+            :aria-label="`Label for ${data.attribute}`"
+            :invalid="Boolean(labelErrors[data.key])"
+            :data-test="`series-label-${data.key}`"
+            @update:modelValue="value => patch(data.key, { label: (value ?? '') as string })"
+          />
+        </FormField>
+      </template>
+    </OnmsColumn>
+
+    <OnmsColumn header="Source">
+      <template #body="{ data }">
+        <span class="source-attribute">{{ data.attribute }}</span>
+        <span
+          class="source-resource"
+          :title="data.resourceId"
+        >{{ data.resourceId }}</span>
+      </template>
+    </OnmsColumn>
+
+    <OnmsColumn
+      header="Consolidation"
+      style="width: 10rem"
+    >
+      <template #body="{ data }">
+        <OnmsSelect
+          :modelValue="data.aggregation"
+          :options="aggregations"
+          :aria-label="`Consolidation function for ${data.label}`"
+          :data-test="`series-aggregation-${data.key}`"
+          @update:modelValue="value => patch(data.key, { aggregation: value as ConsolidationFunctionType })"
+        />
+      </template>
+    </OnmsColumn>
+
+    <OnmsColumn
+      header="Style"
+      style="width: 10rem"
+    >
+      <template #body="{ data }">
+        <OnmsSelect
+          :modelValue="data.style"
+          :options="styles"
+          :aria-label="`Style for ${data.label}`"
+          :data-test="`series-style-${data.key}`"
+          @update:modelValue="value => patch(data.key, { style: value as AdhocSeriesStyle })"
+        />
+      </template>
+    </OnmsColumn>
+
+    <OnmsColumn
+      header="Hide raw"
+      style="width: 10rem"
+    >
+      <template #body="{ data }">
+        <OnmsToggleSwitch
+          :modelValue="data.hidden"
+          :inputId="`series-hidden-${data.key}`"
+          :data-test="`series-hidden-${data.key}`"
+          @update:modelValue="value => patch(data.key, { hidden: value })"
+        />
+        <small
+          v-if="data.hidden && !consumedKeys.has(data.key)"
+          class="hide-raw-hint"
+        >Not used by any expression — still plotted.</small>
+      </template>
+    </OnmsColumn>
+
+    <OnmsColumn
+      header="Actions"
+      style="width: 6rem"
+    >
+      <template #body="{ data }">
+        <OnmsIconButton
+          variant="text"
+          :icon="DeleteIcon"
+          :title="`Remove ${data.label}`"
+          :data-test="`series-remove-${data.key}`"
+          @click="emit('remove', data.key)"
+        />
+      </template>
+    </OnmsColumn>
+  </OnmsTable>
+</template>
+
+<script setup lang="ts">
+import {
+  OnmsColumn,
+  OnmsIconButton,
+  OnmsInputText,
+  OnmsSelect,
+  OnmsTable,
+  OnmsToggleSwitch
+} from '@opennms/onms-ui'
+import { computed } from 'vue'
+
+import DeleteIcon from '@/components/icons/action/Delete.vue'
+import FormField from '@/components/Common/FormField.vue'
+import { AdhocExpression, AdhocGraphConfig, AdhocSeries, AdhocSeriesStyle } from '@/types/adhocGraph'
+import { ConsolidationFunctionType } from '@/types/timeSeries'
+import { expressionReferences, seriesLabelIssues } from './utils/adhocQuery'
+
+const props = defineProps<{
+  series: AdhocSeries[]
+  expressions: AdhocExpression[]
+}>()
+
+const emit = defineEmits<{
+  update: [key: string, patch: Partial<AdhocSeries>]
+  remove: [key: string]
+}>()
+
+const aggregations = Object.values(ConsolidationFunctionType)
+const styles: AdhocSeriesStyle[] = ['line', 'line2', 'line3', 'area', 'stack']
+
+/** Series labels an expression actually consumes — "hide raw" only bites for these. */
+const consumedKeys = computed<Set<string>>(() => {
+  const consumed = new Set<string>()
+
+  for (const entry of props.series) {
+    if (props.expressions.some(expression => expressionReferences(expression.value, entry.label))) {
+      consumed.add(entry.key)
+    }
+  }
+
+  return consumed
+})
+
+const labelErrors = computed<Record<string, string>>(() =>
+  seriesLabelIssues({ series: props.series, expressions: props.expressions } as AdhocGraphConfig))
+
+const patch = (key: string, changes: Partial<AdhocSeries>) => emit('update', key, changes)
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/onms-typography';
+
+.series-empty {
+  @include onms-body-small;
+  margin: 0;
+  color: var(--p-text-muted-color);
+}
+
+.color-swatch {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: var(--p-content-border-radius);
+  background: none;
+  cursor: pointer;
+}
+
+.source-attribute {
+  display: block;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.source-resource {
+  @include onms-body-small;
+  display: block;
+  color: var(--p-text-muted-color);
+  overflow-wrap: anywhere;
+}
+
+.hide-raw-hint {
+  @include onms-body-small;
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--p-text-muted-color);
+}
+</style>

--- a/ui/src/components/AdhocGraphs/SeriesTable.vue
+++ b/ui/src/components/AdhocGraphs/SeriesTable.vue
@@ -13,12 +13,12 @@
         data-test="series-empty"
       >
         Pick one or more datasources above and they will appear here, ready to label,
-        recolour and reference from an expression.
+        recolor and reference from an expression.
       </p>
     </template>
 
     <OnmsColumn
-      header="Colour"
+      header="Color"
       style="width: 5rem"
     >
       <template #body="{ data }">
@@ -26,7 +26,7 @@
           type="color"
           class="color-swatch"
           :value="data.color"
-          :aria-label="`Colour for ${data.label}`"
+          :aria-label="`Color for ${data.label}`"
           :data-test="`series-color-${data.key}`"
           @input="patch(data.key, { color: ($event.target as HTMLInputElement).value })"
         >

--- a/ui/src/components/AdhocGraphs/utils/adhocColors.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocColors.ts
@@ -1,0 +1,147 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { AdhocSeriesStyle } from '@/types/adhocGraph'
+import { DARK_THEME, Theme } from '@/services/themeService'
+
+/**
+ * Categorical series palette, in fixed slot order. The two columns are the same
+ * eight hues stepped for their surface — not two unrelated palettes — and the
+ * ORDER is the colorblind-safety mechanism: adjacent slots are the pairs most
+ * likely to be compared on a line chart, and this ordering is the one that clears
+ * the adjacent-pair separation gates in both modes. Do not re-order or extend it.
+ *
+ * Slots 1-8 are the validated base set. Slots 9-12 were added so that an ad-hoc
+ * graph — which routinely carries more than eight series — gets twelve distinct
+ * hues instead of a second, non-colour encoding channel. They were chosen by
+ * search against the same validator and each sits at least ΔE 14.6 (normal
+ * vision) from every earlier slot, so the gate numbers are unchanged from the
+ * base eight: worst adjacent CVD ΔE 9.1 light / 8.4 dark, worst adjacent
+ * normal-vision ΔE 19.6 light / 19.3 dark.
+ *
+ * Twelve is the ceiling, not an arbitrary stopping point: a fourteen-slot set
+ * drops the worst adjacent CVD pair into the 6-8 band, which is only legal WITH a
+ * secondary encoding — the very thing this palette exists to avoid.
+ *
+ * Three light slots sit below 3:1 against the light surface; the relief for that
+ * is already built into the page — every series is named in the legend with a
+ * colour swatch, and the Data tab shows the same numbers as a table.
+ */
+export const ADHOC_PALETTE_LIGHT: readonly string[] = [
+  '#2a78d6', // blue
+  '#eb6834', // orange
+  '#1baf7a', // aqua
+  '#eda100', // yellow
+  '#e87ba4', // pink
+  '#008300', // green
+  '#4a3aa7', // indigo
+  '#e34948', // red
+  '#bd00cd', // magenta
+  '#905c00', // brown
+  '#7900fc', // violet
+  '#b02c74' //  plum
+]
+
+export const ADHOC_PALETTE_DARK: readonly string[] = [
+  '#3987e5',
+  '#d95926',
+  '#199e70',
+  '#c98500',
+  '#d55181',
+  '#008300',
+  '#9085e9',
+  '#e66767',
+  '#d800ea',
+  '#a76c00',
+  '#8547ff',
+  '#c44085'
+]
+
+/**
+ * Stroke weight per style, mirroring RRDtool's LINE1/LINE2/LINE3.
+ *
+ * Doubled from RRDtool's nominal 1/2/3 pixels: RRDtool renders to a bitmap at a
+ * fixed size, whereas this canvas is laid out in CSS pixels on a display that is
+ * usually 2x, where a 1px stroke all but disappears against the grid.
+ *
+ * Weight varies ONLY because the user asked for it on a specific series. It is
+ * never applied automatically to tell two series apart — a thin or heavy line
+ * reads as a different KIND of series (forecast, threshold, projection) rather
+ * than simply another one. Past the twelfth series the hues repeat and the
+ * rendering stays put; identity then comes from the legend, the hover readout and
+ * the Data tab, and any series can be recoloured by hand.
+ */
+export const SERIES_STROKE_WIDTHS: Readonly<Record<AdhocSeriesStyle, number>> = {
+  line: 2,
+  line2: 4,
+  line3: 6,
+  area: 2,
+  stack: 2
+}
+
+/** The stroke weight for a style; the outline is drawn even on a filled series. */
+export const strokeWidthFor = (style: AdhocSeriesStyle): number => SERIES_STROKE_WIDTHS[style] ?? 2
+
+const paletteFor = (theme: Theme): readonly string[] =>
+  (theme === DARK_THEME ? ADHOC_PALETTE_DARK : ADHOC_PALETTE_LIGHT)
+
+/** The default colour for the series at `index`, in the given theme. */
+export const seriesColor = (index: number, theme: Theme): string => {
+  const palette = paletteFor(theme)
+  return palette[Math.abs(index) % palette.length]
+}
+
+/** How many series can be told apart by colour alone. */
+export const ADHOC_PALETTE_SIZE = ADHOC_PALETTE_LIGHT.length
+
+/**
+ * Re-step a colour for the target theme.
+ *
+ * Colours are persisted as hex (so a colour the user picked by hand survives a
+ * reload or a shared link), which means a config built in light mode carries the
+ * light steps. Any colour still sitting on a palette slot is moved to that slot's
+ * step for `theme`; anything else is a deliberate override and is left alone.
+ */
+export const restepColorForTheme = (color: string, theme: Theme): string => {
+  const from = theme === DARK_THEME ? ADHOC_PALETTE_LIGHT : ADHOC_PALETTE_DARK
+  const to = paletteFor(theme)
+  const slot = from.indexOf(color.toLowerCase())
+  return slot >= 0 ? to[slot] : color
+}
+
+/**
+ * Chart ink (axes, grid, text) pulled from the live PrimeVue theme variables so the
+ * canvas tracks the light/dark toggle. Falls back to readable defaults when the
+ * variables are unavailable (happy-dom in unit tests resolves them to '').
+ */
+export const chartInk = (): { text: string, muted: string, grid: string } => {
+  const styles = typeof window !== 'undefined' && document.documentElement ?
+    window.getComputedStyle(document.documentElement) :
+    null
+  const read = (name: string, fallback: string) => styles?.getPropertyValue(name).trim() || fallback
+
+  return {
+    text: read('--p-text-color', '#0b0b0b'),
+    muted: read('--p-text-muted-color', '#52514e'),
+    grid: read('--p-content-border-color', '#d8d7d2')
+  }
+}

--- a/ui/src/components/AdhocGraphs/utils/adhocColors.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocColors.ts
@@ -32,7 +32,7 @@ import { DARK_THEME, Theme } from '@/services/themeService'
  *
  * Slots 1-8 are the validated base set. Slots 9-12 were added so that an ad-hoc
  * graph — which routinely carries more than eight series — gets twelve distinct
- * hues instead of a second, non-colour encoding channel. They were chosen by
+ * hues instead of a second, non-color encoding channel. They were chosen by
  * search against the same validator and each sits at least ΔE 14.6 (normal
  * vision) from every earlier slot, so the gate numbers are unchanged from the
  * base eight: worst adjacent CVD ΔE 9.1 light / 8.4 dark, worst adjacent
@@ -44,7 +44,7 @@ import { DARK_THEME, Theme } from '@/services/themeService'
  *
  * Three light slots sit below 3:1 against the light surface; the relief for that
  * is already built into the page — every series is named in the legend with a
- * colour swatch, and the Data tab shows the same numbers as a table.
+ * color swatch, and the Data tab shows the same numbers as a table.
  */
 export const ADHOC_PALETTE_LIGHT: readonly string[] = [
   '#2a78d6', // blue
@@ -88,7 +88,7 @@ export const ADHOC_PALETTE_DARK: readonly string[] = [
  * reads as a different KIND of series (forecast, threshold, projection) rather
  * than simply another one. Past the twelfth series the hues repeat and the
  * rendering stays put; identity then comes from the legend, the hover readout and
- * the Data tab, and any series can be recoloured by hand.
+ * the Data tab, and any series can be recolored by hand.
  */
 export const SERIES_STROKE_WIDTHS: Readonly<Record<AdhocSeriesStyle, number>> = {
   line: 2,
@@ -104,21 +104,21 @@ export const strokeWidthFor = (style: AdhocSeriesStyle): number => SERIES_STROKE
 const paletteFor = (theme: Theme): readonly string[] =>
   (theme === DARK_THEME ? ADHOC_PALETTE_DARK : ADHOC_PALETTE_LIGHT)
 
-/** The default colour for the series at `index`, in the given theme. */
+/** The default color for the series at `index`, in the given theme. */
 export const seriesColor = (index: number, theme: Theme): string => {
   const palette = paletteFor(theme)
   return palette[Math.abs(index) % palette.length]
 }
 
-/** How many series can be told apart by colour alone. */
+/** How many series can be told apart by color alone. */
 export const ADHOC_PALETTE_SIZE = ADHOC_PALETTE_LIGHT.length
 
 /**
- * Re-step a colour for the target theme.
+ * Re-step a color for the target theme.
  *
- * Colours are persisted as hex (so a colour the user picked by hand survives a
+ * Colors are persisted as hex (so a color the user picked by hand survives a
  * reload or a shared link), which means a config built in light mode carries the
- * light steps. Any colour still sitting on a palette slot is moved to that slot's
+ * light steps. Any color still sitting on a palette slot is moved to that slot's
  * step for `theme`; anything else is a deliberate override and is left alone.
  */
 export const restepColorForTheme = (color: string, theme: Theme): string => {

--- a/ui/src/components/AdhocGraphs/utils/adhocQuery.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocQuery.ts
@@ -1,0 +1,313 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import {
+  AdhocDatasourceOption,
+  AdhocExpression,
+  AdhocGraphConfig,
+  AdhocSeries
+} from '@/types/adhocGraph'
+import { ConvertedGraphData, GraphMetricsPayload, Metric, StartEndTime } from '@/types'
+
+/** Target number of samples across the range when the user has not chosen one. */
+export const DEFAULT_RESOLUTION = 400
+
+/** Ceiling the measurements API is asked for; also its `maxrows`. */
+export const MAX_RESOLUTION = 4000
+
+/** Smallest step (ms) we will ever ask for — one second. */
+const MIN_STEP_MS = 1000
+
+/**
+ * Reduce a node/resource/attribute triple to a legal JEXL identifier.
+ *
+ * A source label is not cosmetic here: it is the name an expression refers to, and
+ * the measurements API hands it straight to JEXL. Anything that is not a letter,
+ * digit or underscore is collapsed to a single underscore, and a leading digit is
+ * prefixed, because `2_eth0` is not a valid identifier.
+ */
+export const sanitizeLabel = (...parts: (string | undefined)[]): string => {
+  const joined = parts.filter(Boolean).join('_')
+  const cleaned = joined
+    .replace(/[^a-zA-Z0-9]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+  if (!cleaned) {
+    return 'series'
+  }
+
+  return /^[0-9]/.test(cleaned) ? `_${cleaned}` : cleaned
+}
+
+/**
+ * Make `candidate` unique against `taken`, appending _2, _3, … as needed.
+ * Two interfaces on two nodes can easily sanitize to the same string, and a
+ * duplicate label silently makes one series unreachable from expressions.
+ */
+export const uniqueLabel = (candidate: string, taken: Iterable<string>): string => {
+  const used = new Set(taken)
+
+  if (!used.has(candidate)) {
+    return candidate
+  }
+
+  let suffix = 2
+  while (used.has(`${candidate}_${suffix}`)) {
+    suffix++
+  }
+
+  return `${candidate}_${suffix}`
+}
+
+/** The default, collision-free label for a newly selected datasource. */
+export const labelForDatasource = (
+  datasource: AdhocDatasourceOption,
+  taken: Iterable<string>
+): string => uniqueLabel(
+  sanitizeLabel(datasource.nodeLabel, datasource.resourceLabel, datasource.attribute),
+  taken
+)
+
+/**
+ * Whether `expression` references `label` as a whole identifier.
+ *
+ * Word boundaries alone are not enough: `ifInOctets` is a prefix of
+ * `ifInOctets_2`, and a substring match would wrongly mark the shorter series as
+ * consumed. Underscore counts as an identifier character, so the guard rejects a
+ * neighbouring `_` as well as alphanumerics.
+ */
+export const expressionReferences = (expression: string, label: string): boolean => {
+  if (!label) {
+    return false
+  }
+
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(^|[^A-Za-z0-9_])${escaped}([^A-Za-z0-9_]|$)`).test(expression)
+}
+
+/** The step (ms) that yields roughly `resolution` samples across the range. */
+export const stepForRange = (startMs: number, endMs: number, resolution: number): number => {
+  const span = Math.max(0, endMs - startMs)
+  const samples = Math.min(Math.max(Math.round(resolution) || DEFAULT_RESOLUTION, 1), MAX_RESOLUTION)
+  return Math.max(MIN_STEP_MS, Math.floor(span / samples) || MIN_STEP_MS)
+}
+
+/**
+ * Build the POST /rest/measurements body for an ad-hoc graph.
+ *
+ * Two behaviours worth calling out:
+ *  - `relaxed: true`. An ad-hoc selection goes stale the moment a resource is
+ *    deleted or an interface is renamed, and a strict query fails the *whole*
+ *    request over one missing source. Relaxed returns the rest with NaNs.
+ *  - `transient` is derived, not taken on trust. A source is only suppressed when
+ *    the user asked to hide it AND some expression actually consumes it; hiding a
+ *    source nothing references would just produce an empty graph.
+ */
+export const buildMeasurementsPayload = (
+  config: AdhocGraphConfig,
+  time: StartEndTime
+): GraphMetricsPayload => {
+  const start = Number(time.startTime) * 1000
+  const end = Number(time.endTime) * 1000
+  const step = stepForRange(start, end, config.resolution)
+
+  const isConsumed = (series: AdhocSeries) =>
+    config.expressions.some(expression => expressionReferences(expression.value, series.label))
+
+  const source: Metric[] = config.series.map(series => ({
+    aggregation: series.aggregation,
+    attribute: series.attribute,
+    label: series.label,
+    resourceId: series.resourceId,
+    transient: Boolean(series.hidden && isConsumed(series))
+  }))
+
+  const payload: GraphMetricsPayload = {
+    start,
+    end,
+    step,
+    maxrows: MAX_RESOLUTION,
+    relaxed: true,
+    source
+  }
+
+  if (config.expressions.length) {
+    payload.expression = config.expressions.map(expression => ({
+      label: expression.label,
+      value: expression.value,
+      transient: false
+    }))
+  }
+
+  return payload
+}
+
+/** Every series that should appear as a plotted column, sources then expressions. */
+export const plottedSeries = (config: AdhocGraphConfig): (AdhocSeries | AdhocExpression)[] => {
+  const isConsumed = (series: AdhocSeries) =>
+    config.expressions.some(expression => expressionReferences(expression.value, series.label))
+
+  return [
+    ...config.series.filter(series => !(series.hidden && isConsumed(series))),
+    ...config.expressions
+  ]
+}
+
+/**
+ * Per-series label problems, keyed by series key.
+ *
+ * A label is a JEXL identifier, not decoration: blank, duplicated or
+ * non-identifier labels either fail the query outright or silently bind an
+ * expression to the wrong series, so they are errors rather than warnings.
+ */
+export const seriesLabelIssues = (config: AdhocGraphConfig): Record<string, string> => {
+  const counts = new Map<string, number>()
+
+  for (const entry of [...config.series, ...config.expressions]) {
+    counts.set(entry.label, (counts.get(entry.label) ?? 0) + 1)
+  }
+
+  const issues: Record<string, string> = {}
+
+  for (const entry of config.series) {
+    if (!entry.label.trim()) {
+      issues[entry.key] = 'A label is required.'
+    } else if ((counts.get(entry.label) ?? 0) > 1) {
+      issues[entry.key] = 'Labels must be unique.'
+    } else if (sanitizeLabel(entry.label) !== entry.label) {
+      issues[entry.key] = 'Use letters, digits and underscores only.'
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Per-expression problems, keyed by expression id.
+ *
+ * JEXL syntax itself is left to the server — guessing at it here would reject
+ * valid expressions — but a blank expression, or one whose every identifier is
+ * unknown, is always a mistake and is worth catching before the round trip.
+ */
+export interface AdhocExpressionIssue {
+  /** Which input the message belongs beside. */
+  field: 'label' | 'value'
+  message: string
+}
+
+export const expressionIssues = (config: AdhocGraphConfig): Record<string, AdhocExpressionIssue> => {
+  const counts = new Map<string, number>()
+
+  for (const entry of [...config.series, ...config.expressions]) {
+    counts.set(entry.label, (counts.get(entry.label) ?? 0) + 1)
+  }
+
+  const known = new Set(config.series.map(entry => entry.label).filter(Boolean))
+  const issues: Record<string, AdhocExpressionIssue> = {}
+
+  for (const expression of config.expressions) {
+    if (!expression.label.trim()) {
+      issues[expression.id] = { field: 'label', message: 'A name is required.' }
+      continue
+    }
+
+    if ((counts.get(expression.label) ?? 0) > 1) {
+      issues[expression.id] = { field: 'label', message: 'Already used by another series.' }
+      continue
+    }
+
+    if (sanitizeLabel(expression.label) !== expression.label) {
+      issues[expression.id] = { field: 'label', message: 'Use letters, digits and underscores only.' }
+      continue
+    }
+
+    const value = expression.value.trim()
+
+    if (!value) {
+      issues[expression.id] = { field: 'value', message: 'An expression is required.' }
+      continue
+    }
+
+    const identifiers = value.match(/[A-Za-z_][A-Za-z0-9_]*/g) ?? []
+    const unresolved = identifiers.filter(identifier => !known.has(identifier))
+
+    if (identifiers.length && unresolved.length === identifiers.length) {
+      issues[expression.id] = {
+        field: 'value',
+        message: `Unknown label${unresolved.length > 1 ? 's' : ''}: ${unresolved.slice(0, 3).join(', ')}`
+      }
+    }
+  }
+
+  return issues
+}
+
+/** Whether the config is complete enough to send to the measurements API. */
+export const configIsQueryable = (config: AdhocGraphConfig): boolean =>
+  config.series.length > 0 &&
+  !Object.keys(seriesLabelIssues(config)).length &&
+  !Object.keys(expressionIssues(config)).length
+
+/**
+ * The parts of a config that change the server response. Style, colour, title,
+ * vertical label and stacking are re-rendered from data already in hand, so they
+ * deliberately do not appear here and never trigger a refetch.
+ */
+export const querySignature = (config: AdhocGraphConfig, time: StartEndTime): string => JSON.stringify([
+  config.series.map(entry => [entry.resourceId, entry.attribute, entry.aggregation, entry.label, entry.hidden]),
+  config.expressions.map(expression => [expression.label, expression.value]),
+  config.resolution,
+  time.startTime,
+  time.endTime
+])
+
+/**
+ * Adapt an ad-hoc config to the `ConvertedGraphData` shape that the prefab-graph
+ * components already speak, so `GraphDataTable.vue` and `downloadGraphCsv` work
+ * unchanged. Ad-hoc graphs have no RRD print statements, so each metric gets a
+ * trivial one whose header is simply the series label.
+ */
+export const toConvertedGraphData = (config: AdhocGraphConfig): ConvertedGraphData => {
+  const plotted = plottedSeries(config)
+
+  return {
+    title: config.title,
+    verticalLabel: config.verticalLabel,
+    series: [],
+    values: [],
+    properties: {},
+    metrics: plotted.map(item => ({
+      name: item.label,
+      label: item.label,
+      aggregation: 'aggregation' in item ? item.aggregation : 'AVERAGE',
+      attribute: 'attribute' in item ? item.attribute : '',
+      resourceId: 'resourceId' in item ? item.resourceId : ''
+    })),
+    printStatements: plotted.map(item => ({
+      format: '',
+      header: item.label,
+      metric: item.label,
+      value: NaN
+    }))
+  }
+}

--- a/ui/src/components/AdhocGraphs/utils/adhocQuery.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocQuery.ts
@@ -272,13 +272,17 @@ export const configIsQueryable = (config: AdhocGraphConfig): boolean =>
  * The parts of a config that change the server response. Style, colour, title,
  * vertical label and stacking are re-rendered from data already in hand, so they
  * deliberately do not appear here and never trigger a refetch.
+ *
+ * For a relative window the identity is the RANGE, not the instants it currently
+ * resolves to. Re-resolving "last two days" against a newer clock is not a change
+ * of query — and treating it as one would make every Refresh fire twice, once
+ * explicitly and once from the watcher that observes this.
  */
 export const querySignature = (config: AdhocGraphConfig, time: StartEndTime): string => JSON.stringify([
   config.series.map(entry => [entry.resourceId, entry.attribute, entry.aggregation, entry.label, entry.hidden]),
   config.expressions.map(expression => [expression.label, expression.value]),
   config.resolution,
-  time.startTime,
-  time.endTime
+  time.range ? ['range', time.range.unit, time.range.amount] : [time.startTime, time.endTime]
 ])
 
 /**

--- a/ui/src/components/AdhocGraphs/utils/adhocQuery.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocQuery.ts
@@ -94,7 +94,7 @@ export const labelForDatasource = (
  * Word boundaries alone are not enough: `ifInOctets` is a prefix of
  * `ifInOctets_2`, and a substring match would wrongly mark the shorter series as
  * consumed. Underscore counts as an identifier character, so the guard rejects a
- * neighbouring `_` as well as alphanumerics.
+ * neighboring `_` as well as alphanumerics.
  */
 export const expressionReferences = (expression: string, label: string): boolean => {
   if (!label) {
@@ -115,7 +115,7 @@ export const stepForRange = (startMs: number, endMs: number, resolution: number)
 /**
  * Build the POST /rest/measurements body for an ad-hoc graph.
  *
- * Two behaviours worth calling out:
+ * Two behaviors worth calling out:
  *  - `relaxed: true`. An ad-hoc selection goes stale the moment a resource is
  *    deleted or an interface is renamed, and a strict query fails the *whole*
  *    request over one missing source. Relaxed returns the rest with NaNs.
@@ -269,7 +269,7 @@ export const configIsQueryable = (config: AdhocGraphConfig): boolean =>
   !Object.keys(expressionIssues(config)).length
 
 /**
- * The parts of a config that change the server response. Style, colour, title,
+ * The parts of a config that change the server response. Style, color, title,
  * vertical label and stacking are re-rendered from data already in hand, so they
  * deliberately do not appear here and never trigger a refetch.
  *

--- a/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
@@ -28,7 +28,7 @@ import { DEFAULT_RESOLUTION } from './adhocQuery'
 
 /**
  * Field separator inside one series entry. `~` is not legal in a resource id, a
- * sanitized label or a hex colour, so entries never need inner escaping.
+ * sanitized label or a hex color, so entries never need inner escaping.
  */
 const FIELD = '~'
 

--- a/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
@@ -22,7 +22,8 @@
 
 import { AdhocExpression, AdhocGraphConfig, AdhocSeries, AdhocSeriesStyle } from '@/types/adhocGraph'
 import { ConsolidationFunctionType } from '@/types/timeSeries'
-import { StartEndTime } from '@/types'
+import { RelativeTimeRange, StartEndTime } from '@/types'
+import { RANGE_UNITS } from '@/components/Resources/utils/timeRangeOptions'
 import { DEFAULT_RESOLUTION } from './adhocQuery'
 
 /**
@@ -80,6 +81,28 @@ const asAggregation = (value: string): ConsolidationFunctionType =>
 const asColor = (value: string): string =>
   (/^#[0-9a-fA-F]{6}$/.test(value) ? value.toLowerCase() : '')
 
+/**
+ * Parse `range=<unit>:<amount>`, e.g. `range=hours:24`.
+ *
+ * Spelled out rather than encoded as an ISO-8601 duration so the link stays
+ * readable, and so `minutes` can never be confused with `months` the way `PT1M`
+ * and `P1M` can.
+ */
+const asRange = (value: string): RelativeTimeRange | null => {
+  const [unit, rawAmount] = value.split(':')
+  const amount = Number.parseInt(rawAmount ?? '', 10)
+
+  if (!RANGE_UNITS.includes(unit as RelativeTimeRange['unit'])) {
+    return null
+  }
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return null
+  }
+
+  return { unit: unit as RelativeTimeRange['unit'], amount }
+}
+
 const asPositiveInt = (value: string, fallback: number): number => {
   const parsed = Number.parseInt(value, 10)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
@@ -93,11 +116,17 @@ const asPositiveInt = (value: string, fallback: number): number => {
  * of this state is that a user can copy the address bar and send it to someone.
  */
 export const encodeAdhocState = (config: AdhocGraphConfig, time: StartEndTime): RouteQuery => {
-  const query: RouteQuery = {
-    start: String(time.startTime),
-    end: String(time.endTime),
-    fmt: time.format
-  }
+  // A relative window travels as the range itself, NOT as the instants it happened
+  // to resolve to — otherwise a bookmarked "last two days" is frozen to the two
+  // days that were current when the link was made. Only an explicit custom range
+  // is written as absolute start/end.
+  const query: RouteQuery = time.range ?
+    { range: `${time.range.unit}:${time.range.amount}` } :
+    {
+      start: String(time.startTime),
+      end: String(time.endTime),
+      fmt: time.format
+    }
 
   if (config.series.length) {
     query.s = config.series.map(series => [
@@ -162,8 +191,9 @@ export const decodeAdhocState = (query: RouteQuery): AdhocUrlState | null => {
   const rawExpressions = many(query.e)
   const start = first(query.start)
   const end = first(query.end)
+  const range = asRange(first(query.range))
 
-  if (!rawSeries.length && !rawExpressions.length && !start) {
+  if (!rawSeries.length && !rawExpressions.length && !start && !range) {
     return null
   }
 
@@ -227,10 +257,13 @@ export const decodeAdhocState = (query: RouteQuery): AdhocUrlState | null => {
       stacked: first(query.stacked) === '1',
       resolution: asPositiveInt(first(query.res), DEFAULT_RESOLUTION)
     },
+    // A range is returned unresolved: the caller resolves it against the clock at
+    // the moment the page loads, which is the whole point.
     time: {
       startTime,
       endTime,
-      format: first(query.fmt) || 'hours'
+      format: first(query.fmt) || 'hours',
+      ...(range ? { range } : {})
     }
   }
 }

--- a/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
@@ -26,11 +26,29 @@ import { RelativeTimeRange, StartEndTime } from '@/types'
 import { RANGE_UNITS } from '@/components/Resources/utils/timeRangeOptions'
 import { DEFAULT_RESOLUTION } from './adhocQuery'
 
-/**
- * Field separator inside one series entry. `~` is not legal in a resource id, a
- * sanitized label or a hex color, so entries never need inner escaping.
- */
+/** Field separator inside one entry. */
 const FIELD = '~'
+
+/**
+ * Escape a field so the separator survives the round trip.
+ *
+ * An earlier version assumed `~` could not appear inside a field. That is false
+ * for anything the user types: `=~` is JEXL's match operator, so the perfectly
+ * ordinary expression `a =~ [1,2] ? 1 : 0` used to split into extra fields and
+ * decode back as `a =`, silently, taking the style and color with it. Resource ids
+ * can carry one too (a Windows short name such as `PROGRA~1` in a storage path).
+ *
+ * Only `%` and `~` are touched, so a normal link is byte-for-byte what it was —
+ * running whole fields through encodeURIComponent would escape every bracket in
+ * every resource id and inflate the URL against its shareable-length budget for no
+ * benefit. `%` must be escaped first, and unescaped last, or a literal `%7E` would
+ * come back as a separator.
+ */
+const escapeField = (value: string): string =>
+  value.replace(/%/g, '%25').replace(/~/g, '%7E')
+
+const unescapeField = (value: string): string =>
+  value.replace(/%7E/gi, '~').replace(/%25/gi, '%')
 
 /**
  * Above this many characters the query string stops being something a person can
@@ -137,7 +155,7 @@ export const encodeAdhocState = (config: AdhocGraphConfig, time: StartEndTime): 
       series.style,
       series.color,
       series.hidden ? '1' : '0'
-    ].join(FIELD))
+    ].map(escapeField).join(FIELD))
   }
 
   if (config.expressions.length) {
@@ -146,7 +164,7 @@ export const encodeAdhocState = (config: AdhocGraphConfig, time: StartEndTime): 
       expression.value,
       expression.style,
       expression.color
-    ].join(FIELD))
+    ].map(escapeField).join(FIELD))
   }
 
   if (config.title) {
@@ -201,7 +219,8 @@ export const decodeAdhocState = (query: RouteQuery): AdhocUrlState | null => {
   const takenKeys = new Set<string>()
 
   for (const entry of rawSeries) {
-    const [resourceId, attribute, aggregation, label, style, color, hidden] = entry.split(FIELD)
+    const [resourceId, attribute, aggregation, label, style, color, hidden] =
+      entry.split(FIELD).map(unescapeField)
 
     // resourceId + attribute identify the series; without both there is nothing to query.
     if (!resourceId || !attribute) {
@@ -230,7 +249,7 @@ export const decodeAdhocState = (query: RouteQuery): AdhocUrlState | null => {
   const expressions: AdhocExpression[] = []
 
   for (const [index, entry] of rawExpressions.entries()) {
-    const [label, value, style, color] = entry.split(FIELD)
+    const [label, value, style, color] = entry.split(FIELD).map(unescapeField)
 
     if (!label || !value) {
       continue

--- a/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
@@ -1,0 +1,236 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { AdhocExpression, AdhocGraphConfig, AdhocSeries, AdhocSeriesStyle } from '@/types/adhocGraph'
+import { ConsolidationFunctionType } from '@/types/timeSeries'
+import { StartEndTime } from '@/types'
+import { DEFAULT_RESOLUTION } from './adhocQuery'
+
+/**
+ * Field separator inside one series entry. `~` is not legal in a resource id, a
+ * sanitized label or a hex colour, so entries never need inner escaping.
+ */
+const FIELD = '~'
+
+/**
+ * Above this many characters the query string stops being something a person can
+ * paste into chat or a ticket, and some proxies start truncating it. Past the cap
+ * the graph still works — it just stops being shareable, and the caller says so.
+ */
+export const MAX_QUERY_LENGTH = 6000
+
+// A link written before 'scatter' was dropped decodes to 'line' via asStyle.
+const STYLES: AdhocSeriesStyle[] = ['line', 'line2', 'line3', 'area', 'stack']
+
+const AGGREGATIONS = Object.values(ConsolidationFunctionType)
+
+export interface AdhocUrlState {
+  config: AdhocGraphConfig
+  time: StartEndTime
+}
+
+/**
+ * A route query as vue-router hands it over. Repeated keys arrive as arrays, and a
+ * valueless key (`?stacked`) arrives as null — both are accepted so `route.query`
+ * can be passed straight in.
+ */
+export type RouteQuery = Record<string, string | (string | null)[] | null | undefined>
+
+const first = (value: RouteQuery[string]): string => {
+  if (Array.isArray(value)) {
+    return value[0] ?? ''
+  }
+  return value ?? ''
+}
+
+const many = (value: RouteQuery[string]): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string')
+  }
+  return typeof value === 'string' ? [value] : []
+}
+
+const asStyle = (value: string): AdhocSeriesStyle =>
+  (STYLES.includes(value as AdhocSeriesStyle) ? value as AdhocSeriesStyle : 'line')
+
+const asAggregation = (value: string): ConsolidationFunctionType =>
+  (AGGREGATIONS.includes(value as ConsolidationFunctionType) ?
+    value as ConsolidationFunctionType :
+    ConsolidationFunctionType.AVERAGE)
+
+const asColor = (value: string): string =>
+  (/^#[0-9a-fA-F]{6}$/.test(value) ? value.toLowerCase() : '')
+
+const asPositiveInt = (value: string, fallback: number): number => {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+/**
+ * Encode a config + time range as a flat route query.
+ *
+ * Deliberately positional rather than JSON: a JSON blob of twenty series
+ * percent-encodes into something several times longer than the cap, and the point
+ * of this state is that a user can copy the address bar and send it to someone.
+ */
+export const encodeAdhocState = (config: AdhocGraphConfig, time: StartEndTime): RouteQuery => {
+  const query: RouteQuery = {
+    start: String(time.startTime),
+    end: String(time.endTime),
+    fmt: time.format
+  }
+
+  if (config.series.length) {
+    query.s = config.series.map(series => [
+      series.resourceId,
+      series.attribute,
+      series.aggregation,
+      series.label,
+      series.style,
+      series.color,
+      series.hidden ? '1' : '0'
+    ].join(FIELD))
+  }
+
+  if (config.expressions.length) {
+    query.e = config.expressions.map(expression => [
+      expression.label,
+      expression.value,
+      expression.style,
+      expression.color
+    ].join(FIELD))
+  }
+
+  if (config.title) {
+    query.title = config.title
+  }
+
+  if (config.verticalLabel) {
+    query.vlabel = config.verticalLabel
+  }
+
+  if (config.stacked) {
+    query.stacked = '1'
+  }
+
+  if (config.resolution !== DEFAULT_RESOLUTION) {
+    query.res = String(config.resolution)
+  }
+
+  return query
+}
+
+/** Rough length of the encoded query, used to decide whether it is still shareable. */
+export const encodedQueryLength = (query: RouteQuery): number =>
+  Object.entries(query).reduce((total, [key, value]) => {
+    const values = many(value)
+    const parts = values.length ? values : [first(value)]
+    return total + parts.reduce(
+      (sum, part) => sum + key.length + encodeURIComponent(part).length + 2,
+      0
+    )
+  }, 0)
+
+/**
+ * Rebuild a config + time range from a route query.
+ *
+ * Never throws and never returns a half-built series: a hand-edited or truncated
+ * link should degrade to "the parts that parsed" rather than to a blank page.
+ * Returns null when the query carries no ad-hoc state at all.
+ */
+export const decodeAdhocState = (query: RouteQuery): AdhocUrlState | null => {
+  const rawSeries = many(query.s)
+  const rawExpressions = many(query.e)
+  const start = first(query.start)
+  const end = first(query.end)
+
+  if (!rawSeries.length && !rawExpressions.length && !start) {
+    return null
+  }
+
+  const series: AdhocSeries[] = []
+  const takenKeys = new Set<string>()
+
+  for (const entry of rawSeries) {
+    const [resourceId, attribute, aggregation, label, style, color, hidden] = entry.split(FIELD)
+
+    // resourceId + attribute identify the series; without both there is nothing to query.
+    if (!resourceId || !attribute) {
+      continue
+    }
+
+    const key = `${resourceId}|${attribute}`
+
+    if (takenKeys.has(key)) {
+      continue
+    }
+    takenKeys.add(key)
+
+    series.push({
+      key,
+      label: label || attribute,
+      resourceId,
+      attribute,
+      aggregation: asAggregation(aggregation ?? ''),
+      color: asColor(color ?? ''),
+      style: asStyle(style ?? ''),
+      hidden: hidden === '1'
+    })
+  }
+
+  const expressions: AdhocExpression[] = []
+
+  for (const [index, entry] of rawExpressions.entries()) {
+    const [label, value, style, color] = entry.split(FIELD)
+
+    if (!label || !value) {
+      continue
+    }
+
+    expressions.push({
+      id: `expr-${index}`,
+      label,
+      value,
+      style: asStyle(style ?? ''),
+      color: asColor(color ?? '')
+    })
+  }
+
+  const startTime = asPositiveInt(start, 0)
+  const endTime = asPositiveInt(end, 0)
+
+  return {
+    config: {
+      series,
+      expressions,
+      title: first(query.title),
+      verticalLabel: first(query.vlabel),
+      stacked: first(query.stacked) === '1',
+      resolution: asPositiveInt(first(query.res), DEFAULT_RESOLUTION)
+    },
+    time: {
+      startTime,
+      endTime,
+      format: first(query.fmt) || 'hours'
+    }
+  }
+}

--- a/ui/src/components/AdhocGraphs/utils/jexlToRpn.ts
+++ b/ui/src/components/AdhocGraphs/utils/jexlToRpn.ts
@@ -1,0 +1,283 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+/**
+ * Convert the infix JEXL an ad-hoc expression is written in into the RPN that an
+ * RRDtool CDEF requires.
+ *
+ * This is the mirror of `Resources/utils/RpnToJexlConverter.class.ts`, which the
+ * SPA uses to read prefab graphs. That direction is total — every RRD operator
+ * has a JEXL rendering — but this one is not: JEXL is a general expression
+ * language and RRD RPN is a small stack machine, so most JEXL programs have no
+ * translation at all.
+ *
+ * The supported subset is therefore deliberately narrow — numbers, series names,
+ * `+ - * / %`, unary minus and parentheses — and anything outside it is REFUSED
+ * with a reason rather than approximated. A CDEF that silently computes something
+ * other than what the user saw on screen is far worse than no CDEF.
+ */
+
+export interface JexlToRpnSuccess {
+  ok: true
+  rpn: string
+  /** Series names the expression reads, in order of first appearance. */
+  identifiers: string[]
+}
+
+export interface JexlToRpnFailure {
+  ok: false
+  reason: string
+}
+
+export type JexlToRpnResult = JexlToRpnSuccess | JexlToRpnFailure
+
+interface Token {
+  type: 'number' | 'identifier' | 'operator' | 'lparen' | 'rparen'
+  value: string
+}
+
+/** Infix operator → RRD RPN operator, with precedence and associativity. */
+const OPERATORS: Record<string, { rpn: string, precedence: number }> = {
+  '+': { rpn: '+', precedence: 1 },
+  '-': { rpn: '-', precedence: 1 },
+  '*': { rpn: '*', precedence: 2 },
+  '/': { rpn: '/', precedence: 2 },
+  '%': { rpn: '%', precedence: 2 }
+}
+
+/**
+ * Unary minus, kept distinct from binary '-' so precedence works out. RRD RPN has
+ * no negation operator, so `-x` is emitted as `0,x,-`: a literal 0 goes to the
+ * output the moment the unary is seen, and this marker behaves as a high-precedence
+ * binary subtraction from that 0. Doing it here rather than as a post-pass matters
+ * — `-(a + b)` must become `0,a,b,+,-`, which a fix-up over the flat token list
+ * cannot produce.
+ */
+const UNARY_MINUS = 'u-'
+
+const NUMBER = /^\d+(\.\d+)?([eE][+-]?\d+)?/
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*/
+
+const failure = (reason: string): JexlToRpnFailure => ({ ok: false, reason })
+
+const tokenize = (expression: string): Token[] | JexlToRpnFailure => {
+  const tokens: Token[] = []
+  let rest = expression.trim()
+
+  while (rest.length) {
+    const char = rest[0]
+
+    if (/\s/.test(char)) {
+      rest = rest.slice(1)
+      continue
+    }
+
+    if (char === '(') {
+      tokens.push({ type: 'lparen', value: char })
+      rest = rest.slice(1)
+      continue
+    }
+
+    if (char === ')') {
+      tokens.push({ type: 'rparen', value: char })
+      rest = rest.slice(1)
+      continue
+    }
+
+    if (OPERATORS[char]) {
+      tokens.push({ type: 'operator', value: char })
+      rest = rest.slice(1)
+      continue
+    }
+
+    const number = NUMBER.exec(rest)
+    if (number) {
+      tokens.push({ type: 'number', value: number[0] })
+      rest = rest.slice(number[0].length)
+      continue
+    }
+
+    const identifier = IDENTIFIER.exec(rest)
+    if (identifier) {
+      const after = rest.slice(identifier[0].length)
+
+      // An identifier followed by '(' is a function call, and one followed by
+      // ':name' is a JEXL namespace prefix (math:abs(...)). Neither has a general
+      // RRD equivalent, so both are refused by name — and the namespace case has
+      // to be caught here, or the ':' falls through to the ternary check below and
+      // reports the wrong reason.
+      if (/^\s*\(/.test(after)) {
+        return failure(`Function calls are not supported in a graph definition: ${identifier[0]}(...)`)
+      }
+
+      const namespaced = /^\s*:\s*([A-Za-z_][A-Za-z0-9_]*)/.exec(after)
+      if (namespaced) {
+        return failure(
+          `Function calls are not supported in a graph definition: ${identifier[0]}:${namespaced[1]}(...)`
+        )
+      }
+
+      tokens.push({ type: 'identifier', value: identifier[0] })
+      rest = after
+      continue
+    }
+
+    if (char === '?' || char === ':') {
+      return failure('Conditional (? :) expressions are not supported in a graph definition.')
+    }
+
+    if (char === '"' || char === '\'') {
+      return failure('Text values are not supported in a graph definition.')
+    }
+
+    if ('<>=!&|'.includes(char)) {
+      return failure(`Comparison and logical operators are not supported in a graph definition: ${char}`)
+    }
+
+    return failure(`Unsupported character in expression: ${char}`)
+  }
+
+  return tokens
+}
+
+/**
+ * Shunting-yard. Emits RRD RPN, which is comma-separated: `a,8,*`.
+ */
+export const jexlToRpn = (expression: string): JexlToRpnResult => {
+  const tokenized = tokenize(expression)
+
+  if (!Array.isArray(tokenized)) {
+    return tokenized
+  }
+
+  if (!tokenized.length) {
+    return failure('The expression is empty.')
+  }
+
+  const output: string[] = []
+  const stack: string[] = []
+  const identifiers: string[] = []
+  // Distinguishes unary from binary minus, and catches two values in a row.
+  let expectValue = true
+
+  const precedenceOf = (operator: string) =>
+    (operator === UNARY_MINUS ? 3 : OPERATORS[operator].precedence)
+
+  const rpnFor = (operator: string) =>
+    (operator === UNARY_MINUS ? '-' : OPERATORS[operator].rpn)
+
+  for (const token of tokenized) {
+    if (token.type === 'number' || token.type === 'identifier') {
+      if (!expectValue) {
+        return failure(`Missing an operator before '${token.value}'.`)
+      }
+
+      output.push(token.value)
+
+      if (token.type === 'identifier' && !identifiers.includes(token.value)) {
+        identifiers.push(token.value)
+      }
+
+      expectValue = false
+      continue
+    }
+
+    if (token.type === 'operator') {
+      if (expectValue) {
+        if (token.value !== '-') {
+          return failure(`Missing a value before '${token.value}'.`)
+        }
+        // 0 goes out now; the marker subtracts the operand from it later.
+        output.push('0')
+        stack.push(UNARY_MINUS)
+        continue
+      }
+
+      while (stack.length) {
+        const top = stack[stack.length - 1]
+
+        if (top === '(' || precedenceOf(top) < precedenceOf(token.value)) {
+          break
+        }
+
+        output.push(rpnFor(top))
+        stack.pop()
+      }
+
+      stack.push(token.value)
+      expectValue = true
+      continue
+    }
+
+    if (token.type === 'lparen') {
+      if (!expectValue) {
+        return failure('Missing an operator before \'(\'.')
+      }
+      stack.push('(')
+      continue
+    }
+
+    // rparen
+    if (expectValue) {
+      return failure('Missing a value before \')\'.')
+    }
+
+    let matched = false
+
+    while (stack.length) {
+      const top = stack.pop() as string
+
+      if (top === '(') {
+        matched = true
+        break
+      }
+
+      output.push(rpnFor(top))
+    }
+
+    if (!matched) {
+      return failure('Unbalanced parentheses in the expression.')
+    }
+
+    expectValue = false
+  }
+
+  if (expectValue) {
+    return failure('The expression ends with an operator.')
+  }
+
+  while (stack.length) {
+    const top = stack.pop() as string
+
+    if (top === '(') {
+      return failure('Unbalanced parentheses in the expression.')
+    }
+
+    output.push(rpnFor(top))
+  }
+
+  if (!identifiers.length) {
+    return failure('The expression does not reference any series.')
+  }
+
+  return { ok: true, rpn: output.join(','), identifiers }
+}

--- a/ui/src/components/AdhocGraphs/utils/rrdGraphDefinition.ts
+++ b/ui/src/components/AdhocGraphs/utils/rrdGraphDefinition.ts
@@ -279,7 +279,17 @@ export const buildRrdGraphDefinition = (config: AdhocGraphConfig): RrdGraphDefin
   // legibility, since leading whitespace is stripped when the file is read.
   const propertiesCommand = lines.map(escapeForProperties).join(' \\\n ')
 
+  // A report is only rendered if its name appears in the file's `reports=` list.
+  // Emitting the block alone produced a file that parsed fine and drew nothing —
+  // so the list comes with it, ready to use as a standalone file, with a note for
+  // the other case, since a second `reports=` key would override the first rather
+  // than extend it.
   const properties = [
+    `reports=${reportName}`,
+    '',
+    '# Appending to an existing file? Do not paste the line above — add',
+    `# ${reportName} to that file's existing reports= list instead.`,
+    '',
     `report.${reportName}.name=${escapeForProperties(title)}`,
     `report.${reportName}.columns=${columns.join(',')}`,
     `report.${reportName}.type=${type}`,

--- a/ui/src/components/AdhocGraphs/utils/rrdGraphDefinition.ts
+++ b/ui/src/components/AdhocGraphs/utils/rrdGraphDefinition.ts
@@ -1,0 +1,290 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { AdhocGraphConfig, AdhocSeriesStyle } from '@/types/adhocGraph'
+import { jexlToRpn } from './jexlToRpn'
+import { expressionReferences, sanitizeLabel } from './adhocQuery'
+
+/**
+ * Emit an ad-hoc graph as a prefab graph definition — the `report.<name>.*` block
+ * that lives in `$OPENNMS_HOME/etc/snmp-graph.properties.d/`.
+ *
+ * ## Why this only works for a single resource
+ *
+ * A prefab graph is a TEMPLATE bound to one resource. The `{rrd1}`..`{rrdN}`
+ * placeholders in the command are filled in by
+ * `DefaultRrdGraphService.getRrdNames(resource, columns)`, which looks every
+ * column up in ONE `OnmsResource` and throws when an attribute is not on it:
+ *
+ *     throw new IllegalArgumentException("RRD attribute '" + dsNames[i] +
+ *         "' is not available on resource '" + resource.getId() + "'.")
+ *
+ * So a graph whose series span two interfaces — let alone two nodes — has no
+ * prefab representation at all. That is a property of the format, not a gap in
+ * this code, which is why the caller gates on `describeIneligibility` first.
+ *
+ * ## Deliberate omissions
+ *
+ * The time range is not emitted: prefab graphs are time-agnostic and the viewer
+ * supplies start/end. Nor are the CDEFs NaN-guarded the way hand-written OpenNMS
+ * graphs often are (`CDEF:x=raw,UN,0,raw,IF`) — that guard turns gaps into zeroes,
+ * which would make the rendered graph disagree with the ad-hoc graph it came from.
+ */
+
+export interface RrdGraphDefinition {
+  /** The report id, e.g. `adhoc.interfaceSnmp.ifHCInOctets_ifHCOutOctets`. */
+  reportName: string
+  /** Distinct datasource names, in `{rrdN}` order. */
+  columns: string[]
+  /** The resource type the report applies to, e.g. `interfaceSnmp`. */
+  type: string
+  /** The full `report.<name>.*` block, ready to paste into a properties file. */
+  properties: string
+  /**
+   * The effective command, as the server hands it to RRDtool once the properties
+   * file has been read — single-escaped and on one line. `properties` is the same
+   * command with backslashes doubled and split across continuation lines, which is
+   * what a .properties file requires.
+   */
+  command: string
+}
+
+export interface RrdGraphDefinitionFailure {
+  reason: string
+}
+
+export type RrdGraphDefinitionResult = RrdGraphDefinition | RrdGraphDefinitionFailure
+
+export const isRrdGraphDefinition = (
+  result: RrdGraphDefinitionResult
+): result is RrdGraphDefinition => 'properties' in result
+
+/**
+ * The OpenNMS resource type embedded in a resource id, e.g. `interfaceSnmp` from
+ * `node[1].interfaceSnmp[eth0]`.
+ *
+ * Parsed from the last bracket rather than by splitting on '.', because the
+ * bracketed part routinely contains dots and other punctuation
+ * (`node[1].hrStorageIndex[/var/log]`).
+ */
+export const resourceTypeOf = (resourceId: string): string | null => {
+  const lastBracket = resourceId.lastIndexOf('[')
+
+  if (lastBracket <= 0) {
+    return null
+  }
+
+  const match = /([A-Za-z][A-Za-z0-9_]*)$/.exec(resourceId.slice(0, lastBracket))
+  return match?.[1] ?? null
+}
+
+/**
+ * RRD draw command for a series style. Every style the UI offers has one, which is
+ * the point of naming them after these commands in the first place.
+ */
+const DRAW_COMMANDS: Readonly<Record<AdhocSeriesStyle, string>> = {
+  line: 'LINE1',
+  line2: 'LINE2',
+  line3: 'LINE3',
+  area: 'AREA',
+  stack: 'AREA'
+}
+
+const drawCommandFor = (style: AdhocSeriesStyle): string => DRAW_COMMANDS[style] ?? 'LINE1'
+
+/**
+ * Escape text destined for an RRD legend. Colons separate a command's fields, so a
+ * literal one has to be escaped. This is the RRD layer only; the extra doubling a
+ * .properties file needs is applied once, later, by `escapeForProperties`.
+ */
+const escapeLegend = (text: string): string => text.replace(/\\/g, '\\\\').replace(/:/g, '\\:')
+
+/**
+ * Second escaping layer, applied only when writing the .properties form: java's
+ * Properties reader consumes one level of backslash, so every backslash in the
+ * effective command must be doubled. This is why the shipped graphs read
+ * `"Avg  \\: %8.2lf %s"` on disk while RRDtool receives `"Avg  \: %8.2lf %s"`.
+ */
+const escapeForProperties = (text: string): string => text.replace(/\\/g, '\\\\')
+
+/** Escape text destined for a quoted `--title` / `--vertical-label` argument. */
+const escapeQuoted = (text: string): string =>
+  text.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/[\r\n]+/g, ' ').trim()
+
+/** Beyond this many datasources the id stops being readable and gets a count instead. */
+const MAX_NAMED_COLUMNS = 4
+
+/**
+ * The report id, built from what the graph actually reads: its resource type and
+ * its datasource names — `adhoc.interfaceSnmp.ifHCInOctets_ifHCOutOctets`.
+ *
+ * The resource *type* rather than the resource *id*, deliberately. A prefab graph
+ * is a template that renders for every resource of its type, so putting the
+ * instance in the id (`node[1]`, `GigabitEthernet0-0-1`) would tell a later reader
+ * the graph is specific to that interface when it is not. The instance also drags
+ * in `[`, `]` and `:`, all of which need escaping in a .properties key.
+ *
+ * The human-readable graph title is unaffected — it stays on `report.<id>.name`.
+ */
+export const reportNameFor = (resourceId: string, columns: string[]): string => {
+  const type = resourceTypeOf(resourceId) ?? 'resource'
+  const named = columns.slice(0, MAX_NAMED_COLUMNS).map(column => sanitizeLabel(column))
+  const remainder = columns.length - named.length
+  const suffix = remainder > 0 ? `_and_${remainder}_more` : ''
+
+  return `adhoc.${sanitizeLabel(type)}.${named.join('_')}${suffix}`
+}
+
+/** Pad a legend so the GPRINT columns line up, the way the shipped graphs do. */
+const padLegend = (text: string, width: number): string =>
+  (text.length >= width ? text : text + ' '.repeat(width - text.length))
+
+/**
+ * Why this config cannot be expressed as a prefab graph, or null when it can.
+ * Checked before emitting so the UI can explain rather than produce a definition
+ * that throws at render time.
+ */
+export const describeIneligibility = (config: AdhocGraphConfig): string | null => {
+  if (!config.series.length) {
+    return 'There are no series to export yet.'
+  }
+
+  const resourceIds = [...new Set(config.series.map(series => series.resourceId))]
+
+  if (resourceIds.length > 1) {
+    return 'A graph definition is bound to a single resource, but this graph draws on ' +
+      `${resourceIds.length} of them. Narrow the selection to one resource to export it.`
+  }
+
+  if (!resourceTypeOf(resourceIds[0])) {
+    return `The resource type could not be determined from '${resourceIds[0]}'.`
+  }
+
+  for (const expression of config.expressions) {
+    const converted = jexlToRpn(expression.value)
+
+    if (!converted.ok) {
+      return `Expression '${expression.label}' cannot be converted: ${converted.reason}`
+    }
+
+    const known = new Set(config.series.map(series => series.label))
+    const unknown = converted.identifiers.filter(identifier => !known.has(identifier))
+
+    if (unknown.length) {
+      // An expression referring to another expression would need the CDEFs ordered
+      // by dependency; sources only keeps the emitted order trivially correct.
+      return `Expression '${expression.label}' references ${unknown.join(', ')}, ` +
+        'which is not a source series. Graph definitions can only build on sources.'
+    }
+  }
+
+  return null
+}
+
+/**
+ * Build the definition. Returns a failure object when the config is ineligible —
+ * the same check the UI runs to decide whether to offer the export at all.
+ */
+export const buildRrdGraphDefinition = (config: AdhocGraphConfig): RrdGraphDefinitionResult => {
+  const ineligible = describeIneligibility(config)
+
+  if (ineligible) {
+    return { reason: ineligible }
+  }
+
+  const title = config.title.trim() || 'Ad-hoc graph'
+  const type = resourceTypeOf(config.series[0].resourceId) as string
+
+  // {rrdN} is positional over `columns`, so two series reading the same attribute
+  // with different consolidation functions share one column and one placeholder.
+  const columns: string[] = []
+
+  for (const series of config.series) {
+    if (!columns.includes(series.attribute)) {
+      columns.push(series.attribute)
+    }
+  }
+
+  const reportName = reportNameFor(config.series[0].resourceId, columns)
+
+  const lines: string[] = [
+    `--title="${escapeQuoted(title)}"`
+  ]
+
+  if (config.verticalLabel.trim()) {
+    lines.push(`--vertical-label="${escapeQuoted(config.verticalLabel)}"`)
+  }
+
+  for (const series of config.series) {
+    const placeholder = `{rrd${columns.indexOf(series.attribute) + 1}}`
+    lines.push(`DEF:${series.label}=${placeholder}:${series.attribute}:${series.aggregation}`)
+  }
+
+  for (const expression of config.expressions) {
+    const converted = jexlToRpn(expression.value)
+
+    if (!converted.ok) {
+      return { reason: converted.reason }
+    }
+
+    lines.push(`CDEF:${expression.label}=${converted.rpn}`)
+  }
+
+  // A source that is hidden AND consumed keeps its DEF (the CDEF needs it) but is
+  // not drawn — the same rule the measurements query applies via `transient`.
+  const drawn = [
+    ...config.series.filter(series =>
+      !(series.hidden && config.expressions.some(expression =>
+        expressionReferences(expression.value, series.label)))),
+    ...config.expressions
+  ]
+
+  const legendWidth = Math.max(...drawn.map(item => item.label.length))
+
+  for (const item of drawn) {
+    const draw = drawCommandFor(item.style)
+    const stack = item.style === 'stack' ? ':STACK' : ''
+    const legend = escapeLegend(padLegend(item.label, legendWidth))
+
+    lines.push(`${draw}:${item.label}${item.color}:"${legend}"${stack}`)
+    lines.push(`GPRINT:${item.label}:AVERAGE:"Avg \\: %8.2lf %s"`)
+    lines.push(`GPRINT:${item.label}:MIN:"Min \\: %8.2lf %s"`)
+    lines.push(`GPRINT:${item.label}:MAX:"Max \\: %8.2lf %s"`)
+    lines.push(`GPRINT:${item.label}:LAST:"Last \\: %8.2lf %s\\n"`)
+  }
+
+  const command = lines.join(' ')
+
+  // Properties-file form: escape once more, then break across continuation lines.
+  // Every line but the last ends in a backslash; the one-space indent is only for
+  // legibility, since leading whitespace is stripped when the file is read.
+  const propertiesCommand = lines.map(escapeForProperties).join(' \\\n ')
+
+  const properties = [
+    `report.${reportName}.name=${escapeForProperties(title)}`,
+    `report.${reportName}.columns=${columns.join(',')}`,
+    `report.${reportName}.type=${type}`,
+    `report.${reportName}.command=${propertiesCommand}`
+  ].join('\n')
+
+  return { reportName, columns, type, properties, command }
+}

--- a/ui/src/components/AdhocGraphs/utils/rrdGraphDefinition.ts
+++ b/ui/src/components/AdhocGraphs/utils/rrdGraphDefinition.ts
@@ -211,7 +211,7 @@ export const buildRrdGraphDefinition = (config: AdhocGraphConfig): RrdGraphDefin
     return { reason: ineligible }
   }
 
-  const title = config.title.trim() || 'Ad-hoc graph'
+  const title = config.title.trim() || 'Custom performance graph'
   const type = resourceTypeOf(config.series[0].resourceId) as string
 
   // {rrdN} is positional over `columns`, so two series reading the same attribute

--- a/ui/src/components/Configuration/ConfigurationHelper.ts
+++ b/ui/src/components/Configuration/ConfigurationHelper.ts
@@ -44,6 +44,7 @@ import {
   RequisitionHTTPTypes
 } from './copy/requisitionTypes'
 import { scheduleTypes, weekTypes, weekNameTypes, dayTypes } from './copy/scheduleTypes'
+import { copyToClipboard } from '@/composables/useClipboard'
 import cronstrue from 'cronstrue'
 import ipRegex from 'ip-regex'
 import isValidDomain from 'is-valid-domain'
@@ -984,37 +985,6 @@ const validateType = (typeName: string) => {
   return !typeName ? ErrorStrings.Required('Type') : ''
 }
 
-/**
- * Allows for copying to clipboard in both HTTPS & HTTP
- * @param text text to copy
- * @returns promise
- */
-const copyToClipboard = (text: string) => {
-  // navigator clipboard api needs a secure context (https)
-  if (navigator.clipboard && window.isSecureContext) {
-    // navigator clipboard api method'
-    return navigator.clipboard.writeText(text)
-  } else {
-    // text area method
-    const textArea = document.createElement('textarea')
-    textArea.value = text
-    // make the textarea out of viewport
-    textArea.style.position = 'fixed'
-    textArea.style.left = '-999999px'
-    textArea.style.top = '-999999px'
-    document.body.appendChild(textArea)
-    textArea.focus()
-    textArea.select()
-    return new Promise<void>((res, rej) => {
-      if (document.execCommand('copy')) {
-        res()
-      } else {
-        rej()
-      }
-      textArea.remove()
-    })
-  }
-}
 
 export const ConfigurationHelper = {
   obfuscatePassword,

--- a/ui/src/components/Resources/GraphDataTable.vue
+++ b/ui/src/components/Resources/GraphDataTable.vue
@@ -32,10 +32,10 @@
       </thead>
       <tbody>
         <tr
-          v-for="(timestamp, index) in graphData.timestamps"
-          :key="timestamp"
+          v-for="index in rowIndices"
+          :key="graphData.timestamps[index]"
         >
-          <td>{{ !displayRawValues ? graphData.formattedTimestamps[index] : timestamp }}</td>
+          <td class="time-cell">{{ displayRawValues ? graphData.timestamps[index] : displayTime(index) }}</td>
           <td
             v-for="metric of convertedGraphData.metrics"
             :key="metric.name"
@@ -59,7 +59,20 @@
 import { ConvertedGraphData, GraphMetricsResponse } from '@/types'
 import { OnmsCheckbox } from '@opennms/onms-ui'
 import { format } from 'd3'
-import { PropType, ref } from 'vue'
+import { format as formatDate } from 'date-fns'
+import { computed, PropType, ref } from 'vue'
+
+/**
+ * Full local date and time for a table row, matching what the legacy graph view
+ * shows — Backshift renders its Date/Time column with d3's `%c`, which in the
+ * default locale is exactly this: `Mon Aug 10 11:54:25 2026`.
+ *
+ * Deliberately NOT `graphData.formattedTimestamps`. Those are AXIS labels, chosen
+ * for the granularity of the range, and they are wrong on a table: a week-long
+ * range renders as `10/Aug 11:54` with no year, and a year-long one as `Aug/2026`
+ * with no time at all, so rows stop being self-describing and can repeat.
+ */
+const DATETIME_FORMAT = 'EEE MMM d HH:mm:ss yyyy'
 
 const displayRawValues = ref(false)
 const d3format = format('.3s')
@@ -84,6 +97,26 @@ const props = defineProps({
     type: String
   }
 })
+
+/** Timestamps arrive as epoch milliseconds. */
+const displayTime = (index: number): string => {
+  const timestamp = props.graphData.timestamps[index]
+  return Number.isFinite(timestamp) ? formatDate(new Date(timestamp), DATETIME_FORMAT) : ''
+}
+
+/**
+ * Row order as indices into the response arrays: most recent sample first.
+ *
+ * The measurements API returns timestamps ascending, but every graph data table in
+ * OpenNMS reads newest-first — the legacy view walks its rows backwards
+ * (`for (i = N-1; i >= 0; i--)` in jquery.flot.datatable), and this matches it.
+ *
+ * Reversing means reversing the INDICES, not the data. Timestamps and each metric's
+ * values are separate arrays indexed in step, so mapping the values into a new
+ * order instead would pair every timestamp with the wrong reading.
+ */
+const rowIndices = computed<number[]>(() =>
+  props.graphData.timestamps.map((_timestamp, index) => index).reverse())
 
 const getHeaderFromMetricName = (metricName: string): string => {
   for (const statement of props.convertedGraphData.printStatements) {
@@ -136,8 +169,13 @@ const highlightTableText = () => {
     }
     margin-top: 0px;
 
+    // Wide enough for the full date and time without wrapping.
     .time-column {
-      width: 200px;
+      width: 15rem;
+    }
+
+    .time-cell {
+      white-space: nowrap;
     }
   }
 

--- a/ui/src/components/Resources/GraphDataTable.vue
+++ b/ui/src/components/Resources/GraphDataTable.vue
@@ -63,9 +63,20 @@ import { format as formatDate } from 'date-fns'
 import { computed, PropType, ref } from 'vue'
 
 /**
- * Full local date and time for a table row, matching what the legacy graph view
- * shows — Backshift renders its Date/Time column with d3's `%c`, which in the
- * default locale is exactly this: `Mon Aug 10 11:54:25 2026`.
+ * Fixed date and time pattern for a table row: `Mon Aug 10 11:54:25 2026`.
+ *
+ * This reproduces what the legacy graph view renders for an en-US browser, where
+ * Backshift's `d3.time.format("%c")` expands to `%a %b %e %X %Y`. It is NOT the
+ * same mechanism: `%c` is locale-adaptive and resolves differently under a
+ * non-en-US d3 locale, whereas this pattern is the same everywhere. That is
+ * deliberate — one stable, unambiguous rendering is what a data table wants, and
+ * it is the format that was asked for — but it means "matches the legacy view"
+ * holds for the default locale only.
+ *
+ * Rendered in the browser's zone, like the graph's own axis labels
+ * (`Resources/utils/LegendFormatter.ts`), so the Data tab and the Graph tab always
+ * agree. Note this differs from the `v-date` directive used elsewhere in the app,
+ * which honours the server's configured `datetimeformatConfig`.
  *
  * Deliberately NOT `graphData.formattedTimestamps`. Those are AXIS labels, chosen
  * for the granularity of the range, and they are wrong on a table: a week-long

--- a/ui/src/components/Resources/TimeControls.vue
+++ b/ui/src/components/Resources/TimeControls.vue
@@ -65,7 +65,13 @@ import { OnmsButton, OnmsDatePicker, OnmsIcon, OnmsPopover, OnmsSelect } from '@
 import FormField from '@/components/Common/FormField.vue'
 import { add, sub, getUnixTime, differenceInHours, fromUnixTime } from 'date-fns'
 import ArrowDropDown from '@/components/icons/navigation/ArrowDropDown.vue'
-import { HOUR_OPTIONS, TIME_RANGE_OPTIONS, TimeOption } from './utils/timeRangeOptions'
+import {
+  HOUR_OPTIONS,
+  relativeRangeOf,
+  resolveRelativeRange,
+  TIME_RANGE_OPTIONS,
+  TimeOption
+} from './utils/timeRangeOptions'
 
 const emit = defineEmits(['updateTime'])
 
@@ -75,23 +81,35 @@ const startTimeRef = ref<TimeOption>({ label: '1 PM', time: { hours: 13 }})
 const endDateRef = ref()
 const endTimeRef = ref<TimeOption>({ label: '1 PM', time: { hours: 13 }})
 
-const selectedTime = ref('Last Day')
+const selectedTime = ref('Last day')
 
 const disableCustomTimeBtn = computed(() => Boolean(!startDateRef.value || !startTimeRef.value || !endDateRef.value || !endTimeRef.value))
 
 const toggleMenu = (event: Event) => menu.value.toggle(event)
 
+/**
+ * A preset range is relative: it is emitted as a unit/amount alongside the resolved
+ * window so the consumer can re-resolve it later. Only "Apply custom time" below
+ * produces a genuinely absolute window, matching the legacy graph pages.
+ */
 const selectOption = (option: TimeOption) => {
   selectedTime.value = option.label
+
+  const range = relativeRangeOf(option)
+
+  if (range) {
+    emit('updateTime', resolveRelativeRange(range))
+    menu.value.hide()
+    return
+  }
+
+  // Fallback for an option that is not a single unit/amount; treated as absolute.
   const now = new Date()
-  const startTime = getUnixTime(sub(now, option.time))
-  const endTime = getUnixTime(now)
-  const format = Object.keys(option.time)[0]
 
   emit('updateTime', {
-    startTime,
-    endTime,
-    format
+    startTime: getUnixTime(sub(now, option.time)),
+    endTime: getUnixTime(now),
+    format: Object.keys(option.time)[0]
   })
 
   menu.value.hide()
@@ -117,6 +135,8 @@ const applyCustomTime = () => {
     format = 'years'
   }
 
+  // No `range`: an explicit start and end is absolute by definition, and must not
+  // slide when the graph is refreshed or the link is reopened.
   emit('updateTime', {
     startTime,
     endTime,

--- a/ui/src/components/Resources/TimeControls.vue
+++ b/ui/src/components/Resources/TimeControls.vue
@@ -121,7 +121,7 @@ const applyCustomTime = () => {
   const endTime = getUnixTime(add(endDateRef.value, endTimeRef.value.time))
 
   // end - start, as Dates. This previously passed unix SECONDS in the wrong order,
-  // so the difference was always negative and every custom range was labelled as
+  // so the difference was always negative and every custom range was labeled as
   // minutes.
   const difference = differenceInHours(fromUnixTime(endTime), fromUnixTime(startTime))
 

--- a/ui/src/components/Resources/TimeControls.vue
+++ b/ui/src/components/Resources/TimeControls.vue
@@ -19,7 +19,7 @@
           <ul class="onms-list options-col">
             <li
               class="list-item"
-              v-for="option in options"
+              v-for="option in TIME_RANGE_OPTIONS"
               :key="option.label"
               @click="selectOption(option)"
             >{{ option.label }}</li>
@@ -31,7 +31,7 @@
             </FormField>
             <FormField label="Start Time">
               <OnmsSelect
-                :options="times"
+                :options="HOUR_OPTIONS"
                 v-model="startTimeRef"
                 optionLabel="label"
               />
@@ -41,7 +41,7 @@
             </FormField>
             <FormField label="End Time">
               <OnmsSelect
-                :options="times"
+                :options="HOUR_OPTIONS"
                 v-model="endTimeRef"
                 optionLabel="label"
               />
@@ -63,64 +63,19 @@ import { computed, ref } from 'vue'
 
 import { OnmsButton, OnmsDatePicker, OnmsIcon, OnmsPopover, OnmsSelect } from '@opennms/onms-ui'
 import FormField from '@/components/Common/FormField.vue'
-import { add, sub, getUnixTime, differenceInHours } from 'date-fns'
+import { add, sub, getUnixTime, differenceInHours, fromUnixTime } from 'date-fns'
 import ArrowDropDown from '@/components/icons/navigation/ArrowDropDown.vue'
-
-interface TimeOption {
-  label: string
-  time: Record<string, unknown>
-}
+import { HOUR_OPTIONS, TIME_RANGE_OPTIONS, TimeOption } from './utils/timeRangeOptions'
 
 const emit = defineEmits(['updateTime'])
 
 const menu = ref()
 const startDateRef = ref()
-const startTimeRef = ref<TimeOption>({ label: '1 PM', time: { hours: '1' }})
+const startTimeRef = ref<TimeOption>({ label: '1 PM', time: { hours: 13 }})
 const endDateRef = ref()
-const endTimeRef = ref<TimeOption>({ label: '1 PM', time: { hours: '1' }})
+const endTimeRef = ref<TimeOption>({ label: '1 PM', time: { hours: 13 }})
 
 const selectedTime = ref('Last Day')
-const options = [
-  { label: 'Last hour', time: { minutes: '60' }},
-  { label: 'Last 2 hours', time: { hours: '2' }},
-  { label: 'Last 4 hours', time: { hours: '4' }},
-  { label: 'Last 8 hours', time: { hours: '5' }},
-  { label: 'Last 12 hours', time: { hours: '12' }},
-  { label: 'Last day', time: { hours: '24' }},
-  { label: 'Last two days', time: { hours: '48' }},
-  { label: 'Last week', time: { days: '7' }},
-  { label: 'Last month', time: { months: '1' }},
-  { label: 'Last three months', time: { months: '3' }},
-  { label: 'Last six months', time: { months: '6' }},
-  { label: 'Last year', time: { years: '1' }}
-]
-
-const times = [
-  { label: '12 AM', time: { hours: '0' }},
-  { label: '1 AM', time: { hours: '1' }},
-  { label: '2 AM', time: { hours: '2' }},
-  { label: '3 AM', time: { hours: '3' }},
-  { label: '4 AM', time: { hours: '4' }},
-  { label: '5 AM', time: { hours: '5' }},
-  { label: '6 AM', time: { hours: '6' }},
-  { label: '7 AM', time: { hours: '7' }},
-  { label: '8 AM', time: { hours: '8' }},
-  { label: '9 AM', time: { hours: '9' }},
-  { label: '10 AM', time: { hours: '10' }},
-  { label: '11 AM', time: { hours: '11' }},
-  { label: '12 PM', time: { hours: '12' }},
-  { label: '1 PM', time: { hours: '13' }},
-  { label: '2 PM', time: { hours: '14' }},
-  { label: '3 PM', time: { hours: '15' }},
-  { label: '4 PM', time: { hours: '16' }},
-  { label: '5 PM', time: { hours: '17' }},
-  { label: '6 PM', time: { hours: '18' }},
-  { label: '7 PM', time: { hours: '19' }},
-  { label: '8 PM', time: { hours: '20' }},
-  { label: '9 PM', time: { hours: '21' }},
-  { label: '10 PM', time: { hours: '22' }},
-  { label: '11 PM', time: { hours: '23' }}
-]
 
 const disableCustomTimeBtn = computed(() => Boolean(!startDateRef.value || !startTimeRef.value || !endDateRef.value || !endTimeRef.value))
 
@@ -147,7 +102,11 @@ const applyCustomTime = () => {
   const startTime = getUnixTime(add(startDateRef.value, startTimeRef.value.time))
   const endTime = getUnixTime(add(endDateRef.value, endTimeRef.value.time))
 
-  const difference = differenceInHours(startTime, endTime)
+  // end - start, as Dates. This previously passed unix SECONDS in the wrong order,
+  // so the difference was always negative and every custom range was labelled as
+  // minutes.
+  const difference = differenceInHours(fromUnixTime(endTime), fromUnixTime(startTime))
+
   if (difference < 1) {
     format = 'minutes'
   }

--- a/ui/src/components/Resources/utils/graphExport.ts
+++ b/ui/src/components/Resources/utils/graphExport.ts
@@ -1,0 +1,172 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { Chart } from 'chart.js'
+import { jsPDF } from 'jspdf'
+
+import useDownload from '@/composables/useDownload'
+import { ConvertedGraphData, GraphMetricsResponse } from '@/types'
+
+// A safe filename stem from a graph title/definition.
+export const safeFileStem = (name: string): string =>
+  (name || 'graph').replace(/[^\w.-]+/g, '_').replace(/^_+|_+$/g, '') || 'graph'
+
+// Header cells come from graph config text, so neutralize spreadsheet
+// formula-injection prefixes (=,+,-,@,tab,CR) before quoting. Value cells are
+// numbers or ISO timestamps and are emitted raw (guarding them would corrupt
+// legitimate negatives).
+const escapeCsvHeader = (value: string): string => {
+  const guarded = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
+  return /[",\r\n]/.test(guarded) ? `"${guarded.replaceAll('"', '""')}"` : guarded
+}
+
+// One column per plotted metric, one row per timestamp. Times are emitted as ISO
+// strings and values as raw numbers (gaps left blank) so the CSV is analysis-ready.
+export const buildGraphCsv = (graphData: GraphMetricsResponse, converted: ConvertedGraphData): string => {
+  const headerFor = (metricName: string): string => {
+    const statement = converted.printStatements.find(s => s.metric === metricName)
+    return statement?.header || metricName
+  }
+  const columnFor = (metricName: string): number[] => {
+    const index = graphData.labels.indexOf(metricName)
+    return index >= 0 ? (graphData.columns[index]?.values ?? []) : []
+  }
+
+  // Only export metrics that actually have a column in the response; transient or
+  // CDEF metrics absent from labels would otherwise emit a header over blank cells.
+  const columns = converted.metrics
+    .filter(m => m.name && graphData.labels.includes(m.name as string))
+    .map(m => ({ header: headerFor(m.name as string), values: columnFor(m.name as string) }))
+
+  const lines: string[] = []
+  lines.push(['Date/Time', ...columns.map(c => escapeCsvHeader(c.header))].join(','))
+
+  graphData.timestamps.forEach((ts, i) => {
+    const row = [Number.isFinite(ts) ? new Date(ts).toISOString() : '']
+    for (const column of columns) {
+      const value = column.values[i]
+      row.push(value === null || value === undefined || Number.isNaN(value) ? '' : String(value))
+    }
+    lines.push(row.join(','))
+  })
+
+  return lines.join('\r\n')
+}
+
+export const downloadTextFile = (filename: string, text: string, mimeType: string): void => {
+  // Leading BOM so Excel opens the UTF-8 CSV correctly; hand the blob to the
+  // shared useDownload helper rather than rolling a separate anchor here.
+  const blob = new Blob([`\uFEFF${text}`], { type: mimeType })
+  useDownload().downloadBlob(blob, filename)
+}
+
+export const downloadGraphCsv = (
+  graphData: GraphMetricsResponse,
+  converted: ConvertedGraphData,
+  fileStem: string
+): void => {
+  downloadTextFile(`${safeFileStem(fileStem)}.csv`, buildGraphCsv(graphData, converted), 'text/csv;charset=utf-8')
+}
+
+// Chart.js canvases are transparent; flatten onto white so the PDF image is not
+// rendered over a black background.
+const canvasToPngOnWhite = (canvas: HTMLCanvasElement): string => {
+  const flattened = document.createElement('canvas')
+  flattened.width = canvas.width
+  flattened.height = canvas.height
+  const ctx = flattened.getContext('2d')
+  if (!ctx) {
+    return canvas.toDataURL('image/png')
+  }
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(0, 0, flattened.width, flattened.height)
+  ctx.drawImage(canvas, 0, 0)
+  return flattened.toDataURL('image/png')
+}
+
+// Render each live chart inside `container` into a single landscape PDF. The chart
+// image already carries the graph title (Chart.js bakes it in), so only the legend
+// stats are added as text. Returns the number of graphs exported (0 = nothing
+// saved). Note: only DOM-mounted graphs are captured — with infinite scroll the
+// caller may not have loaded them all.
+export const exportGraphsToPdf = (container: HTMLElement, docTitle: string): number => {
+  const canvases = (Array.from(container.querySelectorAll('canvas')) as HTMLCanvasElement[])
+    .filter(c => Chart.getChart(c))
+  if (!canvases.length) {
+    return 0
+  }
+
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'a4' })
+  const pageWidth = doc.internal.pageSize.getWidth()
+  const pageHeight = doc.internal.pageSize.getHeight()
+  const margin = 40
+  const contentWidth = pageWidth - margin * 2
+  let y = margin
+  let exported = 0
+
+  doc.setFontSize(15)
+  doc.text(docTitle, margin, y)
+  y += 24
+
+  for (const canvas of canvases) {
+    try {
+      const legend = (document.getElementById(`${canvas.id}-lc`)?.innerText ?? '').trim()
+      const legendLines = legend ? (doc.splitTextToSize(legend, contentWidth) as string[]) : []
+      const legendHeight = legendLines.length * 12
+
+      // preserve aspect ratio, but never let a single graph exceed one page
+      const ratio = canvas.height / canvas.width || 0.4
+      let imgWidth = contentWidth
+      let imgHeight = imgWidth * ratio
+      const maxImgHeight = pageHeight - margin * 2 - legendHeight - 12
+      if (imgHeight > maxImgHeight) {
+        imgHeight = Math.max(60, maxImgHeight)
+        imgWidth = Math.min(contentWidth, imgHeight / ratio)
+      }
+
+      // new page if the block doesn't fit in what's left (unless already at the top)
+      if (y + imgHeight + legendHeight + 12 > pageHeight - margin && y > margin) {
+        doc.addPage()
+        y = margin
+      }
+
+      doc.addImage(canvasToPngOnWhite(canvas), 'PNG', margin, y, imgWidth, imgHeight)
+      y += imgHeight + 6
+      if (legendLines.length) {
+        doc.setFontSize(9)
+        doc.text(legendLines, margin, y)
+        y += legendHeight
+      }
+      y += 12
+      exported++
+    } catch {
+      // a tainted or over-large canvas shouldn't abort the whole export
+      continue
+    }
+  }
+
+  if (!exported) {
+    return 0
+  }
+  useDownload().downloadBlob(doc.output('blob'), `${safeFileStem(docTitle)}.pdf`)
+  return exported
+}

--- a/ui/src/components/Resources/utils/timeRangeOptions.ts
+++ b/ui/src/components/Resources/utils/timeRangeOptions.ts
@@ -20,7 +20,9 @@
 /// License.
 ///
 
+import { getUnixTime, sub } from 'date-fns'
 import type { Duration } from 'date-fns'
+import { RelativeTimeRange, StartEndTime } from '@/types'
 
 export interface TimeOption {
   label: string
@@ -78,3 +80,42 @@ export const HOUR_OPTIONS: TimeOption[] = [
   { label: '10 PM', time: { hours: 22 }},
   { label: '11 PM', time: { hours: 23 }}
 ]
+
+/** Units a relative range may use; anything else is rejected when decoding a link. */
+export const RANGE_UNITS: RelativeTimeRange['unit'][] =
+  ['minutes', 'hours', 'days', 'weeks', 'months', 'years']
+
+/** The window shown before anything is picked. */
+export const DEFAULT_RANGE: RelativeTimeRange = { unit: 'hours', amount: 24 }
+
+/**
+ * Reduce a picker option to a relative range.
+ *
+ * Every option carries exactly one duration field (there is a test for it), so a
+ * single unit/amount pair describes any of them without loss. Returns null for
+ * anything that does not fit, so a malformed option degrades to an absolute
+ * window rather than a wrong relative one.
+ */
+export const relativeRangeOf = (option: TimeOption): RelativeTimeRange | null => {
+  const fields = Object.entries(option.time)
+    .filter(([, amount]) => typeof amount === 'number' && amount > 0)
+
+  if (fields.length !== 1) {
+    return null
+  }
+
+  const [unit, amount] = fields[0] as [RelativeTimeRange['unit'], number]
+  return RANGE_UNITS.includes(unit) ? { unit, amount } : null
+}
+
+/**
+ * Resolve a relative range against the clock. `now` is injectable so callers can
+ * be tested without freezing time globally.
+ */
+export const resolveRelativeRange = (range: RelativeTimeRange, now: Date = new Date()): StartEndTime => ({
+  startTime: getUnixTime(sub(now, { [range.unit]: range.amount })),
+  endTime: getUnixTime(now),
+  // The unit doubles as the axis-label granularity, as it always has.
+  format: range.unit,
+  range
+})

--- a/ui/src/components/Resources/utils/timeRangeOptions.ts
+++ b/ui/src/components/Resources/utils/timeRangeOptions.ts
@@ -1,0 +1,80 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import type { Duration } from 'date-fns'
+
+export interface TimeOption {
+  label: string
+  /**
+   * A date-fns Duration. The values MUST be numbers, not strings: date-fns sums
+   * fields before applying them (`months + years * 12`, `days + weeks * 7`,
+   * `minutes + hours * 60`), and a string first operand makes `+` concatenate
+   * instead of add — so `{ minutes: '60' }` subtracted 600 minutes, not 60, and
+   * `{ days: '7' }` subtracted 70 days. Multiplication coerces, which is why only
+   * the hours-only options ever looked right.
+   */
+  time: Duration
+}
+
+/** Relative ranges offered by the time picker, newest first. */
+export const TIME_RANGE_OPTIONS: TimeOption[] = [
+  { label: 'Last hour', time: { hours: 1 }},
+  { label: 'Last 2 hours', time: { hours: 2 }},
+  { label: 'Last 4 hours', time: { hours: 4 }},
+  { label: 'Last 8 hours', time: { hours: 8 }},
+  { label: 'Last 12 hours', time: { hours: 12 }},
+  { label: 'Last day', time: { hours: 24 }},
+  { label: 'Last two days', time: { hours: 48 }},
+  { label: 'Last week', time: { days: 7 }},
+  { label: 'Last month', time: { months: 1 }},
+  { label: 'Last three months', time: { months: 3 }},
+  { label: 'Last six months', time: { months: 6 }},
+  { label: 'Last year', time: { years: 1 }}
+]
+
+/** Hour-of-day choices for the custom range. */
+export const HOUR_OPTIONS: TimeOption[] = [
+  { label: '12 AM', time: { hours: 0 }},
+  { label: '1 AM', time: { hours: 1 }},
+  { label: '2 AM', time: { hours: 2 }},
+  { label: '3 AM', time: { hours: 3 }},
+  { label: '4 AM', time: { hours: 4 }},
+  { label: '5 AM', time: { hours: 5 }},
+  { label: '6 AM', time: { hours: 6 }},
+  { label: '7 AM', time: { hours: 7 }},
+  { label: '8 AM', time: { hours: 8 }},
+  { label: '9 AM', time: { hours: 9 }},
+  { label: '10 AM', time: { hours: 10 }},
+  { label: '11 AM', time: { hours: 11 }},
+  { label: '12 PM', time: { hours: 12 }},
+  { label: '1 PM', time: { hours: 13 }},
+  { label: '2 PM', time: { hours: 14 }},
+  { label: '3 PM', time: { hours: 15 }},
+  { label: '4 PM', time: { hours: 16 }},
+  { label: '5 PM', time: { hours: 17 }},
+  { label: '6 PM', time: { hours: 18 }},
+  { label: '7 PM', time: { hours: 19 }},
+  { label: '8 PM', time: { hours: 20 }},
+  { label: '9 PM', time: { hours: 21 }},
+  { label: '10 PM', time: { hours: 22 }},
+  { label: '11 PM', time: { hours: 23 }}
+]

--- a/ui/src/composables/useClipboard.ts
+++ b/ui/src/composables/useClipboard.ts
@@ -1,0 +1,70 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+/**
+ * Copy text to the clipboard, over HTTPS or plain HTTP.
+ *
+ * Extracted from ConfigurationHelper (which still re-exports it, so its callers
+ * are unchanged) so that copying does not require importing that module and its
+ * cronstrue / ip-regex / is-valid-domain dependencies.
+ *
+ * The fallback is not optional polish: `navigator.clipboard` exists only in a
+ * secure context, and an OpenNMS server reached over plain HTTP on anything but
+ * localhost is not one — so on a typical deployment the modern API is simply
+ * absent and the textarea path is what actually runs.
+ *
+ * Call this synchronously from the click handler. Both paths need the transient
+ * user activation that a click provides, and awaiting anything first can lose it.
+ */
+export const copyToClipboard = (text: string): Promise<void> => {
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(text)
+  }
+
+  const textArea = document.createElement('textarea')
+  textArea.value = text
+  // Park it outside the viewport so selecting it does not scroll the page.
+  textArea.style.position = 'fixed'
+  textArea.style.left = '-999999px'
+  textArea.style.top = '-999999px'
+  document.body.appendChild(textArea)
+  textArea.focus()
+  textArea.select()
+
+  return new Promise<void>((resolve, reject) => {
+    try {
+      if (document.execCommand('copy')) {
+        resolve()
+      } else {
+        reject(new Error('Copy command was rejected by the browser.'))
+      }
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error(String(error)))
+    } finally {
+      textArea.remove()
+    }
+  })
+}
+
+const useClipboard = () => ({ copyToClipboard })
+
+export default useClipboard

--- a/ui/src/composables/useDownload.ts
+++ b/ui/src/composables/useDownload.ts
@@ -36,7 +36,18 @@ const useDownload = () => {
     generateDownload(blob, name)
   }
 
-  return { downloadFile }
+  /**
+   * Download an already-built Blob (e.g. a client-generated CSV or PDF) under
+   * the given name, reusing the same anchor mechanism as downloadFile.
+   *
+   * @param  {Blob}    blob  the file contents
+   * @param  {string}  name  the download filename
+   */
+  const downloadBlob = (blob: Blob, name: string): void => {
+    generateDownload(blob, name)
+  }
+
+  return { downloadFile, downloadBlob }
 }
 
 export default useDownload

--- a/ui/src/containers/AdhocGraphs.vue
+++ b/ui/src/containers/AdhocGraphs.vue
@@ -1,0 +1,28 @@
+<template>
+  <div id="adhoc-card">
+    <AdhocGraphBuilder :viewOnly="viewOnly" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import AdhocGraphBuilder from '@/components/AdhocGraphs/AdhocGraphBuilder.vue'
+
+// Set by the /adhoc-graphs/view route, which renders the graph on its own.
+withDefaults(defineProps<{ viewOnly?: boolean }>(), { viewOnly: false })
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/onms-elevation';
+
+#adhoc-card {
+  @include onms-elevation(2);
+  background: var(--p-content-background);
+  padding: 15px;
+  height: calc(100vh - 110px);
+  // The builder owns scrolling: it scrolls as a whole while building, and not at
+  // all once expanded, where the chart is sized to the space that is left.
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -189,6 +189,19 @@ const router = createRouter({
       component: () => import('@/containers/NodeDetails.vue')
     },
     {
+      path: '/adhoc-graphs',
+      name: 'AdhocGraphs',
+      component: () => import('@/containers/AdhocGraphs.vue')
+    },
+    {
+      // Graph-only view of an ad-hoc graph, rendered entirely from the query
+      // string. This is what the builder's pop-out button opens in a new tab.
+      path: '/adhoc-graphs/view',
+      name: 'AdhocGraphsView',
+      component: () => import('@/containers/AdhocGraphs.vue'),
+      props: { viewOnly: true }
+    },
+    {
       path: '/resource-graphs',
       name: 'ResourceGraphs',
       component: () => import('@/containers/ResourceGraphs.vue'),

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -66,7 +66,7 @@ import { getLogs, getLog } from './logsService'
 import { getWhoAmI } from './whoAmIService'
 import { getInfo } from './infoService'
 import { getOpenApiV1, getOpenApi } from './helpService'
-import { getResources, getResourceForNode } from './resourceService'
+import { getResources, getResourceForNode, getResourceById } from './resourceService'
 import { getPlugins } from './pluginService'
 import {
   getUsageStatistics,
@@ -118,6 +118,7 @@ export default {
   getPreFabGraphs,
   getDefinitionData,
   getResourceForNode,
+  getResourceById,
   getGraphDefinitionsByResourceId,
   getPlugins,
   getServiceTypes,

--- a/ui/src/services/resourceService.ts
+++ b/ui/src/services/resourceService.ts
@@ -53,4 +53,25 @@ const getResourceForNode = async (name: string): Promise<Resource | null> => {
   }
 }
 
-export { getResources, getResourceForNode }
+/**
+ * Full detail (including rrdGraphAttributes) for a single resource.
+ *
+ * Resource ids embed brackets and may contain spaces or other reserved characters
+ * (e.g. `node[1].hrStorageIndex[C: Label]`), so the id is percent-encoded rather
+ * than interpolated raw the way the older graph endpoints do.
+ */
+const getResourceById = async (id: string): Promise<Resource | null> => {
+  try {
+    const resp = await rest.get(`${endpoint}/${encodeURIComponent(id)}`)
+
+    if (resp.status === 204) {
+      return null
+    }
+
+    return resp.data
+  } catch (_err) {
+    return null
+  }
+}
+
+export { getResources, getResourceForNode, getResourceById }

--- a/ui/src/stores/adhocGraphStore.ts
+++ b/ui/src/stores/adhocGraphStore.ts
@@ -36,6 +36,28 @@ export const nodeCriteriaOf = (resourceId: string): string | null => {
   return match?.[1] ?? null
 }
 
+/**
+ * Characters that are FIQL syntax rather than data: the boolean separators, the
+ * comparison operators, grouping parentheses and the wildcard.
+ */
+const FIQL_SYNTAX = /[,;()=!<>~*]/g
+
+/**
+ * Make a free-text search box safe to interpolate into a FIQL filter.
+ *
+ * `label==*<term>*` is string concatenation, so a comma or semicolon typed in the
+ * box used to terminate the comparison and produce a malformed filter — the
+ * request failed and the picker simply went empty with nothing to explain it.
+ *
+ * The offending characters are dropped rather than escaped: they are FIQL
+ * grammar, not values, and node labels are host names that do not contain them.
+ * Dropping them searches for the rest of what was typed, which is what a search
+ * box is expected to do. (If CXF's FIQL parser turns out to support quoted
+ * values, quoting would be strictly better — this is a guard, not real escaping.)
+ */
+export const toFiqlSearchTerm = (term: string): string =>
+  term.replace(FIQL_SYNTAX, ' ').trim().replace(/\s+/g, ' ')
+
 /** Page size for the node picker's server-side search. */
 const NODE_SEARCH_LIMIT = 100
 
@@ -46,19 +68,32 @@ const NODE_SEARCH_LIMIT = 100
  */
 const FETCH_CONCURRENCY = 6
 
-/** Run `worker` over `items`, at most `limit` in flight, preserving input order. */
+/**
+ * Run `worker` over `items`, at most `limit` in flight, preserving input order.
+ *
+ * Each item is isolated: a worker that rejects yields `null` for that item and the
+ * rest still complete. Without this the whole batch rides on the service functions
+ * never throwing — and one rejection would escape Promise.all, propagate out of
+ * loadResources, and strand `resourcesLoading` at true with a spinner that never
+ * stops. One unreachable resource should cost that resource, not the page.
+ */
 const mapWithConcurrency = async <T, R>(
   items: T[],
   limit: number,
   worker: (item: T) => Promise<R>
-): Promise<R[]> => {
-  const results = new Array<R>(items.length)
+): Promise<(R | null)[]> => {
+  const results = new Array<R | null>(items.length).fill(null)
   let cursor = 0
 
   const runner = async () => {
     while (cursor < items.length) {
       const index = cursor++
-      results[index] = await worker(items[index])
+
+      try {
+        results[index] = await worker(items[index])
+      } catch (_error) {
+        results[index] = null
+      }
     }
   }
 
@@ -111,10 +146,10 @@ export const useAdhocGraphStore = defineStore('adhocGraphStore', () => {
       order: SORT.ASCENDING
     }
 
-    const trimmed = term.trim()
+    const searchable = toFiqlSearchTerm(term)
 
-    if (trimmed) {
-      queryParameters._s = `label==*${trimmed}*`
+    if (searchable) {
+      queryParameters._s = `label==*${searchable}*`
     }
 
     const resp = await API.getNodes(queryParameters)
@@ -156,11 +191,19 @@ export const useAdhocGraphStore = defineStore('adhocGraphStore', () => {
 
     resourcesLoading.value = true
 
-    const responses = await mapWithConcurrency(
-      nodes,
-      FETCH_CONCURRENCY,
-      node => API.getResourceForNode(node.id).then(resource => ({ node, resource }))
-    )
+    let responses
+    try {
+      responses = await mapWithConcurrency(
+        nodes,
+        FETCH_CONCURRENCY,
+        node => API.getResourceForNode(node.id).then(resource => ({ node, resource }))
+      )
+    } catch (_error) {
+      // mapWithConcurrency isolates per item, so this is unreachable in practice —
+      // it is here so no future change can leave the spinner running forever.
+      resourcesLoading.value = false
+      return
+    }
 
     if (requestId !== resourceRequestId) {
       return
@@ -168,7 +211,13 @@ export const useAdhocGraphStore = defineStore('adhocGraphStore', () => {
 
     const options: AdhocResourceOption[] = []
 
-    for (const { node, resource } of responses) {
+    for (const response of responses) {
+      // null means that node's lookup failed; the others still populate.
+      if (!response) {
+        continue
+      }
+
+      const { node, resource } = response
       const children = (resource as Resource | null)?.children?.resource ?? []
 
       for (const child of children) {
@@ -212,11 +261,17 @@ export const useAdhocGraphStore = defineStore('adhocGraphStore', () => {
 
     datasourcesLoading.value = true
 
-    const responses = await mapWithConcurrency(
-      resources,
-      FETCH_CONCURRENCY,
-      resource => API.getResourceById(resource.id).then(detail => ({ resource, detail }))
-    )
+    let responses
+    try {
+      responses = await mapWithConcurrency(
+        resources,
+        FETCH_CONCURRENCY,
+        resource => API.getResourceById(resource.id).then(detail => ({ resource, detail }))
+      )
+    } catch (_error) {
+      datasourcesLoading.value = false
+      return
+    }
 
     if (requestId !== datasourceRequestId) {
       return
@@ -224,7 +279,12 @@ export const useAdhocGraphStore = defineStore('adhocGraphStore', () => {
 
     const options: AdhocDatasourceOption[] = []
 
-    for (const { resource, detail } of responses) {
+    for (const response of responses) {
+      if (!response) {
+        continue
+      }
+
+      const { resource, detail } = response
       const attributes = Object.keys((detail as Resource | null)?.rrdGraphAttributes ?? {}).sort()
 
       for (const attribute of attributes) {
@@ -335,10 +395,12 @@ export const useAdhocGraphStore = defineStore('adhocGraphStore', () => {
     const nodes: AdhocNodeOption[] = []
     const options: AdhocResourceOption[] = []
 
-    for (const { criterion, resource } of responses) {
-      if (!resource) {
+    for (const response of responses) {
+      if (!response?.resource) {
         continue
       }
+
+      const { criterion, resource } = response
 
       nodes.push({ id: criterion, label: resource.label })
 

--- a/ui/src/stores/adhocGraphStore.ts
+++ b/ui/src/stores/adhocGraphStore.ts
@@ -1,0 +1,451 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import API from '@/services'
+import { GraphMetricsPayload, GraphMetricsResponse, QueryParameters, Resource, SORT } from '@/types'
+import { AdhocDatasourceOption, AdhocNodeOption, AdhocResourceOption } from '@/types/adhocGraph'
+
+/**
+ * The node a resource belongs to, as `m_nodeDao.get()` accepts it — a bare node id
+ * from `node[1].interfaceSnmp[eth0]`, or a foreign-source pair from
+ * `nodeSource[Demo:1].interfaceSnmp[eth0]`.
+ */
+export const nodeCriteriaOf = (resourceId: string): string | null => {
+  const match = /^(?:node|nodeSource)\[([^\]]+)\]/.exec(resourceId)
+  return match?.[1] ?? null
+}
+
+/** Page size for the node picker's server-side search. */
+const NODE_SEARCH_LIMIT = 100
+
+/**
+ * How many resource/datasource lookups run at once. Each selected resource costs
+ * one GET, so a "select all" on a switch with 400 interfaces would otherwise open
+ * 400 sockets at once and get throttled or dropped.
+ */
+const FETCH_CONCURRENCY = 6
+
+/** Run `worker` over `items`, at most `limit` in flight, preserving input order. */
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> => {
+  const results = new Array<R>(items.length)
+  let cursor = 0
+
+  const runner = async () => {
+    while (cursor < items.length) {
+      const index = cursor++
+      results[index] = await worker(items[index])
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => runner())
+  )
+
+  return results
+}
+
+export const useAdhocGraphStore = defineStore('adhocGraphStore', () => {
+  const nodeOptions = ref<AdhocNodeOption[]>([])
+  const selectedNodes = ref<AdhocNodeOption[]>([])
+  const nodesLoading = ref(false)
+
+  const resourceOptions = ref<AdhocResourceOption[]>([])
+  const selectedResources = ref<AdhocResourceOption[]>([])
+  const resourcesLoading = ref(false)
+
+  const datasourceOptions = ref<AdhocDatasourceOption[]>([])
+  const selectedDatasources = ref<AdhocDatasourceOption[]>([])
+  const datasourcesLoading = ref(false)
+
+  const measurements = ref<GraphMetricsResponse | null>(null)
+  const queryLoading = ref(false)
+  const queryError = ref('')
+
+  // Monotonic request ids, following the pattern in nodeStore: a response is only
+  // applied when no newer request of the same kind has started since it was issued.
+  // Every list here is driven by free-text typing or multi-select clicks, so
+  // out-of-order responses are the normal case, not an edge case.
+  let nodeRequestId = 0
+  let resourceRequestId = 0
+  let datasourceRequestId = 0
+  let queryRequestId = 0
+
+  /**
+   * Search nodes server-side. The picker never pulls the whole node table — an
+   * install with six figures of nodes has to stay usable — so the list is always
+   * the top `NODE_SEARCH_LIMIT` matches for the current term.
+   */
+  const searchNodes = async (term: string) => {
+    const requestId = ++nodeRequestId
+    nodesLoading.value = true
+
+    const queryParameters: QueryParameters = {
+      limit: NODE_SEARCH_LIMIT,
+      offset: 0,
+      orderBy: 'label',
+      order: SORT.ASCENDING
+    }
+
+    const trimmed = term.trim()
+
+    if (trimmed) {
+      queryParameters._s = `label==*${trimmed}*`
+    }
+
+    const resp = await API.getNodes(queryParameters)
+
+    if (requestId !== nodeRequestId) {
+      return
+    }
+
+    const found = resp ? resp.node.map(node => ({ id: String(node.id), label: node.label })) : []
+    const selectedIds = new Set(selectedNodes.value.map(node => node.id))
+
+    // Selected nodes are pinned to the top and never dropped by a later search.
+    // Without this, choosing a node and then searching for a different one hides
+    // the first — and a restored link, whose nodes are rarely in the default page,
+    // would show nothing selected at all.
+    nodeOptions.value = [
+      ...selectedNodes.value,
+      ...found.filter(node => !selectedIds.has(node.id))
+    ]
+    nodesLoading.value = false
+  }
+
+  /**
+   * Replace the resource list with the children of every selected node.
+   *
+   * Selections below this level are pruned rather than cleared: dropping one node
+   * must not throw away the resources and datasources chosen on the others.
+   */
+  const loadResources = async () => {
+    const requestId = ++resourceRequestId
+    const nodes = [...selectedNodes.value]
+
+    if (!nodes.length) {
+      resourceOptions.value = []
+      resourcesLoading.value = false
+      await pruneResourceSelection()
+      return
+    }
+
+    resourcesLoading.value = true
+
+    const responses = await mapWithConcurrency(
+      nodes,
+      FETCH_CONCURRENCY,
+      node => API.getResourceForNode(node.id).then(resource => ({ node, resource }))
+    )
+
+    if (requestId !== resourceRequestId) {
+      return
+    }
+
+    const options: AdhocResourceOption[] = []
+
+    for (const { node, resource } of responses) {
+      const children = (resource as Resource | null)?.children?.resource ?? []
+
+      for (const child of children) {
+        options.push({
+          id: child.id,
+          label: child.label,
+          typeLabel: child.typeLabel || 'Other',
+          nodeId: node.id,
+          nodeLabel: resource?.label || node.label
+        })
+      }
+    }
+
+    resourceOptions.value = options
+    resourcesLoading.value = false
+    await pruneResourceSelection()
+  }
+
+  const pruneResourceSelection = async () => {
+    const available = new Set(resourceOptions.value.map(option => option.id))
+    const kept = selectedResources.value.filter(resource => available.has(resource.id))
+
+    if (kept.length !== selectedResources.value.length) {
+      selectedResources.value = kept
+    }
+
+    await loadDatasources()
+  }
+
+  /** Replace the datasource list with the graphable attributes of every selected resource. */
+  const loadDatasources = async () => {
+    const requestId = ++datasourceRequestId
+    const resources = [...selectedResources.value]
+
+    if (!resources.length) {
+      datasourceOptions.value = []
+      datasourcesLoading.value = false
+      pruneDatasourceSelection()
+      return
+    }
+
+    datasourcesLoading.value = true
+
+    const responses = await mapWithConcurrency(
+      resources,
+      FETCH_CONCURRENCY,
+      resource => API.getResourceById(resource.id).then(detail => ({ resource, detail }))
+    )
+
+    if (requestId !== datasourceRequestId) {
+      return
+    }
+
+    const options: AdhocDatasourceOption[] = []
+
+    for (const { resource, detail } of responses) {
+      const attributes = Object.keys((detail as Resource | null)?.rrdGraphAttributes ?? {}).sort()
+
+      for (const attribute of attributes) {
+        options.push({
+          key: `${resource.id}|${attribute}`,
+          resourceId: resource.id,
+          resourceLabel: resource.label,
+          nodeId: resource.nodeId,
+          nodeLabel: resource.nodeLabel,
+          attribute
+        })
+      }
+    }
+
+    datasourceOptions.value = options
+    datasourcesLoading.value = false
+    pruneDatasourceSelection()
+  }
+
+  const pruneDatasourceSelection = () => {
+    const available = new Set(datasourceOptions.value.map(option => option.key))
+    const kept = selectedDatasources.value.filter(datasource => available.has(datasource.key))
+
+    if (kept.length !== selectedDatasources.value.length) {
+      selectedDatasources.value = kept
+    }
+  }
+
+  const setSelectedNodes = async (nodes: AdhocNodeOption[]) => {
+    selectedNodes.value = nodes
+    await loadResources()
+  }
+
+  const setSelectedResources = async (resources: AdhocResourceOption[]) => {
+    selectedResources.value = resources
+    await loadDatasources()
+  }
+
+  const setSelectedDatasources = (datasources: AdhocDatasourceOption[]) => {
+    selectedDatasources.value = datasources
+  }
+
+  /**
+   * Adopt datasources directly, without walking the cascade.
+   *
+   * Used as the fallback when a link names a resource the server no longer has:
+   * the stand-in keeps the series in the picker and in the graph (the query is
+   * relaxed, so it comes back as NaN) instead of silently dropping it.
+   */
+  const adoptDatasources = (datasources: AdhocDatasourceOption[]) => {
+    const byKey = new Map(datasourceOptions.value.map(option => [option.key, option]))
+
+    for (const datasource of datasources) {
+      if (!byKey.has(datasource.key)) {
+        byKey.set(datasource.key, datasource)
+      }
+    }
+
+    datasourceOptions.value = [...byKey.values()]
+    selectedDatasources.value = datasources.map(datasource => byKey.get(datasource.key) as AdhocDatasourceOption)
+  }
+
+  /**
+   * Rebuild the whole selection from the resource/attribute pairs in a shared link.
+   *
+   * A link carries only resource ids and attribute names, so the node and resource
+   * panes have nothing to show unless the cascade is walked backwards: derive the
+   * node from each resource id, fetch it for its label and children, then mark the
+   * referenced resources and datasources as selected. Anything the server no longer
+   * knows about falls back to a stand-in rather than vanishing from the graph.
+   */
+  const restoreSelection = async (sources: { resourceId: string, attribute: string }[]) => {
+    const resourceIds = [...new Set(sources.map(source => source.resourceId))]
+    const criteria = [...new Set(
+      resourceIds.map(nodeCriteriaOf).filter((value): value is string => Boolean(value))
+    )]
+
+    const wantedKeys = new Set(sources.map(source => `${source.resourceId}|${source.attribute}`))
+
+    const standIns = (): AdhocDatasourceOption[] => sources.map(source => ({
+      key: `${source.resourceId}|${source.attribute}`,
+      resourceId: source.resourceId,
+      resourceLabel: source.resourceId,
+      nodeId: nodeCriteriaOf(source.resourceId) ?? '',
+      nodeLabel: '',
+      attribute: source.attribute
+    }))
+
+    if (!criteria.length) {
+      adoptDatasources(standIns())
+      return
+    }
+
+    // Claim the cascade so a search or selection made while this is in flight wins.
+    const requestId = ++resourceRequestId
+    resourcesLoading.value = true
+
+    const responses = await mapWithConcurrency(
+      criteria,
+      FETCH_CONCURRENCY,
+      criterion => API.getResourceForNode(criterion).then(resource => ({ criterion, resource }))
+    )
+
+    if (requestId !== resourceRequestId) {
+      return
+    }
+
+    const nodes: AdhocNodeOption[] = []
+    const options: AdhocResourceOption[] = []
+
+    for (const { criterion, resource } of responses) {
+      if (!resource) {
+        continue
+      }
+
+      nodes.push({ id: criterion, label: resource.label })
+
+      for (const child of resource.children?.resource ?? []) {
+        options.push({
+          id: child.id,
+          label: child.label,
+          typeLabel: child.typeLabel || 'Other',
+          nodeId: criterion,
+          nodeLabel: resource.label
+        })
+      }
+    }
+
+    selectedNodes.value = nodes
+
+    // Show the restored nodes at the top of the picker. They are rarely in the
+    // default first page of results, so without this the pane would look empty
+    // even though the nodes are selected.
+    const restoredIds = new Set(nodes.map(node => node.id))
+    nodeOptions.value = [
+      ...nodes,
+      ...nodeOptions.value.filter(node => !restoredIds.has(node.id))
+    ]
+
+    resourceOptions.value = options
+    selectedResources.value = options.filter(option => resourceIds.includes(option.id))
+    resourcesLoading.value = false
+
+    await loadDatasources()
+
+    const available = new Map(datasourceOptions.value.map(option => [option.key, option]))
+    const missing = standIns().filter(standIn => !available.has(standIn.key))
+
+    if (missing.length) {
+      for (const standIn of missing) {
+        available.set(standIn.key, standIn)
+      }
+      datasourceOptions.value = [...available.values()]
+    }
+
+    selectedDatasources.value = [...available.values()].filter(option => wantedKeys.has(option.key))
+  }
+
+  const runQuery = async (payload: GraphMetricsPayload) => {
+    const requestId = ++queryRequestId
+    queryLoading.value = true
+    queryError.value = ''
+
+    const resp = await API.getGraphMetrics(payload)
+
+    if (requestId !== queryRequestId) {
+      return
+    }
+
+    if (resp) {
+      measurements.value = resp
+    } else {
+      measurements.value = null
+      queryError.value = 'Could not retrieve measurements for this selection.'
+    }
+
+    queryLoading.value = false
+  }
+
+  const clearAll = () => {
+    // Bump every request id so responses still in flight are discarded rather than
+    // repopulating the lists the user just cleared.
+    nodeRequestId++
+    resourceRequestId++
+    datasourceRequestId++
+    queryRequestId++
+
+    selectedNodes.value = []
+    selectedResources.value = []
+    selectedDatasources.value = []
+    resourceOptions.value = []
+    datasourceOptions.value = []
+    measurements.value = null
+    queryError.value = ''
+    resourcesLoading.value = false
+    datasourcesLoading.value = false
+    queryLoading.value = false
+  }
+
+  return {
+    nodeOptions,
+    selectedNodes,
+    nodesLoading,
+    resourceOptions,
+    selectedResources,
+    resourcesLoading,
+    datasourceOptions,
+    selectedDatasources,
+    datasourcesLoading,
+    measurements,
+    queryLoading,
+    queryError,
+    searchNodes,
+    loadResources,
+    loadDatasources,
+    setSelectedNodes,
+    setSelectedResources,
+    setSelectedDatasources,
+    adoptDatasources,
+    restoreSelection,
+    runQuery,
+    clearAll
+  }
+})

--- a/ui/src/types/adhocGraph.ts
+++ b/ui/src/types/adhocGraph.ts
@@ -1,0 +1,100 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { ConsolidationFunctionType } from '@/types/timeSeries'
+
+/**
+ * How a single series is drawn, named after the RRDtool draw commands these map
+ * onto: `line`/`line2`/`line3` are LINE1/LINE2/LINE3 and differ only in stroke
+ * weight, exactly as they do in a prefab graph definition.
+ *
+ * Chart.js has no native "stack" type (stacking is a scale-level concern), so
+ * `stack` means "filled area, and switch the y scale to stacked", matching how the
+ * prefab graphs express AREA vs STACK.
+ */
+export type AdhocSeriesStyle = 'line' | 'line2' | 'line3' | 'area' | 'stack'
+
+/** A node that can be expanded into resources. */
+export interface AdhocNodeOption {
+  id: string
+  label: string
+}
+
+/** A resource beneath a node, as returned by /rest/resources/fornode/{nodeCriteria}. */
+export interface AdhocResourceOption {
+  id: string
+  label: string
+  typeLabel: string
+  nodeId: string
+  nodeLabel: string
+}
+
+/**
+ * One graphable attribute on one resource. `key` is the selection identity used
+ * everywhere (list selection, series lookup, URL state) — a resource id alone is not
+ * unique because a resource exposes many attributes.
+ */
+export interface AdhocDatasourceOption {
+  key: string
+  resourceId: string
+  resourceLabel: string
+  nodeId: string
+  nodeLabel: string
+  attribute: string
+}
+
+/**
+ * A plotted source series. `label` doubles as the JEXL identifier an expression can
+ * reference, so it is sanitized and unique across the config (see adhocQuery.ts).
+ * `hidden` maps to the measurements API's `transient` flag: fetch the data so
+ * expressions can use it, but do not return it as a column to plot.
+ */
+export interface AdhocSeries {
+  key: string
+  label: string
+  resourceId: string
+  attribute: string
+  aggregation: ConsolidationFunctionType
+  color: string
+  style: AdhocSeriesStyle
+  hidden: boolean
+}
+
+/** A derived series computed server-side from source labels via a JEXL expression. */
+export interface AdhocExpression {
+  id: string
+  label: string
+  value: string
+  color: string
+  style: AdhocSeriesStyle
+}
+
+/** Everything that defines an ad-hoc graph, minus the time range. */
+export interface AdhocGraphConfig {
+  series: AdhocSeries[]
+  expressions: AdhocExpression[]
+  title: string
+  verticalLabel: string
+  stacked: boolean
+  /** Target number of data points across the range; drives the computed step. */
+  resolution: number
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -482,6 +482,10 @@ export interface GraphMetricsPayload {
   step: number
   source: Metric[]
   expression?: { label: string; transient: boolean; value: string }[]
+  /** Cap on returned rows; the server downsamples further if the step would exceed it. */
+  maxrows?: number
+  /** When true a missing/unknown source yields NaNs instead of failing the whole query. */
+  relaxed?: boolean
 }
 
 export interface GraphDefinition {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -423,10 +423,24 @@ export interface AppInfo {
   version: string
 }
 
+/**
+ * A window anchored to "now" rather than to fixed instants — the thing a user
+ * actually picks when they choose "Last two days". Carried alongside the resolved
+ * timestamps so the window can be recomputed later: a bookmarked link, or a
+ * Refresh minutes after the selection, both need the LATEST two days, not the two
+ * days that were current when the choice was made.
+ */
+export interface RelativeTimeRange {
+  unit: 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'years'
+  amount: number
+}
+
 export interface StartEndTime {
   startTime: string | number
   endTime: string | number
   format: string
+  /** Present when the window came from a relative range and can be re-resolved. */
+  range?: RelativeTimeRange
 }
 
 export interface ResourceDefinitionsApiResponse extends ApiResponse {

--- a/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
+++ b/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
@@ -277,6 +277,121 @@ describe('AdhocGraphBuilder', () => {
     })
   })
 
+  describe('relative time ranges', () => {
+    const selectOne = async (store: ReturnType<typeof useAdhocGraphStore>) => {
+      await store.setSelectedNodes([{ id: '1', label: 'switch-01' }])
+      await flushPromises()
+      await store.setSelectedResources([store.resourceOptions[0]])
+      await flushPromises()
+      store.setSelectedDatasources([store.datasourceOptions[0]])
+      await flushPromises()
+    }
+
+    const windowOf = (call: number) => {
+      const payload = getGraphMetrics.mock.calls[call][0]
+      return { start: payload.start, end: payload.end, span: payload.end - payload.start }
+    }
+
+    it('defaults to a relative window rather than a frozen one', async () => {
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOne(store)
+
+      await wrapper.find('[data-test="toolbar-refresh"]').trigger('click')
+      await flushPromises()
+
+      expect(getGraphMetrics).toHaveBeenCalled()
+      // 24h default.
+      expect(windowOf(getGraphMetrics.mock.calls.length - 1).span).toBe(24 * 3600 * 1000)
+    })
+
+    // The reported bug: a bookmark held the instants current when it was made.
+    it('resolves a bookmarked range against the clock now, not when it was saved', async () => {
+      routeQuery = {
+        s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~0`,
+        range: 'hours:2'
+      }
+
+      const before = Date.now()
+      mountBuilder()
+      await flushPromises()
+
+      const { start, end, span } = windowOf(0)
+      expect(span).toBe(2 * 3600 * 1000)
+      // The window ends about now — not at some timestamp baked into the link.
+      expect(end).toBeGreaterThanOrEqual(before - 5000)
+      expect(start).toBe(end - span)
+    })
+
+    it('still honours an absolute range from a custom-time link', async () => {
+      routeQuery = {
+        s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~0`,
+        start: '1704067200',
+        end: '1704070800'
+      }
+
+      mountBuilder()
+      await flushPromises()
+
+      expect(windowOf(0).start).toBe(1_704_067_200_000)
+      expect(windowOf(0).end).toBe(1_704_070_800_000)
+    })
+
+    // Also broken before: Refresh re-sent the window captured at selection time.
+    it('slides the window forward on Refresh', async () => {
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOne(store)
+      await wrapper.find('[data-test="toolbar-refresh"]').trigger('click')
+      await flushPromises()
+
+      const first = windowOf(getGraphMetrics.mock.calls.length - 1)
+
+      vi.setSystemTime(new Date(Date.now() + 3_600_000))
+      await wrapper.find('[data-test="toolbar-refresh"]').trigger('click')
+      await flushPromises()
+
+      const second = windowOf(getGraphMetrics.mock.calls.length - 1)
+      expect(second.end - first.end).toBeGreaterThanOrEqual(3_500_000)
+      expect(second.span).toBe(first.span)
+      vi.useRealTimers()
+    })
+
+    it('does not slide an absolute window on Refresh', async () => {
+      routeQuery = {
+        s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~0`,
+        start: '1704067200',
+        end: '1704070800'
+      }
+
+      const { wrapper } = mountBuilder()
+      await flushPromises()
+
+      vi.setSystemTime(new Date(Date.now() + 3_600_000))
+      await wrapper.find('[data-test="toolbar-refresh"]').trigger('click')
+      await flushPromises()
+
+      const last = windowOf(getGraphMetrics.mock.calls.length - 1)
+      expect(last.start).toBe(1_704_067_200_000)
+      expect(last.end).toBe(1_704_070_800_000)
+      vi.useRealTimers()
+    })
+
+    it('shares a relative link as a range, not as instants', async () => {
+      copyToClipboard.mockResolvedValue(undefined)
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOne(store)
+
+      await wrapper.find('[data-test="toolbar-share"]').trigger('click')
+      await flushPromises()
+
+      const url = decodeURIComponent(copyToClipboard.mock.calls[0][0] as string)
+      expect(url).toContain('range=hours:24')
+      expect(url).not.toContain('start=')
+    })
+  })
+
   describe('the Series and Expressions panels', () => {
     const panels = (wrapper: ReturnType<typeof mount>) =>
       Object.fromEntries(wrapper.findAllComponents({ name: 'OnmsPanel' })

--- a/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
+++ b/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
@@ -26,6 +26,11 @@ vi.mock('@/services', () => ({
 let routeQuery: Record<string, unknown> = {}
 const routerReplace = vi.fn()
 const copyToClipboard = vi.fn()
+const showSnackBar = vi.fn()
+
+vi.mock('@/composables/useSnackbar', () => ({
+  default: () => ({ showSnackBar, hideSnackbar: vi.fn() })
+}))
 
 vi.mock('@/composables/useClipboard', () => ({
   copyToClipboard: (text: string) => copyToClipboard(text),
@@ -219,6 +224,78 @@ describe('AdhocGraphBuilder', () => {
     await flushPromises()
 
     expect(routerReplace).not.toHaveBeenCalled()
+  })
+
+  // Blanking the address bar silently meant a large graph quietly stopped being
+  // bookmarkable, with no signal until someone tried to copy the link.
+  describe('outgrowing the URL', () => {
+    /**
+     * Overflow MAX_QUERY_LENGTH (6000) with as few series as possible: a handful of
+     * very long resource ids rather than a hundred short ones, so the reconcile and
+     * encode work stays small enough not to time out under full-suite load.
+     */
+    const manySeries = (store: ReturnType<typeof useAdhocGraphStore>, count: number) =>
+      store.setSelectedDatasources(Array.from({ length: count }, (_unused, index) => {
+        const resourceId = `node[${index}].interfaceSnmp[${'Gigabit0-0-'.repeat(30)}${index}]`
+        return {
+          key: `${resourceId}|ifHCInOctets`,
+          resourceId,
+          resourceLabel: `interface-${index}`,
+          nodeId: String(index),
+          nodeLabel: `switch-${index}`,
+          attribute: 'ifHCInOctets'
+        }
+      }))
+
+    /**
+     * Poll until `check` holds. The URL writer is debounced behind real promises,
+     * so fake timers make this test depend on how many microtask turns the machine
+     * happens to need — it passed alone and failed under full-suite load.
+     */
+    const waitFor = async (check: () => boolean, timeoutMs = 3000) => {
+      const deadline = Date.now() + timeoutMs
+      while (Date.now() < deadline) {
+        await flushPromises()
+        if (check()) {
+          return
+        }
+        await new Promise(resolve => setTimeout(resolve, 25))
+      }
+      throw new Error('condition never held')
+    }
+
+    const warnings = () => showSnackBar.mock.calls
+      .filter(call => String((call[0] as { msg?: string })?.msg ?? '').includes('too many series'))
+
+    it('clears the query and says so once the graph will not fit', async () => {
+      // Something in the address bar to clear, but not enough to trigger hydration.
+      routeQuery = { title: 'WAN traffic' }
+      const { store } = mountBuilder()
+      await flushPromises()
+
+      manySeries(store, 20)
+      await waitFor(() => warnings().length > 0)
+
+      // The address bar is cleared rather than left describing a stale graph...
+      expect(routerReplace).toHaveBeenCalledWith({ query: {}})
+      // ...and the user is told, rather than discovering it at copy time.
+      expect(warnings()[0][0]).toEqual(expect.objectContaining({ error: true }))
+    }, 20000)
+
+    it('warns once, not on every edit', async () => {
+      const { store } = mountBuilder()
+      await flushPromises()
+
+      manySeries(store, 20)
+      await waitFor(() => warnings().length > 0)
+
+      manySeries(store, 22)
+      await waitFor(() => routerReplace.mock.calls.length > 0 || true)
+      await new Promise(resolve => setTimeout(resolve, 600))
+      await flushPromises()
+
+      expect(warnings()).toHaveLength(1)
+    }, 20000)
   })
 
   describe('the copy-link button', () => {

--- a/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
+++ b/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
@@ -1,0 +1,507 @@
+import { createTestingPinia } from '@pinia/testing'
+import { flushPromises, mount } from '@vue/test-utils'
+import { setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import { defineComponent, h } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AdhocGraphBuilder from '@/components/AdhocGraphs/AdhocGraphBuilder.vue'
+import { useAdhocGraphStore } from '@/stores/adhocGraphStore'
+import { useMenuStore } from '@/stores/menuStore'
+
+const getNodes = vi.fn()
+const getResourceForNode = vi.fn()
+const getResourceById = vi.fn()
+const getGraphMetrics = vi.fn()
+
+vi.mock('@/services', () => ({
+  default: {
+    getNodes: (...args: unknown[]) => getNodes(...args),
+    getResourceForNode: (...args: unknown[]) => getResourceForNode(...args),
+    getResourceById: (...args: unknown[]) => getResourceById(...args),
+    getGraphMetrics: (...args: unknown[]) => getGraphMetrics(...args)
+  }
+}))
+
+let routeQuery: Record<string, unknown> = {}
+const routerReplace = vi.fn()
+const copyToClipboard = vi.fn()
+
+vi.mock('@/composables/useClipboard', () => ({
+  copyToClipboard: (text: string) => copyToClipboard(text),
+  default: () => ({ copyToClipboard })
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(() => ({
+    path: '/adhoc-graphs',
+    get query() {
+      return routeQuery
+    }
+  })),
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: routerReplace }))
+}))
+
+// Chart.js needs a real 2d context; happy-dom's canvas has none. The chart itself
+// is covered by the adhocQuery unit tests — what matters here is the page wiring.
+vi.mock('@/components/AdhocGraphs/AdhocChart.vue', () => ({
+  default: defineComponent({
+    name: 'AdhocChart',
+    props: {
+      config: { type: Object, required: true },
+      measurements: { type: Object, default: null },
+      time: { type: Object, required: true },
+      loading: { type: Boolean, default: false },
+      error: { type: String, default: '' },
+      expanded: { type: Boolean, default: false }
+    },
+    setup(_props, { expose }) {
+      expose({ exportTarget: () => null })
+      return () => h('div', { 'data-test': 'chart-stub' })
+    }
+  })
+}))
+
+const RESOURCE_ID = 'node[1].interfaceSnmp[eth0]'
+
+// Every mounted builder is torn down after its test: the URL sync and the query
+// are debounced, so a leaked instance's timer would otherwise fire during a later
+// test and call the shared router mock.
+const mounted: ReturnType<typeof mount>[] = []
+
+const mountBuilder = (props: Record<string, unknown> = {}) => {
+  const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+  setActivePinia(pinia)
+  useMenuStore().mainMenu = { homeUrl: '/opennms' } as never
+
+  const wrapper = mount(AdhocGraphBuilder, {
+    props,
+    global: {
+      plugins: [PrimeVue, pinia],
+      stubs: { BreadCrumbs: true, RouterLink: true }
+    }
+  })
+
+  mounted.push(wrapper)
+
+  return { wrapper, store: useAdhocGraphStore() }
+}
+
+describe('AdhocGraphBuilder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routeQuery = {}
+    // appStore reads the saved theme at setup; this happy-dom build does not put
+    // localStorage on the global, so give it a minimal stand-in.
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => undefined,
+      removeItem: () => undefined
+    })
+    getNodes.mockResolvedValue({ node: [{ id: '1', label: 'switch-01' }] })
+    getResourceForNode.mockResolvedValue({
+      id: 'node[1]',
+      label: 'switch-01',
+      children: { resource: [{ id: RESOURCE_ID, label: 'eth0', typeLabel: 'SNMP Interface Data' }] }
+    })
+    getResourceById.mockResolvedValue({ rrdGraphAttributes: { ifHCInOctets: {}, ifHCOutOctets: {}}})
+    getGraphMetrics.mockResolvedValue({ labels: ['x'], columns: [{ values: [1] }], timestamps: [0] })
+  })
+
+  afterEach(() => {
+    while (mounted.length) {
+      mounted.pop()?.unmount()
+    }
+  })
+
+  it('searches for nodes on mount and renders the three picker columns', async () => {
+    const { wrapper } = mountBuilder()
+    await flushPromises()
+
+    expect(getNodes).toHaveBeenCalled()
+    expect(wrapper.find('[data-test="nodes-list"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="resources-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="datasources-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="series-empty"]').exists()).toBe(true)
+  })
+
+  it('walks the node -> resource -> datasource cascade and builds a series row', async () => {
+    const { wrapper, store } = mountBuilder()
+    await flushPromises()
+
+    await store.setSelectedNodes([{ id: '1', label: 'switch-01' }])
+    await flushPromises()
+    expect(wrapper.find('[data-test="resources-list"]').exists()).toBe(true)
+
+    await store.setSelectedResources([store.resourceOptions[0]])
+    await flushPromises()
+    expect(store.datasourceOptions.map(option => option.attribute)).toEqual(['ifHCInOctets', 'ifHCOutOctets'])
+
+    store.setSelectedDatasources([store.datasourceOptions[0]])
+    await flushPromises()
+
+    const key = `${RESOURCE_ID}|ifHCInOctets`
+    expect(wrapper.find('[data-test="series-grid"]').exists()).toBe(true)
+    expect(wrapper.find(`[data-test="series-label-${key}"]`).exists()).toBe(true)
+  })
+
+  it('keeps an edited label when an unrelated datasource is added', async () => {
+    const { wrapper, store } = mountBuilder()
+    await flushPromises()
+
+    await store.setSelectedNodes([{ id: '1', label: 'switch-01' }])
+    await flushPromises()
+    await store.setSelectedResources([store.resourceOptions[0]])
+    await flushPromises()
+
+    store.setSelectedDatasources([store.datasourceOptions[0]])
+    await flushPromises()
+
+    const key = `${RESOURCE_ID}|ifHCInOctets`
+    const input = wrapper.find(`input[data-test="series-label-${key}"]`)
+    await input.setValue('renamed_by_hand')
+    await flushPromises()
+
+    // Ticking a second datasource must reconcile, not rebuild.
+    store.setSelectedDatasources([...store.datasourceOptions])
+    await flushPromises()
+
+    const labels = wrapper.findAll('input[data-test^="series-label-"]')
+      .map(field => (field.element as HTMLInputElement).value)
+
+    expect(labels).toContain('renamed_by_hand')
+    expect(labels).toHaveLength(2)
+  })
+
+  it('restores a shared link: series, title and time range', async () => {
+    routeQuery = {
+      s: `${RESOURCE_ID}~ifHCInOctets~MAX~in_octets~area~#2a78d6~0`,
+      start: '1704067200',
+      end: '1704070800',
+      fmt: 'hours',
+      title: 'WAN traffic'
+    }
+
+    const { wrapper, store } = mountBuilder()
+    await flushPromises()
+
+    expect(store.selectedDatasources.map(datasource => datasource.key)).toEqual([`${RESOURCE_ID}|ifHCInOctets`])
+
+    // Regression: a restored link used to populate only the datasource pane,
+    // leaving Nodes with nothing selected and Resources empty.
+    expect(store.selectedNodes.map(node => node.id)).toEqual(['1'])
+    expect(store.nodeOptions.map(node => node.id)).toContain('1')
+    expect(store.selectedResources.map(resource => resource.id)).toEqual([RESOURCE_ID])
+    expect(store.resourceOptions.map(resource => resource.id)).toContain(RESOURCE_ID)
+    expect(wrapper.find('[data-test="resources-list"]').exists()).toBe(true)
+
+    const titleField = wrapper.find('input[data-test="toolbar-title"]')
+    expect((titleField.element as HTMLInputElement).value).toBe('WAN traffic')
+
+    // Restoring a link must query immediately rather than waiting for a manual refresh.
+    expect(getGraphMetrics).toHaveBeenCalled()
+    const payload = getGraphMetrics.mock.calls[0][0]
+    expect(payload.start).toBe(1_704_067_200_000)
+    expect(payload.relaxed).toBe(true)
+    expect(payload.source).toEqual([{
+      aggregation: 'MAX',
+      attribute: 'ifHCInOctets',
+      label: 'in_octets',
+      resourceId: RESOURCE_ID,
+      transient: false
+    }])
+  })
+
+  it('does not rewrite the address bar while hydrating a link', async () => {
+    routeQuery = { s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~0`, start: '1704067200', end: '1704070800' }
+
+    mountBuilder()
+    await flushPromises()
+
+    expect(routerReplace).not.toHaveBeenCalled()
+  })
+
+  describe('the copy-link button', () => {
+    const selectOneDatasource = async (store: ReturnType<typeof useAdhocGraphStore>) => {
+      await store.setSelectedNodes([{ id: '1', label: 'switch-01' }])
+      await flushPromises()
+      await store.setSelectedResources([store.resourceOptions[0]])
+      await flushPromises()
+      store.setSelectedDatasources([store.datasourceOptions[0]])
+      await flushPromises()
+    }
+
+    it('copies an absolute URL carrying the current selection', async () => {
+      copyToClipboard.mockResolvedValue(undefined)
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOneDatasource(store)
+
+      await wrapper.find('[data-test="toolbar-share"]').trigger('click')
+      await flushPromises()
+
+      expect(copyToClipboard).toHaveBeenCalledTimes(1)
+      const copied = copyToClipboard.mock.calls[0][0] as string
+      expect(copied.startsWith(window.location.origin)).toBe(true)
+      expect(copied).toContain('#/adhoc-graphs?')
+      expect(decodeURIComponent(copied)).toContain('ifHCInOctets')
+    })
+
+    // The address bar is written by a debounced watcher, so reading
+    // window.location.href would hand out the previous state's link.
+    it('reflects an edit made moments earlier, before the URL sync has run', async () => {
+      copyToClipboard.mockResolvedValue(undefined)
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOneDatasource(store)
+
+      const key = `${RESOURCE_ID}|ifHCInOctets`
+      await wrapper.find(`input[data-test="series-label-${key}"]`).setValue('renamed_just_now')
+      await wrapper.find('[data-test="toolbar-share"]').trigger('click')
+      await flushPromises()
+
+      expect(routerReplace).not.toHaveBeenCalled()
+      expect(decodeURIComponent(copyToClipboard.mock.calls[0][0] as string)).toContain('renamed_just_now')
+    })
+
+    it('warns instead of copying when the browser refuses', async () => {
+      copyToClipboard.mockRejectedValue(new Error('denied'))
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOneDatasource(store)
+
+      await wrapper.find('[data-test="toolbar-share"]').trigger('click')
+      await flushPromises()
+
+      expect(copyToClipboard).toHaveBeenCalled()
+    })
+  })
+
+  describe('the Series and Expressions panels', () => {
+    const panels = (wrapper: ReturnType<typeof mount>) =>
+      Object.fromEntries(wrapper.findAllComponents({ name: 'OnmsPanel' })
+        .map(panel => [String(panel.props('header')).split(' (')[0], panel]))
+
+    it('opens Series and closes Expressions on a fresh page', async () => {
+      const { wrapper } = mountBuilder()
+      await flushPromises()
+
+      const found = panels(wrapper)
+      expect(found.Series.props('toggleable')).toBe(true)
+      expect(found.Series.props('collapsed')).toBe(false)
+      expect(found.Expressions.props('collapsed')).toBe(true)
+    })
+
+    it('counts what each panel holds, so a closed one still says something', async () => {
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await store.setSelectedNodes([{ id: '1', label: 'switch-01' }])
+      await flushPromises()
+      await store.setSelectedResources([store.resourceOptions[0]])
+      await flushPromises()
+      store.setSelectedDatasources([...store.datasourceOptions])
+      await flushPromises()
+
+      expect(panels(wrapper).Series.props('header')).toBe('Series (2)')
+      expect(panels(wrapper).Expressions.props('header')).toBe('Expressions (0)')
+    })
+
+    // A link carrying expressions should show them; hidden, the graph would look
+    // like it came from its sources alone.
+    it('opens Expressions when a restored link defines some', async () => {
+      routeQuery = {
+        s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~1`,
+        e: 'bits~in_octets * 8~line~#eb6834',
+        start: '1704067200',
+        end: '1704070800'
+      }
+
+      const { wrapper } = mountBuilder()
+      await flushPromises()
+
+      const found = panels(wrapper)
+      expect(found.Expressions.props('collapsed')).toBe(false)
+      expect(found.Expressions.props('header')).toBe('Expressions (1)')
+    })
+
+    it('leaves Expressions closed when a restored link has none', async () => {
+      routeQuery = {
+        s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~0`,
+        start: '1704067200',
+        end: '1704070800'
+      }
+
+      const { wrapper } = mountBuilder()
+      await flushPromises()
+
+      expect(panels(wrapper).Expressions.props('collapsed')).toBe(true)
+    })
+
+    it('does not reopen a panel the user closed', async () => {
+      const { wrapper } = mountBuilder()
+      await flushPromises()
+
+      panels(wrapper).Series.vm.$emit('update:collapsed', true)
+      await flushPromises()
+      expect(panels(wrapper).Series.props('collapsed')).toBe(true)
+
+      // Selecting datasources fills the panel but must not force it back open.
+      const store = useAdhocGraphStore()
+      await store.setSelectedNodes([{ id: '1', label: 'switch-01' }])
+      await flushPromises()
+      await store.setSelectedResources([store.resourceOptions[0]])
+      await flushPromises()
+      store.setSelectedDatasources([...store.datasourceOptions])
+      await flushPromises()
+
+      expect(panels(wrapper).Series.props('collapsed')).toBe(true)
+    })
+  })
+
+  describe('expanding and popping out', () => {
+    const selectOne = async (store: ReturnType<typeof useAdhocGraphStore>) => {
+      await store.setSelectedNodes([{ id: '1', label: 'switch-01' }])
+      await flushPromises()
+      await store.setSelectedResources([store.resourceOptions[0]])
+      await flushPromises()
+      store.setSelectedDatasources([store.datasourceOptions[0]])
+      await flushPromises()
+    }
+
+    it('hides the pickers and editors while expanded, and restores them', async () => {
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOne(store)
+
+      expect(wrapper.find('[data-test="nodes-list"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="series-grid"]').exists()).toBe(true)
+
+      await wrapper.find('[data-test="toolbar-expand"]').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('[data-test="nodes-list"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="series-grid"]').exists()).toBe(false)
+      // The chart itself stays, and is told to fill the space.
+      expect(wrapper.findComponent({ name: 'AdhocChart' }).props('expanded')).toBe(true)
+
+      // The editing fields go too — expanded means "show me the graph", and they
+      // cost two rows of the height the plot needs.
+      expect(wrapper.find('[data-test="toolbar-title"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="toolbar-resolution"]').exists()).toBe(false)
+
+      // The root drives the flex layout that keeps everything on screen.
+      expect(wrapper.find('.adhoc-builder').classes()).toContain('is-expanded')
+
+      await wrapper.find('[data-test="toolbar-expand"]').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('[data-test="nodes-list"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="toolbar-title"]').exists()).toBe(true)
+      expect(wrapper.find('.adhoc-builder').classes()).not.toContain('is-expanded')
+    })
+
+    it('leaves the expanded view on Escape', async () => {
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOne(store)
+
+      await wrapper.find('[data-test="toolbar-expand"]').trigger('click')
+      await flushPromises()
+      expect(wrapper.find('[data-test="nodes-list"]').exists()).toBe(false)
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      await flushPromises()
+
+      expect(wrapper.find('[data-test="nodes-list"]').exists()).toBe(true)
+    })
+
+    it('opens the view route in a new tab, carrying the current selection', async () => {
+      const open = vi.fn().mockReturnValue({})
+      vi.stubGlobal('open', open)
+
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOne(store)
+
+      await wrapper.find('[data-test="toolbar-popout"]').trigger('click')
+      await flushPromises()
+
+      expect(open).toHaveBeenCalledTimes(1)
+      const [url, target, features] = open.mock.calls[0]
+      expect(url).toContain('#/adhoc-graphs/view?')
+      expect(decodeURIComponent(url as string)).toContain('ifHCInOctets')
+      expect(target).toBe('_blank')
+      expect(features).toBe('noopener')
+    })
+
+    it('warns when the browser blocks the pop-out', async () => {
+      vi.stubGlobal('open', vi.fn().mockReturnValue(null))
+
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+      await selectOne(store)
+
+      await wrapper.find('[data-test="toolbar-popout"]').trigger('click')
+      await flushPromises()
+
+      // No throw, and the builder is still usable.
+      expect(wrapper.find('[data-test="nodes-list"]').exists()).toBe(true)
+    })
+  })
+
+  describe('the graph-only view route', () => {
+    it('renders the chart from the URL with no pickers, editors or edit controls', async () => {
+      routeQuery = {
+        s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~0`,
+        start: '1704067200',
+        end: '1704070800',
+        title: 'WAN traffic'
+      }
+
+      const { wrapper } = mountBuilder({ viewOnly: true })
+      await flushPromises()
+
+      expect(wrapper.find('[data-test="nodes-list"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="series-grid"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="toolbar-title"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="toolbar-clear"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="toolbar-expand"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="toolbar-popout"]').exists()).toBe(false)
+
+      // Still a graph, still refreshable and exportable, and titled.
+      expect(wrapper.findComponent({ name: 'AdhocChart' }).props('expanded')).toBe(true)
+      expect(wrapper.find('[data-test="toolbar-refresh"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('WAN traffic')
+      expect(getGraphMetrics).toHaveBeenCalled()
+    })
+
+    it('offers a way back to the builder', async () => {
+      routeQuery = { s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~0`, start: '1704067200', end: '1704070800' }
+
+      const { wrapper } = mountBuilder({ viewOnly: true })
+      await flushPromises()
+
+      expect(wrapper.find('[data-test="adhoc-open-builder"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="adhoc-info-icon"]').exists()).toBe(false)
+    })
+  })
+
+  it('clears every column and the config on Clear all', async () => {
+    const { wrapper, store } = mountBuilder()
+    await flushPromises()
+
+    await store.setSelectedNodes([{ id: '1', label: 'switch-01' }])
+    await flushPromises()
+    await store.setSelectedResources([store.resourceOptions[0]])
+    await flushPromises()
+    store.setSelectedDatasources([...store.datasourceOptions])
+    await flushPromises()
+
+    await wrapper.find('[data-test="toolbar-clear"]').trigger('click')
+    await flushPromises()
+
+    expect(store.selectedNodes).toEqual([])
+    expect(store.selectedDatasources).toEqual([])
+    expect(wrapper.find('[data-test="series-empty"]').exists()).toBe(true)
+  })
+})

--- a/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
+++ b/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
@@ -323,7 +323,7 @@ describe('AdhocGraphBuilder', () => {
       expect(start).toBe(end - span)
     })
 
-    it('still honours an absolute range from a custom-time link', async () => {
+    it('still honors an absolute range from a custom-time link', async () => {
       routeQuery = {
         s: `${RESOURCE_ID}~ifHCInOctets~AVERAGE~in_octets~line~#2a78d6~0`,
         start: '1704067200',

--- a/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
+++ b/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
@@ -229,6 +229,18 @@ describe('AdhocGraphBuilder', () => {
   // Blanking the address bar silently meant a large graph quietly stopped being
   // bookmarkable, with no signal until someone tried to copy the link.
   describe('the toolbar', () => {
+    // MenuHeaderIT locates this page by //div[@id='app']//h2[text()='Custom
+    // Performance Graphs']; if the tag or the text changes, that smoke test breaks
+    // in CI rather than here, so pin it.
+    it('renders the page title as an h2 with the exact text the smoke test matches', async () => {
+      const { wrapper } = mountBuilder()
+      await flushPromises()
+
+      const headings = wrapper.findAll('h2').map(h => h.text())
+      expect(headings).toContain('Custom Performance Graphs')
+      expect(wrapper.find('.header .heading h2').exists()).toBe(true)
+    })
+
     it('labels the time range control, which otherwise only shows its value', async () => {
       const { wrapper } = mountBuilder()
       await flushPromises()
@@ -691,7 +703,10 @@ describe('AdhocGraphBuilder', () => {
       // Still a graph, still refreshable and exportable, and titled.
       expect(wrapper.findComponent({ name: 'AdhocChart' }).props('expanded')).toBe(true)
       expect(wrapper.find('[data-test="toolbar-refresh"]').exists()).toBe(true)
-      expect(wrapper.text()).toContain('WAN traffic')
+      // The page heading names the page; the graph's own title is drawn on the plot.
+      expect(wrapper.text()).toContain('Custom Performance Graphs')
+      expect(wrapper.findComponent({ name: 'AdhocChart' }).props('config'))
+        .toEqual(expect.objectContaining({ title: 'WAN traffic' }))
       expect(getGraphMetrics).toHaveBeenCalled()
     })
 

--- a/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
+++ b/ui/tests/components/AdhocGraphs/AdhocGraphBuilder.test.ts
@@ -228,6 +228,34 @@ describe('AdhocGraphBuilder', () => {
 
   // Blanking the address bar silently meant a large graph quietly stopped being
   // bookmarkable, with no signal until someone tried to copy the link.
+  describe('the toolbar', () => {
+    it('labels the time range control, which otherwise only shows its value', async () => {
+      const { wrapper } = mountBuilder()
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('Time Range:')
+      expect(wrapper.find('[data-test="toolbar-time-range"]').exists()).toBe(true)
+    })
+
+    // OnmsIconButton has no loading state, so an in-flight query disables Refresh
+    // rather than spinning it; the chart shows the spinner.
+    it('disables Refresh while a query is in flight', async () => {
+      const { wrapper, store } = mountBuilder()
+      await flushPromises()
+
+      const refreshDisabled = () =>
+        wrapper.find('[data-test="toolbar-refresh"]').attributes('disabled') !== undefined
+
+      store.queryLoading = true
+      await flushPromises()
+      expect(refreshDisabled()).toBe(true)
+
+      store.queryLoading = false
+      await flushPromises()
+      expect(refreshDisabled()).toBe(true) // still disabled: no series selected yet
+    })
+  })
+
   describe('outgrowing the URL', () => {
     /**
      * Overflow MAX_QUERY_LENGTH (6000) with as few series as possible: a handful of

--- a/ui/tests/components/AdhocGraphs/RrdDefinitionDialog.test.ts
+++ b/ui/tests/components/AdhocGraphs/RrdDefinitionDialog.test.ts
@@ -1,0 +1,138 @@
+import { createTestingPinia } from '@pinia/testing'
+import { flushPromises, mount } from '@vue/test-utils'
+import { setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import RrdDefinitionDialog from '@/components/AdhocGraphs/RrdDefinitionDialog.vue'
+import { DEFAULT_RESOLUTION } from '@/components/AdhocGraphs/utils/adhocQuery'
+import { AdhocGraphConfig, AdhocSeries } from '@/types/adhocGraph'
+import { ConsolidationFunctionType } from '@/types/timeSeries'
+
+const copyToClipboard = vi.fn()
+
+vi.mock('@/composables/useClipboard', () => ({
+  copyToClipboard: (text: string) => copyToClipboard(text),
+  default: () => ({ copyToClipboard })
+}))
+
+const RESOURCE = 'node[1].interfaceSnmp[eth0]'
+
+const series = (overrides: Partial<AdhocSeries> = {}): AdhocSeries => ({
+  key: `${RESOURCE}|ifInOctets`,
+  label: 'ifInOctets',
+  resourceId: RESOURCE,
+  attribute: 'ifInOctets',
+  aggregation: ConsolidationFunctionType.AVERAGE,
+  color: '#2a78d6',
+  style: 'line',
+  hidden: false,
+  ...overrides
+})
+
+const config = (overrides: Partial<AdhocGraphConfig> = {}): AdhocGraphConfig => ({
+  series: [series()],
+  expressions: [],
+  title: 'WAN traffic',
+  verticalLabel: 'bits per second',
+  stacked: false,
+  resolution: DEFAULT_RESOLUTION,
+  ...overrides
+})
+
+// OnmsDialog teleports its content to document.body (appendTo defaults to 'body'),
+// so the dialog's DOM is outside the wrapper and has to be queried from the
+// document rather than through wrapper.find().
+const q = (dataTest: string) => document.querySelector(`[data-test="${dataTest}"]`)
+
+const textOf = (dataTest: string) => (q(dataTest)?.textContent ?? '').replace(/\s+/g, ' ')
+
+const click = async (dataTest: string) => {
+  const element = q(dataTest)
+  expect(element, `no element for ${dataTest}`).not.toBeNull();
+  (element as HTMLElement).click()
+  await flushPromises()
+}
+
+const mounted: ReturnType<typeof mount>[] = []
+
+// The dialog's content lands in the DOM a tick after mount, so every case awaits
+// it rather than querying synchronously.
+const mountDialog = async (graphConfig: AdhocGraphConfig) => {
+  const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+  setActivePinia(pinia)
+
+  const wrapper = mount(RrdDefinitionDialog, {
+    props: { visible: true, config: graphConfig },
+    global: { plugins: [PrimeVue, pinia] },
+    attachTo: document.body
+  })
+
+  mounted.push(wrapper)
+  await flushPromises()
+  return wrapper
+}
+
+describe('RrdDefinitionDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    copyToClipboard.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    while (mounted.length) {
+      mounted.pop()?.unmount()
+    }
+    document.body.innerHTML = ''
+  })
+
+  it('renders the definition for a single-resource graph', async () => {
+    await mountDialog(config())
+    const text = textOf('rrd-definition-text')
+
+    expect(text).toContain('report.adhoc.interfaceSnmp.ifInOctets.columns=ifInOctets')
+    expect(text).toContain('report.adhoc.interfaceSnmp.ifInOctets.type=interfaceSnmp')
+    expect(text).toContain('DEF:ifInOctets={rrd1}:ifInOctets:AVERAGE')
+    expect(q('rrd-definition-blocked')).toBeNull()
+  })
+
+  it('copies the definition, not just the command', async () => {
+    await mountDialog(config())
+
+    await click('rrd-definition-copy')
+
+    expect(copyToClipboard).toHaveBeenCalledTimes(1)
+    const copied = copyToClipboard.mock.calls[0][0] as string
+    expect(copied).toContain('report.adhoc.interfaceSnmp.ifInOctets.name=WAN traffic')
+    expect(copied).toContain('report.adhoc.interfaceSnmp.ifInOctets.command=')
+  })
+
+  // The gate is the point of the feature: explain rather than emit a definition
+  // that would throw when the server tries to resolve {rrd2}.
+  it('explains why a multi-resource graph cannot be exported, and offers no copy', async () => {
+    await mountDialog(config({
+      series: [
+        series(),
+        series({ key: 'b', resourceId: 'node[2].interfaceSnmp[eth1]', label: 'other', attribute: 'ifOutOctets' })
+      ]
+    }))
+
+    expect(q('rrd-definition-blocked')).not.toBeNull()
+    expect(textOf('rrd-definition-blocked')).toContain('bound to a single resource')
+    expect(q('rrd-definition-text')).toBeNull()
+    expect(q('rrd-definition-copy')).toBeNull()
+  })
+
+  it('explains an expression it cannot convert', async () => {
+    await mountDialog(config({
+      expressions: [{ id: 'e1', label: 'x', value: 'math:abs(ifInOctets)', color: '#eb6834', style: 'line' }]
+    }))
+    expect(textOf('rrd-definition-blocked')).toContain('Function calls are not supported')
+  })
+
+  it('emits close from the close button', async () => {
+    const wrapper = await mountDialog(config())
+    await click('rrd-definition-close')
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+})

--- a/ui/tests/components/AdhocGraphs/adhocColors.test.ts
+++ b/ui/tests/components/AdhocGraphs/adhocColors.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ADHOC_PALETTE_DARK,
+  ADHOC_PALETTE_LIGHT,
+  ADHOC_PALETTE_SIZE,
+  restepColorForTheme,
+  seriesColor,
+  strokeWidthFor
+} from '@/components/AdhocGraphs/utils/adhocColors'
+import { DARK_THEME, LIGHT_THEME } from '@/services/themeService'
+
+describe('seriesColor', () => {
+  it('walks the palette in slot order', () => {
+    expect(seriesColor(0, LIGHT_THEME)).toBe(ADHOC_PALETTE_LIGHT[0])
+    expect(seriesColor(3, LIGHT_THEME)).toBe(ADHOC_PALETTE_LIGHT[3])
+  })
+
+  it('uses the dark steps in dark mode', () => {
+    expect(seriesColor(0, DARK_THEME)).toBe(ADHOC_PALETTE_DARK[0])
+  })
+
+  it('repeats the hues rather than inventing new ones past the last slot', () => {
+    expect(seriesColor(ADHOC_PALETTE_LIGHT.length, LIGHT_THEME)).toBe(ADHOC_PALETTE_LIGHT[0])
+  })
+})
+
+describe('the palette itself', () => {
+  it('carries twelve slots in both modes', () => {
+    expect(ADHOC_PALETTE_LIGHT).toHaveLength(12)
+    expect(ADHOC_PALETTE_DARK).toHaveLength(12)
+    expect(ADHOC_PALETTE_SIZE).toBe(12)
+  })
+
+  // Slots 1-8 are the validated base set; the four added for ad-hoc graphs must
+  // not disturb them, or every existing graph silently changes colour.
+  it('leaves the original eight slots untouched', () => {
+    expect(ADHOC_PALETTE_LIGHT.slice(0, 8)).toEqual([
+      '#2a78d6', '#eb6834', '#1baf7a', '#eda100', '#e87ba4', '#008300', '#4a3aa7', '#e34948'
+    ])
+    expect(ADHOC_PALETTE_DARK.slice(0, 8)).toEqual([
+      '#3987e5', '#d95926', '#199e70', '#c98500', '#d55181', '#008300', '#9085e9', '#e66767'
+    ])
+  })
+
+  it('has no duplicate slots, so no two series share a colour by accident', () => {
+    expect(new Set(ADHOC_PALETTE_LIGHT).size).toBe(ADHOC_PALETTE_LIGHT.length)
+    expect(new Set(ADHOC_PALETTE_DARK).size).toBe(ADHOC_PALETTE_DARK.length)
+  })
+
+  it('is all six-digit lowercase hex, as restepColorForTheme assumes', () => {
+    for (const color of [...ADHOC_PALETTE_LIGHT, ...ADHOC_PALETTE_DARK]) {
+      expect(color).toMatch(/^#[0-9a-f]{6}$/)
+    }
+  })
+})
+
+// Weight follows the RRDtool LINE1/2/3 family the styles are named after, doubled
+// because a 1px stroke disappears on a 2x display.
+describe('strokeWidthFor', () => {
+  it('steps the line styles 2 / 4 / 6', () => {
+    expect(strokeWidthFor('line')).toBe(2)
+    expect(strokeWidthFor('line2')).toBe(4)
+    expect(strokeWidthFor('line3')).toBe(6)
+  })
+
+  it('outlines a filled series at the base weight', () => {
+    expect(strokeWidthFor('area')).toBe(2)
+    expect(strokeWidthFor('stack')).toBe(2)
+  })
+
+  // Nothing derives weight from the series index any more; only the chosen style.
+  it('depends on the style alone', () => {
+    expect(strokeWidthFor('line')).toBe(strokeWidthFor('line'))
+    expect(new Set(['line', 'line2', 'line3'].map(s => strokeWidthFor(s as never))).size).toBe(3)
+  })
+})
+
+describe('restepColorForTheme', () => {
+  it('moves a palette colour to the other mode\'s step', () => {
+    expect(restepColorForTheme(ADHOC_PALETTE_LIGHT[1], DARK_THEME)).toBe(ADHOC_PALETTE_DARK[1])
+    expect(restepColorForTheme(ADHOC_PALETTE_DARK[1], LIGHT_THEME)).toBe(ADHOC_PALETTE_LIGHT[1])
+  })
+
+  it('leaves a hand-picked colour alone', () => {
+    expect(restepColorForTheme('#123456', DARK_THEME)).toBe('#123456')
+  })
+})

--- a/ui/tests/components/AdhocGraphs/adhocColors.test.ts
+++ b/ui/tests/components/AdhocGraphs/adhocColors.test.ts
@@ -33,7 +33,7 @@ describe('the palette itself', () => {
   })
 
   // Slots 1-8 are the validated base set; the four added for ad-hoc graphs must
-  // not disturb them, or every existing graph silently changes colour.
+  // not disturb them, or every existing graph silently changes color.
   it('leaves the original eight slots untouched', () => {
     expect(ADHOC_PALETTE_LIGHT.slice(0, 8)).toEqual([
       '#2a78d6', '#eb6834', '#1baf7a', '#eda100', '#e87ba4', '#008300', '#4a3aa7', '#e34948'
@@ -43,7 +43,7 @@ describe('the palette itself', () => {
     ])
   })
 
-  it('has no duplicate slots, so no two series share a colour by accident', () => {
+  it('has no duplicate slots, so no two series share a color by accident', () => {
     expect(new Set(ADHOC_PALETTE_LIGHT).size).toBe(ADHOC_PALETTE_LIGHT.length)
     expect(new Set(ADHOC_PALETTE_DARK).size).toBe(ADHOC_PALETTE_DARK.length)
   })
@@ -77,12 +77,12 @@ describe('strokeWidthFor', () => {
 })
 
 describe('restepColorForTheme', () => {
-  it('moves a palette colour to the other mode\'s step', () => {
+  it('moves a palette color to the other mode\'s step', () => {
     expect(restepColorForTheme(ADHOC_PALETTE_LIGHT[1], DARK_THEME)).toBe(ADHOC_PALETTE_DARK[1])
     expect(restepColorForTheme(ADHOC_PALETTE_DARK[1], LIGHT_THEME)).toBe(ADHOC_PALETTE_LIGHT[1])
   })
 
-  it('leaves a hand-picked colour alone', () => {
+  it('leaves a hand-picked color alone', () => {
     expect(restepColorForTheme('#123456', DARK_THEME)).toBe('#123456')
   })
 })

--- a/ui/tests/components/AdhocGraphs/adhocQuery.test.ts
+++ b/ui/tests/components/AdhocGraphs/adhocQuery.test.ts
@@ -9,6 +9,7 @@ import {
   labelForDatasource,
   MAX_RESOLUTION,
   plottedSeries,
+  querySignature,
   sanitizeLabel,
   seriesLabelIssues,
   stepForRange,
@@ -270,6 +271,33 @@ describe('expressionIssues', () => {
   it('reports a blank name against the label field', () => {
     const issues = expressionIssues(config({ series: [series()], expressions: [expression({ label: '' })] }))
     expect(issues['expr-1']).toEqual({ field: 'label', message: 'A name is required.' })
+  })
+})
+
+describe('querySignature', () => {
+  const relative = { startTime: 1704067200, endTime: 1704153600, format: 'hours', range: { unit: 'hours' as const, amount: 24 }}
+
+  // Re-resolving a relative window is not a change of query. If it were, every
+  // Refresh would fire twice — once explicitly, once from the watcher.
+  it('is unchanged when a relative window slides forward', () => {
+    const later = { ...relative, startTime: 1704070800, endTime: 1704157200 }
+
+    expect(querySignature(config({ series: [series()] }), later))
+      .toBe(querySignature(config({ series: [series()] }), relative))
+  })
+
+  it('changes when the range itself changes', () => {
+    const other = { ...relative, range: { unit: 'hours' as const, amount: 2 }}
+
+    expect(querySignature(config({ series: [series()] }), other))
+      .not.toBe(querySignature(config({ series: [series()] }), relative))
+  })
+
+  it('still tracks the instants of an absolute window', () => {
+    const later = { startTime: 1704070800, endTime: 1704157200, format: 'hours' }
+
+    expect(querySignature(config({ series: [series()] }), later))
+      .not.toBe(querySignature(config({ series: [series()] }), time))
   })
 })
 

--- a/ui/tests/components/AdhocGraphs/adhocQuery.test.ts
+++ b/ui/tests/components/AdhocGraphs/adhocQuery.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildMeasurementsPayload,
+  configIsQueryable,
+  DEFAULT_RESOLUTION,
+  expressionIssues,
+  expressionReferences,
+  labelForDatasource,
+  MAX_RESOLUTION,
+  plottedSeries,
+  sanitizeLabel,
+  seriesLabelIssues,
+  stepForRange,
+  toConvertedGraphData,
+  uniqueLabel
+} from '@/components/AdhocGraphs/utils/adhocQuery'
+import { StartEndTime } from '@/types'
+import { AdhocDatasourceOption, AdhocExpression, AdhocGraphConfig, AdhocSeries } from '@/types/adhocGraph'
+import { ConsolidationFunctionType } from '@/types/timeSeries'
+
+const series = (overrides: Partial<AdhocSeries> = {}): AdhocSeries => ({
+  key: 'node[1].interfaceSnmp[eth0]|ifHCInOctets',
+  label: 'ifHCInOctets',
+  resourceId: 'node[1].interfaceSnmp[eth0]',
+  attribute: 'ifHCInOctets',
+  aggregation: ConsolidationFunctionType.AVERAGE,
+  color: '#2a78d6',
+  style: 'line',
+  hidden: false,
+  ...overrides
+})
+
+const expression = (overrides: Partial<AdhocExpression> = {}): AdhocExpression => ({
+  id: 'expr-1',
+  label: 'bits',
+  value: 'ifHCInOctets * 8',
+  color: '#eb6834',
+  style: 'line',
+  ...overrides
+})
+
+const config = (overrides: Partial<AdhocGraphConfig> = {}): AdhocGraphConfig => ({
+  series: [],
+  expressions: [],
+  title: '',
+  verticalLabel: '',
+  stacked: false,
+  resolution: DEFAULT_RESOLUTION,
+  ...overrides
+})
+
+// 2024-01-01T00:00:00Z .. +1h, in the seconds that StartEndTime carries
+const time: StartEndTime = { startTime: 1704067200, endTime: 1704070800, format: 'hours' }
+
+describe('sanitizeLabel', () => {
+  it('reduces a node/resource/attribute triple to a JEXL identifier', () => {
+    expect(sanitizeLabel('switch-01.example.com', 'eth0 (WAN)', 'ifHCInOctets'))
+      .toBe('switch_01_example_com_eth0_WAN_ifHCInOctets')
+  })
+
+  it('collapses runs of separators and trims the ends', () => {
+    expect(sanitizeLabel('  a -- b  ')).toBe('a_b')
+  })
+
+  it('prefixes a leading digit so the result is a legal identifier', () => {
+    expect(sanitizeLabel('10.1.1.1', 'ifInOctets')).toBe('_10_1_1_1_ifInOctets')
+  })
+
+  it('falls back rather than returning an empty identifier', () => {
+    expect(sanitizeLabel('***')).toBe('series')
+    expect(sanitizeLabel(undefined)).toBe('series')
+  })
+})
+
+describe('uniqueLabel', () => {
+  it('returns the candidate when it is free', () => {
+    expect(uniqueLabel('ifInOctets', ['other'])).toBe('ifInOctets')
+  })
+
+  it('suffixes past every taken variant', () => {
+    expect(uniqueLabel('ifInOctets', ['ifInOctets', 'ifInOctets_2'])).toBe('ifInOctets_3')
+  })
+
+  it('de-duplicates two resources that sanitize identically', () => {
+    const datasource = (resourceId: string): AdhocDatasourceOption => ({
+      key: `${resourceId}|ifInOctets`,
+      resourceId,
+      resourceLabel: 'eth 0',
+      nodeId: '1',
+      nodeLabel: 'switch',
+      attribute: 'ifInOctets'
+    })
+
+    const first = labelForDatasource(datasource('node[1].interfaceSnmp[eth-0]'), [])
+    const second = labelForDatasource(datasource('node[1].interfaceSnmp[eth_0]'), [first])
+
+    expect(first).toBe('switch_eth_0_ifInOctets')
+    expect(second).toBe('switch_eth_0_ifInOctets_2')
+  })
+})
+
+describe('expressionReferences', () => {
+  it('matches a whole identifier', () => {
+    expect(expressionReferences('ifInOctets * 8', 'ifInOctets')).toBe(true)
+    expect(expressionReferences('(ifInOctets+ifOutOctets)', 'ifOutOctets')).toBe(true)
+  })
+
+  // The reason this is not a substring test: a shorter label is a prefix of its own
+  // de-duplicated sibling, and a false match would wrongly suppress the raw series.
+  it('does not match a label that is only a prefix of the identifier used', () => {
+    expect(expressionReferences('ifInOctets_2 * 8', 'ifInOctets')).toBe(false)
+  })
+
+  it('is false for an empty label', () => {
+    expect(expressionReferences('anything', '')).toBe(false)
+  })
+})
+
+describe('stepForRange', () => {
+  it('divides the range by the requested resolution', () => {
+    expect(stepForRange(0, 3_600_000, 360)).toBe(10_000)
+  })
+
+  it('never returns a sub-second step', () => {
+    expect(stepForRange(0, 100, 400)).toBe(1000)
+    expect(stepForRange(0, 0, 400)).toBe(1000)
+  })
+
+  it('clamps an absurd resolution to the supported ceiling', () => {
+    expect(stepForRange(0, 4_000_000_000, 10_000_000)).toBe(1_000_000)
+  })
+})
+
+describe('buildMeasurementsPayload', () => {
+  it('converts seconds to millis and asks for a relaxed, bounded query', () => {
+    const payload = buildMeasurementsPayload(config({ series: [series()] }), time)
+
+    expect(payload.start).toBe(1_704_067_200_000)
+    expect(payload.end).toBe(1_704_070_800_000)
+    expect(payload.relaxed).toBe(true)
+    expect(payload.maxrows).toBe(MAX_RESOLUTION)
+    expect(payload.step).toBe(9000)
+  })
+
+  it('emits one source per series with its label and aggregation', () => {
+    const payload = buildMeasurementsPayload(
+      config({ series: [series({ aggregation: ConsolidationFunctionType.MAX })] }),
+      time
+    )
+
+    expect(payload.source).toEqual([{
+      aggregation: 'MAX',
+      attribute: 'ifHCInOctets',
+      label: 'ifHCInOctets',
+      resourceId: 'node[1].interfaceSnmp[eth0]',
+      transient: false
+    }])
+  })
+
+  it('omits the expression list entirely when there are none', () => {
+    expect(buildMeasurementsPayload(config({ series: [series()] }), time).expression).toBeUndefined()
+  })
+
+  it('marks a hidden source transient only when an expression consumes it', () => {
+    const consumed = buildMeasurementsPayload(
+      config({ series: [series({ hidden: true })], expressions: [expression()] }),
+      time
+    )
+    expect(consumed.source[0].transient).toBe(true)
+    expect(consumed.expression).toEqual([{ label: 'bits', value: 'ifHCInOctets * 8', transient: false }])
+
+    // Hiding a source nothing references would just yield an empty graph, so the
+    // flag is derived rather than taken on trust.
+    const unconsumed = buildMeasurementsPayload(
+      config({ series: [series({ hidden: true })], expressions: [expression({ value: 'somethingElse * 8' })] }),
+      time
+    )
+    expect(unconsumed.source[0].transient).toBe(false)
+  })
+})
+
+describe('plottedSeries', () => {
+  it('drops a consumed hidden source and appends the expressions', () => {
+    const plotted = plottedSeries(config({
+      series: [series({ hidden: true }), series({ key: 'k2', label: 'ifHCOutOctets', attribute: 'ifHCOutOctets' })],
+      expressions: [expression()]
+    }))
+
+    expect(plotted.map(item => item.label)).toEqual(['ifHCOutOctets', 'bits'])
+  })
+
+  it('keeps a hidden source that no expression consumes', () => {
+    const plotted = plottedSeries(config({ series: [series({ hidden: true })] }))
+    expect(plotted.map(item => item.label)).toEqual(['ifHCInOctets'])
+  })
+})
+
+describe('toConvertedGraphData', () => {
+  it('produces the metrics/printStatements shape the prefab components consume', () => {
+    const converted = toConvertedGraphData(config({
+      series: [series()],
+      expressions: [expression()],
+      title: 'Traffic',
+      verticalLabel: 'bits/sec'
+    }))
+
+    expect(converted.title).toBe('Traffic')
+    expect(converted.verticalLabel).toBe('bits/sec')
+    expect(converted.metrics.map(metric => metric.name)).toEqual(['ifHCInOctets', 'bits'])
+    expect(converted.printStatements.map(statement => statement.header)).toEqual(['ifHCInOctets', 'bits'])
+    expect(converted.printStatements.every(statement => statement.metric === statement.header)).toBe(true)
+  })
+})
+
+describe('seriesLabelIssues', () => {
+  it('is empty for a well-formed config', () => {
+    expect(seriesLabelIssues(config({ series: [series()] }))).toEqual({})
+  })
+
+  it('flags blank, duplicate and non-identifier labels', () => {
+    const blank = series({ key: 'a', label: '  ' })
+    const dupeOne = series({ key: 'b', label: 'same' })
+    const dupeTwo = series({ key: 'c', label: 'same' })
+    const bad = series({ key: 'd', label: 'has space' })
+
+    const issues = seriesLabelIssues(config({ series: [blank, dupeOne, dupeTwo, bad] }))
+
+    expect(issues.a).toBe('A label is required.')
+    expect(issues.b).toBe('Labels must be unique.')
+    expect(issues.c).toBe('Labels must be unique.')
+    expect(issues.d).toBe('Use letters, digits and underscores only.')
+  })
+
+  it('treats an expression name as occupying the same namespace', () => {
+    const issues = seriesLabelIssues(config({
+      series: [series({ key: 'a', label: 'shared' })],
+      expressions: [expression({ label: 'shared' })]
+    }))
+
+    expect(issues.a).toBe('Labels must be unique.')
+  })
+})
+
+describe('expressionIssues', () => {
+  it('is empty when the expression names a known label', () => {
+    expect(expressionIssues(config({ series: [series()], expressions: [expression()] }))).toEqual({})
+  })
+
+  it('reports a blank expression against the value field', () => {
+    const issues = expressionIssues(config({ series: [series()], expressions: [expression({ value: '  ' })] }))
+    expect(issues['expr-1']).toEqual({ field: 'value', message: 'An expression is required.' })
+  })
+
+  it('reports an expression whose every identifier is unknown', () => {
+    const issues = expressionIssues(config({ series: [series()], expressions: [expression({ value: 'nope * 8' })] }))
+    expect(issues['expr-1']).toEqual({ field: 'value', message: 'Unknown label: nope' })
+  })
+
+  // JEXL functions and constants would be flagged by a stricter rule; only a
+  // reference to nothing at all is unambiguously wrong.
+  it('accepts an expression that mixes a known label with unknown identifiers', () => {
+    const issues = expressionIssues(config({
+      series: [series()],
+      expressions: [expression({ value: 'math:abs(ifHCInOctets)' })]
+    }))
+    expect(issues['expr-1']).toBeUndefined()
+  })
+
+  it('reports a blank name against the label field', () => {
+    const issues = expressionIssues(config({ series: [series()], expressions: [expression({ label: '' })] }))
+    expect(issues['expr-1']).toEqual({ field: 'label', message: 'A name is required.' })
+  })
+})
+
+describe('configIsQueryable', () => {
+  it('is false with no series', () => {
+    expect(configIsQueryable(config())).toBe(false)
+  })
+
+  it('is true for a valid series-only config', () => {
+    expect(configIsQueryable(config({ series: [series()] }))).toBe(true)
+  })
+
+  it('is false while any series or expression is invalid', () => {
+    expect(configIsQueryable(config({ series: [series({ label: '' })] }))).toBe(false)
+    expect(configIsQueryable(config({
+      series: [series()],
+      expressions: [expression({ value: '' })]
+    }))).toBe(false)
+  })
+})

--- a/ui/tests/components/AdhocGraphs/adhocUrlState.test.ts
+++ b/ui/tests/components/AdhocGraphs/adhocUrlState.test.ts
@@ -88,6 +88,52 @@ describe('encodeAdhocState / decodeAdhocState', () => {
   })
 })
 
+describe('relative time ranges in the URL', () => {
+  const relative: StartEndTime = { startTime: 1704067200, endTime: 1704153600, format: 'hours', range: { unit: 'hours', amount: 24 }}
+
+  // The bug this fixes: absolute instants freeze a bookmark to whenever it was made.
+  it('writes the range instead of the instants it resolved to', () => {
+    const query = encodeAdhocState(fullConfig, relative)
+
+    expect(query.range).toBe('hours:24')
+    expect(query.start).toBeUndefined()
+    expect(query.end).toBeUndefined()
+  })
+
+  it('round-trips the range unresolved, for the caller to anchor to now', () => {
+    const restored = decodeAdhocState(encodeAdhocState(fullConfig, relative))
+
+    expect(restored?.time.range).toEqual({ unit: 'hours', amount: 24 })
+  })
+
+  it('still writes absolute instants for a custom range', () => {
+    const query = encodeAdhocState(fullConfig, time)
+
+    expect(query.range).toBeUndefined()
+    expect(query.start).toBe('1704067200')
+    expect(query.end).toBe('1704070800')
+  })
+
+  it('decodes a range-only link, with no start or end present', () => {
+    const restored = decodeAdhocState({ range: 'days:7' })
+
+    expect(restored).not.toBeNull()
+    expect(restored?.time.range).toEqual({ unit: 'days', amount: 7 })
+  })
+
+  it('ignores a nonsense range rather than sliding by something arbitrary', () => {
+    for (const value of ['fortnights:2', 'hours:0', 'hours:-3', 'hours', 'hours:abc', '']) {
+      expect(decodeAdhocState({ range: value, start: '1704067200' })?.time.range, value).toBeUndefined()
+    }
+  })
+
+  it('prefers the range when a link somehow carries both', () => {
+    const restored = decodeAdhocState({ range: 'hours:2', start: '1704067200', end: '1704070800' })
+
+    expect(restored?.time.range).toEqual({ unit: 'hours', amount: 2 })
+  })
+})
+
 describe('decodeAdhocState is defensive', () => {
   it('drops entries with no resource id or attribute rather than throwing', () => {
     const restored = decodeAdhocState({

--- a/ui/tests/components/AdhocGraphs/adhocUrlState.test.ts
+++ b/ui/tests/components/AdhocGraphs/adhocUrlState.test.ts
@@ -88,6 +88,67 @@ describe('encodeAdhocState / decodeAdhocState', () => {
   })
 })
 
+// `~` separates the fields inside an entry, and users type it: `=~` is JEXL's
+// match operator. Before these fields were escaped, `a =~ [1,2] ? 1 : 0` decoded
+// back as `a =` — silently, taking the style and color with it.
+describe('the field separator survives values that contain it', () => {
+  const withExpression = (value: string, label = 'bits'): AdhocGraphConfig => ({
+    ...fullConfig,
+    expressions: [{ id: 'e1', label, value, color: '#eb6834', style: 'line' }]
+  })
+
+  const roundTrip = (input: AdhocGraphConfig) => decodeAdhocState(encodeAdhocState(input, time))
+
+  it('round-trips a JEXL match operator without truncating it', () => {
+    const value = 'in_octets =~ [1,2] ? 1 : 0'
+    const restored = roundTrip(withExpression(value))
+
+    expect(restored?.config.expressions[0].value).toBe(value)
+    // The fields after the tilde used to be shifted out of place.
+    expect(restored?.config.expressions[0].style).toBe('line')
+    expect(restored?.config.expressions[0].color).toBe('#eb6834')
+  })
+
+  it('round-trips a bare tilde and several of them', () => {
+    expect(roundTrip(withExpression('~in_octets'))?.config.expressions[0].value).toBe('~in_octets')
+    expect(roundTrip(withExpression('a ~ b ~ c'))?.config.expressions[0].value).toBe('a ~ b ~ c')
+  })
+
+  it('round-trips a tilde in an expression name', () => {
+    expect(roundTrip(withExpression('in_octets * 8', 'od~d'))?.config.expressions[0].label).toBe('od~d')
+  })
+
+  // A literal percent must not be mistaken for the escape it produces.
+  it('round-trips a literal percent, and a literal %7E', () => {
+    expect(roundTrip(withExpression('in_octets % 100'))?.config.expressions[0].value).toBe('in_octets % 100')
+    expect(roundTrip(withExpression('a %7E b'))?.config.expressions[0].value).toBe('a %7E b')
+    expect(roundTrip(withExpression('a %25 b'))?.config.expressions[0].value).toBe('a %25 b')
+  })
+
+  // Storage resources can carry a Windows short name.
+  it('round-trips a tilde in a resource id', () => {
+    const resourceId = 'node[1].hrStorageIndex[C:\\PROGRA~1]'
+    const restored = roundTrip({
+      ...fullConfig,
+      series: [{ ...fullConfig.series[0], resourceId, key: `${resourceId}|ifInOctets` }],
+      expressions: []
+    })
+
+    expect(restored?.config.series[0].resourceId).toBe(resourceId)
+    expect(restored?.config.series[0].attribute).toBe('ifHCInOctets')
+    expect(restored?.config.series[0].color).toBe('#2a78d6')
+  })
+
+  it('leaves an ordinary link unchanged, so URLs do not grow', () => {
+    const query = encodeAdhocState(fullConfig, time)
+    const entries = Array.isArray(query.s) ? query.s : [query.s]
+
+    for (const entry of entries) {
+      expect(entry).not.toContain('%')
+    }
+  })
+})
+
 describe('relative time ranges in the URL', () => {
   const relative: StartEndTime = { startTime: 1704067200, endTime: 1704153600, format: 'hours', range: { unit: 'hours', amount: 24 }}
 

--- a/ui/tests/components/AdhocGraphs/adhocUrlState.test.ts
+++ b/ui/tests/components/AdhocGraphs/adhocUrlState.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_RESOLUTION } from '@/components/AdhocGraphs/utils/adhocQuery'
+import {
+  decodeAdhocState,
+  encodeAdhocState,
+  encodedQueryLength,
+  MAX_QUERY_LENGTH,
+  RouteQuery
+} from '@/components/AdhocGraphs/utils/adhocUrlState'
+import { StartEndTime } from '@/types'
+import { AdhocGraphConfig } from '@/types/adhocGraph'
+import { ConsolidationFunctionType } from '@/types/timeSeries'
+
+const time: StartEndTime = { startTime: 1704067200, endTime: 1704070800, format: 'hours' }
+
+const fullConfig: AdhocGraphConfig = {
+  series: [
+    {
+      key: 'node[1].interfaceSnmp[eth0]|ifHCInOctets',
+      label: 'in_octets',
+      resourceId: 'node[1].interfaceSnmp[eth0]',
+      attribute: 'ifHCInOctets',
+      aggregation: ConsolidationFunctionType.MAX,
+      color: '#2a78d6',
+      style: 'area',
+      hidden: true
+    },
+    {
+      key: 'node[2].interfaceSnmp[eth1]|ifHCOutOctets',
+      label: 'out_octets',
+      resourceId: 'node[2].interfaceSnmp[eth1]',
+      attribute: 'ifHCOutOctets',
+      aggregation: ConsolidationFunctionType.AVERAGE,
+      color: '#eb6834',
+      style: 'line3',
+      hidden: false
+    }
+  ],
+  expressions: [
+    { id: 'expr-1', label: 'total_bits', value: '(in_octets + out_octets) * 8', color: '#1baf7a', style: 'stack' }
+  ],
+  title: 'WAN traffic',
+  verticalLabel: 'bits/sec',
+  stacked: true,
+  resolution: 800
+}
+
+describe('encodeAdhocState / decodeAdhocState', () => {
+  it('round-trips a complete graph', () => {
+    const restored = decodeAdhocState(encodeAdhocState(fullConfig, time))
+
+    expect(restored).not.toBeNull()
+    expect(restored?.time).toEqual(time)
+    expect(restored?.config.title).toBe('WAN traffic')
+    expect(restored?.config.verticalLabel).toBe('bits/sec')
+    expect(restored?.config.stacked).toBe(true)
+    expect(restored?.config.resolution).toBe(800)
+    expect(restored?.config.series).toEqual(fullConfig.series)
+    // The id is regenerated on decode; everything else survives.
+    expect(restored?.config.expressions).toEqual([{ ...fullConfig.expressions[0], id: 'expr-0' }])
+  })
+
+  it('omits defaulted fields so a simple graph gets a short link', () => {
+    const query = encodeAdhocState({ ...fullConfig, title: '', verticalLabel: '', stacked: false, resolution: DEFAULT_RESOLUTION }, time)
+
+    expect(query.title).toBeUndefined()
+    expect(query.vlabel).toBeUndefined()
+    expect(query.stacked).toBeUndefined()
+    expect(query.res).toBeUndefined()
+  })
+
+  it('returns null when the query carries no ad-hoc state', () => {
+    expect(decodeAdhocState({})).toBeNull()
+    expect(decodeAdhocState({ unrelated: 'value' })).toBeNull()
+  })
+
+  it('accepts a single-series query that vue-router hands over as a bare string', () => {
+    const restored = decodeAdhocState({
+      s: 'node[1].x|ifInOctets~ifInOctets~AVERAGE~in~line~#2a78d6~0',
+      start: '1704067200',
+      end: '1704070800',
+      fmt: 'hours'
+    })
+
+    expect(restored?.config.series).toHaveLength(1)
+    expect(restored?.config.series[0].label).toBe('in')
+  })
+})
+
+describe('decodeAdhocState is defensive', () => {
+  it('drops entries with no resource id or attribute rather than throwing', () => {
+    const restored = decodeAdhocState({
+      s: ['', '~~~~~~', 'only-a-resource-id', 'node[1]~ifInOctets~AVERAGE~in~line~#2a78d6~0'],
+      start: '1704067200'
+    })
+
+    expect(restored?.config.series.map(entry => entry.attribute)).toEqual(['ifInOctets'])
+  })
+
+  it('drops a duplicate series so one selection cannot be plotted twice', () => {
+    const entry = 'node[1]~ifInOctets~AVERAGE~in~line~#2a78d6~0'
+    expect(decodeAdhocState({ s: [entry, entry] })?.config.series).toHaveLength(1)
+  })
+
+  it('keeps a weighted line style through a round trip', () => {
+    const restored = decodeAdhocState({ s: 'node[1]~ifInOctets~AVERAGE~in~line2~#2a78d6~0' })
+    expect(restored?.config.series[0].style).toBe('line2')
+  })
+
+  it('falls back on unrecognised aggregations, styles and colours', () => {
+    const restored = decodeAdhocState({ s: 'node[1]~ifInOctets~BOGUS~in~spiral~red~0' })
+    const entry = restored?.config.series[0]
+
+    expect(entry?.aggregation).toBe(ConsolidationFunctionType.AVERAGE)
+    expect(entry?.style).toBe('line')
+    expect(entry?.color).toBe('')
+  })
+
+  it('drops an expression missing its name or value', () => {
+    const restored = decodeAdhocState({
+      s: 'node[1]~ifInOctets~AVERAGE~in~line~#2a78d6~0',
+      e: ['~in * 8', 'nameless~', 'bits~in * 8~line~#eb6834']
+    })
+
+    expect(restored?.config.expressions.map(expression => expression.label)).toEqual(['bits'])
+  })
+
+  it('falls back to a sane time range and resolution on garbage input', () => {
+    const restored = decodeAdhocState({ s: 'node[1]~ifInOctets', start: 'yesterday', end: '-5', res: '0' })
+
+    expect(restored?.time.startTime).toBe(0)
+    expect(restored?.time.endTime).toBe(0)
+    expect(restored?.time.format).toBe('hours')
+    expect(restored?.config.resolution).toBe(DEFAULT_RESOLUTION)
+  })
+
+  it('tolerates a null-valued key from a query like ?stacked', () => {
+    expect(() => decodeAdhocState({ s: null, e: [null], stacked: null, start: null })).not.toThrow()
+  })
+})
+
+describe('encodedQueryLength', () => {
+  it('grows with the number of series and flags an unshareable selection', () => {
+    const short = encodeAdhocState(fullConfig, time)
+    expect(encodedQueryLength(short)).toBeLessThan(MAX_QUERY_LENGTH)
+
+    const many: AdhocGraphConfig = {
+      ...fullConfig,
+      series: Array.from({ length: 60 }, (_unused, index) => ({
+        ...fullConfig.series[0],
+        key: `node[${index}].interfaceSnmp[GigabitEthernet0-0-${index}]|ifHCInOctets`,
+        label: `in_octets_${index}`,
+        resourceId: `node[${index}].interfaceSnmp[GigabitEthernet0-0-${index}]`
+      }))
+    }
+
+    expect(encodedQueryLength(encodeAdhocState(many, time))).toBeGreaterThan(MAX_QUERY_LENGTH)
+  })
+
+  it('counts a bare-string value as well as an array one', () => {
+    const query: RouteQuery = { s: 'abc' }
+    expect(encodedQueryLength(query)).toBeGreaterThan(0)
+  })
+})

--- a/ui/tests/components/AdhocGraphs/adhocUrlState.test.ts
+++ b/ui/tests/components/AdhocGraphs/adhocUrlState.test.ts
@@ -154,7 +154,7 @@ describe('decodeAdhocState is defensive', () => {
     expect(restored?.config.series[0].style).toBe('line2')
   })
 
-  it('falls back on unrecognised aggregations, styles and colours', () => {
+  it('falls back on unrecognized aggregations, styles and colors', () => {
     const restored = decodeAdhocState({ s: 'node[1]~ifInOctets~BOGUS~in~spiral~red~0' })
     const entry = restored?.config.series[0]
 

--- a/ui/tests/components/AdhocGraphs/jexlToRpn.test.ts
+++ b/ui/tests/components/AdhocGraphs/jexlToRpn.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+
+import { jexlToRpn, JexlToRpnSuccess } from '@/components/AdhocGraphs/utils/jexlToRpn'
+import RpnToJexlConverter from '@/components/Resources/utils/RpnToJexlConverter.class'
+
+const rpnOf = (expression: string): string => {
+  const result = jexlToRpn(expression)
+  expect(result.ok, `expected ${expression} to convert`).toBe(true)
+  return (result as JexlToRpnSuccess).rpn
+}
+
+const reasonOf = (expression: string): string => {
+  const result = jexlToRpn(expression)
+  expect(result.ok, `expected ${expression} to be refused`).toBe(false)
+  return (result as { ok: false, reason: string }).reason
+}
+
+/** Evaluate RRD RPN over a scope, so a conversion can be checked by its result. */
+const evaluateRpn = (rpn: string, scope: Record<string, number>): number => {
+  const stack: number[] = []
+
+  for (const token of rpn.split(',')) {
+    if (['+', '-', '*', '/', '%'].includes(token)) {
+      const b = stack.pop() as number
+      const a = stack.pop() as number
+      stack.push(
+        token === '+' ? a + b :
+          token === '-' ? a - b :
+            token === '*' ? a * b :
+              token === '/' ? a / b : a % b
+      )
+      continue
+    }
+
+    stack.push(token in scope ? scope[token] : Number(token))
+  }
+
+  expect(stack).toHaveLength(1)
+  return stack[0]
+}
+
+describe('jexlToRpn', () => {
+  it('converts the canonical octets-to-bits expression', () => {
+    expect(rpnOf('ifHCInOctets * 8')).toBe('ifHCInOctets,8,*')
+  })
+
+  it('collects the series it references, in order, without duplicates', () => {
+    const result = jexlToRpn('(a + b) / a') as JexlToRpnSuccess
+    expect(result.identifiers).toEqual(['a', 'b'])
+  })
+
+  it('honours operator precedence', () => {
+    expect(rpnOf('a + b * c')).toBe('a,b,c,*,+')
+    expect(rpnOf('(a + b) * c')).toBe('a,b,+,c,*')
+  })
+
+  it('is left-associative for equal precedence', () => {
+    expect(rpnOf('a - b - c')).toBe('a,b,-,c,-')
+    expect(rpnOf('a / b / c')).toBe('a,b,/,c,/')
+  })
+
+  it('accepts decimal and scientific literals', () => {
+    expect(rpnOf('a * 1.5')).toBe('a,1.5,*')
+    expect(rpnOf('a / 1e6')).toBe('a,1e6,/')
+  })
+
+  // RRD RPN has no negation operator, so -x has to become 0,x,- — and crucially
+  // the 0 belongs before the whole operand, not just its last token.
+  it('expands unary minus, including over a parenthesised operand', () => {
+    expect(rpnOf('-a')).toBe('0,a,-')
+    expect(rpnOf('-(a + b)')).toBe('0,a,b,+,-')
+    expect(rpnOf('-a * b')).toBe('0,a,-,b,*')
+    expect(rpnOf('a - -b')).toBe('a,0,b,-,-')
+  })
+
+  it('produces RPN that evaluates to the same number as the infix form', () => {
+    const scope = { a: 12, b: 5, c: 2 }
+    const cases: [string, number][] = [
+      ['a + b * c', 12 + 5 * 2],
+      ['(a + b) * c', (12 + 5) * 2],
+      ['a - b - c', 12 - 5 - 2],
+      ['-a * b', -12 * 5],
+      ['-(a + b)', -(12 + 5)],
+      ['a % b', 12 % 5],
+      ['a * 8 / 1000', 12 * 8 / 1000]
+    ]
+
+    for (const [expression, expected] of cases) {
+      expect(evaluateRpn(rpnOf(expression), scope), expression).toBeCloseTo(expected, 9)
+    }
+  })
+
+  // The SPA already ships the opposite converter for reading prefab graphs, so a
+  // conversion can be checked by feeding it back and comparing to the input.
+  it('round-trips through the existing RpnToJexlConverter', () => {
+    const converter = new RpnToJexlConverter()
+
+    expect(converter.convert(rpnOf('ifInOctets * 8'))).toBe('(ifInOctets * 8)')
+    expect(converter.convert(rpnOf('(a + b) * c'))).toBe('((a + b) * c)')
+    expect(converter.convert(rpnOf('a + b * c'))).toBe('(a + (b * c))')
+  })
+
+  describe('refuses what RRD RPN cannot express', () => {
+    it('function calls, naming the function', () => {
+      expect(reasonOf('math:abs(a)')).toContain('Function calls are not supported')
+    })
+
+    it('conditionals', () => {
+      expect(reasonOf('a > 0 ? a : 0')).toMatch(/Comparison|Conditional/)
+    })
+
+    it('comparison and logical operators', () => {
+      expect(reasonOf('a > b')).toContain('Comparison and logical operators')
+      expect(reasonOf('a && b')).toContain('Comparison and logical operators')
+    })
+
+    it('text values', () => {
+      expect(reasonOf('a + "x"')).toContain('Text values are not supported')
+    })
+  })
+
+  describe('refuses malformed input', () => {
+    it('an empty expression', () => {
+      expect(reasonOf('   ')).toBe('The expression is empty.')
+    })
+
+    it('an expression with no series in it', () => {
+      expect(reasonOf('8 * 2')).toBe('The expression does not reference any series.')
+    })
+
+    it('unbalanced parentheses', () => {
+      expect(reasonOf('(a + b')).toContain('Unbalanced parentheses')
+      expect(reasonOf('a + b)')).toContain('Unbalanced parentheses')
+    })
+
+    it('a trailing operator', () => {
+      expect(reasonOf('a *')).toBe('The expression ends with an operator.')
+    })
+
+    it('two values in a row', () => {
+      expect(reasonOf('a b')).toContain('Missing an operator')
+    })
+  })
+})

--- a/ui/tests/components/AdhocGraphs/jexlToRpn.test.ts
+++ b/ui/tests/components/AdhocGraphs/jexlToRpn.test.ts
@@ -49,7 +49,7 @@ describe('jexlToRpn', () => {
     expect(result.identifiers).toEqual(['a', 'b'])
   })
 
-  it('honours operator precedence', () => {
+  it('honors operator precedence', () => {
     expect(rpnOf('a + b * c')).toBe('a,b,c,*,+')
     expect(rpnOf('(a + b) * c')).toBe('a,b,+,c,*')
   })

--- a/ui/tests/components/AdhocGraphs/rrdGraphDefinition.test.ts
+++ b/ui/tests/components/AdhocGraphs/rrdGraphDefinition.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_RESOLUTION } from '@/components/AdhocGraphs/utils/adhocQuery'
+import {
+  buildRrdGraphDefinition,
+  describeIneligibility,
+  isRrdGraphDefinition,
+  reportNameFor,
+  resourceTypeOf,
+  RrdGraphDefinition
+} from '@/components/AdhocGraphs/utils/rrdGraphDefinition'
+import RrdGraphConverter from '@/components/Resources/utils/RrdGraphConverter.class'
+import { PreFabGraph } from '@/types'
+import { AdhocExpression, AdhocGraphConfig, AdhocSeries } from '@/types/adhocGraph'
+import { ConsolidationFunctionType } from '@/types/timeSeries'
+
+const RESOURCE = 'node[1].interfaceSnmp[eth0]'
+
+const series = (overrides: Partial<AdhocSeries> = {}): AdhocSeries => ({
+  key: `${RESOURCE}|ifInOctets`,
+  label: 'ifInOctets',
+  resourceId: RESOURCE,
+  attribute: 'ifInOctets',
+  aggregation: ConsolidationFunctionType.AVERAGE,
+  color: '#2a78d6',
+  style: 'line',
+  hidden: false,
+  ...overrides
+})
+
+const expression = (overrides: Partial<AdhocExpression> = {}): AdhocExpression => ({
+  id: 'expr-1',
+  label: 'bitsIn',
+  value: 'ifInOctets * 8',
+  color: '#eb6834',
+  style: 'line',
+  ...overrides
+})
+
+const config = (overrides: Partial<AdhocGraphConfig> = {}): AdhocGraphConfig => ({
+  series: [series()],
+  expressions: [],
+  title: 'WAN traffic',
+  verticalLabel: 'bits per second',
+  stacked: false,
+  resolution: DEFAULT_RESOLUTION,
+  ...overrides
+})
+
+const build = (input: AdhocGraphConfig): RrdGraphDefinition => {
+  const result = buildRrdGraphDefinition(input)
+  expect(isRrdGraphDefinition(result), JSON.stringify(result)).toBe(true)
+  return result as RrdGraphDefinition
+}
+
+/** Feed a built definition back through the SPA's own prefab-graph parser. */
+const parseBack = (definition: RrdGraphDefinition) => {
+  const graphDef = {
+    name: definition.reportName,
+    title: 'WAN traffic',
+    columns: definition.columns,
+    command: definition.command,
+    externalValues: [],
+    propertiesValues: [],
+    suppress: [],
+    types: [definition.type],
+    description: null,
+    height: null,
+    width: null,
+    order: 0
+  } as PreFabGraph
+
+  return new RrdGraphConverter({ graphDef, resourceId: RESOURCE }).model
+}
+
+describe('resourceTypeOf', () => {
+  it('reads the type out of a resource id', () => {
+    expect(resourceTypeOf('node[1].interfaceSnmp[eth0]')).toBe('interfaceSnmp')
+    expect(resourceTypeOf('node[1].nodeSnmp[]')).toBe('nodeSnmp')
+    expect(resourceTypeOf('nodeSource[Demo:1].interfaceSnmp[eth0]')).toBe('interfaceSnmp')
+  })
+
+  // The bracketed part routinely contains dots and slashes, so splitting on '.'
+  // would pick the wrong token.
+  it('is not confused by punctuation inside the brackets', () => {
+    expect(resourceTypeOf('node[1].hrStorageIndex[/var/log.d]')).toBe('hrStorageIndex')
+  })
+
+  it('returns null when there is no type to read', () => {
+    expect(resourceTypeOf('nonsense')).toBeNull()
+    expect(resourceTypeOf('[1]')).toBeNull()
+  })
+})
+
+describe('reportNameFor', () => {
+  it('names the report after the resource type and its datasources', () => {
+    expect(reportNameFor(RESOURCE, ['ifHCInOctets', 'ifHCOutOctets']))
+      .toBe('adhoc.interfaceSnmp.ifHCInOctets_ifHCOutOctets')
+  })
+
+  // A prefab graph renders for every resource of its type, so the instance must
+  // not appear in the id — it would read as "this graph is only for eth0".
+  it('leaves the resource instance out of the id', () => {
+    const name = reportNameFor('node[7].interfaceSnmp[GigabitEthernet0-0-1]', ['ifInOctets'])
+
+    expect(name).toBe('adhoc.interfaceSnmp.ifInOctets')
+    expect(name).not.toContain('7')
+    expect(name).not.toContain('Gigabit')
+  })
+
+  it('summarises rather than listing every datasource once there are many', () => {
+    const name = reportNameFor(RESOURCE, ['a', 'b', 'c', 'd', 'e', 'f'])
+
+    expect(name).toBe('adhoc.interfaceSnmp.a_b_c_d_and_2_more')
+  })
+
+  it('produces a key-safe id even from an odd resource id or datasource', () => {
+    const name = reportNameFor('node[1].hrStorageIndex[/var/log.d]', ['hrStorage Used'])
+
+    expect(name).toBe('adhoc.hrStorageIndex.hrStorage_Used')
+    expect(name).toMatch(/^[A-Za-z0-9_.]+$/)
+  })
+
+  it('falls back when the resource type cannot be read', () => {
+    expect(reportNameFor('nonsense', ['ifInOctets'])).toBe('adhoc.resource.ifInOctets')
+  })
+})
+
+describe('describeIneligibility', () => {
+  it('accepts a single-resource graph', () => {
+    expect(describeIneligibility(config())).toBeNull()
+  })
+
+  it('refuses an empty graph', () => {
+    expect(describeIneligibility(config({ series: [] }))).toContain('no series')
+  })
+
+  // The reason this whole feature is gated: {rrdN} resolves against one resource.
+  it('refuses a graph spanning two resources, and says how many', () => {
+    const reason = describeIneligibility(config({
+      series: [series(), series({ key: 'b', resourceId: 'node[2].interfaceSnmp[eth1]', label: 'other' })]
+    }))
+
+    expect(reason).toContain('bound to a single resource')
+    expect(reason).toContain('2 of them')
+  })
+
+  it('refuses an expression it cannot convert, with the converter reason', () => {
+    const reason = describeIneligibility(config({
+      expressions: [expression({ value: 'math:abs(ifInOctets)' })]
+    }))
+
+    expect(reason).toContain('Expression \'bitsIn\'')
+    expect(reason).toContain('Function calls are not supported')
+  })
+
+  it('refuses an expression built on another expression', () => {
+    const reason = describeIneligibility(config({
+      expressions: [expression(), expression({ id: 'expr-2', label: 'doubled', value: 'bitsIn * 2' })]
+    }))
+
+    expect(reason).toContain('which is not a source series')
+  })
+})
+
+describe('buildRrdGraphDefinition', () => {
+  it('emits the four report properties', () => {
+    const definition = build(config())
+
+    expect(definition.reportName).toBe('adhoc.interfaceSnmp.ifInOctets')
+    expect(definition.type).toBe('interfaceSnmp')
+    expect(definition.columns).toEqual(['ifInOctets'])
+    // The title stays the human-readable name; only the id is derived.
+    expect(definition.properties).toContain('report.adhoc.interfaceSnmp.ifInOctets.name=WAN traffic')
+    expect(definition.properties).toContain('report.adhoc.interfaceSnmp.ifInOctets.columns=ifInOctets')
+    expect(definition.properties).toContain('report.adhoc.interfaceSnmp.ifInOctets.type=interfaceSnmp')
+  })
+
+  it('emits a DEF per series with its consolidation function', () => {
+    const definition = build(config({
+      series: [series(), series({ key: 'b', label: 'ifOutOctets', attribute: 'ifOutOctets', aggregation: ConsolidationFunctionType.MAX })]
+    }))
+
+    expect(definition.command).toContain('DEF:ifInOctets={rrd1}:ifInOctets:AVERAGE')
+    expect(definition.command).toContain('DEF:ifOutOctets={rrd2}:ifOutOctets:MAX')
+    expect(definition.columns).toEqual(['ifInOctets', 'ifOutOctets'])
+  })
+
+  // {rrdN} is positional over `columns`, so one attribute read at two consolidation
+  // functions is a single column referenced twice.
+  it('shares one column between two series on the same attribute', () => {
+    const definition = build(config({
+      series: [
+        series(),
+        series({ key: 'b', label: 'ifInOctetsMax', aggregation: ConsolidationFunctionType.MAX })
+      ]
+    }))
+
+    expect(definition.columns).toEqual(['ifInOctets'])
+    expect(definition.command).toContain('DEF:ifInOctets={rrd1}:ifInOctets:AVERAGE')
+    expect(definition.command).toContain('DEF:ifInOctetsMax={rrd1}:ifInOctets:MAX')
+  })
+
+  it('emits a CDEF in RPN for each expression', () => {
+    const definition = build(config({ expressions: [expression()] }))
+    expect(definition.command).toContain('CDEF:bitsIn=ifInOctets,8,*')
+  })
+
+  // The style names exist to line up with these commands one-for-one.
+  it('maps every style onto its RRD draw command', () => {
+    expect(build(config()).command).toContain('LINE1:ifInOctets#2a78d6:')
+    expect(build(config({ series: [series({ style: 'line2' })] })).command).toContain('LINE2:ifInOctets#2a78d6:')
+    expect(build(config({ series: [series({ style: 'line3' })] })).command).toContain('LINE3:ifInOctets#2a78d6:')
+    expect(build(config({ series: [series({ style: 'area' })] })).command).toContain('AREA:ifInOctets#2a78d6:')
+
+    const stacked = build(config({ series: [series({ style: 'stack' })] })).command
+    expect(stacked).toContain('AREA:ifInOctets#2a78d6:')
+    expect(stacked).toContain(':STACK')
+  })
+
+  it('emits Avg/Min/Max/Last GPRINTs for each drawn series', () => {
+    const command = build(config()).command
+    for (const cf of ['AVERAGE', 'MIN', 'MAX', 'LAST']) {
+      expect(command).toContain(`GPRINT:ifInOctets:${cf}:`)
+    }
+  })
+
+  // Same rule the measurements query applies via `transient`: keep the data, drop
+  // the drawing.
+  it('keeps the DEF but draws nothing for a hidden, consumed series', () => {
+    const definition = build(config({
+      series: [series({ hidden: true })],
+      expressions: [expression()]
+    }))
+
+    expect(definition.command).toContain('DEF:ifInOctets=')
+    expect(definition.command).not.toContain('LINE1:ifInOctets#')
+    expect(definition.command).toContain('LINE1:bitsIn#')
+  })
+
+  it('draws a hidden series that no expression consumes', () => {
+    const definition = build(config({ series: [series({ hidden: true })] }))
+    expect(definition.command).toContain('LINE1:ifInOctets#')
+  })
+
+  it('omits the vertical label when there is none', () => {
+    expect(build(config({ verticalLabel: '  ' })).command).not.toContain('--vertical-label')
+  })
+
+  // The id no longer depends on the title, so an untitled graph still gets a
+  // meaningful one — which is the point of deriving it from the data.
+  it('still names an untitled graph after its datasources', () => {
+    const definition = build(config({ title: '' }))
+    expect(definition.reportName).toBe('adhoc.interfaceSnmp.ifInOctets')
+    expect(definition.command).toContain('--title="Ad-hoc graph"')
+  })
+
+  it('names a multi-datasource report after all of them', () => {
+    const definition = build(config({
+      series: [series(), series({ key: 'b', label: 'ifOutOctets', attribute: 'ifOutOctets' })]
+    }))
+    expect(definition.reportName).toBe('adhoc.interfaceSnmp.ifInOctets_ifOutOctets')
+  })
+})
+
+describe('escaping', () => {
+  it('single-escapes the effective command and doubles it for the properties file', () => {
+    const definition = build(config())
+
+    // What RRDtool receives.
+    expect(definition.command).toContain('GPRINT:ifInOctets:AVERAGE:"Avg \\: %8.2lf %s"')
+    // What goes on disk, matching the shipped snmp-graph.properties.d files.
+    expect(definition.properties).toContain('GPRINT:ifInOctets:AVERAGE:"Avg \\\\: %8.2lf %s"')
+  })
+
+  it('escapes a quote in the title rather than breaking the argument', () => {
+    const definition = build(config({ title: 'The "big" one' }))
+    expect(definition.command).toContain('--title="The \\"big\\" one"')
+  })
+
+  it('breaks the properties command across continuation lines', () => {
+    const lines = build(config()).properties.split('\n')
+    const continuations = lines.filter(line => line.endsWith(' \\'))
+
+    expect(continuations.length).toBeGreaterThan(0)
+    // Every continuation line but the last of the block ends in a backslash.
+    expect(lines[lines.length - 1].endsWith('\\')).toBe(false)
+  })
+})
+
+// The SPA already contains the parser for this format (a TypeScript port of
+// Backshift), so a generated definition can be checked by reading it back.
+describe('round-trips through RrdGraphConverter', () => {
+  it('recovers the title, vertical label and metrics of a simple graph', () => {
+    const model = parseBack(build(config()))
+
+    expect(model.title).toBe('WAN traffic')
+    expect(model.verticalLabel).toBe('bits per second')
+    expect(model.metrics.map((metric: { name?: string }) => metric.name)).toContain('ifInOctets')
+    expect(model.metrics[0].attribute).toBe('ifInOctets')
+    expect(model.metrics[0].aggregation).toBe('AVERAGE')
+    expect(model.metrics[0].resourceId).toBe(RESOURCE)
+  })
+
+  it('recovers the drawn series, their colours and their order', () => {
+    const model = parseBack(build(config({
+      series: [
+        series({ style: 'area', color: '#1baf7a' }),
+        series({ key: 'b', label: 'ifOutOctets', attribute: 'ifOutOctets', color: '#eb6834' })
+      ]
+    })))
+
+    const drawn = model.series.filter((entry: { type: string }) => entry.type !== 'hidden')
+    expect(drawn.map((entry: { metric: string }) => entry.metric)).toEqual(['ifInOctets', 'ifOutOctets'])
+    expect(drawn[0].type).toBe('area')
+    expect(drawn[0].color).toBe('#1baf7a')
+    expect(drawn[1].type).toBe('line')
+    expect(drawn[1].color).toBe('#eb6834')
+  })
+
+  it('recovers an expression as a JEXL metric equivalent to the original', () => {
+    const model = parseBack(build(config({ expressions: [expression()] })))
+    const derived = model.metrics.find((metric: { name?: string }) => metric.name === 'bitsIn') as { expression: string }
+
+    expect(derived).toBeDefined()
+    // The CDEF went out as RPN and came back as JEXL — the same arithmetic the
+    // user typed into the expression editor.
+    expect(derived.expression.replace(/\s+/g, '')).toBe('(ifInOctets*8)')
+  })
+
+  // A GPRINT with a consolidation function makes the converter synthesise its own
+  // consolidated metric (ifInOctets_AVERAGE_<id>), so the statements are matched
+  // by their format rather than by metric name.
+  it('recovers an Avg/Min/Max/Last legend for the drawn series', () => {
+    const model = parseBack(build(config()))
+    const formats = model.printStatements
+      .map((statement: { format: string }) => statement.format)
+      .filter((format: string) => format.includes('%8.2lf'))
+
+    expect(formats).toHaveLength(4)
+    expect(formats[0]).toContain('Avg')
+    expect(formats[1]).toContain('Min')
+    expect(formats[2]).toContain('Max')
+    expect(formats[3]).toContain('Last')
+
+    // The escaped colon survived both escaping layers and came back as a plain one.
+    expect(formats[0]).toContain('Avg : ')
+
+    const consolidated = model.printStatements
+      .filter((statement: { format: string }) => statement.format.includes('%8.2lf'))
+      .map((statement: { metric: string }) => statement.metric)
+    expect(consolidated.every((metric: string) => metric.startsWith('ifInOctets_'))).toBe(true)
+  })
+})

--- a/ui/tests/components/AdhocGraphs/rrdGraphDefinition.test.ts
+++ b/ui/tests/components/AdhocGraphs/rrdGraphDefinition.test.ts
@@ -164,6 +164,16 @@ describe('describeIneligibility', () => {
 })
 
 describe('buildRrdGraphDefinition', () => {
+  // Without a reports= entry the file parses and draws nothing, which is a
+  // particularly unhelpful failure: no error, just no graph.
+  it('includes the reports= line so a pasted file works as it stands', () => {
+    const definition = build(config())
+
+    expect(definition.properties.split('\n')[0]).toBe(`reports=${definition.reportName}`)
+    expect(definition.properties).toContain('# Appending to an existing file?')
+    expect(definition.properties).toContain(`# ${definition.reportName} to that file's existing reports= list`)
+  })
+
   it('emits the four report properties', () => {
     const definition = build(config())
 

--- a/ui/tests/components/AdhocGraphs/rrdGraphDefinition.test.ts
+++ b/ui/tests/components/AdhocGraphs/rrdGraphDefinition.test.ts
@@ -108,7 +108,7 @@ describe('reportNameFor', () => {
     expect(name).not.toContain('Gigabit')
   })
 
-  it('summarises rather than listing every datasource once there are many', () => {
+  it('summarizes rather than listing every datasource once there are many', () => {
     const name = reportNameFor(RESOURCE, ['a', 'b', 'c', 'd', 'e', 'f'])
 
     expect(name).toBe('adhoc.interfaceSnmp.a_b_c_d_and_2_more')
@@ -302,7 +302,7 @@ describe('round-trips through RrdGraphConverter', () => {
     expect(model.metrics[0].resourceId).toBe(RESOURCE)
   })
 
-  it('recovers the drawn series, their colours and their order', () => {
+  it('recovers the drawn series, their colors and their order', () => {
     const model = parseBack(build(config({
       series: [
         series({ style: 'area', color: '#1baf7a' }),

--- a/ui/tests/components/AdhocGraphs/rrdGraphDefinition.test.ts
+++ b/ui/tests/components/AdhocGraphs/rrdGraphDefinition.test.ts
@@ -262,7 +262,7 @@ describe('buildRrdGraphDefinition', () => {
   it('still names an untitled graph after its datasources', () => {
     const definition = build(config({ title: '' }))
     expect(definition.reportName).toBe('adhoc.interfaceSnmp.ifInOctets')
-    expect(definition.command).toContain('--title="Ad-hoc graph"')
+    expect(definition.command).toContain('--title="Custom performance graph"')
   })
 
   it('names a multi-datasource report after all of them', () => {

--- a/ui/tests/components/Resources/GraphDataTable.test.ts
+++ b/ui/tests/components/Resources/GraphDataTable.test.ts
@@ -1,0 +1,99 @@
+import { format as formatDate } from 'date-fns'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it } from 'vitest'
+
+import GraphDataTable from '@/components/Resources/GraphDataTable.vue'
+import { ConvertedGraphData, GraphMetricsResponse } from '@/types'
+
+// Three samples, ascending, which is the order the measurements API returns.
+// The expected strings below are derived from these with date-fns rather than
+// hard-coded, so the suite does not depend on the machine's time zone.
+const graphData = {
+  timestamps: [1704067200000, 1704067500000, 1704067800000],
+  // Axis labels — deliberately unlike what the table should render.
+  formattedTimestamps: ['00:00', '00:05', '00:10'],
+  labels: ['ifInOctets'],
+  columns: [{ values: [10, 20, 30] }],
+  formattedLabels: []
+} as unknown as GraphMetricsResponse
+
+const convertedGraphData = {
+  title: '',
+  verticalLabel: '',
+  series: [],
+  values: [],
+  properties: {},
+  metrics: [{ name: 'ifInOctets', label: 'ifInOctets', aggregation: 'AVERAGE', attribute: 'ifInOctets', resourceId: 'r' }],
+  printStatements: [{ format: '', header: 'ifInOctets', metric: 'ifInOctets', value: NaN }]
+} as unknown as ConvertedGraphData
+
+const mountTable = () => mount(GraphDataTable, {
+  props: { id: 'test', graphData, convertedGraphData },
+  global: { plugins: [PrimeVue] }
+})
+
+const rows = (wrapper: ReturnType<typeof mountTable>) =>
+  wrapper.findAll('tbody tr').map(row => row.findAll('td').map(cell => cell.text()))
+
+const at = (index: number) => formatDate(new Date(graphData.timestamps[index]), 'EEE MMM d HH:mm:ss yyyy')
+
+describe('GraphDataTable Date/Time column', () => {
+  // Matches the legacy graph view, which renders this column with d3's `%c`.
+  it('shows a full local date and time, not the axis label', () => {
+    const first = rows(mountTable())[0][0]
+
+    // Local time, so assert the shape rather than a literal that only holds in UTC.
+    expect(first).toMatch(/^[A-Z][a-z]{2} [A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}:\d{2} \d{4}$/)
+    expect(first).toBe(at(2))
+    expect(first).not.toBe('00:10')
+  })
+
+  it('still shows epoch milliseconds when Raw values is ticked', async () => {
+    const wrapper = mountTable()
+    await wrapper.find('input[type="checkbox"]').setValue(true)
+
+    expect(rows(wrapper)[0][0]).toBe('1704067800000')
+  })
+
+  it('renders an empty cell rather than "Invalid Date" for a missing timestamp', () => {
+    const wrapper = mount(GraphDataTable, {
+      props: {
+        id: 'test',
+        graphData: { ...graphData, timestamps: [Number.NaN] } as unknown as GraphMetricsResponse,
+        convertedGraphData
+      },
+      global: { plugins: [PrimeVue] }
+    })
+
+    expect(rows(wrapper as never)[0][0]).toBe('')
+  })
+})
+
+describe('GraphDataTable row order', () => {
+  // Matches the legacy view, which walks its rows backwards.
+  it('puts the most recent sample first, everywhere', () => {
+    expect(rows(mountTable())).toEqual([
+      [at(2), '30.0'],
+      [at(1), '20.0'],
+      [at(0), '10.0']
+    ])
+  })
+
+  // The timestamp and its values are separate arrays indexed in step, so the
+  // reversal has to act on the indices. Reversing the data instead would pair
+  // each timestamp with the wrong reading — silently.
+  it('keeps every reading with its own timestamp', () => {
+    const ascending = graphData.timestamps.map((timestamp, index) =>
+      [formatDate(new Date(timestamp), 'EEE MMM d HH:mm:ss yyyy'), `${graphData.columns[0].values[index]}.0`])
+
+    expect(rows(mountTable())).toEqual([...ascending].reverse())
+  })
+
+  it('reverses the raw values view too', async () => {
+    const wrapper = mountTable()
+    await wrapper.find('input[type="checkbox"]').setValue(true)
+
+    expect(rows(wrapper)[0][0]).toBe('1704067800000')
+  })
+})

--- a/ui/tests/components/Resources/timeRangeOptions.test.ts
+++ b/ui/tests/components/Resources/timeRangeOptions.test.ts
@@ -1,0 +1,99 @@
+import { differenceInCalendarDays, differenceInCalendarMonths, sub } from 'date-fns'
+import { describe, expect, it } from 'vitest'
+
+import { HOUR_OPTIONS, TIME_RANGE_OPTIONS } from '@/components/Resources/utils/timeRangeOptions'
+
+// A date well away from a DST boundary or month end, so the arithmetic below is
+// unambiguous.
+const NOW = new Date('2026-08-10T12:00:00Z')
+
+const hoursBack = (duration: Parameters<typeof sub>[1]) =>
+  (NOW.getTime() - sub(NOW, duration).getTime()) / 3_600_000
+
+const optionFor = (label: string) => {
+  const option = TIME_RANGE_OPTIONS.find(entry => entry.label === label)
+  expect(option, `no option labelled ${label}`).toBeDefined()
+  return option!
+}
+
+/**
+ * The regression these guard: date-fns sums duration fields before applying them
+ * (`minutes + hours * 60`, `days + weeks * 7`, `months + years * 12`). A string
+ * first operand turns that `+` into concatenation, so `{ minutes: '60' }` went
+ * back 600 minutes and `{ days: '7' }` went back 70 days. Seven of the twelve
+ * ranges were wrong; only the hours-only ones survived, because multiplication
+ * coerces where addition does not.
+ */
+describe('TIME_RANGE_OPTIONS', () => {
+  it('uses numeric duration values throughout', () => {
+    for (const option of TIME_RANGE_OPTIONS) {
+      for (const [field, value] of Object.entries(option.time)) {
+        expect(typeof value, `${option.label}.${field} must be a number`).toBe('number')
+      }
+    }
+  })
+
+  it.each([
+    ['Last hour', 1],
+    ['Last 2 hours', 2],
+    ['Last 4 hours', 4],
+    ['Last 8 hours', 8],
+    ['Last 12 hours', 12],
+    ['Last day', 24],
+    ['Last two days', 48]
+  ])('%s goes back exactly %i hours', (label, expected) => {
+    expect(hoursBack(optionFor(label).time)).toBe(expected)
+  })
+
+  it('Last week goes back exactly 7 days', () => {
+    expect(differenceInCalendarDays(NOW, sub(NOW, optionFor('Last week').time))).toBe(7)
+  })
+
+  it.each([
+    ['Last month', 1],
+    ['Last three months', 3],
+    ['Last six months', 6]
+  ])('%s goes back exactly %i months', (label, expected) => {
+    expect(differenceInCalendarMonths(NOW, sub(NOW, optionFor(label).time))).toBe(expected)
+  })
+
+  it('Last year goes back exactly 12 months', () => {
+    expect(differenceInCalendarMonths(NOW, sub(NOW, optionFor('Last year').time))).toBe(12)
+  })
+
+  it('is ordered shortest range first, with no duplicate labels', () => {
+    const spans = TIME_RANGE_OPTIONS.map(option => hoursBack(option.time))
+    const sorted = [...spans].sort((a, b) => a - b)
+
+    expect(spans).toEqual(sorted)
+    expect(new Set(TIME_RANGE_OPTIONS.map(option => option.label)).size).toBe(TIME_RANGE_OPTIONS.length)
+  })
+
+  // The emitted `format` is Object.keys(time)[0], which drives the x-axis label
+  // granularity, so every option needs exactly one field.
+  it('carries exactly one duration field per option', () => {
+    for (const option of TIME_RANGE_OPTIONS) {
+      expect(Object.keys(option.time), option.label).toHaveLength(1)
+    }
+  })
+})
+
+describe('HOUR_OPTIONS', () => {
+  it('covers all 24 hours of the day in order', () => {
+    expect(HOUR_OPTIONS).toHaveLength(24)
+    expect(HOUR_OPTIONS.map(option => option.time.hours)).toEqual(
+      Array.from({ length: 24 }, (_unused, hour) => hour)
+    )
+  })
+
+  it('labels midnight and noon as 12 AM and 12 PM', () => {
+    expect(HOUR_OPTIONS[0].label).toBe('12 AM')
+    expect(HOUR_OPTIONS[12].label).toBe('12 PM')
+  })
+
+  it('uses numeric hours, so add() cannot concatenate them', () => {
+    for (const option of HOUR_OPTIONS) {
+      expect(typeof option.time.hours, option.label).toBe('number')
+    }
+  })
+})

--- a/ui/tests/components/Resources/timeRangeOptions.test.ts
+++ b/ui/tests/components/Resources/timeRangeOptions.test.ts
@@ -18,7 +18,7 @@ const hoursBack = (duration: Parameters<typeof sub>[1]) =>
 
 const optionFor = (label: string) => {
   const option = TIME_RANGE_OPTIONS.find(entry => entry.label === label)
-  expect(option, `no option labelled ${label}`).toBeDefined()
+  expect(option, `no option labeled ${label}`).toBeDefined()
   return option!
 }
 

--- a/ui/tests/components/Resources/timeRangeOptions.test.ts
+++ b/ui/tests/components/Resources/timeRangeOptions.test.ts
@@ -1,7 +1,13 @@
 import { differenceInCalendarDays, differenceInCalendarMonths, sub } from 'date-fns'
 import { describe, expect, it } from 'vitest'
 
-import { HOUR_OPTIONS, TIME_RANGE_OPTIONS } from '@/components/Resources/utils/timeRangeOptions'
+import {
+  DEFAULT_RANGE,
+  HOUR_OPTIONS,
+  relativeRangeOf,
+  resolveRelativeRange,
+  TIME_RANGE_OPTIONS
+} from '@/components/Resources/utils/timeRangeOptions'
 
 // A date well away from a DST boundary or month end, so the arithmetic below is
 // unambiguous.
@@ -95,5 +101,59 @@ describe('HOUR_OPTIONS', () => {
     for (const option of HOUR_OPTIONS) {
       expect(typeof option.time.hours, option.label).toBe('number')
     }
+  })
+})
+
+describe('relativeRangeOf', () => {
+  it('reduces every preset to a single unit and amount', () => {
+    for (const option of TIME_RANGE_OPTIONS) {
+      const range = relativeRangeOf(option)
+      expect(range, option.label).not.toBeNull()
+      expect(range!.amount).toBeGreaterThan(0)
+    }
+  })
+
+  it('reads the unit and amount the label promises', () => {
+    const byLabel = (label: string) => relativeRangeOf(TIME_RANGE_OPTIONS.find(o => o.label === label)!)
+
+    expect(byLabel('Last hour')).toEqual({ unit: 'hours', amount: 1 })
+    expect(byLabel('Last two days')).toEqual({ unit: 'hours', amount: 48 })
+    expect(byLabel('Last week')).toEqual({ unit: 'days', amount: 7 })
+    expect(byLabel('Last six months')).toEqual({ unit: 'months', amount: 6 })
+  })
+
+  it('refuses a duration that is not one clean unit', () => {
+    expect(relativeRangeOf({ label: 'mixed', time: { hours: 1, minutes: 30 }})).toBeNull()
+    expect(relativeRangeOf({ label: 'empty', time: {}})).toBeNull()
+  })
+})
+
+describe('resolveRelativeRange', () => {
+  it('anchors the window to the clock it is given', () => {
+    const resolved = resolveRelativeRange({ unit: 'hours', amount: 2 }, NOW)
+
+    expect(resolved.endTime).toBe(Math.floor(NOW.getTime() / 1000))
+    expect(Number(resolved.endTime) - Number(resolved.startTime)).toBe(7200)
+  })
+
+  // The point of the whole exercise: the same range resolved later must move.
+  it('slides forward when resolved against a later clock', () => {
+    const range = { unit: 'hours', amount: 24 } as const
+    const earlier = resolveRelativeRange(range, NOW)
+    const later = resolveRelativeRange(range, new Date(NOW.getTime() + 3_600_000))
+
+    expect(Number(later.endTime) - Number(earlier.endTime)).toBe(3600)
+    expect(Number(later.startTime) - Number(earlier.startTime)).toBe(3600)
+    // Same width, different position.
+    expect(Number(later.endTime) - Number(later.startTime))
+      .toBe(Number(earlier.endTime) - Number(earlier.startTime))
+  })
+
+  it('carries the range along so it can be resolved again', () => {
+    expect(resolveRelativeRange(DEFAULT_RANGE, NOW).range).toEqual(DEFAULT_RANGE)
+  })
+
+  it('uses the unit as the axis-label granularity', () => {
+    expect(resolveRelativeRange({ unit: 'days', amount: 7 }, NOW).format).toBe('days')
   })
 })

--- a/ui/tests/composables/useClipboard.test.ts
+++ b/ui/tests/composables/useClipboard.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { copyToClipboard } from '@/composables/useClipboard'
+
+// The reason this composable exists rather than a bare navigator.clipboard call:
+// an OpenNMS server reached over plain HTTP on anything but localhost is not a
+// secure context, so the modern API is absent and the textarea path is what runs.
+describe('copyToClipboard', () => {
+  const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+
+  const setContext = (secure: boolean, clipboard: unknown) => {
+    Object.defineProperty(window, 'isSecureContext', { value: secure, configurable: true })
+    Object.defineProperty(navigator, 'clipboard', { value: clipboard, configurable: true })
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard)
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('uses the clipboard API in a secure context', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setContext(true, { writeText })
+
+    await copyToClipboard('https://example.com/#/adhoc-graphs?s=a')
+
+    expect(writeText).toHaveBeenCalledWith('https://example.com/#/adhoc-graphs?s=a')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('falls back to a textarea when the context is not secure', async () => {
+    const writeText = vi.fn()
+    setContext(false, { writeText })
+    const execCommand = vi.fn().mockReturnValue(true)
+    document.execCommand = execCommand as never
+
+    await copyToClipboard('plain-http-link')
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('falls back when the clipboard API is missing entirely', async () => {
+    setContext(true, undefined)
+    const execCommand = vi.fn().mockReturnValue(true)
+    document.execCommand = execCommand as never
+
+    await copyToClipboard('no-clipboard-api')
+
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('rejects, and leaves no textarea behind, when the copy command fails', async () => {
+    setContext(false, undefined)
+    document.execCommand = vi.fn().mockReturnValue(false) as never
+
+    await expect(copyToClipboard('nope')).rejects.toThrow()
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('cleans up the textarea even when execCommand throws', async () => {
+    setContext(false, undefined)
+    document.execCommand = vi.fn(() => {
+      throw new Error('blocked')
+    }) as never
+
+    await expect(copyToClipboard('nope')).rejects.toThrow('blocked')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+})

--- a/ui/tests/onms-ui/OnmsListbox.test.ts
+++ b/ui/tests/onms-ui/OnmsListbox.test.ts
@@ -26,6 +26,63 @@ describe('OnmsListbox', () => {
     expect(inner.props('listStyle')).toBe('max-height: 200px')
   })
 
+  it('forwards the multi-select and option-shape props', () => {
+    const objectOptions = [{ id: 'a', name: 'A', group: 'G' }]
+    const inner = mount(OnmsListbox, {
+      props: {
+        options: objectOptions,
+        multiple: true,
+        optionLabel: 'name',
+        optionValue: 'id',
+        optionDisabled: 'locked',
+        optionGroupLabel: 'group',
+        optionGroupChildren: 'items',
+        dataKey: 'id',
+        checkmark: true,
+        filterFields: ['name', 'group'],
+        scrollHeight: '18rem',
+        virtualScrollerOptions: { itemSize: 52 },
+        emptyMessage: 'Nothing here',
+        emptyFilterMessage: 'No matches',
+        disabled: true
+      },
+      global: globalPlugins
+    }).findComponent({ name: 'Listbox' })
+    expect(inner.props('multiple')).toBe(true)
+    expect(inner.props('optionLabel')).toBe('name')
+    expect(inner.props('optionValue')).toBe('id')
+    expect(inner.props('optionDisabled')).toBe('locked')
+    expect(inner.props('optionGroupLabel')).toBe('group')
+    expect(inner.props('optionGroupChildren')).toBe('items')
+    expect(inner.props('dataKey')).toBe('id')
+    expect(inner.props('checkmark')).toBe(true)
+    expect(inner.props('filterFields')).toEqual(['name', 'group'])
+    expect(inner.props('scrollHeight')).toBe('18rem')
+    expect(inner.props('virtualScrollerOptions')).toEqual({ itemSize: 52 })
+    expect(inner.props('emptyMessage')).toBe('Nothing here')
+    expect(inner.props('emptyFilterMessage')).toBe('No matches')
+    expect(inner.props('disabled')).toBe(true)
+  })
+
+  // Plain clicking must toggle a selection in a multi-select picker; PrimeVue's own
+  // default of requiring ctrl/cmd is the behaviour users report as broken.
+  it('defaults metaKeySelection to false', () => {
+    const inner = mount(OnmsListbox, {
+      props: { options, multiple: true },
+      global: globalPlugins
+    }).findComponent({ name: 'Listbox' })
+    expect(inner.props('metaKeySelection')).toBe(false)
+  })
+
+  it('forwards the option slot', () => {
+    const wrapper = mount(OnmsListbox, {
+      props: { options },
+      slots: { option: '<span class="custom-option">custom</span>' },
+      global: globalPlugins
+    })
+    expect(wrapper.findAll('.custom-option').length).toBe(options.length)
+  })
+
   it('re-emits update:modelValue from the inner listbox', () => {
     const wrapper = mount(OnmsListbox, { props: { options }, global: globalPlugins })
     wrapper.findComponent({ name: 'Listbox' }).vm.$emit('update:modelValue', 'b')

--- a/ui/tests/onms-ui/OnmsListbox.test.ts
+++ b/ui/tests/onms-ui/OnmsListbox.test.ts
@@ -27,51 +27,43 @@ describe('OnmsListbox', () => {
   })
 
   it('forwards the multi-select and option-shape props', () => {
-    const objectOptions = [{ id: 'a', name: 'A', group: 'G' }]
+    const objectOptions = [{ id: 'a', name: 'A' }]
     const inner = mount(OnmsListbox, {
       props: {
         options: objectOptions,
         multiple: true,
         optionLabel: 'name',
-        optionValue: 'id',
-        optionDisabled: 'locked',
-        optionGroupLabel: 'group',
-        optionGroupChildren: 'items',
         dataKey: 'id',
         checkmark: true,
-        filterFields: ['name', 'group'],
         scrollHeight: '18rem',
         virtualScrollerOptions: { itemSize: 52 },
-        emptyMessage: 'Nothing here',
-        emptyFilterMessage: 'No matches',
+        emptyMessage: 'Nothing to show',
         disabled: true
       },
       global: globalPlugins
     }).findComponent({ name: 'Listbox' })
     expect(inner.props('multiple')).toBe(true)
     expect(inner.props('optionLabel')).toBe('name')
-    expect(inner.props('optionValue')).toBe('id')
-    expect(inner.props('optionDisabled')).toBe('locked')
-    expect(inner.props('optionGroupLabel')).toBe('group')
-    expect(inner.props('optionGroupChildren')).toBe('items')
     expect(inner.props('dataKey')).toBe('id')
     expect(inner.props('checkmark')).toBe(true)
-    expect(inner.props('filterFields')).toEqual(['name', 'group'])
     expect(inner.props('scrollHeight')).toBe('18rem')
     expect(inner.props('virtualScrollerOptions')).toEqual({ itemSize: 52 })
-    expect(inner.props('emptyMessage')).toBe('Nothing here')
-    expect(inner.props('emptyFilterMessage')).toBe('No matches')
+    expect(inner.props('emptyMessage')).toBe('Nothing to show')
     expect(inner.props('disabled')).toBe(true)
   })
 
-  // Plain clicking must toggle a selection in a multi-select picker; PrimeVue's own
-  // default of requiring ctrl/cmd is the behaviour users report as broken.
-  it('defaults metaKeySelection to false', () => {
-    const inner = mount(OnmsListbox, {
-      props: { options, multiple: true },
+  it('renders emptyMessage when there are no options', () => {
+    const wrapper = mount(OnmsListbox, {
+      props: { options: [], emptyMessage: 'Nothing to show' },
       global: globalPlugins
-    }).findComponent({ name: 'Listbox' })
-    expect(inner.props('metaKeySelection')).toBe(false)
+    })
+    expect(wrapper.text()).toContain('Nothing to show')
+  })
+
+  it('defaults disabled to false', () => {
+    const inner = mount(OnmsListbox, { props: { options }, global: globalPlugins })
+      .findComponent({ name: 'Listbox' })
+    expect(inner.props('disabled')).toBe(false)
   })
 
   it('forwards the option slot', () => {

--- a/ui/tests/onms-ui/OnmsTabs.test.ts
+++ b/ui/tests/onms-ui/OnmsTabs.test.ts
@@ -1,9 +1,21 @@
 import { OnmsTab, OnmsTabList, OnmsTabPanel, OnmsTabPanels, OnmsTabs } from '@opennms/onms-ui'
 import { mount } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
-const mountTabs = (tabsProps: Record<string, unknown> = {}) => mount(OnmsTabs, {
+// PrimeVue's TabList schedules updateInkBar on a timer at mount and never clears
+// it. A wrapper left mounted lets that timer outlive the test environment, and it
+// then throws "HTMLElement is not defined" as an uncaught exception — which fails
+// the whole run, intermittently, depending on how the suite happens to be
+// scheduled. Unmounting after each test disposes the timer with the component.
+const mounted: ReturnType<typeof mount>[] = []
+
+const track = (wrapper: ReturnType<typeof mount>) => {
+  mounted.push(wrapper)
+  return wrapper
+}
+
+const mountTabs = (tabsProps: Record<string, unknown> = {}) => track(mount(OnmsTabs, {
   props: { value: 0, ...tabsProps },
   global: {
     plugins: [PrimeVue],
@@ -21,9 +33,15 @@ const mountTabs = (tabsProps: Record<string, unknown> = {}) => mount(OnmsTabs, {
         <OnmsTabPanel :value="1">Panel two</OnmsTabPanel>
       </OnmsTabPanels>`
   }
-})
+}))
 
 describe('OnmsTabs family contract', () => {
+  afterEach(() => {
+    while (mounted.length) {
+      mounted.pop()?.unmount()
+    }
+  })
+
   it('maps value onto PrimeVue Tabs and renders tab labels', () => {
     const wrapper = mountTabs()
     expect(wrapper.findComponent({ name: 'Tabs' }).props('value')).toBe(0)
@@ -38,10 +56,10 @@ describe('OnmsTabs family contract', () => {
   })
 
   it('accepts string values', () => {
-    const wrapper = mount(OnmsTabs, {
+    const wrapper = track(mount(OnmsTabs, {
       props: { value: 'alarms' },
       global: { plugins: [PrimeVue] }
-    })
+    }))
     expect(wrapper.findComponent({ name: 'Tabs' }).props('value')).toBe('alarms')
   })
 

--- a/ui/tests/stores/adhocGraphStore.test.ts
+++ b/ui/tests/stores/adhocGraphStore.test.ts
@@ -1,0 +1,370 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { nodeCriteriaOf, useAdhocGraphStore } from '@/stores/adhocGraphStore'
+import { AdhocDatasourceOption, AdhocResourceOption } from '@/types/adhocGraph'
+
+const getNodes = vi.fn()
+const getResourceForNode = vi.fn()
+const getResourceById = vi.fn()
+const getGraphMetrics = vi.fn()
+
+vi.mock('@/services', () => ({
+  default: {
+    getNodes: (...args: unknown[]) => getNodes(...args),
+    getResourceForNode: (...args: unknown[]) => getResourceForNode(...args),
+    getResourceById: (...args: unknown[]) => getResourceById(...args),
+    getGraphMetrics: (...args: unknown[]) => getGraphMetrics(...args)
+  }
+}))
+
+/** A node resource whose children are the graphable sub-resources. */
+const nodeResource = (nodeLabel: string, childIds: string[]) => ({
+  id: `node[${nodeLabel}]`,
+  label: nodeLabel,
+  children: {
+    resource: childIds.map(id => ({ id, label: id, typeLabel: 'SNMP Interface Data' }))
+  }
+})
+
+const resourceOption = (id: string): AdhocResourceOption => ({
+  id,
+  label: id,
+  typeLabel: 'SNMP Interface Data',
+  nodeId: '1',
+  nodeLabel: 'switch-01'
+})
+
+describe('useAdhocGraphStore', () => {
+  let store: ReturnType<typeof useAdhocGraphStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useAdhocGraphStore()
+    vi.clearAllMocks()
+    getNodes.mockResolvedValue({ node: [], totalCount: 0, count: 0, offset: 0 })
+    getResourceForNode.mockResolvedValue(null)
+    getResourceById.mockResolvedValue(null)
+    getGraphMetrics.mockResolvedValue(null)
+  })
+
+  describe('searchNodes', () => {
+    it('asks for a bounded, label-ordered page and maps the response', async () => {
+      getNodes.mockResolvedValue({ node: [{ id: '7', label: 'switch-01' }] })
+
+      await store.searchNodes('')
+
+      expect(getNodes).toHaveBeenCalledWith(expect.objectContaining({ limit: 100, orderBy: 'label' }))
+      expect(getNodes.mock.calls[0][0]._s).toBeUndefined()
+      expect(store.nodeOptions).toEqual([{ id: '7', label: 'switch-01' }])
+    })
+
+    it('sends a FIQL contains search when a term is given', async () => {
+      await store.searchNodes('  core  ')
+      expect(getNodes.mock.calls[0][0]._s).toBe('label==*core*')
+    })
+
+    it('empties the list when the request fails', async () => {
+      getNodes.mockResolvedValue({ node: [{ id: '7', label: 'switch-01' }] })
+      await store.searchNodes('')
+
+      getNodes.mockResolvedValue(false)
+      await store.searchNodes('nope')
+
+      expect(store.nodeOptions).toEqual([])
+    })
+  })
+
+  describe('the selection cascade', () => {
+    it('loads the children of every selected node', async () => {
+      getResourceForNode.mockImplementation((id: string) =>
+        Promise.resolve(nodeResource(`switch-${id}`, [`node[${id}].interfaceSnmp[eth0]`])))
+
+      await store.setSelectedNodes([{ id: '1', label: 'a' }, { id: '2', label: 'b' }])
+
+      expect(store.resourceOptions.map(option => option.id)).toEqual([
+        'node[1].interfaceSnmp[eth0]',
+        'node[2].interfaceSnmp[eth0]'
+      ])
+      expect(store.resourceOptions[0].nodeLabel).toBe('switch-1')
+    })
+
+    it('loads the sorted graphable attributes of every selected resource', async () => {
+      getResourceById.mockResolvedValue({ rrdGraphAttributes: { ifHCOutOctets: {}, ifHCInOctets: {}}})
+
+      await store.setSelectedResources([resourceOption('node[1].interfaceSnmp[eth0]')])
+
+      expect(store.datasourceOptions.map(option => option.attribute)).toEqual(['ifHCInOctets', 'ifHCOutOctets'])
+      expect(store.datasourceOptions[0].key).toBe('node[1].interfaceSnmp[eth0]|ifHCInOctets')
+    })
+
+    it('prunes only the selections that disappeared when a node is deselected', async () => {
+      getResourceForNode.mockImplementation((id: string) =>
+        Promise.resolve(nodeResource(`switch-${id}`, [`node[${id}].interfaceSnmp[eth0]`])))
+      getResourceById.mockImplementation((id: string) =>
+        Promise.resolve({ rrdGraphAttributes: { ifHCInOctets: {}}, id }))
+
+      await store.setSelectedNodes([{ id: '1', label: 'a' }, { id: '2', label: 'b' }])
+      await store.setSelectedResources([
+        resourceOption('node[1].interfaceSnmp[eth0]'),
+        resourceOption('node[2].interfaceSnmp[eth0]')
+      ])
+      store.setSelectedDatasources([...store.datasourceOptions])
+      expect(store.selectedDatasources).toHaveLength(2)
+
+      // Dropping node 2 must not disturb what was chosen under node 1.
+      await store.setSelectedNodes([{ id: '1', label: 'a' }])
+
+      expect(store.selectedResources.map(resource => resource.id)).toEqual(['node[1].interfaceSnmp[eth0]'])
+      expect(store.selectedDatasources.map(datasource => datasource.key))
+        .toEqual(['node[1].interfaceSnmp[eth0]|ifHCInOctets'])
+    })
+
+    it('clears the whole cascade when the last node is deselected', async () => {
+      getResourceForNode.mockResolvedValue(nodeResource('switch-1', ['node[1].interfaceSnmp[eth0]']))
+      getResourceById.mockResolvedValue({ rrdGraphAttributes: { ifHCInOctets: {}}})
+
+      await store.setSelectedNodes([{ id: '1', label: 'a' }])
+      await store.setSelectedResources([resourceOption('node[1].interfaceSnmp[eth0]')])
+      store.setSelectedDatasources([...store.datasourceOptions])
+
+      await store.setSelectedNodes([])
+
+      expect(store.resourceOptions).toEqual([])
+      expect(store.selectedResources).toEqual([])
+      expect(store.datasourceOptions).toEqual([])
+      expect(store.selectedDatasources).toEqual([])
+    })
+  })
+
+  describe('out-of-order responses', () => {
+    it('ignores a superseded node search', async () => {
+      let releaseSlow: (value: unknown) => void = () => undefined
+      getNodes
+        .mockReturnValueOnce(new Promise((resolve) => {
+          releaseSlow = resolve
+        }))
+        .mockResolvedValueOnce({ node: [{ id: '2', label: 'fast' }] })
+
+      const slow = store.searchNodes('slow')
+      await store.searchNodes('fast')
+
+      releaseSlow({ node: [{ id: '1', label: 'slow' }] })
+      await slow
+
+      expect(store.nodeOptions).toEqual([{ id: '2', label: 'fast' }])
+    })
+
+    it('ignores a superseded resource load', async () => {
+      let releaseSlow: (value: unknown) => void = () => undefined
+      getResourceForNode
+        .mockReturnValueOnce(new Promise((resolve) => {
+          releaseSlow = resolve
+        }))
+        .mockResolvedValueOnce(nodeResource('fast', ['node[2].interfaceSnmp[eth0]']))
+
+      const slow = store.setSelectedNodes([{ id: '1', label: 'slow' }])
+      await store.setSelectedNodes([{ id: '2', label: 'fast' }])
+
+      releaseSlow(nodeResource('slow', ['node[1].interfaceSnmp[eth0]']))
+      await slow
+
+      expect(store.resourceOptions.map(option => option.id)).toEqual(['node[2].interfaceSnmp[eth0]'])
+    })
+  })
+
+  describe('adoptDatasources', () => {
+    it('injects link-restored sources as both the options and the selection', () => {
+      const restored: AdhocDatasourceOption[] = [{
+        key: 'node[1].interfaceSnmp[eth0]|ifHCInOctets',
+        resourceId: 'node[1].interfaceSnmp[eth0]',
+        resourceLabel: 'node[1].interfaceSnmp[eth0]',
+        nodeId: '',
+        nodeLabel: '',
+        attribute: 'ifHCInOctets'
+      }]
+
+      store.adoptDatasources(restored)
+
+      expect(store.datasourceOptions).toHaveLength(1)
+      expect(store.selectedDatasources.map(datasource => datasource.key)).toEqual([restored[0].key])
+    })
+
+    it('prefers an already-loaded option over the sparse stand-in from a link', async () => {
+      getResourceById.mockResolvedValue({ rrdGraphAttributes: { ifHCInOctets: {}}})
+      await store.setSelectedResources([resourceOption('node[1].interfaceSnmp[eth0]')])
+
+      store.adoptDatasources([{
+        key: 'node[1].interfaceSnmp[eth0]|ifHCInOctets',
+        resourceId: 'node[1].interfaceSnmp[eth0]',
+        resourceLabel: 'node[1].interfaceSnmp[eth0]',
+        nodeId: '',
+        nodeLabel: '',
+        attribute: 'ifHCInOctets'
+      }])
+
+      expect(store.datasourceOptions).toHaveLength(1)
+      expect(store.selectedDatasources[0].nodeLabel).toBe('switch-01')
+    })
+  })
+
+  describe('nodeCriteriaOf', () => {
+    it('reads a bare node id', () => {
+      expect(nodeCriteriaOf('node[42].interfaceSnmp[eth0]')).toBe('42')
+    })
+
+    it('reads a foreign-source pair', () => {
+      expect(nodeCriteriaOf('nodeSource[Demo:1].interfaceSnmp[eth0]')).toBe('Demo:1')
+    })
+
+    it('is null when there is no node part', () => {
+      expect(nodeCriteriaOf('nonsense')).toBeNull()
+    })
+  })
+
+  describe('restoreSelection', () => {
+    beforeEach(() => {
+      getResourceForNode.mockImplementation((criterion: string) =>
+        Promise.resolve(nodeResource(`switch-${criterion}`, [
+          `node[${criterion}].interfaceSnmp[eth0]`,
+          `node[${criterion}].interfaceSnmp[eth1]`
+        ])))
+      getResourceById.mockResolvedValue({ rrdGraphAttributes: { ifHCInOctets: {}, ifHCOutOctets: {}}})
+    })
+
+    // The bug this covers: a shared link populated only the datasource pane, so
+    // the node and resource panes showed nothing selected.
+    it('populates all three panes from the link sources', async () => {
+      await store.restoreSelection([
+        { resourceId: 'node[1].interfaceSnmp[eth0]', attribute: 'ifHCInOctets' }
+      ])
+
+      expect(store.selectedNodes).toEqual([{ id: '1', label: 'switch-1' }])
+      expect(store.nodeOptions).toContainEqual({ id: '1', label: 'switch-1' })
+      expect(store.selectedResources.map(resource => resource.id)).toEqual(['node[1].interfaceSnmp[eth0]'])
+      expect(store.selectedDatasources.map(datasource => datasource.key))
+        .toEqual(['node[1].interfaceSnmp[eth0]|ifHCInOctets'])
+    })
+
+    it('offers the siblings of a restored resource, so the picker is usable', async () => {
+      await store.restoreSelection([
+        { resourceId: 'node[1].interfaceSnmp[eth0]', attribute: 'ifHCInOctets' }
+      ])
+
+      expect(store.resourceOptions.map(resource => resource.id)).toEqual([
+        'node[1].interfaceSnmp[eth0]',
+        'node[1].interfaceSnmp[eth1]'
+      ])
+      expect(store.datasourceOptions.map(datasource => datasource.attribute))
+        .toEqual(['ifHCInOctets', 'ifHCOutOctets'])
+    })
+
+    it('restores real labels rather than the raw resource id', async () => {
+      await store.restoreSelection([
+        { resourceId: 'node[1].interfaceSnmp[eth0]', attribute: 'ifHCInOctets' }
+      ])
+
+      expect(store.selectedDatasources[0].nodeLabel).toBe('switch-1')
+      expect(store.selectedDatasources[0].resourceLabel).toBe('node[1].interfaceSnmp[eth0]')
+      expect(store.selectedResources[0].nodeLabel).toBe('switch-1')
+    })
+
+    it('restores a selection spanning two nodes', async () => {
+      await store.restoreSelection([
+        { resourceId: 'node[1].interfaceSnmp[eth0]', attribute: 'ifHCInOctets' },
+        { resourceId: 'node[2].interfaceSnmp[eth1]', attribute: 'ifHCOutOctets' }
+      ])
+
+      expect(store.selectedNodes.map(node => node.id)).toEqual(['1', '2'])
+      expect(store.selectedResources.map(resource => resource.id)).toEqual([
+        'node[1].interfaceSnmp[eth0]',
+        'node[2].interfaceSnmp[eth1]'
+      ])
+      expect(store.selectedDatasources).toHaveLength(2)
+    })
+
+    it('keeps a stand-in for a resource the server no longer knows about', async () => {
+      getResourceForNode.mockResolvedValue(null)
+
+      await store.restoreSelection([
+        { resourceId: 'node[9].interfaceSnmp[gone]', attribute: 'ifHCInOctets' }
+      ])
+
+      // Series must survive: the query is relaxed, so it comes back as NaN rather
+      // than silently disappearing from the graph.
+      expect(store.selectedDatasources.map(datasource => datasource.key))
+        .toEqual(['node[9].interfaceSnmp[gone]|ifHCInOctets'])
+    })
+
+    it('falls back to stand-ins when no node can be parsed at all', async () => {
+      await store.restoreSelection([{ resourceId: 'nonsense', attribute: 'ifHCInOctets' }])
+
+      expect(getResourceForNode).not.toHaveBeenCalled()
+      expect(store.selectedDatasources.map(datasource => datasource.key)).toEqual(['nonsense|ifHCInOctets'])
+    })
+  })
+
+  describe('searchNodes keeps the selection visible', () => {
+    it('pins selected nodes to the top of a later, unrelated search', async () => {
+      getResourceForNode.mockResolvedValue(nodeResource('switch-1', ['node[1].interfaceSnmp[eth0]']))
+      await store.setSelectedNodes([{ id: '1', label: 'switch-1' }])
+
+      getNodes.mockResolvedValue({ node: [{ id: '2', label: 'router-2' }] })
+      await store.searchNodes('router')
+
+      expect(store.nodeOptions.map(node => node.id)).toEqual(['1', '2'])
+    })
+
+    it('does not list a selected node twice when the search also returns it', async () => {
+      getResourceForNode.mockResolvedValue(nodeResource('switch-1', ['node[1].interfaceSnmp[eth0]']))
+      await store.setSelectedNodes([{ id: '1', label: 'switch-1' }])
+
+      getNodes.mockResolvedValue({ node: [{ id: '1', label: 'switch-1' }, { id: '2', label: 'router-2' }] })
+      await store.searchNodes('')
+
+      expect(store.nodeOptions.map(node => node.id)).toEqual(['1', '2'])
+    })
+  })
+
+  describe('runQuery', () => {
+    it('stores the measurements on success', async () => {
+      getGraphMetrics.mockResolvedValue({ labels: ['in'], columns: [{ values: [1] }] })
+
+      await store.runQuery({ start: 0, end: 1, step: 1, source: [] })
+
+      expect(store.measurements).toEqual({ labels: ['in'], columns: [{ values: [1] }] })
+      expect(store.queryError).toBe('')
+      expect(store.queryLoading).toBe(false)
+    })
+
+    it('reports an error and drops stale data on failure', async () => {
+      getGraphMetrics.mockResolvedValue({ labels: ['in'], columns: [{ values: [1] }] })
+      await store.runQuery({ start: 0, end: 1, step: 1, source: [] })
+
+      getGraphMetrics.mockResolvedValue(null)
+      await store.runQuery({ start: 0, end: 1, step: 1, source: [] })
+
+      expect(store.measurements).toBeNull()
+      expect(store.queryError).not.toBe('')
+    })
+  })
+
+  describe('clearAll', () => {
+    it('resets every list and discards responses still in flight', async () => {
+      let releaseSlow: (value: unknown) => void = () => undefined
+      getResourceForNode.mockReturnValueOnce(new Promise((resolve) => {
+        releaseSlow = resolve
+      }))
+
+      const slow = store.setSelectedNodes([{ id: '1', label: 'a' }])
+      store.clearAll()
+
+      releaseSlow(nodeResource('switch-1', ['node[1].interfaceSnmp[eth0]']))
+      await slow
+
+      expect(store.selectedNodes).toEqual([])
+      expect(store.resourceOptions).toEqual([])
+      expect(store.measurements).toBeNull()
+    })
+  })
+})

--- a/ui/tests/stores/adhocGraphStore.test.ts
+++ b/ui/tests/stores/adhocGraphStore.test.ts
@@ -1,7 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { nodeCriteriaOf, useAdhocGraphStore } from '@/stores/adhocGraphStore'
+import { nodeCriteriaOf, toFiqlSearchTerm, useAdhocGraphStore } from '@/stores/adhocGraphStore'
 import { AdhocDatasourceOption, AdhocResourceOption } from '@/types/adhocGraph'
 
 const getNodes = vi.fn()
@@ -72,6 +72,81 @@ describe('useAdhocGraphStore', () => {
       await store.searchNodes('nope')
 
       expect(store.nodeOptions).toEqual([])
+    })
+  })
+
+  // `label==*<term>*` is string concatenation: a comma or semicolon typed in the
+  // search box used to terminate the comparison, producing a malformed filter, a
+  // failed request and an empty picker with nothing to explain it.
+  describe('toFiqlSearchTerm', () => {
+    it('leaves an ordinary host name alone', () => {
+      expect(toFiqlSearchTerm('core-switch-01.example.com')).toBe('core-switch-01.example.com')
+    })
+
+    it('drops every character that is FIQL grammar', () => {
+      for (const char of [',', ';', '(', ')', '=', '!', '<', '>', '~', '*']) {
+        expect(toFiqlSearchTerm(`a${char}b`), char).toBe('a b')
+      }
+    })
+
+    it('collapses the whitespace it leaves behind and trims', () => {
+      expect(toFiqlSearchTerm('  core,,;;switch  ')).toBe('core switch')
+    })
+
+    it('reduces a term of pure syntax to nothing, so no filter is sent', () => {
+      expect(toFiqlSearchTerm(',;()')).toBe('')
+    })
+  })
+
+  describe('searchNodes escapes the filter', () => {
+    it('does not let a comma break out of the comparison', async () => {
+      await store.searchNodes('core,switch')
+
+      expect(getNodes.mock.calls[0][0]._s).toBe('label==*core switch*')
+    })
+
+    it('sends no filter at all when nothing searchable remains', async () => {
+      await store.searchNodes(';;;')
+
+      expect(getNodes.mock.calls[0][0]._s).toBeUndefined()
+    })
+  })
+
+  describe('a failing lookup is isolated', () => {
+    // Without per-item isolation one rejection escapes Promise.all, propagates out
+    // of loadResources and strands resourcesLoading at true.
+    it('keeps the other nodes when one rejects, and stops the spinner', async () => {
+      getResourceForNode.mockImplementation((id: string) => (id === '1' ?
+        Promise.reject(new Error('boom')) :
+        Promise.resolve(nodeResource(`switch-${id}`, [`node[${id}].interfaceSnmp[eth0]`]))))
+
+      await store.setSelectedNodes([{ id: '1', label: 'a' }, { id: '2', label: 'b' }])
+
+      expect(store.resourceOptions.map(option => option.id)).toEqual(['node[2].interfaceSnmp[eth0]'])
+      expect(store.resourcesLoading).toBe(false)
+    })
+
+    it('keeps the other resources when a datasource lookup rejects', async () => {
+      getResourceById.mockImplementation((id: string) => (id.includes('eth0') ?
+        Promise.reject(new Error('boom')) :
+        Promise.resolve({ rrdGraphAttributes: { ifHCInOctets: {}}})))
+
+      await store.setSelectedResources([
+        resourceOption('node[1].interfaceSnmp[eth0]'),
+        resourceOption('node[1].interfaceSnmp[eth1]')
+      ])
+
+      expect(store.datasourceOptions.map(option => option.resourceId)).toEqual(['node[1].interfaceSnmp[eth1]'])
+      expect(store.datasourcesLoading).toBe(false)
+    })
+
+    it('does not strand the spinner when every lookup rejects', async () => {
+      getResourceForNode.mockRejectedValue(new Error('boom'))
+
+      await store.setSelectedNodes([{ id: '1', label: 'a' }])
+
+      expect(store.resourceOptions).toEqual([])
+      expect(store.resourcesLoading).toBe(false)
     })
   })
 


### PR DESCRIPTION
Replace the jsp adhoc graphs workflow with a modern, feature-rich Vue SPA.

This also contains fixes for issues encountered while developing it:
* The time-picker had broken durations for 7 of 12 choices
 * The Data tab in the Vue graphs was backwards, and lacked a real timestamp (was HH:MM)
 * OnmsTabs.test.ts was flakey and failed about 1 time in 3

<img width="2936" height="1443" alt="image" src="https://github.com/user-attachments/assets/d0ccdeb2-cecc-42dd-8c23-6d516ef8f478" />

<img width="2936" height="1443" alt="image" src="https://github.com/user-attachments/assets/e471af2e-4436-4eb1-9b20-745f64c99709" />

<img width="2936" height="1443" alt="image" src="https://github.com/user-attachments/assets/c7227085-020b-4425-9b55-a7bd7f86730b" />

<img width="2936" height="1443" alt="image" src="https://github.com/user-attachments/assets/054b9946-eb4b-4aae-a6b6-8312b073ac61" />

[Ad-Hoc_Graph.pdf](https://github.com/user-attachments/files/30990615/Ad-Hoc_Graph.pdf)

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20208

