### PR TITLE
NMS-20209: Bump jackson, okhttp and jsoup in smoke tests.

### DIFF
--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -51,7 +51,7 @@
     <camelVersion>2.21.5</camelVersion>
     <groovyVersion>3.0.21</groovyVersion>
     <frontendPluginVersion>0.0.29</frontendPluginVersion>
-    <jackson2Version>2.18.6</jackson2Version>
+    <jackson2Version>2.18.9</jackson2Version>
     <jersey.version>2.46</jersey.version>
     <jestVersion>5.3.4</jestVersion>
     <junit5Version>5.9.2</junit5Version>
@@ -65,7 +65,7 @@
     <testcontainers.version>1.20.6</testcontainers.version>
     <netty4Version>4.1.99.Final</netty4Version>
     <jna.version>5.8.0</jna.version>
-    <okhttpVersion>3.10.0</okhttpVersion>
+    <okhttpVersion>4.9.3</okhttpVersion>
     <test.fork.count>0</test.fork.count>
     <!-- Limit ITs to 30 minutes by default -->
     <test.fork.timeout>1800</test.fork.timeout>
@@ -817,7 +817,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.15.3</version>
+      <version>1.23.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.mwiede</groupId>


### PR DESCRIPTION
This update should resolve some dependabot alerts

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20209

