### PR TITLE
NMS-20216: Fix regression CXF 3.6.12 caused by hardcoded default cap of 50 multipart attachments per request

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
@@ -61,6 +61,8 @@
         <entry key="search.timezone.support" value="false"/>
         <!-- see https://issues.apache.org/jira/browse/CXF-8684 -->
         <entry key="default.wae.mapper.least.specific" value="false"/>
+        <!-- CXF defaults to 50 multipart attachments per request as of 3.6.12; raise it for bulk uploads like EventConfRestService.uploadEventConfFiles -->
+        <entry key="attachment-max-count" value="300"/>
       </jaxrs:properties>
       <jaxrs:extensionMappings>
         <entry key="json" value="application/json" />


### PR DESCRIPTION
### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20216

