### PR TITLE
NMS-20180: Fix various menu-related issues after NMS-20174 Review

### DIFF
--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/AuthorityPrincipal.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/AuthorityPrincipal.java
@@ -23,6 +23,7 @@ package org.opennms.web.springframework.security;
 
 import java.io.Serializable;
 import java.security.Principal;
+import java.util.Locale;
 import java.util.Objects;
 
 import org.springframework.security.core.GrantedAuthority;
@@ -35,7 +36,7 @@ public class AuthorityPrincipal implements Principal, Serializable {
         m_name = null;
     }
     public AuthorityPrincipal(final GrantedAuthority authority) {
-        m_name = authority.getAuthority().toLowerCase().replaceFirst("^role_", "");
+        m_name = authority.getAuthority().toLowerCase(Locale.ROOT).replaceFirst("^role_", "");
     }
 
     @Override

--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/LoginModuleUtils.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/LoginModuleUtils.java
@@ -123,7 +123,7 @@ public abstract class LoginModuleUtils {
         if (handler.requiresAdminRole()) {
             allowed = false;
             for (final Principal principal : principals) {
-                final String name = principal.getName().toLowerCase().replaceAll("^role_", "");
+                final String name = principal.getName().toLowerCase(Locale.ROOT).replaceAll("^role_", "");
                 if ("admin".equals(name)) {
                     allowed = true;
                 }

--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/LoginModuleUtils.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/LoginModuleUtils.java
@@ -26,6 +26,7 @@ import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -158,7 +159,9 @@ public abstract class LoginModuleUtils {
             return true;
         }
 
-        String urlLower = url.toLowerCase();
+        // Locale.ROOT: under a Turkish default locale, "I".toLowerCase() is a
+        // dotless ı, so "/API" would no longer match the "/api" prefix.
+        String urlLower = url.toLowerCase(Locale.ROOT);
 
         return Arrays.stream(INVALID_SAVED_REQUEST_URL_SUFFIXES).anyMatch(urlLower::endsWith)
                 || Arrays.stream(INVALID_SAVED_REQUEST_URL_PREFIXES)

--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/OpenNMSAuthSuccessHandler.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/OpenNMSAuthSuccessHandler.java
@@ -72,12 +72,8 @@ public class OpenNMSAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
                 // make sure we are redirecting to an actual page, not e.g. a URL to an asset
                 // TODO: Determine why assets are getting saved in the requestCache
-                if (useSavedRequest) {
-                    final String servletPathLower = savedRequest.getServletPath().toLowerCase();
-
-                    if (LoginModuleUtils.isInvalidSavedRequestUrl(servletPathLower)) {
-                        useSavedRequest = false;
-                    }
+                if (useSavedRequest && LoginModuleUtils.isInvalidSavedRequestUrl(savedRequest.getServletPath())) {
+                    useSavedRequest = false;
                 }
 
                 if (useSavedRequest) {

--- a/features/springframework-security/src/test/java/org/opennms/web/springframework/security/LoginModuleUtilsTest.java
+++ b/features/springframework-security/src/test/java/org/opennms/web/springframework/security/LoginModuleUtilsTest.java
@@ -24,6 +24,8 @@ package org.opennms.web.springframework.security;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Locale;
+
 import org.junit.Test;
 
 public class LoginModuleUtilsTest {
@@ -53,6 +55,20 @@ public class LoginModuleUtilsTest {
         assertTrue(LoginModuleUtils.isInvalidSavedRequestUrl("/api/v2"));
         assertTrue(LoginModuleUtils.isInvalidSavedRequestUrl("/api/v2/nodes"));
         assertTrue(LoginModuleUtils.isInvalidSavedRequestUrl("/REST/menu"));
+    }
+
+    @Test
+    public void testMatchingIsDefaultLocaleIndependent() {
+        // Under a Turkish default locale, locale-sensitive toLowerCase() turns
+        // "I" into a dotless ı, so "/API" would slip past the "/api" prefix.
+        final Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            assertTrue(LoginModuleUtils.isInvalidSavedRequestUrl("/API/v2/nodes"));
+            assertTrue(LoginModuleUtils.isInvalidSavedRequestUrl("/API"));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     @Test

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -347,8 +347,11 @@
     <intercept-url pattern="/assets/**" access="hasAnyRole('ROLE_ANONYMOUS','ROLE_USER','ROLE_DASHBOARD')" />
     <!-- Vue menu bundle (static js/css/fonts). Must be anonymous: bootstrap.jsp preloads it from the
          login page, and an auth redirect there gets cached by Safari/Firefox as text/html for the
-         asset URL, breaking the menu on all JSP pages after login (NMS-20174). -->
-    <intercept-url pattern="/ui-components/**" access="hasAnyRole('ROLE_ANONYMOUS','ROLE_USER','ROLE_DASHBOARD')" />
+         asset URL, breaking the menu on all JSP pages after login (NMS-20174). Deliberately limited
+         to assets/**: the unpacked dist-menu artifact also ships an index.html (the Vite build
+         input) at /ui-components/, which nothing links to and which must not be anonymously
+         reachable (NMS-20180). -->
+    <intercept-url pattern="/ui-components/assets/**" access="hasAnyRole('ROLE_ANONYMOUS','ROLE_USER','ROLE_DASHBOARD')" />
 
     <intercept-url pattern="/admin/ng-requisitions/**" access="hasAnyRole('ROLE_PROVISION','ROLE_ADMIN')" />
     <intercept-url pattern="/admin/classification/index.jsp" access="hasAnyRole('ROLE_FLOW_MANAGER','ROLE_ADMIN')" />

--- a/opennms-webapp/src/main/webapp/includes/bootstrap.jsp
+++ b/opennms-webapp/src/main/webapp/includes/bootstrap.jsp
@@ -242,7 +242,17 @@
   </script>
   <link rel="stylesheet" href="<%= __baseHref %>ui-components/assets/index.css<%= __menuAssetsVersion %>" media="screen" />
   <%-- Start fetching/compiling the menu bundle now rather than when the parser
-       reaches its <script type="module"> tag near the end of the body. --%>
+       reaches its <script type="module"> tag near the end of the body.
+
+       These two links are deliberately emitted on 'quiet' pages too, including
+       the unauthenticated login page: preloading there warms the cache while
+       the user types their credentials, so the menu mounts instantly on the
+       first post-login page. This is only safe because the bundle is
+       anonymously accessible (see the /ui-components/assets/** rule in
+       applicationContext-spring-security.xml) — without that rule the preload
+       would cache an auth redirect as text/html under the asset URL and break
+       the menu on every JSP page after login (NMS-20174). Keep the two in
+       sync. --%>
   <link rel="modulepreload" href="<%= __baseHref %>ui-components/assets/index.js<%= __menuAssetsVersion %>" />
 </head>
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/WebappIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/WebappIT.java
@@ -148,13 +148,16 @@ public class WebappIT {
    * JSP page after login.
    */
   @Test
-  public void verifyMenuBundleAssetsAreAnonymouslyAccessible() {
+  public void verifyMenuBundleJsAssetIsAnonymouslyAccessible() {
     given().redirects().follow(false)
         .get("ui-components/assets/index.js")
         .then().assertThat()
         .statusCode(200)
         .header("Content-Type", containsString("javascript"));
+  }
 
+  @Test
+  public void verifyMenuBundleCssAssetIsAnonymouslyAccessible() {
     given().redirects().follow(false)
         .get("ui-components/assets/index.css")
         .then().assertThat()
@@ -173,7 +176,8 @@ public class WebappIT {
     given().redirects().follow(false)
         .get("ui-components/index.html")
         .then().assertThat()
-        .statusCode(302);
+        .statusCode(302)
+        .header("Location", containsString("login.jsp"));
   }
 
   /**

--- a/smoke-test/src/test/java/org/opennms/smoketest/WebappIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/WebappIT.java
@@ -22,14 +22,17 @@
 package org.opennms.smoketest;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import org.apache.http.client.ClientProtocolException;
 import org.junit.After;
@@ -135,6 +138,66 @@ public class WebappIT {
             .statusCode(200)
             .header("Cache-Control", not("no-store"))
             .header("Pragma", not("no-cache"));
+  }
+
+  /**
+   * NMS-20174: the Vue menu bundle must be accessible without authentication.
+   * bootstrap.jsp preloads it from the (unauthenticated) login page; if that
+   * request is answered with an auth redirect instead, Safari and Firefox cache
+   * the text/html response under the asset URL and the menu never mounts on any
+   * JSP page after login.
+   */
+  @Test
+  public void verifyMenuBundleAssetsAreAnonymouslyAccessible() {
+    given().redirects().follow(false)
+        .get("ui-components/assets/index.js")
+        .then().assertThat()
+        .statusCode(200)
+        .header("Content-Type", containsString("javascript"));
+
+    given().redirects().follow(false)
+        .get("ui-components/assets/index.css")
+        .then().assertThat()
+        .statusCode(200)
+        .header("Content-Type", containsString("css"));
+  }
+
+  /**
+   * NMS-20180: only the menu bundle's assets/ directory is anonymous. The
+   * dist-menu artifact also ships an index.html (the Vite build input) at
+   * /ui-components/, which nothing links to and which must keep requiring
+   * authentication like any other page.
+   */
+  @Test
+  public void verifyMenuIndexHtmlRequiresAuthentication() {
+    given().redirects().follow(false)
+        .get("ui-components/index.html")
+        .then().assertThat()
+        .statusCode(302);
+  }
+
+  /**
+   * NMS-20174: the login page references the menu bundle only as preload links
+   * (deliberate cache warming for the first post-login page) and must never
+   * execute it. An unauthenticated menu run fires REST calls that trigger the
+   * browser's native basic-auth popup on the login page and pollute the
+   * post-login saved request (the password gate's Skip button then redirects
+   * to /rest, which browsers download as a file).
+   */
+  @Test
+  public void verifyLoginPageDoesNotExecuteMenuBundle() {
+    final String body = given()
+        .get("login.jsp")
+        .then().assertThat()
+        .statusCode(200)
+        .extract().response().body().asString();
+
+    // Positive control: the page still references the bundle (as a preload) —
+    // this keeps the negative assertion below meaningful if URLs change shape.
+    assertTrue("expected login.jsp to preload the menu bundle. Body: " + body,
+        body.contains("ui-components/assets/index.js"));
+    assertFalse("login.jsp must not contain a script tag executing the menu bundle. Body: " + body,
+        Pattern.compile("<script[^>]+ui-components/assets/index\\.js").matcher(body).find());
   }
 
   /**

--- a/ui/tests/components/Menu/UserSelfServiceMenuItem.test.ts
+++ b/ui/tests/components/Menu/UserSelfServiceMenuItem.test.ts
@@ -122,5 +122,6 @@ describe('UserSelfServiceMenuItem.vue', () => {
     await nextTick()
 
     expect(performLogout).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
   })
 })


### PR DESCRIPTION
Fix various issues found in PR review for NMS-20174 (PR #8758) ("Fix Menubar/SideMenu issues in Firefox and Safari on JSP pages").

There were 9 different items. 5 are fixed here. 4 have been deferred as they represent more work or tradeoffs.

## Fixed Items

**Fix 1** — narrowed anonymous rule: `applicationContext-spring-security.xml` now grants `/ui-components/assets/**` instead of `/ui-components/**`, with a comment explaining why (due to the stray `index.html` in the `dist-menu` artifact, NMS-20180). `/ui-components/index.html` now falls through to the `/** → ROLE_USER` catch-all, so it 302s to login like any other page.

**Fix 3** — comment only: extended the `bootstrap.jsp` head comment to mark the login-page stylesheet + modulepreload as deliberate cache-warming, cross-referencing the anonymous rule it depends on.

**Fix 4** — test gap: added `expect(event.defaultPrevented).toBe(false)` to the "does not cancel navigation for regular items" test.

**FIx 7** — `WebappIT` smoke tests (three new tests): anonymous GET of the menu JS/CSS returns 200 with the right content types; `ui-components/index.html` requires auth (302, pinning fix 1's narrowing); and `login.jsp` contains no `<script>` tag for the menu bundle — with a positive control asserting the preload link is present so the negative assertion stays meaningful.

**Fix 9** — locale-safe URL matching (`LoginModuleUtils.java:163`): `toLowerCase()` → `toLowerCase(Locale.ROOT)`, with a comment explaining the Turkish `dotless-ı` problem and added tests.

## Deferred Items

These four items were identified while reviewing the NMS-20174 fixes (PR #8758) but deliberately **not** fixed in NMS-20180. I will open separate tickets to follow up.

### 1. Vue menu disappeared from nine popup JSPs (documentation / QA spot-check)

**What happened.** NMS-20174 fix #2 made `bootstrap.jsp` honor *both* quiet
mechanisms (the `param.quiet` include parameter **and** the `Bootstrap.flags("quiet")`
request attribute). The PR description only mentions `login.jsp`, but nine other JSPs
also set the quiet *flag* and therefore silently lost the Vue menu with that change:

- `admin/discovery/add-er.jsp`
- `admin/discovery/add-ex-url.jsp`
- `admin/discovery/add-ir.jsp`
- `admin/discovery/add-specific.jsp`
- `admin/discovery/add-url.jsp`
- `admin/userGroupView/users/newPassword.jsp`
- `graph/forecast.jsp`
- `graph/nrtg.jsp`
- `includes/legendInfo-box.jsp`

**Why it is probably fine.** Every one of these is opened via `window.open` as a
popup/utility window. Losing the menu there is almost certainly the *intended*
rendering — and the pre-fix behavior (menu app executing in a popup that had asked
for quiet mode) is a plausible source of the original "menus overlapping content"
symptom.

---

### 2. Cache-buster stats the menu bundle files on every legacy page render

**What happens today.** `includes/bootstrap.jsp` computes the `?v=` cache-buster for
the menu bundle by calling `application.getRealPath(...)` + `File.lastModified()`
for **both** `index.js` and `index.css` on **every** JSP page render (two filesystem
stats per request). The `load-assets.jsp` precedent it mirrors reads a *cached*
`AssetLocator.lastModified()` instead.

**Suggested fix.** Memoize the computed version in a `ServletContext` attribute,
keyed on (or invalidated by) the files' mtimes, or re-checked on a short TTL.

**Tradeoffs / why it was deferred.**

- Two stats per render is noise next to JSP rendering cost; the OS caches the inode.
  There is no observed performance problem.
- A naive memoization (compute once, cache forever) breaks the hot-copy developer
  workflow (`build-and-copy.sh`, ui/CLAUDE.md instructions): newly copied bundles
  would keep serving the stale `?v=` until a webapp restart. A correct fix needs
  mtime-keyed or TTL-based invalidation — more code for marginal benefit.
- **If item 3 below (content-hashed filenames) is done, this entire code block is
  deleted anyway.** Fixing this separately is only worthwhile if content-hashing is
  rejected or slips.

**Action:** will consider folding it into the content-hashing work if/when we proceed with that./

---

### 3. Content-hashed filenames for the menu bundle (replace `?v=<mtime>`)

**What happens today.** The menu bundle is built with fixed filenames
(`ui/vite.config.menu.ts` → `assets/index.js`, `assets/index.css`) because
`bootstrap.jsp` hardcodes the URLs. Cache correctness relies on a `?v=<deployed file
mtime>` query parameter appended by `bootstrap.jsp` (added in NMS-20174 fix #6).

**Why `?v=` is not durable.**

1. **In-place overwrite skew (the core problem).** 
2. **Per-node divergence.**
3. **Second-class caching.**

**Suggested fix.**

Leaving out details, but adding a content hash to all filenames.

**Costs / risks.**

- JSP + Java + Vite config + assembly all change together; needs its own Playwright
  re-verification
- Manifest resolution becomes a runtime dependency of every legacy page: a missing
  or unreadable manifest must fail loudly with a sane fallback, or the menu breaks.
- Dev hot-copy workflow changes: stale hashed files accumulate in the target
  directory (already true for the main SPA — ui/CLAUDE.md documents the occasional
  `rm assets/*.*`), and the manifest must be copied along with the assets.
- Aligns the menu app with the main SPA, which already uses Vite's default hashed
  filenames.

**Action:** Will open a separate ticket to do the full content-hash + manifest change, targeted at the next
major release (Horizon 37).
---

## 4. Root fix for REST/API requests polluting the Spring Security request cache

Omitting details, but this is a larger effort as part of fixing `OpenNMSAuthSuccessHandler` and `HttpSessionRequestCache` to not saved assets in the cache, and to more properly handle redirects.

**Action:** Will open a separate ticket to do a comprehensive fix in Horizon 37.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20180
