### PR TITLE
NMS-20246: Fail the build on dangling static image references in the webapp

### DIFF
--- a/opennms-webapp/src/test/java/org/opennms/web/StaticAssetReferenceTest.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/StaticAssetReferenceTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+/**
+ * Verifies that every statically written <code>images/...</code> reference in the webapp
+ * resolves to a file that is actually present under <code>src/main/webapp</code>.
+ *
+ * A dangling image reference in a JSP produces no compile error, no build failure and no
+ * server-side error -- the page renders with a broken image or a blank background, and the
+ * only symptom is a 404 in the browser. That makes it easy to delete an image that is still
+ * in use: NMS-20091 removed 61 unreferenced files from <code>images/</code>, and the one
+ * mistake it made (a wallpaper whose only consumers were downstream PoweredBy JSPs) went
+ * unnoticed until someone looked at a login page. This test turns that class of mistake
+ * into a build failure.
+ *
+ * Note what this deliberately does <em>not</em> do: it never asserts that an image is
+ * referenced. Unused files are a cleanup question for a human, not a test failure.
+ */
+public class StaticAssetReferenceTest {
+
+    /**
+     * Surefire runs with the module directory as the working directory, so the webapp
+     * sources are addressable as a relative path. NavBarControllerTest relies on the same
+     * convention via {@code new MockServletContext("file:src/main/webapp")}.
+     */
+    private static final Path WEBAPP_ROOT = Path.of("src", "main", "webapp");
+
+    /** File types that can carry a static reference to an image. */
+    private static final Set<String> SCANNED_SUFFIXES =
+            Set.of(".jsp", ".jspf", ".tag", ".tagx", ".ftl", ".html", ".htm", ".css", ".js");
+
+    /**
+     * Matches an image path anchored on its {@code images/} segment, which covers every form
+     * these references take in practice: bare ({@code images/foo.png}), server-absolute
+     * ({@code /opennms/images/foo.png}) and JSTL-wrapped ({@code <c:url value="/images/foo.png"/>}).
+     *
+     * <p>The character class excludes quotes and whitespace, so a path assembled at runtime
+     * ({@code "images/" + name + ".png"}) simply does not match rather than matching wrongly.
+     *
+     * <p>The lookbehind skips {@code assets/images/...}, which lives in the core/web-assets
+     * module, is served from a different root, and is already checked at build time -- webpack's
+     * file-loader fails the bundle on an unresolvable {@code url()}.
+     */
+    private static final Pattern IMAGE_REFERENCE = Pattern.compile(
+            "(?<!assets/)images/[A-Za-z0-9_@.+-]+(?:/[A-Za-z0-9_@.+-]+)*\\.(?:png|jpe?g|gif|svg|ico|webp|bmp)",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Guards against the scan silently finding nothing -- a vacuous pass would be worse than
+     * no test at all. The real number is comfortably above this; the floor only has to catch
+     * a broken walk, a wrong working directory or a regex that stops matching.
+     */
+    private static final int MINIMUM_EXPECTED_REFERENCES = 10;
+
+    @Test
+    public void everyStaticImageReferenceResolvesToAFile() throws IOException {
+        assertTrue(WEBAPP_ROOT.toAbsolutePath() + " does not exist; is the working directory the "
+                + "opennms-webapp module root?", Files.isDirectory(WEBAPP_ROOT));
+
+        // Reference -> the files that use it, so a failure says where to look.
+        final Map<String, Set<String>> referenceToSources = new TreeMap<>();
+
+        try (Stream<Path> tree = Files.walk(WEBAPP_ROOT)) {
+            final List<Path> scannable = tree
+                    .filter(Files::isRegularFile)
+                    .filter(StaticAssetReferenceTest::isScannable)
+                    .sorted()
+                    .toList();
+
+            for (final Path source : scannable) {
+                final String contents = Files.readString(source, StandardCharsets.UTF_8);
+                final Matcher matcher = IMAGE_REFERENCE.matcher(contents);
+                while (matcher.find()) {
+                    referenceToSources
+                            .computeIfAbsent(normalize(matcher.group()), key -> new TreeSet<>())
+                            .add(WEBAPP_ROOT.relativize(source).toString());
+                }
+            }
+        }
+
+        assertTrue("Found only " + referenceToSources.size() + " image references under "
+                        + WEBAPP_ROOT + ", expected at least " + MINIMUM_EXPECTED_REFERENCES
+                        + ". The scan is probably broken rather than the webapp.",
+                referenceToSources.size() >= MINIMUM_EXPECTED_REFERENCES);
+
+        final StringBuilder failures = new StringBuilder();
+        for (final Map.Entry<String, Set<String>> entry : referenceToSources.entrySet()) {
+            final String problem = describeIfUnresolvable(entry.getKey());
+            if (problem != null) {
+                failures.append(System.lineSeparator())
+                        .append("  ").append(problem)
+                        .append(System.lineSeparator())
+                        .append("      referenced by: ").append(String.join(", ", entry.getValue()));
+            }
+        }
+
+        if (failures.length() > 0) {
+            fail("Image references in the webapp that do not resolve to a file under "
+                    + WEBAPP_ROOT + ". Restore the file, or update the reference if the image is "
+                    + "genuinely gone -- do not leave the reference dangling, because nothing else "
+                    + "in the build will catch it:" + failures);
+        }
+    }
+
+    private static boolean isScannable(final Path path) {
+        final String name = path.getFileName().toString().toLowerCase();
+        return SCANNED_SUFFIXES.stream().anyMatch(name::endsWith);
+    }
+
+    /** Trims the leading path so the reference is relative to the webapp root. */
+    private static String normalize(final String reference) {
+        final int imagesSegment = reference.toLowerCase().indexOf("images/");
+        return reference.substring(imagesSegment).replaceAll("/{2,}", "/");
+    }
+
+    /**
+     * @return a description of why the reference does not resolve, or null when it is fine.
+     */
+    private static String describeIfUnresolvable(final String reference) {
+        final Path target = WEBAPP_ROOT.resolve(reference);
+        if (!Files.isRegularFile(target)) {
+            return reference + " -- no such file";
+        }
+        // macOS and Windows resolve paths case-insensitively while the deployment target does
+        // not, so a reference that only differs in case works for the developer who wrote it
+        // and 404s in production. Compare against the name as it is actually spelled on disk.
+        final String onDisk = actualCaseOf(target);
+        if (onDisk != null && !onDisk.equals(reference)) {
+            return reference + " -- case does not match the file on disk, which is " + onDisk;
+        }
+        return null;
+    }
+
+    /**
+     * @return the reference spelled with the case each path segment actually has on disk, or
+     *         null if that cannot be determined.
+     */
+    private static String actualCaseOf(final Path target) {
+        try {
+            final Path real = target.toRealPath();
+            final Path realRoot = WEBAPP_ROOT.toRealPath();
+            if (!real.startsWith(realRoot)) {
+                // A symlink pointing outside the webapp; existence is all we can reasonably assert.
+                return null;
+            }
+            return realRoot.relativize(real).toString().replace(java.io.File.separatorChar, '/');
+        } catch (final IOException e) {
+            return null;
+        }
+    }
+}

--- a/opennms-webapp/src/test/java/org/opennms/web/StaticAssetReferenceTest.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/StaticAssetReferenceTest.java
@@ -21,13 +21,17 @@
  */
 package org.opennms.web;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,8 +44,8 @@ import java.util.stream.Stream;
 import org.junit.Test;
 
 /**
- * Verifies that every statically written <code>images/...</code> reference in the webapp
- * resolves to a file that is actually present under <code>src/main/webapp</code>.
+ * Verifies that every statically written reference to a local <code>images/...</code> file in the
+ * webapp resolves to a file that is actually present under <code>src/main/webapp</code>.
  *
  * A dangling image reference in a JSP produces no compile error, no build failure and no
  * server-side error -- the page renders with a broken image or a blank background, and the
@@ -68,25 +72,23 @@ public class StaticAssetReferenceTest {
             Set.of(".jsp", ".jspf", ".tag", ".tagx", ".ftl", ".html", ".htm", ".css", ".js");
 
     /**
-     * Matches an image path anchored on its {@code images/} segment, which covers every form
-     * these references take in practice: bare ({@code images/foo.png}), server-absolute
-     * ({@code /opennms/images/foo.png}) and JSTL-wrapped ({@code <c:url value="/images/foo.png"/>}).
+     * Matches a whole URL or path token ending in an image extension. The character class
+     * excludes quotes, whitespace and CSS delimiters, so a match is naturally bounded by the
+     * attribute quoting or the {@code url(...)} parentheses that surround it, and a path
+     * assembled at runtime ({@code "images/" + name + ".png"}) does not match at all.
      *
-     * <p>The character class excludes quotes and whitespace, so a path assembled at runtime
-     * ({@code "images/" + name + ".png"}) simply does not match rather than matching wrongly.
-     *
-     * <p>The lookbehind skips {@code assets/images/...}, which lives in the core/web-assets
-     * module, is served from a different root, and is already checked at build time -- webpack's
-     * file-loader fails the bundle on an unresolvable {@code url()}.
+     * <p>Deciding whether a token is a local webapp image is left to
+     * {@link #localWebappImageReference(String)}, which inspects the token's path segments.
+     * Matching the token first and classifying it second is what keeps an external URL or a
+     * directory merely ending in "images" from being mistaken for a local reference.
      */
-    private static final Pattern IMAGE_REFERENCE = Pattern.compile(
-            "(?<!assets/)images/[A-Za-z0-9_@.+-]+(?:/[A-Za-z0-9_@.+-]+)*\\.(?:png|jpe?g|gif|svg|ico|webp|bmp)",
-            Pattern.CASE_INSENSITIVE);
+    private static final Pattern IMAGE_TOKEN = Pattern.compile(
+            "[A-Za-z0-9_@.:/+~%-]*\\.(?:png|jpe?g|gif|svg|ico|webp|bmp)", Pattern.CASE_INSENSITIVE);
 
     /**
      * Guards against the scan silently finding nothing -- a vacuous pass would be worse than
      * no test at all. The real number is comfortably above this; the floor only has to catch
-     * a broken walk, a wrong working directory or a regex that stops matching.
+     * a broken walk, a wrong working directory or a pattern that stops matching.
      */
     private static final int MINIMUM_EXPECTED_REFERENCES = 10;
 
@@ -107,11 +109,14 @@ public class StaticAssetReferenceTest {
 
             for (final Path source : scannable) {
                 final String contents = Files.readString(source, StandardCharsets.UTF_8);
-                final Matcher matcher = IMAGE_REFERENCE.matcher(contents);
+                final Matcher matcher = IMAGE_TOKEN.matcher(contents);
                 while (matcher.find()) {
-                    referenceToSources
-                            .computeIfAbsent(normalize(matcher.group()), key -> new TreeSet<>())
-                            .add(WEBAPP_ROOT.relativize(source).toString());
+                    final String reference = localWebappImageReference(matcher.group());
+                    if (reference != null) {
+                        referenceToSources
+                                .computeIfAbsent(reference, key -> new TreeSet<>())
+                                .add(WEBAPP_ROOT.relativize(source).toString());
+                    }
                 }
             }
         }
@@ -140,15 +145,89 @@ public class StaticAssetReferenceTest {
         }
     }
 
+    @Test
+    public void recognizesTheReferenceFormsUsedInTheWebapp() {
+        // Bare, as written in a page that lives at the webapp root.
+        assertEquals("images/foo.png", localWebappImageReference("images/foo.png"));
+        // Server-absolute, and the JSTL <c:url value="..."/> form once the tag is stripped.
+        assertEquals("images/foo.png", localWebappImageReference("/opennms/images/foo.png"));
+        assertEquals("images/foo.png", localWebappImageReference("/images/foo.png"));
+        // Relative, as written in a page in a subdirectory.
+        assertEquals("images/foo.png", localWebappImageReference("../images/foo.png"));
+        // Nested below images/, which is where the wallpapers live.
+        assertEquals("images/wallpapers/bar.jpg",
+                localWebappImageReference("images/wallpapers/bar.jpg"));
+        // Case is preserved so a mismatch against the file on disk is still reportable.
+        assertEquals("Images/foo.png", localWebappImageReference("/opennms/Images/foo.png"));
+    }
+
+    @Test
+    public void ignoresImagesHostedElsewhere() {
+        // An external URL cannot be checked against the local filesystem, and its path
+        // happening to contain an images/ segment must not be read as a local reference.
+        assertNull(localWebappImageReference("https://cdn.example.com/images/x.png"));
+        assertNull(localWebappImageReference("http://cdn.example.com/images/x.png"));
+        // Protocol-relative.
+        assertNull(localWebappImageReference("//cdn.example.com/images/x.png"));
+    }
+
+    @Test
+    public void ignoresDirectoriesThatMerelyEndInImages() {
+        // "images" has to be a whole path segment. A directory whose name ends in it is a
+        // different directory, and resolving these against images/ would invent a file that
+        // was never referenced.
+        assertNull(localWebappImageReference("/opennms/custom-images/logo.png"));
+        assertNull(localWebappImageReference("myimages/logo.png"));
+        assertNull(localWebappImageReference("theme_images/logo.png"));
+    }
+
+    @Test
+    public void ignoresWebAssetsImages() {
+        // core/web-assets is served from a different root and is already checked at build
+        // time: webpack's file-loader fails the bundle on an unresolvable url().
+        assertNull(localWebappImageReference("assets/images/foo.png"));
+        assertNull(localWebappImageReference("/opennms/assets/images/foo.png"));
+    }
+
+    @Test
+    public void ignoresTokensThatAreNotImagePathsAtAll() {
+        assertNull(localWebappImageReference("foo.png"));
+        assertNull(localWebappImageReference("graph/graph.png"));
+        // images/ with nothing after it is not a reference to a file.
+        assertNull(localWebappImageReference("images/"));
+    }
+
     private static boolean isScannable(final Path path) {
         final String name = path.getFileName().toString().toLowerCase();
         return SCANNED_SUFFIXES.stream().anyMatch(name::endsWith);
     }
 
-    /** Trims the leading path so the reference is relative to the webapp root. */
-    private static String normalize(final String reference) {
-        final int imagesSegment = reference.toLowerCase().indexOf("images/");
-        return reference.substring(imagesSegment).replaceAll("/{2,}", "/");
+    /**
+     * Classifies a matched URL or path token and reduces it to a path relative to the webapp
+     * root. References are anchored on the {@code images/} segment, which is how they are
+     * served ({@code /opennms/images/...}) regardless of where the referring page sits.
+     *
+     * @return the reference relative to the webapp root, or null when the token is not a
+     *         reference to a local webapp image and therefore cannot be checked here.
+     */
+    static String localWebappImageReference(final String token) {
+        // Anything with a scheme, or protocol-relative, is served by another host.
+        if (token.contains("://") || token.startsWith("//")) {
+            return null;
+        }
+
+        final String[] segments = token.replaceAll("/{2,}", "/").split("/");
+        // Stop before the last segment: "images" must be a directory, with a file after it.
+        for (int i = 0; i < segments.length - 1; i++) {
+            if (!"images".equalsIgnoreCase(segments[i])) {
+                continue;
+            }
+            if (i > 0 && "assets".equalsIgnoreCase(segments[i - 1])) {
+                return null;
+            }
+            return String.join("/", Arrays.copyOfRange(segments, i, segments.length));
+        }
+        return null;
     }
 
     /**
@@ -181,7 +260,7 @@ public class StaticAssetReferenceTest {
                 // A symlink pointing outside the webapp; existence is all we can reasonably assert.
                 return null;
             }
-            return realRoot.relativize(real).toString().replace(java.io.File.separatorChar, '/');
+            return realRoot.relativize(real).toString().replace(File.separatorChar, '/');
         } catch (final IOException e) {
             return null;
         }


### PR DESCRIPTION
# NMS-20246: Fail the build on dangling static image references in the webapp

## Summary

Adds a single unit test, `opennms-webapp/src/test/java/org/opennms/web/StaticAssetReferenceTest.java`, that scans the webapp sources for statically written `images/...` references and fails the build if any of them does not resolve to a file that is actually present.

No runtime code changes, no new dependencies, no configuration changes. Runs in about 0.13s.

## Why

A missing image referenced from a JSP is invisible to the build. There is no compile error, no packaging error and no server-side error — the page renders with a broken image or a blank background, and the only trace is a 404 in the browser. Nothing in CI looks at it.

That is what made the `images/` cleanup in NMS-20091 risky. It removed 61 unreferenced files on the strength of a reference audit, which was the right call and correctly scoped for this repository. But where such an audit is wrong, the mistake is silent: one of the removed wallpapers was still referenced by customized JSPs in a downstream distribution built from this code, and the breakage only surfaced when someone happened to open a login page.

The audit itself was not the problem — the absence of any mechanical check was. This test supplies one, so the next `images/` cleanup gets a build failure instead of a bug report.

## What the test does

Walks `src/main/webapp` and reads every `.jsp`, `.jspf`, `.tag`, `.tagx`, `.ftl`, `.html`, `.htm`, `.css` and `.js` file. Matching happens in two steps, which is what keeps it from guessing:

1. **Match the whole token.** A regex picks up complete URL or path tokens ending in an image extension. Its character class excludes quotes, whitespace and CSS delimiters, so a token is naturally bounded by the attribute quoting or `url(...)` parentheses around it.
2. **Classify the token by its path segments.** A token counts as a local webapp image only when `images` is an *entire* path segment followed by a filename, the token carries no URL scheme, and it is not protocol-relative.

That covers the reference forms the webapp actually uses — bare `images/foo.png`, server-absolute `/opennms/images/foo.png`, relative `../images/foo.png`, and the JSTL `<c:url value="/images/foo.png"/>` form — while excluding anything that cannot be checked against the local filesystem or is simply a different directory.

Each surviving reference must resolve to a regular file under `src/main/webapp`. References are additionally compared against the case the file has on disk, so a mismatch that works on a case-insensitive developer filesystem cannot reach a case-sensitive deployment as a 404.

On failure the assertion names the unresolved reference and every file that refers to it:

```
Image references in the webapp that do not resolve to a file under src/main/webapp.
Restore the file, or update the reference if the image is genuinely gone -- do not
leave the reference dangling, because nothing else in the build will catch it:
  images/wallpapers/background_dark.png -- no such file
      referenced by: account/selfService/passwordGate.jsp, login.jsp
```

## Review feedback addressed

The first version of the matcher anchored on the literal text `images/` with nothing to its left, which produced false positives on two shapes, both confirmed to fail the build on an otherwise unrelated commit:

```
<img src="https://cdn.example.com/images/x.png">
<img src="/opennms/custom-images/logo.png">
```

The first is served by another host and cannot be checked locally. The second is a different directory, and was reported as a missing `images/logo.png` — a file nothing had referenced.

The fix is the match-then-classify split described above, rather than a boundary assertion added to the regex. Splitting on `/` and requiring a whole segment also excludes the `myimages/` and `theme_images/` shapes, and turns the `assets/` exclusion into an ordinary segment comparison instead of a lookbehind, so both exclusions are now expressed the same way.

Each of these cases is pinned by a named unit test over the classifier, none of which touch the filesystem. Note that the defect only ever produced false *positives* — a failing build on an innocent commit, never a silently missed dangling reference — but it would have made the test a nuisance the first time someone added a CDN image, which is how a check like this ends up disabled.


## Scope and deliberate omissions

**It never asserts that an image *is* referenced.** Flagging unused files is exactly the reasoning that produced the original incident, so it is out of scope by design. Dead files remain a judgment call.

**`assets/images/...` is excluded.** Those belong to `core/web-assets`, are served from a different root, and are already checked at build time — `webpack.config.js` uses `file-loader`, which fails the bundle on an unresolvable `url()`. The plain JSPs have no bundler, which is precisely why they need this test.

**Runtime-constructed paths are skipped by construction.** The pattern's character class excludes quotes and whitespace, so `"images/" + name + ".png"` does not match rather than matching incorrectly. Exactly one image-like reference in the webapp falls outside the pattern, `graph/graph.png` in `graph/adhoc4.jsp`, which is a servlet URL rather than a file.

**Guards against a vacuous pass.** The test asserts that the webapp root exists and that the scan found at least 10 references, because a test that silently finds nothing is worse than no test. The relative-path convention follows the existing `NavBarControllerTest`, which resolves `src/main/webapp` the same way.

Two limits worth stating: the test checks source, not the assembled WAR, so it will not catch a file that exists but is excluded from packaging; and it does not cover images referenced from SCSS or Vue in the newer UI. Both would be separate checks.

## Notes for reviewers

* **Test-only change, no UI impact**, so the branch does not carry `-smoke`. It adds no runtime code and cannot alter rendered output.
* No files under `$OPENNMS_HOME/etc/` are touched, as required for a `foundation-*` target.
* New code, and it is itself the test.
* The behavior is documented in the test's class-level Javadoc, including why the unused-file direction is intentionally not checked. No user-facing documentation change seemed warranted; happy to add some if a reviewer disagrees.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20246
