### PR TITLE
NMS-19841: Karaf's SimpleDownloadTask race causes intermittent FileNotFoundException

### DIFF
--- a/container/karaf-features-core-patch/pom.xml
+++ b/container/karaf-features-core-patch/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.container</artifactId>
+        <version>36.0.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.opennms.container</groupId>
+    <artifactId>org.opennms.container.karaf-features-core-patch</artifactId>
+    <packaging>pom</packaging>
+    <name>OpenNMS :: Container :: karaf-features-core Patch</name>
+    <description>
+        NMS-19841: org.apache.karaf.features.core's SimpleDownloadTask (used to stage
+        wrap:/blueprint:/spring: bundle URLs, e.g. wrap:mvn:.../protobuf-java/... , into a
+        local file before the OSGi framework installs them) picks a destination filename
+        derived only from the URL, then does:
+
+            if (file.exists() &amp;&amp; !file.delete()) throw ...;
+            tmpFile.renameTo(file);
+
+        Two overlapping resolutions of the same URL - each with their own DownloadManager,
+        e.g. Karaf's own boot feature install racing a feature install triggered shortly
+        after by container startup tooling - can each pass the initial "does file already
+        exist" check before either finishes, and the second one's delete() can remove the
+        first one's freshly written file out from under a reader that is mid-open, raising
+        FileNotFoundException. This is a genuine bug in Karaf itself: it is still present,
+        unsynchronized, in the same form on the Karaf project's main branch, so bumping the
+        Karaf version does not fix it.
+
+        This module rebuilds org.apache.karaf.features.core with a patched
+        SimpleDownloadTask that replaces the delete-then-renameTo sequence with
+        Files.move(..., REPLACE_EXISTING[, ATOMIC_MOVE]), so a concurrent reader always
+        observes either the old or the new (equivalent) file, never a missing one. The
+        assembly module (container/karaf, used by the Horizon/core distribution) copies
+        this over the bundle that Karaf's framework feature put into its assembled
+        system/ directory.
+
+        Filed upstream as https://github.com/apache/karaf/issues/2808 . Should Apache
+        Karaf fix this, this module can be deleted once that fixed version is picked up.
+    </description>
+
+    <properties>
+        <license.skipAddThirdParty>true</license.skipAddThirdParty>
+        <karafFeaturesCoreJar>org.apache.karaf.features.core-${karafVersion}.jar</karafFeaturesCoreJar>
+    </properties>
+
+    <dependencies>
+        <!-- provides the classes SimpleDownloadTask compiles against (its sibling
+             classes in the same package, plus the embedded org.apache.karaf.util
+             classes) - not shipped, only used to build the compile classpath -->
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>org.apache.karaf.features.core</artifactId>
+            <version>${karafVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4jVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-original-karaf-features-core</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.karaf.features</groupId>
+                                    <artifactId>org.apache.karaf.features.core</artifactId>
+                                    <version>${karafVersion}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}/original</outputDirectory>
+                                    <destFileName>${karafFeaturesCoreJar}</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- packaging is "pom" so the default lifecycle does not bind
+                     compilation on its own - compile the one patched class
+                     explicitly, matching the original's class file version (55 =
+                     Java 11) so it drops into the bundle unchanged otherwise -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile-patched-simple-download-task</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>11</release>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven.antrun.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>patch-karaf-features-core-simple-download-task</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <unzip src="${project.build.directory}/original/${karafFeaturesCoreJar}"
+                                       dest="${project.build.directory}/bundle"/>
+
+                                <!-- overlay the recompiled class over the original -->
+                                <copy overwrite="true"
+                                      file="${project.build.directory}/classes/org/apache/karaf/features/internal/download/impl/SimpleDownloadTask.class"
+                                      tofile="${project.build.directory}/bundle/org/apache/karaf/features/internal/download/impl/SimpleDownloadTask.class"/>
+
+                                <!-- repack; passing the original manifest keeps the OSGi
+                                     headers untouched and writes META-INF/MANIFEST.MF as
+                                     the first entry, which Karaf's JarInputStream based
+                                     manifest readers depend on -->
+                                <jar destfile="${project.build.directory}/${karafFeaturesCoreJar}"
+                                     basedir="${project.build.directory}/bundle"
+                                     manifest="${project.build.directory}/bundle/META-INF/MANIFEST.MF"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-patched-karaf-features-core</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/${karafFeaturesCoreJar}</file>
+                                    <type>jar</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/container/karaf-features-core-patch/src/main/java/org/apache/karaf/features/internal/download/impl/SimpleDownloadTask.java
+++ b/container/karaf-features-core-patch/src/main/java/org/apache/karaf/features/internal/download/impl/SimpleDownloadTask.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.features.internal.download.impl;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.karaf.util.StreamUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SimpleDownloadTask extends AbstractRetryableDownloadTask {
+
+    private static final String BLUEPRINT_PREFIX = "blueprint:";
+    private static final String SPRING_PREFIX = "spring:";
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractDownloadTask.class);
+
+    private File basePath;
+
+    public SimpleDownloadTask(ScheduledExecutorService executorService, String url, File basePath) {
+        super(executorService, url);
+        this.basePath = basePath;
+    }
+
+    @Override
+    protected File download(Exception previousExceptionNotUsed) throws Exception {
+        LOG.trace("Downloading [" + url + "]");
+
+        if (url.startsWith(BLUEPRINT_PREFIX) || url.startsWith(SPRING_PREFIX)) {
+            return downloadBlueprintOrSpring();
+        }
+
+        try {
+            basePath.mkdirs();
+            if (!basePath.isDirectory()) {
+                throw new IOException("Unable to create directory " + basePath.toString());
+            }
+
+            URL urlObj = new URL(url);
+            File file = new File(basePath, getFileName(urlObj));
+            if (file.exists()) {
+                return file;
+            }
+
+            File dir = new File(System.getProperty("karaf.data"), "tmp");
+            dir.mkdirs();
+            if (!dir.isDirectory()) {
+                throw new IOException("Unable to create directory " + dir.toString());
+            }
+
+            File tmpFile = Files.createTempFile(dir.toPath(), "download-", null).toFile();
+
+            urlObj = new URL(DownloadManagerHelper.stripStartLevel(urlObj.toString()));
+            try (InputStream is = urlObj.openStream();
+                 OutputStream os = new FileOutputStream(tmpFile)) {
+                StreamUtils.copy(is, os);
+            }
+
+            // OPENNMS (NMS-19841, filed upstream as apache/karaf#2808): the target
+            // filename is derived solely from the URL, so
+            // two overlapping downloads of the same URL (e.g. from two feature installs
+            // that race against each other, each with their own DownloadManager/cache)
+            // both land here. The original delete()-then-renameTo() left a window where
+            // `file` did not exist at all, which a concurrent reader could observe as a
+            // FileNotFoundException. Files.move(..., REPLACE_EXISTING) replaces the
+            // destination in one atomic filesystem operation instead, so a concurrent
+            // reader always sees either the old or the new (equivalent) content.
+            try {
+                Files.move(tmpFile.toPath(), file.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tmpFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            return file;
+        } catch (Exception ignore) {
+            throw new IOException("Could not download [" + this.url + "]", ignore);
+        }
+    }
+
+    // we only want the filename itself, not the whole path
+    private String getFileName(URL urlObj) {
+        String url = urlObj.getFile();
+        // ENTESB-1394: we do not want all these decorators from wrap: protocol
+        // or any inlined maven repos
+        url = DownloadManagerHelper.stripUrl(url);
+        url = DownloadManagerHelper.removeInlinedMavenRepositoryUrl(url);
+        int unixPos = url.lastIndexOf('/');
+        int windowsPos = url.lastIndexOf('\\');
+        url = url.substring(Math.max(unixPos, windowsPos) + 1);
+        url = Integer.toHexString(urlObj.toString().hashCode()) + "-" + url;
+        return url;
+    }
+
+    protected File downloadBlueprintOrSpring() throws Exception {
+        // when downloading an embedded blueprint or spring xml file, then it must be as a temporary file
+        File dir = new File(System.getProperty("karaf.data"), "tmp");
+        dir.mkdirs();
+        File tmpFile = Files.createTempFile(dir.toPath(), "download-", null).toFile();
+        try (InputStream is = new URL(url).openStream();
+             OutputStream os = new FileOutputStream(tmpFile))
+        {
+            StreamUtils.copy(is, os);
+        }
+        return tmpFile;
+    }
+
+    @Override
+    protected Retry isRetryable(IOException e) {
+        // TODO: check http errors, etc.
+        return super.isRetryable(e);
+    }
+
+}

--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -217,6 +217,36 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <execution>
+                        <!-- NMS-19841 (filed upstream as apache/karaf#2808):
+                             org.apache.karaf.features.core's SimpleDownloadTask stages
+                             wrap:/blueprint:/spring: bundle URLs (e.g.
+                             wrap:mvn:.../protobuf-java/...) via an unsynchronized
+                             delete-then-renameTo, so two overlapping resolutions of the
+                             same URL can delete the file out from under a reader that is
+                             mid-open, raising FileNotFoundException at runtime. Replace it
+                             with the patched jar from container/karaf-features-core-patch,
+                             built the same way as the pax-url-aether replacement above. -->
+                        <id>replace-racy-karaf-features-core</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.opennms.container</groupId>
+                                    <artifactId>org.opennms.container.karaf-features-core-patch</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}/assembly/system/org/apache/karaf/features/org.apache.karaf.features.core/${karafVersion}</outputDirectory>
+                                    <destFileName>org.apache.karaf.features.core-${karafVersion}.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -10,10 +10,11 @@
   <packaging>pom</packaging>
   <name>OpenNMS :: OSGi Container</name>
   <modules>
-    <!-- these two must come before "karaf" and "shared": they patch the Karaf
-         pax-url-aether bundle both assemblies pull into their system/ directory -->
+    <!-- these must come before "karaf" and "shared": they patch Karaf bundles
+         both assemblies pull into their system/ directory -->
     <module>plexus-utils-relocated</module>
     <module>pax-url-aether-patch</module>
+    <module>karaf-features-core-patch</module>
     <module>branding</module>
     <module>features</module>
     <module>karaf</module>

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -236,6 +236,36 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <execution>
+                        <!-- NMS-19841 (filed upstream as apache/karaf#2808):
+                             org.apache.karaf.features.core's SimpleDownloadTask stages
+                             wrap:/blueprint:/spring: bundle URLs (e.g.
+                             wrap:mvn:.../protobuf-java/...) via an unsynchronized
+                             delete-then-renameTo, so two overlapping resolutions of the
+                             same URL can delete the file out from under a reader that is
+                             mid-open, raising FileNotFoundException at runtime. Replace it
+                             with the patched jar from container/karaf-features-core-patch,
+                             built the same way as the pax-url-aether replacement above. -->
+                        <id>replace-racy-karaf-features-core</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.opennms.container</groupId>
+                                    <artifactId>org.opennms.container.karaf-features-core-patch</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}/assembly/system/org/apache/karaf/features/org.apache.karaf.features.core/${karafVersion}</outputDirectory>
+                                    <destFileName>org.apache.karaf.features.core-${karafVersion}.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
While investigating  `FileNotFoundException: /opt/opennms/data/tmp/xxxx-protobuf-java-3.25.5.jar `(Karaf Maven staging fails) error from NMS-19841, I came across this issue which could be contributing to the error.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19841

