### PR TITLE
NMS-20182: Various UI fixes after the PrimeVue / OnmsUI migration

### DIFF
--- a/core/web-assets/src/main/assets/style/opennms-theme.scss
+++ b/core/web-assets/src/main/assets/style/opennms-theme.scss
@@ -370,6 +370,32 @@ iframe.vaadin-fullscreen {
   padding-top: var(--onms-legacy-content-offset);
   padding-left: var(--onms-legacy-content-offset);
 
+  // Stack the page in a column at least as tall as the window, so that #footer
+  // ends up at the bottom of the window on a short page instead of stopping
+  // wherever the content happens to end — the same result the Vue SPA gets from
+  // its layout grid's 1fr content row. On a page taller than the window there is
+  // no slack to take and the footer simply follows the content, as before.
+  // `box-sizing: border-box` is global, so 100vh already covers the padding-top
+  // above, and body carries no margin or padding of its own: the column starts at
+  // the top of the viewport and ends exactly at its bottom.
+  //
+  // bootstrap.jsp wraps everything but the footer in #content-body to keep this
+  // container down to two flex items. Page markup must not become flex items
+  // itself: that stretches inline-level children (a .btn-group grew to the full
+  // content width on the outage list), collapses elements whose width comes from
+  // auto margins (<hr> shrank to nothing on the reports page), and stops margin
+  // collapsing. Inside the plain block that is #content-body, all of it lays out
+  // exactly as it did before.
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+
+  // Takes every bit of leftover height (and never shrinks below its content), so
+  // the footer after it is left sitting at the bottom of the column.
+  > #content-body {
+    flex: 1 0 auto;
+  }
+
   // Revert padding as growl added this, which was required in bootstrap 3 but is
   // no longer required, so without this the padding to the right is too much
   .growl-container > .growl-item {

--- a/opennms-base-assembly/src/main/filtered/etc/search-actions.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/search-actions.xml
@@ -209,6 +209,10 @@
             <role>ROLE_ADMIN</role>
         </roles>
     </action>
+    <action>
+        <label>Resource Graphs (Preview)</label>
+        <url>ui/index.html#/resource-graphs</url>
+    </action>
 
     <!-- Distributed Monitoring Card -->
     <action>
@@ -303,5 +307,15 @@
     <action>
         <label>Show Nodes without Flows</label>
         <url>ui/index.html#/nodes?flows=false</url>
+    </action>
+
+    <!-- Maps -->
+    <action>
+        <label>Geographical Map</label>
+        <url>ui/index.html#/map</url>
+    </action>
+    <action>
+        <label>Topology Map</label>
+        <url>topology</url>
     </action>
 </actions>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
@@ -319,8 +319,8 @@
     <a class="btn btn-secondary" href="<%=this.makeLink(callback, parms, "long", favorite)%>" title="Detailed List of Alarms">Long Listing</a>
       </c:otherwise>
     </c:choose>
-    <a class="btn btn-secondary text-white" onclick="$('#severityLegendModal').modal()">Severity Legend</a>
-    <a class="btn btn-secondary text-white" onclick="$('#helpModal').modal()">Help</a>
+    <a class="btn btn-secondary" onclick="$('#severityLegendModal').modal()">Severity Legend</a>
+    <a class="btn btn-secondary" onclick="$('#helpModal').modal()">Help</a>
 
     <% if (req.isUserInRole( Authentication.ROLE_ADMIN ) || !req.isUserInRole( Authentication.ROLE_READONLY)) { %>
       <% if ( alarmCount > 0 ) { %>

--- a/opennms-webapp/src/main/webapp/account/selfService/passwordGate.jsp
+++ b/opennms-webapp/src/main/webapp/account/selfService/passwordGate.jsp
@@ -236,3 +236,16 @@
         </div>
     </div>
 </div>
+
+<%--
+  These pages include bootstrap.jsp but not bootstrap-footer.jsp — they are
+  deliberately footer-less — so nothing else closes the two <div> tags that
+  include opens. Close them here: #content is a flex column at least as tall as
+  the window (see #content in opennms-theme.scss), and leaving the wrapper open
+  would put this page's markup and any later content in the wrong box. The
+  matching tags are in bootstrap.jsp, so they are emitted from JSP fragments to
+  keep the Eclipse HTML validator quiet, as that file does. <body> and <html>
+  stay unclosed here exactly as before.
+--%>
+<%= "</div>" %><!-- id="content-body" -->
+<%= "</div>" %><!-- id="content" class="container-fluid" -->

--- a/opennms-webapp/src/main/webapp/includes/bootstrap-footer.jsp
+++ b/opennms-webapp/src/main/webapp/includes/bootstrap-footer.jsp
@@ -48,6 +48,21 @@
     XssRequestWrapper req = new XssRequestWrapper(request);
 %>
 
+<%-- Close the #content-body wrapper opened in bootstrap.jsp, so the footer is a
+     sibling of it rather than inside it — that is what lets #content-body take
+     the slack and leave the footer at the bottom. Guarded by the same
+     'superQuiet' test as the #content close below, since that branch emits
+     neither div. Closed here, ahead of the footer markup, rather than with
+     #content at the end of this file. --%>
+<c:choose>
+    <c:when test="${param.superQuiet == 'true'}">
+        <%-- nothing to do --%>
+    </c:when>
+    <c:otherwise>
+        <%= "</div>" %><!-- id="content-body" -->
+    </c:otherwise>
+</c:choose>
+
 <c:choose>
     <c:when test="${param.quiet == 'true'}">
         <!-- Not displaying footer -->

--- a/opennms-webapp/src/main/webapp/includes/bootstrap-footer.jsp
+++ b/opennms-webapp/src/main/webapp/includes/bootstrap-footer.jsp
@@ -95,9 +95,20 @@
     </c:otherwise>
 </c:choose>
 
+<%--
+  Whatever an install drops in includes/custom-footer lands here, between the
+  footer and the close of #content — which is a flex column (see #content in
+  opennms-theme.scss). Give it a plain block of its own to live in, for the same
+  reason #content-body exists: as direct flex items, inline-level markup would be
+  stretched and anything sized by auto margins would collapse. Inside this div it
+  lays out normally, and #content keeps a hand-countable set of items.
+--%>
 <%
     File extraIncludes = new File(request.getSession().getServletContext().getRealPath("includes") + File.separator + "custom-footer");
     if (extraIncludes.exists()) {
+%>
+<div id="custom-footer">
+<%
         for (File file : extraIncludes.listFiles()) {
             if (file.isFile()) {
                 pageContext.setAttribute("file", "custom-footer/" + file.getName());
@@ -106,6 +117,9 @@
 <%
             }
         }
+%>
+</div>
+<%
     }
 %>
 

--- a/opennms-webapp/src/main/webapp/includes/bootstrap.jsp
+++ b/opennms-webapp/src/main/webapp/includes/bootstrap.jsp
@@ -326,6 +326,16 @@
 
     <%= "<div id=\"content\" class=\"container-fluid\">" %>
 
+    <%-- #content is a flex column at least as tall as the window, so the footer
+         can sit at the bottom of a short page instead of stopping wherever the
+         content ends (see #content / #content-body in opennms-theme.scss). This
+         wrapper holds everything except the footer, which keeps #content down to
+         two flex items: page markup lays out inside a plain block exactly as it
+         did before, rather than becoming flex items itself (which stretched
+         inline-level children like .btn-group and collapsed <hr> elements).
+         Closed in bootstrap-footer.jsp, just before the footer. --%>
+    <%= "<div id=\"content-body\">" %>
+
     <%-- Vue menus: do not display if 'quiet' is true (whether requested via the
          'quiet' include param or the Bootstrap 'quiet' flag, e.g. login.jsp), or
          if 'oldmenu' query string param is true. On unauthenticated quiet pages

--- a/opennms-webapp/src/main/webapp/login.jsp
+++ b/opennms-webapp/src/main/webapp/login.jsp
@@ -232,3 +232,16 @@
        </div>
   </div>
 </div>
+
+<%--
+  These pages include bootstrap.jsp but not bootstrap-footer.jsp — they are
+  deliberately footer-less — so nothing else closes the two <div> tags that
+  include opens. Close them here: #content is a flex column at least as tall as
+  the window (see #content in opennms-theme.scss), and leaving the wrapper open
+  would put this page's markup and any later content in the wrong box. The
+  matching tags are in bootstrap.jsp, so they are emitted from JSP fragments to
+  keep the Eclipse HTML validator quiet, as that file does. <body> and <html>
+  stay unclosed here exactly as before.
+--%>
+<%= "</div>" %><!-- id="content-body" -->
+<%= "</div>" %><!-- id="content" class="container-fluid" -->

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminPageIT.java
@@ -77,7 +77,7 @@ public class AdminPageIT extends OpenNMSSeleniumIT {
         // Service Monitoring
         new String[] { "Configure Scheduled Outages", "//form//input[@value='New Name']" },
         new String[] { "Manage and Unmanage Interfaces and Services", "//span[text()='Manage and Unmanage Interfaces and Services']" },
-        new String[] { "Manage Business Services", "//div[@id='content']/iframe[@name='bsm-admin-page']" },
+        new String[] { "Manage Business Services", "//div[@id='content']//iframe[@name='bsm-admin-page']" },
 
         // Performance Measurement
         new String[] { "Manage SNMP Data Collection Config", "//div[@id='app']//h1[text()='Manage SNMP Data Collection Sources']" },
@@ -92,9 +92,9 @@ public class AdminPageIT extends OpenNMSSeleniumIT {
         // Additional Tools
         new String[] { "Configure Grafana Endpoints (Reports only)", "//div/ul/li/a[contains(text(),'Grafana Endpoints')]" },
         new String[] { "Instrumentation Log Reader", "//span[text()='Filtering']" },
-        new String[] { "SNMP MIB Compiler", "//div[@id='content']/iframe[@name='mib-compiler']" },
-        new String[] { "Surveillance Views Configuration", "//div[@id='content']/iframe[@name='surveillance-views-config']" },
-        new String[] { "JMX Configuration Generator", "//div[@id='content']/iframe[@name='jmx-config-ui']" },
+        new String[] { "SNMP MIB Compiler", "//div[@id='content']//iframe[@name='mib-compiler']" },
+        new String[] { "Surveillance Views Configuration", "//div[@id='content']//iframe[@name='surveillance-views-config']" },
+        new String[] { "JMX Configuration Generator", "//div[@id='content']//iframe[@name='jmx-config-ui']" },
         new String[] { "Usage Statistics Sharing", "//div[contains(@class, 'card')]//span[text()='Usage Statistics Sharing']" },
         new String[] { "Product Update Enrollment", "//div[contains(@class, 'admin-product-update-enrollment-form-wrapper')]" }
     };
@@ -207,7 +207,7 @@ public class AdminPageIT extends OpenNMSSeleniumIT {
         // ...and create it by hitting the button
         findElementByName("newApplicationSubmit").click();
         // now click the edit link...
-        findElementByXpath("//*[@id=\"content\"]/table/tbody/tr[2]/td[2]/a").click();
+        findElementByXpath("//*[@id=\"content\"]//table/tbody/tr[2]/td[2]/a").click();
         // ...and check for the given text.
         // This will fail if the text is not properly escaped, as a user dialogue will appear.
         waitUntil(pageContainsText("Edit application foobar"));

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -81,7 +81,7 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Customized Reports']")));
 
         clickMenuItem("Dashboards", "Surveillance Dashboard");
-        driver.switchTo().frame(findElementByXpath("/html/body/div/iframe"));
+        driver.switchTo().frame(findElementByXpath("/html/body/div//iframe"));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//span[text()='Surveillance view: default']")));
 
         driver.switchTo().parentFrame();
@@ -115,7 +115,7 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
 
         clickMenuItem("Monitoring", "Surveillance View");
         // switchTo() by xpath is much faster than by ID
-        driver.switchTo().frame(findElementByXpath("/html/body/div/iframe"));
+        driver.switchTo().frame(findElementByXpath("/html/body/div//iframe"));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//span[text()='Surveillance view: default']")));
         driver.switchTo().parentFrame();
         frontPage();

--- a/ui/packages/onms-ui/src/components/OnmsDialog.vue
+++ b/ui/packages/onms-ui/src/components/OnmsDialog.vue
@@ -8,6 +8,7 @@
     :closeOnEscape="closeOnEscape"
     :appendTo="appendTo"
     :style="width ? { width } : undefined"
+    :block-scroll="modal"
     :pt="unsafePt as never"
     @update:visible="emit('update:visible', $event)"
     @hide="emit('hide')"
@@ -28,6 +29,11 @@ import Dialog from 'primevue/dialog'
 // Seam wrapper (NMS-20029) around PrimeVue Dialog. Sizing is expressed via the
 // `width` prop (maps to an inline style) so consumers never touch PrimeVue
 // styling APIs. Header content is text-only via the `header` prop.
+//
+// `blockScroll` tracks `modal` (PrimeVue defaults it to false): a modal dialog
+// must not let the wheel scroll the page behind it, while a non-modal one leaves
+// the page interactive by definition (NMS-20182). OnmsConfirmationDialog and
+// OnmsMessageDialog wrap this component, so they inherit the behavior.
 withDefaults(defineProps<{
   visible: boolean
   header?: string

--- a/ui/packages/onms-ui/src/components/OnmsDrawer.vue
+++ b/ui/packages/onms-ui/src/components/OnmsDrawer.vue
@@ -4,6 +4,7 @@
     :position="position"
     :header="header"
     :style="width ? { width } : undefined"
+    :block-scroll="true"
     :pt="unsafePt as never"
     @update:visible="emit('update:visible', $event)"
     @hide="emit('hide')"
@@ -25,6 +26,12 @@ import Drawer from 'primevue/drawer'
 // design (every OpenNMS drawer does; PrimeVue's own default is left). Sizing
 // via `width` (inline style) so consumers never touch styling APIs. Modal +
 // dismissable behavior uses PrimeVue defaults (both true).
+//
+// `blockScroll` is forced on (PrimeVue defaults it to false): the drawer is
+// always modal, and without it the wheel over an open drawer scrolls the page
+// behind, so the page's scrollbar looked like the drawer's (NMS-20182). See the
+// `html:has(body.p-overflow-hidden)` rule in main/App.vue for why the body class
+// PrimeVue sets is not enough on its own.
 withDefaults(defineProps<{
   visible: boolean
   position?: 'left' | 'right' | 'top' | 'bottom' | 'full'

--- a/ui/src/components/Common/FormField.vue
+++ b/ui/src/components/Common/FormField.vue
@@ -14,6 +14,16 @@
         aria-hidden="true"
       >*</span>
     </label>
+    <!-- Presentational stand-in for a label, so a field that has none still lines
+         its control up with the labelled fields beside it (e.g. an action button
+         in a form row). A real <label> element, so it picks up exactly the same
+         typography and spacing as the labelled case; aria-hidden and without a
+         `for`, so it says nothing to assistive tech. -->
+    <label
+      v-else-if="reserveLabelSpace"
+      class="form-field__label"
+      aria-hidden="true"
+    >&nbsp;</label>
     <slot
       :errorId="errorId"
       :invalid="invalid"
@@ -40,12 +50,14 @@ const props = withDefaults(defineProps<{
   required?: boolean
   error?: string
   hint?: string
+  reserveLabelSpace?: boolean
 }>(), {
   label: undefined,
   for: undefined,
   required: false,
   error: undefined,
-  hint: undefined
+  hint: undefined,
+  reserveLabelSpace: false
 })
 
 // `for` is a reserved word; alias it for use in the template.

--- a/ui/src/components/Device/DCBTable.vue
+++ b/ui/src/components/Device/DCBTable.vue
@@ -405,7 +405,4 @@ const onLastBackupDateClick = (config: DeviceConfigBackup) => {
     }
   }
 }
-a:visited {
-  color: var(--p-primary-color) !important;
-}
 </style>

--- a/ui/src/components/Layout/Footer.vue
+++ b/ui/src/components/Layout/Footer.vue
@@ -1,5 +1,4 @@
 <template>
-  <div style="height: 1rem"></div>
   <div class="footer">
     <p>
       OpenNMS <a href="../about/index.jsp">Copyright</a> © {{ mainMenu.copyrightDates || '--' }}

--- a/ui/src/components/Layout/Footer.vue
+++ b/ui/src/components/Layout/Footer.vue
@@ -22,10 +22,27 @@ const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 
 </script>
 
+<style lang="scss">
+// Shared footer band height, mirroring --onms-header-height in Menubar.vue. Pages
+// that size themselves against the height the app shell leaves them subtract this
+// (Map, Logs, SCV), so it lives here, next to the element it describes, instead of
+// being repeated as a literal in each of them.
+//
+// It is the band this component actually draws: one 1.5rem line of text, 0.5rem of
+// padding above and below, and the 1px top border. `.footer` takes its min-height
+// from the token, so the two cannot drift apart. Note it is a *min*: at very narrow
+// widths the copyright line wraps and the band grows past the token, which is the
+// one case those page calculations still under-count.
+:root {
+  --onms-footer-height: calc(1.5rem + 1rem + 1px);
+}
+</style>
+
 <style lang="scss" scoped>
 .footer {
   display: block;
   text-align: center;
+  min-height: var(--onms-footer-height);
   margin-left: -1rem;
   margin-right: -1rem;
   padding: 0.5rem 0.5rem;

--- a/ui/src/components/Logs/Editor.vue
+++ b/ui/src/components/Logs/Editor.vue
@@ -95,13 +95,12 @@ const init = (editor: any) => {
 @import "@/styles/onms-tokens";
 // Fit the height the app shell leaves for page content, or the page pushes the
 // footer past the bottom of the window and clips it. The shell takes the masthead
-// (--onms-header-height) off the top and the footer band (41px: a 1.5rem line,
-// 0.5rem of padding either side and a 1px top border) off the bottom.
+// (--onms-header-height) off the top and the footer band (--onms-footer-height) off the bottom.
 //
 // This page also stacks a breadcrumb row (51px) above the card the editor sits
 // in, and that card pads it by 15px top and bottom.
 .editor {
-  height: calc(100vh - var(--onms-header-height, 3.75rem) - 41px - 51px - 30px);
+  height: calc(100vh - var(--onms-header-height, 3.75rem) - var(--onms-footer-height, 41px) - 51px - 30px);
   display: flex;
   flex-direction: column;
   border: 1px solid var(--p-content-border-color);

--- a/ui/src/components/Logs/Editor.vue
+++ b/ui/src/components/Logs/Editor.vue
@@ -93,8 +93,15 @@ const init = (editor: any) => {
 
 <style lang="scss" scoped>
 @import "@/styles/onms-tokens";
+// Fit the height the app shell leaves for page content, or the page pushes the
+// footer past the bottom of the window and clips it. The shell takes the masthead
+// (--onms-header-height) off the top and the footer band (41px: a 1.5rem line,
+// 0.5rem of padding either side and a 1px top border) off the bottom.
+//
+// This page also stacks a breadcrumb row (51px) above the card the editor sits
+// in, and that card pads it by 15px top and bottom.
 .editor {
-  height: calc(100vh - 120px);
+  height: calc(100vh - var(--onms-header-height, 3.75rem) - 41px - 51px - 30px);
   display: flex;
   flex-direction: column;
   border: 1px solid var(--p-content-border-color);

--- a/ui/src/components/Logs/Logs.vue
+++ b/ui/src/components/Logs/Logs.vue
@@ -22,7 +22,13 @@ import { useLogStore } from '@/stores/logStore'
 const logStore = useLogStore()
 const logs = computed(() => logStore.logs)
 const selectedLog = ref(logStore.selectedLog)
-const listStyle = 'max-height: calc(100vh - 260px)'
+// Cap the scrolling list so this column cannot outgrow the editor beside it and
+// push the app footer off the bottom of the window. Same subtraction as the
+// editor in Logs/Editor.vue — masthead (--onms-header-height), the 41px footer
+// band, this page's 51px breadcrumb row and the card's 30px of padding — plus
+// what sits above the list inside this column: the 40px "Search Logs" heading
+// and the Listbox's 62px filter box.
+const listStyle = 'max-height: calc(100vh - var(--onms-header-height, 3.75rem) - 41px - 51px - 30px - 102px)'
 
 // Keep the Listbox highlight in sync with the store's selected log, including
 // when it is refreshed or changed outside this component.

--- a/ui/src/components/Logs/Logs.vue
+++ b/ui/src/components/Logs/Logs.vue
@@ -24,11 +24,11 @@ const logs = computed(() => logStore.logs)
 const selectedLog = ref(logStore.selectedLog)
 // Cap the scrolling list so this column cannot outgrow the editor beside it and
 // push the app footer off the bottom of the window. Same subtraction as the
-// editor in Logs/Editor.vue — masthead (--onms-header-height), the 41px footer
-// band, this page's 51px breadcrumb row and the card's 30px of padding — plus
-// what sits above the list inside this column: the 40px "Search Logs" heading
-// and the Listbox's 62px filter box.
-const listStyle = 'max-height: calc(100vh - var(--onms-header-height, 3.75rem) - 41px - 51px - 30px - 102px)'
+// editor in Logs/Editor.vue — masthead (--onms-header-height), the footer band
+// (--onms-footer-height), this page's 51px breadcrumb row and the card's 30px of
+// padding — plus what sits above the list inside this column: the 40px "Search
+// Logs" heading and the Listbox's 62px filter box.
+const listStyle = 'max-height: calc(100vh - var(--onms-header-height, 3.75rem) - var(--onms-footer-height, 41px) - 51px - 30px - 102px)'
 
 // Keep the Listbox highlight in sync with the store's selected log, including
 // when it is refreshed or changed outside this component.

--- a/ui/src/components/Nodes/ColumnSelectionDrawer.vue
+++ b/ui/src/components/Nodes/ColumnSelectionDrawer.vue
@@ -145,10 +145,11 @@ watch(() => nodeListStore.columns, (newColumns) => {
 </script>
 
 <style lang="scss" scoped>
+// No height/overflow here on purpose: PrimeVue's own `.p-drawer-content` is the
+// drawer's scroll container. A second scroller nested inside it drew its own
+// scrollbar next to the page's (NMS-20182).
 .drawer-content {
   padding: 20px;
-  height: 100%;
-  overflow: auto;
 }
 
 .spacer-large {

--- a/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
+++ b/ui/src/components/Nodes/NodeAdvancedFiltersDrawer.vue
@@ -454,10 +454,11 @@ defineExpose({
 @use '@/styles/onms-tokens' as variables;
 @use '@/styles/onms-typography' as *;
 
+// No height/overflow here on purpose: PrimeVue's own `.p-drawer-content` is the
+// drawer's scroll container. A second scroller nested inside it drew its own
+// scrollbar next to the page's (NMS-20182).
 .node-filters-drawer-custom-padding {
   padding: 20px;
-  height: 100%;
-  overflow: auto;
 
   // The onms grid `gap` only spaces columns, so consecutive filter rows were
   // cramped vertically. Give each stacked row/group breathing room.

--- a/ui/src/components/SCV/SCVForm.vue
+++ b/ui/src/components/SCV/SCVForm.vue
@@ -174,7 +174,11 @@ const addAttribute = () => scvStore.addAttribute()
 .form-container {
   @include onms-elevation(1);
   background: var(--p-content-background);
-  height: calc(100vh - 149px);
+  // Fit the height the app shell leaves for page content, or the page pushes the
+  // footer past the bottom of the window and clips it: the masthead
+  // (--onms-header-height) off the top, the footer band (41px) off the bottom,
+  // then this page's breadcrumb row (51px) and .scv-container's 2px padding.
+  height: calc(100vh - var(--onms-header-height, 3.75rem) - 41px - 51px - 4px);
   display: flex;
   flex-direction: column;
   padding: 0px 15px 15px 15px;

--- a/ui/src/components/SCV/SCVForm.vue
+++ b/ui/src/components/SCV/SCVForm.vue
@@ -176,9 +176,10 @@ const addAttribute = () => scvStore.addAttribute()
   background: var(--p-content-background);
   // Fit the height the app shell leaves for page content, or the page pushes the
   // footer past the bottom of the window and clips it: the masthead
-  // (--onms-header-height) off the top, the footer band (41px) off the bottom,
-  // then this page's breadcrumb row (51px) and .scv-container's 2px padding.
-  height: calc(100vh - var(--onms-header-height, 3.75rem) - 41px - 51px - 4px);
+  // (--onms-header-height) off the top, the footer band (--onms-footer-height) off
+  // the bottom, then this page's breadcrumb row (51px) and .scv-container's 2px
+  // padding.
+  height: calc(100vh - var(--onms-header-height, 3.75rem) - var(--onms-footer-height, 41px) - 51px - 4px);
   display: flex;
   flex-direction: column;
   padding: 0px 15px 15px 15px;

--- a/ui/src/components/SnmpConfiguration/SnmpConfigDetailsPanel.vue
+++ b/ui/src/components/SnmpConfiguration/SnmpConfigDetailsPanel.vue
@@ -61,12 +61,14 @@
                 </FormField>
               </div>
               <div class="onms-col-6 add-range-col">
-                <OnmsButton
-                  label="Add"
-                  :disabled="!firstIpAddress && !lastIpAddress && !ipMatchValue"
-                  @click="onAddRange"
-                  data-test="add-definition-range-button"
-                />
+                <FormField :reserve-label-space="true">
+                  <OnmsButton
+                    label="Add"
+                    :disabled="!firstIpAddress && !lastIpAddress && !ipMatchValue"
+                    @click="onAddRange"
+                    data-test="add-definition-range-button"
+                  />
+                </FormField>
               </div>
             </div>
           </div>
@@ -637,8 +639,10 @@ onMounted(() => {
 
   // Align the Add button with the IPLIKE input. The input's column also holds a
   // hint below it (which can wrap), so centering against the full cell pushes the
-  // button too low. Instead top-align the button and match the input height, so
-  // the button and input line up (and their centers coincide).
+  // button too low. Instead the button sits in a FormField of its own with
+  // `reserveLabelSpace`, which lays out the label box the sibling fields have and
+  // leaves the button where their inputs are — no offset to keep in sync here.
+  // Matching the input height (3rem) then makes their centers coincide too.
   .add-range-col {
     display: flex;
     align-items: flex-start;
@@ -646,7 +650,6 @@ onMounted(() => {
     :deep(.p-button) {
       height: 3rem;
       min-width: 8rem;
-      margin-top: 0.5rem;
     }
   }
 

--- a/ui/src/containers/Map.vue
+++ b/ui/src/containers/Map.vue
@@ -68,13 +68,12 @@ onMounted(async () => {
 <style scoped lang="scss">
 // Fit the height the app shell leaves for page content, or the page pushes the
 // footer past the bottom of the window and clips it. The shell takes the masthead
-// (--onms-header-height) off the top and the footer band (41px: a 1.5rem line,
-// 0.5rem of padding either side and a 1px top border) off the bottom.
+// (--onms-header-height) off the top and the footer band (--onms-footer-height) off the bottom.
 //
 // The map is the whole page — no breadcrumbs or heading above it — so the shell's
 // own chrome is all there is to subtract.
 .map-panes {
-  height: calc(100vh - var(--onms-header-height, 3.75rem) - 41px);
+  height: calc(100vh - var(--onms-header-height, 3.75rem) - var(--onms-footer-height, 41px));
 }
 
 .bottom-pane {

--- a/ui/src/containers/Map.vue
+++ b/ui/src/containers/Map.vue
@@ -4,9 +4,8 @@
       <splitpanes
         :dbl-click-splitter="true"
         @pane-maximize="minimizeBottomPane"
-        class="default-theme"
+        class="default-theme map-panes"
         horizontal
-        style="height: calc(100vh - 80px)"
         ref="split"
         @resize="resize"
       >
@@ -67,6 +66,17 @@ onMounted(async () => {
 </script>
 
 <style scoped lang="scss">
+// Fit the height the app shell leaves for page content, or the page pushes the
+// footer past the bottom of the window and clips it. The shell takes the masthead
+// (--onms-header-height) off the top and the footer band (41px: a 1.5rem line,
+// 0.5rem of padding either side and a 1px top border) off the bottom.
+//
+// The map is the whole page — no breadcrumbs or heading above it — so the shell's
+// own chrome is all there is to subtract.
+.map-panes {
+  height: calc(100vh - var(--onms-header-height, 3.75rem) - 41px);
+}
+
 .bottom-pane {
   position: relative;
 }

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -82,6 +82,15 @@ html {
   overflow-x: hidden;
   scrollbar-gutter: stable;
 }
+// The UA's default 8px body margin sits outside .app-layout's `min-height:
+// 100vh`, so the shell overflowed the viewport by it: even a page whose content
+// fits scrolled ~16px, and its footer stopped short of the bottom of the window.
+// Drop the margin so the shell is exactly as tall as the viewport — the layout's
+// own padding already clears the fixed menubar and rail, and legacy JSP pages
+// have carried a margin-less body all along (NMS-20182).
+body {
+  margin: 0;
+}
 // The `.p-overlay-mask` arm covers nesting: PrimeVue's block/unblock is not
 // reference-counted, so closing a dialog opened *inside* an open drawer strips
 // the body class and unlocked the page while the drawer was still up. The mask

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -91,13 +91,20 @@ html {
 body {
   margin: 0;
 }
-// The `.p-overlay-mask` arm covers nesting: PrimeVue's block/unblock is not
-// reference-counted, so closing a dialog opened *inside* an open drawer strips
-// the body class and unlocked the page while the drawer was still up. The mask
-// element exists for exactly as long as a modal overlay is open, so matching it
-// keeps the lock until the last one closes.
+// The mask arms cover nesting: PrimeVue's block/unblock is not reference-counted,
+// so closing a dialog opened *inside* an open drawer strips the body class and
+// unlocked the page while the drawer was still up. A mask element exists for
+// exactly as long as its overlay is open, so matching it keeps the lock until the
+// last one closes (PrimeVue drops its own body class in `onAfterLeave`, so both
+// mechanisms expire together).
+//
+// Match the dialog and drawer masks specifically, not `.p-overlay-mask` on its
+// own: DataTable, Tree, TreeTable, Image, Galleria and SpeedDial put that class
+// on their masks unconditionally, so a bare `:has(.p-overlay-mask)` would freeze
+// page scroll for the length of, say, a table's loading state.
 html:has(body.p-overflow-hidden),
-html:has(.p-overlay-mask) {
+html:has(.p-dialog-mask.p-overlay-mask),
+html:has(.p-drawer-mask.p-overlay-mask) {
   overflow: hidden;
 }
 // Offsets for the SPA content, clearing the two fixed chrome elements:

--- a/ui/src/main/App.vue
+++ b/ui/src/main/App.vue
@@ -66,8 +66,30 @@ onMounted(() => {
 @import '@/styles/onms-typography';
 @import "@/styles/onms-tokens";
 
+// `overflow-x: hidden` makes <html> itself the SPA's scroll container: the
+// other axis can no longer compute to `visible`, so the body's overflow is not
+// propagated to the viewport. That is why PrimeVue's `blockScroll` — which only
+// adds `.p-overflow-hidden` (overflow: hidden) to <body> — cannot stop the page
+// scrolling on its own here, and the wheel over an open drawer/dialog kept
+// scrolling the content behind it. Lock the real scroller instead, keyed off the
+// same body class so it tracks PrimeVue's own lock state (NMS-20182).
+//
+// `scrollbar-gutter: stable` reserves the scrollbar's width permanently. Without
+// it, locking removes the page scrollbar and the fixed chrome (Menubar, side
+// rail) jumps ~15px wider; PrimeVue's `padding-right` compensation only shifts
+// in-flow content, never fixed elements.
 html {
   overflow-x: hidden;
+  scrollbar-gutter: stable;
+}
+// The `.p-overlay-mask` arm covers nesting: PrimeVue's block/unblock is not
+// reference-counted, so closing a dialog opened *inside* an open drawer strips
+// the body class and unlocked the page while the drawer was still up. The mask
+// element exists for exactly as long as a modal overlay is open, so matching it
+// keeps the lock until the last one closes.
+html:has(body.p-overflow-hidden),
+html:has(.p-overlay-mask) {
+  overflow: hidden;
 }
 // Offsets for the SPA content, clearing the two fixed chrome elements:
 // - padding-top clears the fixed top menu bar (Menubar, --onms-header-height).

--- a/ui/src/styles/onms-base.scss
+++ b/ui/src/styles/onms-base.scss
@@ -85,11 +85,12 @@ a {
 a:hover {
   text-decoration: underline;
 }
-a:visited {
-  // App convention: visited links keep the normal color (mirrors the override
-  // in opennms-styles.scss), rather than a distinct visited color.
-  color: var(--onms-clickable-normal);
-}
+// No `a:visited` rule on purpose. App convention is that visited links keep the
+// normal color, and the `a` rule above already does that for both states (an
+// author declaration beats the UA's visited color). Restating it as `a:visited`
+// adds a pseudo-class to the selector, which then outranks single-class button
+// styles — e.g. Bootstrap's `.btn-secondary` on the alarm/event list menus,
+// whose white label turned blue once the link had been visited (NMS-20182).
 
 .sr-text {
   position: absolute;

--- a/ui/src/styles/opennms-styles.scss
+++ b/ui/src/styles/opennms-styles.scss
@@ -133,14 +133,17 @@ a:visited {
 
 // Native form controls on legacy pages: <select> (e.g. the Alarm/Event/Outage
 // list filters, `select.form-control.custom-select`), checkboxes (e.g. the
-// alarm list's 'Ack' column), and radios (e.g. graph/admin pages). In dark
-// mode PrimeVue sets `color-scheme: dark` on the document, so the browser
-// paints native form controls dark — but legacy pages are light-only, leaving
-// selects dark-on-dark and checkboxes/radios dark-on-light-page. Force native
-// controls to render light (readable in both modes, and the <select> option
-// popup renders light too). The Vue menu uses PrimeVue components rather than
-// native controls, so it is unaffected.
+// alarm list's 'Ack' column), radios (e.g. graph/admin pages), and unstyled
+// <textarea>s (e.g. the alarm detail page's Sticky/Journal memos, which carry
+// no `.form-control` class and so get no explicit background from Bootstrap).
+// In dark mode PrimeVue sets `color-scheme: dark` on the document, so the
+// browser paints native form controls dark — but legacy pages are light-only,
+// leaving selects and textareas dark-on-dark and checkboxes/radios
+// dark-on-light-page. Force native controls to render light (readable in both
+// modes, and the <select> option popup renders light too). The Vue menu uses
+// PrimeVue components rather than native controls, so it is unaffected.
 select,
+textarea,
 input[type='checkbox'],
 input[type='radio'] {
   color-scheme: light;

--- a/ui/src/styles/opennms-styles.scss
+++ b/ui/src/styles/opennms-styles.scss
@@ -125,12 +125,6 @@ body .v-app.topo_default.topologyui {
   transition: margin-left 0.1s linear;
 }
 
-// Visited links keep the normal color (no distinct visited color), matching the
-// app convention in onms-base.scss.
-a:visited {
-  color: var(--onms-clickable-normal);
-}
-
 // Native form controls on legacy pages: <select> (e.g. the Alarm/Event/Outage
 // list filters, `select.form-control.custom-select`), checkboxes (e.g. the
 // alarm list's 'Ack' column), radios (e.g. graph/admin pages), and unstyled

--- a/ui/tests/components/Common/FormField.test.ts
+++ b/ui/tests/components/Common/FormField.test.ts
@@ -22,6 +22,28 @@ describe('FormField.vue', () => {
     expect(withRequired.find('.form-field__required').text()).toBe('*')
   })
 
+  it('reserves the label box with an inert stand-in when reserveLabelSpace is set without a label', () => {
+    const wrapper = mount(FormField, { props: { reserveLabelSpace: true }})
+    const spacer = wrapper.find('label.form-field__label')
+    expect(spacer.exists()).toBe(true)
+    expect(spacer.attributes('aria-hidden')).toBe('true')
+    expect(spacer.attributes('for')).toBeUndefined()
+    expect(spacer.text().trim()).toBe('')
+  })
+
+  it('renders no label at all when reserveLabelSpace is not set', () => {
+    const wrapper = mount(FormField, {})
+    expect(wrapper.find('label').exists()).toBe(false)
+  })
+
+  it('prefers a real label over the reserved stand-in', () => {
+    const wrapper = mount(FormField, { props: { label: 'Port', for: 'trap-port', reserveLabelSpace: true }})
+    const labels = wrapper.findAll('label.form-field__label')
+    expect(labels).toHaveLength(1)
+    expect(labels[0].text()).toContain('Port')
+    expect(labels[0].attributes('aria-hidden')).toBeUndefined()
+  })
+
   it('renders the default slot content (the control)', () => {
     const wrapper = mount(FormField, {
       props: { label: 'Port' },


### PR DESCRIPTION
# NMS-20182: Various UI fixes after the PrimeVue / OnmsUI migration

A batch of independent UI fixes left over from the move to PrimeVue and the `onms-ui` seam
layer. Each is small and self-contained; they are grouped here to avoid seven near-empty PRs.
Every change was verified against a running instance rather than by inspection alone.

Summarized most of the changes, but left some detail in here for future reference (e.g. re how footers were fixed).

---

## 1. Alarm Details Sticky/Journal memo textareas unreadable in dark mode

**Fix.** Added `textarea` to the existing rule in `opennms-styles.scss` that already pins native
selects, checkboxes and radios to `color-scheme: light`. Legacy textareas are now dark-on-light in
both themes. Only the menu bundle loads this stylesheet, so the SPA's PrimeVue `Textarea` is
unaffected.

---

## 2. `a:visited` overriding button label colors

**Problem.** On the Alarm and Event list pages, menu buttons rendered blue-on-grey instead of
white once their URL had been visited — "View all alarms", "Short/Long Listing", "View all events"
and the `Next` pagination button. Items rendered as anchors *without* an `href` stayed white.

**Cause.** `a:visited` includes a pseudo-class, so it outranks Bootstrap's single-class
`.btn-secondary`.

**Fix.** Removed the rule from both places it was declared, and dropped some previous workarounds.

---

## 3. Drawers and modal dialogs let the page scroll behind them

**Problem.** Opening a drawer (e.g. Customize Columns on the Node List) and scrolling scrolled the
node table behind it — the page's scrollbar sat at the viewport edge and read as the drawer's. The
Advanced Filters drawer was worse: it showed two adjacent scrollbars, only one of which was its own.

**Fix.** Three parts:

- Turned on PrimeVue's `blockScroll` in the seam wrappers.
- `blockScroll` alone was not enough: `html { overflow-x: hidden }` makes `<html>` the SPA's scroll
  container, so the body class PrimeVue toggles never reaches the element that actually scrolls. The
  lock is now applied to `<html>`; added `scrollbar-gutter: stable` so hiding the page scrollbar does not shift the fixed masthead and rail.
- Removed the two node drawers' inner `height: 100%; overflow: auto`, so PrimeVue's
  `.p-drawer-content` is each drawer's single scroll container.

Trade-off worth calling out: `scrollbar-gutter: stable` reserves the gutter permanently, so every SPA
page gives up ~15px of width whether it scrolls or not. The alternative is the fixed masthead and
rail jumping 15px every time an overlay opens.

---

## 4. SNMP "Add" button not aligned with the inputs beside it

**Problem.** On the SNMP configuration details panel, the Add button's top edge sat a label-height
above the tops of the IP address inputs in the same row.

**Fix.** Used `FormField` and gave it a `reserveLabelSpace` prop

---

## 5. JSP footer stopped at the end of content instead of the bottom of the window

**Problem.** On JSP pages the footer sat wherever the content ended — hundreds of pixels above the
bottom of the window on short pages (157px into a 969px viewport on the node list). The SPA already
behaves correctly: footer at the window bottom when content is short, after the content when it
scrolls.

**Fix.** `#content` becomes a flex column with `min-height: 100vh`, the same shape the SPA gets from
its layout grid's `1fr` content row. Because page markup must not become flex items — that stretches
inline-level children and collapses ones sized by auto margins — `bootstrap.jsp` now wraps everything
but the footer in a `#content-body` div. `#content` therefore has exactly two flex items, all page
markup lays out inside a plain block exactly as before, `#content-body` takes the slack and the
footer follows it.

The `custom-footer` includes an install can contribute are emitted after the footer, so they get a
plain `#custom-footer` block for the same reason, and the two footer-less pages (`login.jsp`,
`passwordGate.jsp`) close the wrapper themselves since they never include the footer.

Also dropped the SPA's default `body` margin, which sat outside `.app-layout`'s `min-height: 100vh`
and made every page overflow the viewport by ~16px. Both stacks now put the footer exactly at the
bottom edge.

Vaadin pages emit no `#content` and are deliberately untouched.

---

## 6. SPA footer's spacer div caused scrollbars with nothing to scroll

**Problem.** Pages whose content wanted exactly the height the shell leaves them — SNMP Config,
OpenAPI, Resource Graphs — grew a scrollbar for 16px of nothing.

**Cause.** A `<div style="height: 1rem">` inside the layout's footer row made that row 57px tall
instead of 41px, taking 16px from the `1fr` content row.

**Fix.** Removed the spacer. The footer looks the same without it — it keeps its own padding and top
border — and those pages now fit exactly.

`ui/src/components/Layout/Footer.vue`

---

## 7. Map, Logs and SCV pages clipped the footer

**Problem.** These three pages overflowed the viewport and pushed the footer off the bottom of the
window — most visibly on the map, where it was cut in half.

**Cause.** Each sizes its tall element with a hand-picked `calc(100vh - x)`, and each `x` was too
small for the chrome actually above and below it.

**Fix.** Derive the subtraction instead of guessing it.

---

## 8. Searchable Vue pages (unrelated, folded in)

Added Vue Resource Graphs, Geographical Map and Topological Map to `search-actions.xml` so they turn
up in search.

---

## Review round

Four items from review, fixed in `NMS-20182: Address PR review on the footer and scroll-lock
changes`:

- **`custom-footer` includes were outside the wrapper.** They are emitted after the footer, so an
  install's markup landed as a direct flex item of `#content` — the exact case `#content-body`
  exists to prevent. Now wrapped in a
  `#custom-footer` block, emitted only when the directory exists. Wrapping rather than moving the
  `#content-body` close, because these includes belong *after* the footer.
- **The scroll lock matched `.p-overlay-mask` too broadly.** DataTable, Tree, TreeTable, Image,
  Galleria and SpeedDial all hard-code that class on their masks, while Dialog and Drawer add it only
  when modal — so the day anyone wires up `OnmsTable`'s loading prop, every table fetch would have
  frozen page scroll. Narrowed to `.p-dialog-mask.p-overlay-mask` / `.p-drawer-mask.p-overlay-mask`,
  which keeps the nesting fix and cannot over-match. On the leave transition: PrimeVue's own
  `disableDocumentSettings()` also runs in `onAfterLeave`, so both mechanisms expire together and
  this adds no lag.
- **The 41px footer band was a literal in four files**, derived from a `Footer.vue` height this PR
  changes. Now a real `--onms-footer-height` token defined in `Footer.vue` next to the element it
  describes, mirroring how `Menubar.vue` owns `--onms-header-height`; `.footer` takes its
  `min-height` from the token so the two cannot drift. Note it is a *min*: at very narrow widths the
  copyright line wraps and the band exceeds the token, the one case those page calculations still
  under-count.
- **`login.jsp` and `passwordGate.jsp` left the divs unclosed** — they include `bootstrap.jsp` but
  deliberately not `bootstrap-footer.jsp`. Both now close `#content-body` and `#content` themselves.
  They stay footer-less by design.

Three items reviewed and consciously left alone:

- The repeated `51px` / `30px` / `4px` chrome literals. Same drift exposure as the footer band, but
  breadcrumbs are slated for removal in a near-future release.
- `search-actions.xml`: "Topology Map" does point at the legacy Vaadin page, so the commit message's
  "Vue pages" framing is loose, and the `(Preview)` suffix is inconsistent with "Geographical Map".
  Cosmetic; both entries work as intended.
- `scrollbar-gutter: stable`, accepted knowingly — see the trade-off note above.

---

## Known follow-ups (not in this PR)

- Deployed SPA and menu assets have unhashed filenames (`assets/index.js`), so browsers serve stale
  bundles after a deploy. Worth a separate issue — it also makes local verification error-prone.
- Form rows align labels and controls per-field, so a label that wraps to two lines pushes its own
  input down and out of line with its neighbours. Fixing that properly means putting label/control/
  hint on shared grid tracks (CSS subgrid).
- Map, Logs and SCV still use pixel arithmetic for their heights rather than the flex-fill pattern
  in `AdhocChart.vue`. Converting them would need the app shell to hand its height down, which
  touches every page.


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20182
