### PR TITLE
NMS-20254: Expose a discovered link's interfaces on its graph API edge

### DIFF
--- a/features/graph/provider/legacy/pom.xml
+++ b/features/graph/provider/legacy/pom.xml
@@ -48,5 +48,16 @@
             <artifactId>org.opennms.features.topology.api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Only for the Vaadin Item the legacy Edge interface returns. -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-compatibility-server</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/features/graph/provider/legacy/src/main/java/org/opennms/netmgt/graph/provider/legacy/LegacyEdge.java
+++ b/features/graph/provider/legacy/src/main/java/org/opennms/netmgt/graph/provider/legacy/LegacyEdge.java
@@ -22,6 +22,7 @@
 package org.opennms.netmgt.graph.provider.legacy;
 
 import org.opennms.features.topology.api.topo.Edge;
+import org.opennms.features.topology.api.topo.LinkDetailsAware;
 import org.opennms.netmgt.graph.api.VertexRef;
 import org.opennms.netmgt.graph.api.generic.GenericEdge;
 import org.opennms.netmgt.graph.domain.AbstractDomainEdge;
@@ -32,12 +33,40 @@ public class LegacyEdge extends AbstractDomainEdge {
     }
 
     public LegacyEdge(Edge legacyEdge) {
-        super(GenericEdge.builder()
+        super(toGenericEdge(legacyEdge));
+    }
+
+    /** Provider-local: an ifIndex means nothing on a business-service edge. */
+    public interface Properties {
+        String SOURCE_IFINDEX = "sourceIfIndex";
+        String TARGET_IFINDEX = "targetIfIndex";
+        String DISCOVERY_PROTOCOL = "discoveryProtocol";
+    }
+
+    /**
+     * Only the endpoint node refs used to survive here, dropping the interfaces
+     * discovery had already resolved.
+     */
+    private static GenericEdge toGenericEdge(Edge legacyEdge) {
+        final GenericEdge.GenericEdgeBuilder builder = GenericEdge.builder()
                 .id(legacyEdge.getId())
                 .label(legacyEdge.getLabel())
                 .namespace(legacyEdge.getNamespace())
                 .source(new VertexRef(legacyEdge.getSource().getNamespace(), legacyEdge.getSource().getVertex().getId()))
-                .target(new VertexRef(legacyEdge.getTarget().getNamespace(), legacyEdge.getTarget().getVertex().getId()))
-                .build());
+                .target(new VertexRef(legacyEdge.getTarget().getNamespace(), legacyEdge.getTarget().getVertex().getId()));
+        if (legacyEdge instanceof LinkDetailsAware) {
+            final LinkDetailsAware link = (LinkDetailsAware) legacyEdge;
+            // Strings because the REST converters have no case for a boxed
+            // Integer and fall back to toString() anyway, as nodeID already does.
+            builder.property(Properties.SOURCE_IFINDEX, asString(link.getSourceIfIndex()));
+            builder.property(Properties.TARGET_IFINDEX, asString(link.getTargetIfIndex()));
+            // The builder drops nulls, so an unresolved end is absent.
+            builder.property(Properties.DISCOVERY_PROTOCOL, link.getDiscoveryProtocol());
+        }
+        return builder.build();
+    }
+
+    private static String asString(final Integer ifIndex) {
+        return ifIndex == null ? null : String.valueOf(ifIndex);
     }
 }

--- a/features/graph/provider/legacy/src/test/java/org/opennms/netmgt/graph/provider/legacy/LegacyEdgeTest.java
+++ b/features/graph/provider/legacy/src/test/java/org/opennms/netmgt/graph/provider/legacy/LegacyEdgeTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.graph.provider.legacy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+import org.opennms.features.topology.api.topo.AbstractEdge;
+import org.opennms.features.topology.api.topo.DefaultVertexRef;
+import org.opennms.features.topology.api.topo.Edge;
+import org.opennms.features.topology.api.topo.LinkDetailsAware;
+import org.opennms.netmgt.graph.api.generic.GenericEdge;
+
+/** What survives the legacy-to-generic edge conversion. */
+public class LegacyEdgeTest {
+
+    private static final String NAMESPACE = "nodes";
+
+    private static class PlainEdge extends AbstractEdge implements Edge {
+        PlainEdge() {
+            super(NAMESPACE, "edge-1", vertex("source"), vertex("target"));
+        }
+    }
+
+    private static class LinkEdge extends PlainEdge implements LinkDetailsAware {
+        private final Integer sourceIfIndex;
+        private final Integer targetIfIndex;
+
+        LinkEdge(final Integer sourceIfIndex, final Integer targetIfIndex) {
+            this.sourceIfIndex = sourceIfIndex;
+            this.targetIfIndex = targetIfIndex;
+        }
+
+        @Override
+        public Integer getSourceIfIndex() {
+            return sourceIfIndex;
+        }
+
+        @Override
+        public Integer getTargetIfIndex() {
+            return targetIfIndex;
+        }
+
+        @Override
+        public String getDiscoveryProtocol() {
+            return "LLDP";
+        }
+    }
+
+    private static DefaultVertexRef vertex(final String id) {
+        return new DefaultVertexRef(NAMESPACE, id, id);
+    }
+
+    private static GenericEdge convert(final Edge edge) {
+        return new LegacyEdge(edge).asGenericEdge();
+    }
+
+    /** Pins the wire type: strings, not numbers. */
+    @Test
+    public void carriesInterfaceIdentityAndProtocolAsStrings() {
+        final GenericEdge converted = convert(new LinkEdge(2, 47));
+
+        assertEquals("2", converted.getProperty(LegacyEdge.Properties.SOURCE_IFINDEX));
+        assertEquals("47", converted.getProperty(LegacyEdge.Properties.TARGET_IFINDEX));
+        assertEquals("LLDP", converted.getProperty(LegacyEdge.Properties.DISCOVERY_PROTOCOL));
+    }
+
+    /** Each ifIndex belongs to the endpoint its ref names. */
+    @Test
+    public void pairsEachIfIndexWithItsOwnEndpoint() {
+        final GenericEdge converted = convert(new LinkEdge(2, 47));
+
+        assertEquals("source", converted.getSource().getId());
+        assertEquals("2", converted.getProperty(LegacyEdge.Properties.SOURCE_IFINDEX));
+        assertEquals("target", converted.getTarget().getId());
+        assertEquals("47", converted.getProperty(LegacyEdge.Properties.TARGET_IFINDEX));
+    }
+
+    @Test
+    public void keepsTheEndpointsItAlwaysKept() {
+        final GenericEdge converted = convert(new LinkEdge(2, 47));
+
+        assertEquals("edge-1", converted.getId());
+        assertEquals(NAMESPACE, converted.getNamespace());
+    }
+
+    /** One-sided discovery: the absent end is missing, not empty. */
+    @Test
+    public void omitsAnEndThatNeverResolved() {
+        final GenericEdge converted = convert(new LinkEdge(2, null));
+
+        assertEquals("2", converted.getProperty(LegacyEdge.Properties.SOURCE_IFINDEX));
+        assertFalse(converted.getProperties().containsKey(LegacyEdge.Properties.TARGET_IFINDEX));
+    }
+
+    @Test
+    public void addsNothingToAnEdgeThatKnowsNoLink() {
+        final GenericEdge converted = convert(new PlainEdge());
+
+        assertFalse(converted.getProperties().containsKey(LegacyEdge.Properties.SOURCE_IFINDEX));
+        assertFalse(converted.getProperties().containsKey(LegacyEdge.Properties.TARGET_IFINDEX));
+        assertFalse(converted.getProperties().containsKey(LegacyEdge.Properties.DISCOVERY_PROTOCOL));
+    }
+}

--- a/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/topo/LinkDetailsAware.java
+++ b/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/topo/LinkDetailsAware.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.topology.api.topo;
+
+/**
+ * An edge that knows the network link behind it. Enlinkd resolves both ends
+ * while building the topology; this exposes them to consumers outside the
+ * Vaadin plugins.
+ */
+public interface LinkDetailsAware {
+
+    /** Null if discovery never resolved this end. */
+    Integer getSourceIfIndex();
+
+    /** Null if discovery never resolved this end. */
+    Integer getTargetIfIndex();
+
+    /**
+     * The enlinkd {@code ProtocolSupported} name. A combined view holds several
+     * protocols in one namespace, so the namespace does not identify an edge's.
+     * Includes the synthetic topologies, whose ends have no ifIndex.
+     */
+    String getDiscoveryProtocol();
+}

--- a/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/topo/LinkDetailsAware.java
+++ b/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/topo/LinkDetailsAware.java
@@ -36,8 +36,9 @@ public interface LinkDetailsAware {
 
     /**
      * The enlinkd {@code ProtocolSupported} name. A combined view holds several
-     * protocols in one namespace, so the namespace does not identify an edge's.
-     * Includes the synthetic topologies, whose ends have no ifIndex.
+     * protocols in one namespace, so the namespace does not identify an edge's
+     * discovery protocol. Includes the synthetic topologies, whose ends have no
+     * ifIndex.
      */
     String getDiscoveryProtocol();
 }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdEdge.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdEdge.java
@@ -23,10 +23,11 @@ package org.opennms.features.topology.plugins.topo.linkd.internal;
 
 import org.opennms.features.topology.api.topo.AbstractEdge;
 import org.opennms.features.topology.api.topo.Edge;
+import org.opennms.features.topology.api.topo.LinkDetailsAware;
 import org.opennms.features.topology.api.topo.simple.SimpleConnector;
 import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
 
-public class LinkdEdge extends AbstractEdge implements Edge {
+public class LinkdEdge extends AbstractEdge implements Edge, LinkDetailsAware {
 
     public static LinkdEdge create(String id,
             LinkdPort sourceport, LinkdPort targetport,
@@ -99,5 +100,19 @@ public class LinkdEdge extends AbstractEdge implements Edge {
     public LinkdPort getTargetPort() {
         return m_targetPort;
     }
-    
+
+    @Override
+    public Integer getSourceIfIndex() {
+        return m_sourcePort.getIfIndex();
+    }
+
+    @Override
+    public Integer getTargetIfIndex() {
+        return m_targetPort.getIfIndex();
+    }
+
+    @Override
+    public String getDiscoveryProtocol() {
+        return m_discoveredBy.name();
+    }
 }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProviderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProviderTest.java
@@ -42,6 +42,7 @@ import org.opennms.features.topology.api.topo.DefaultVertexRef;
 import org.opennms.features.topology.api.topo.Defaults;
 import org.opennms.features.topology.api.topo.Edge;
 import org.opennms.features.topology.api.topo.EdgeRef;
+import org.opennms.features.topology.api.topo.LinkDetailsAware;
 import org.opennms.features.topology.api.topo.Vertex;
 import org.opennms.features.topology.api.topo.VertexRef;
 import org.opennms.features.topology.api.topo.simple.SimpleLeafVertex;
@@ -325,6 +326,29 @@ public class EnhancedLinkdTopologyProviderTest {
         assertEquals(0, countCDP);
         assertEquals(0, countISIS);
         assertEquals(0, countBRIDGE);
+    }
+
+    /** Real provider-built edges, and clones, which is all getEdges() returns. */
+    @Test
+    public void testEdgesCarryLinkDetails() {
+        m_topologyProvider.refresh();
+
+        int withBothIfIndexes = 0;
+        for (Edge edge : m_topologyProvider.getCurrentGraph().getEdges()) {
+            final LinkdEdge linkdEdge = (LinkdEdge) edge;
+            final LinkDetailsAware link = linkdEdge;
+
+            assertEquals(linkdEdge.getDiscoveredBy().name(), link.getDiscoveryProtocol());
+
+            // A swap would be invisible downstream: same type either way.
+            assertEquals(linkdEdge.getSourcePort().getIfIndex(), link.getSourceIfIndex());
+            assertEquals(linkdEdge.getTargetPort().getIfIndex(), link.getTargetIfIndex());
+
+            if (link.getSourceIfIndex() != null && link.getTargetIfIndex() != null) {
+                withBothIfIndexes++;
+            }
+        }
+        assertTrue("no edge resolved an ifIndex at both ends", withBothIfIndexes > 0);
     }
 
     @Test


### PR DESCRIPTION
Targeting this at foundation-2026 so it's available for additional preview work later this year.

Edges served by /api/v2/graphs now carry sourceIfIndex, targetIfIndex and discoveryProtocol (this ties a rendered link to the two interfaces it runs between).  I think this was pretty much always meant to be there based on some older NMS issues but it looks like we just never passed it through.

The values are strings. The graph REST converters have no case for a boxed Integer and fall through to toString(), so an Integer would serialize identically while claiming to be a number. PathOutageGraphProvider already writes nodeID this way.

The keys live on LegacyEdge rather than GenericProperties, which is offered for any element and where an ifIndex means nothing on a business-service or application edge. BusinessServiceEdge nests its keys the same way.

Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20254

