### PR TITLE
NMS-20262: JSON snmp-config wipes inherited timeout and retry values

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpConfigRestService.java
@@ -33,7 +33,10 @@ import javax.ws.rs.core.Response;
 import com.google.common.base.Strings;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonMethod;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.config.SnmpConfigUtils;
 import org.opennms.netmgt.config.SnmpConfigUtils.DefinitionContentsValidationStatus;
@@ -63,6 +66,17 @@ public class SnmpConfigRestService implements SnmpConfigRestApi {
     private static final String MODULE_NAME = "web rest api";
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // The SnmpConfig getters substitute a default when the underlying field is unset, so serializing
+    // through them would turn every inherited value into an explicit one. Bind to the fields instead
+    // and drop nulls, so a downloaded file only carries what was actually configured.
+    private static final ObjectMapper downloadObjectMapper = new ObjectMapper();
+    static {
+        downloadObjectMapper.setVisibility(JsonMethod.GETTER, JsonAutoDetect.Visibility.NONE);
+        downloadObjectMapper.setVisibility(JsonMethod.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+        downloadObjectMapper.setVisibility(JsonMethod.FIELD, JsonAutoDetect.Visibility.ANY);
+        downloadObjectMapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+    }
 
     public static final String DEFINITION_MISSING_CONTENTS_MESSAGE = "Definition must have at least one specific IP, IP range or IP match specified.";
     public static final String DEFINITION_CANNOT_MIX_RANGE_AND_IPMATCH_MESSAGE =
@@ -286,7 +300,7 @@ public class SnmpConfigRestService implements SnmpConfigRestApi {
                 // the codehaus.jackson JsonProvider
                 // The codehaus.jackson DefaultPrettyPrinter doesn't have the best output,
                 // it adds extra whitespace, but it'll do for now
-                String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(snmpConfig);
+                String json = downloadObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(snmpConfig);
                 byteArray = json.getBytes(StandardCharsets.UTF_8);
             }
         } catch (Exception e) {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/SnmpConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/SnmpConfigRestServiceIT.java
@@ -49,11 +49,13 @@ import org.springframework.test.context.web.WebAppConfiguration;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -815,6 +817,50 @@ public class SnmpConfigRestServiceIT extends AbstractSpringJerseyRestTestCase {
         }
 
         assertConfigValid(config);
+    }
+
+    @Test
+    public void testJsonRoundTripPreservesInheritedValues() {
+        // the definitions in snmp-config.xml set no timeout/retry of their own
+        SnmpAgentConfig before = (SnmpAgentConfig) snmpConfigRestApi.getConfigForIp("127.0.0.1", "Default").getEntity();
+        assertEquals(800, before.getTimeout());
+        assertEquals(3, before.getRetries());
+
+        final Response download = snmpConfigRestApi.downloadConfig(null);
+        assertEquals(200, download.getStatus());
+        final byte[] json = (byte[]) download.getEntity();
+        assertNotNull(json);
+
+        SnmpConfig downloaded = null;
+
+        try {
+            downloaded = mapper.readValue(new String(json, StandardCharsets.UTF_8), SnmpConfig.class);
+        } catch (Exception e) {
+            Assert.fail("Error parsing downloaded Json file.");
+        }
+
+        for (final Definition definition : downloaded.getDefinitions()) {
+            assertFalse(definition.hasTimeout());
+            assertFalse(definition.hasRetry());
+            assertFalse(definition.hasPort());
+        }
+
+        final Attachment attachment = mock(Attachment.class);
+        final ContentDisposition cd = mock(ContentDisposition.class);
+        when(cd.getParameter("filename")).thenReturn("snmp-config.json");
+        when(attachment.getContentDisposition()).thenReturn(cd);
+        when(attachment.getObject(InputStream.class)).thenReturn(new ByteArrayInputStream(json));
+
+        assertEquals(200, snmpConfigRestApi.uploadConfig(attachment).getStatus());
+
+        SnmpAgentConfig after = (SnmpAgentConfig) snmpConfigRestApi.getConfigForIp("127.0.0.1", "Default").getEntity();
+        assertEquals(800, after.getTimeout());
+        assertEquals(3, after.getRetries());
+
+        // a download of the re-uploaded config should be identical to the first one
+        final Response second = snmpConfigRestApi.downloadConfig(null);
+        assertEquals(200, second.getStatus());
+        assertArrayEquals(json, (byte[]) second.getEntity());
     }
 
     @Test


### PR DESCRIPTION
GET /rest/v2/snmp-config/download?format=json can’t do a proper restore. It serializes SnmpConfig through its getters, and those getters substitute a default when the backing field is null, so values a definition inherited from the top-level config are written out as if they had been set on the definition.

I validated this by setting a global timeout="1800" and a definition with a read-community, the effective timeout for 127.0.0.1 drops from 1800 to 0 after a JSON download/upload cycle.  

I don’t think this is intended behavior so this is a fix for it and a test.

Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20262

